### PR TITLE
feat: configurable slug casing for non-English wikis (Issue #111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Configurable file name casing (Issue #111).** A new `File Name Casing` setting (`lower` / `preserve`) controls whether generated wiki filenames are lowercased. The default `lower` preserves backwards-compatible behaviour. `preserve` is recommended for languages where lowercase changes meaning — most notably German, where all nouns are capitalised (`Mitochondrien`, not `mitochondrien`). The setting applies consistently across all file-creation paths (ingest, lint stub creation, summary pages). Slug-based comparison for deduplication and conflict detection always uses lowercase internally, so matching remains correct regardless of the chosen casing mode. Available in all 8 interface languages.
+
 ### Fixed
 - **Tags silently lost on re-ingest and multi-source merge (Issue #114).** Two distinct failure modes caused manually-set `tags:` to be overwritten on every subsequent ingest:
   - `createSummaryPage()` regenerated source pages from scratch on every re-ingest without checking for existing content. Manually corrected tags were discarded. Fix: read existing source page frontmatter before generation; if `tags:` is already populated, carry it forward as the `tagsValue` injected into the LLM prompt (existing tags > source-note tags > LLM concept name fallback).

--- a/src/__tests__/__support__/engine-context.ts
+++ b/src/__tests__/__support__/engine-context.ts
@@ -100,6 +100,7 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   tagVocabularyMode: 'default',
   customEntityTags: '',
   customConceptTags: '',
+  slugCase: 'lower' as const,
 };
 
 // ── Mock EngineContext ───────────────────────────────────────────

--- a/src/__tests__/root/utils.test.ts
+++ b/src/__tests__/root/utils.test.ts
@@ -911,6 +911,7 @@ describe('getGranularityInstruction', () => {
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('injects concrete entity and concept limits for custom mode', () => {
@@ -964,6 +965,7 @@ describe('appendGranularityToPrompt', () => {
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('appends granularity instruction to existing prompt', () => {
@@ -1014,6 +1016,7 @@ describe('getGranularityFixLimits', () => {
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('returns user-defined limits for custom mode', () => {

--- a/src/__tests__/root/utils.test.ts
+++ b/src/__tests__/root/utils.test.ts
@@ -1672,6 +1672,7 @@ describe('buildActiveTagVocabularySection (Issue #85 v6 — prompt injection)', 
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('in default mode, lists the hardcoded VALID_ENTITY_TAGS', () => {
@@ -1747,6 +1748,7 @@ describe('appendTagVocabularyToPrompt (Issue #85 v6 — end-to-end prompt inject
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('appends active tag vocabulary section after the base prompt', () => {
@@ -1821,6 +1823,7 @@ describe('enforceFrontmatterConstraints (Issue #85 v6 — preserve LLM intent)',
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('retains out-of-vocab tags (does NOT silently drop them)', () => {
@@ -1928,6 +1931,7 @@ describe('getActiveSourceTags (Issue #85 v7)', () => {
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   it('returns the hardcoded VALID_SOURCE_TAGS list', () => {

--- a/src/__tests__/wiki/lint/scanners.test.ts
+++ b/src/__tests__/wiki/lint/scanners.test.ts
@@ -193,6 +193,7 @@ describe('scanTagViolations', () => {
     tagVocabularyMode: 'default',
     customEntityTags: '',
     customConceptTags: '',
+    slugCase: 'lower' as const,
   };
 
   function makeEntityPage(path: string, tags: string[] | string, withTitle = false): ScannerPage {

--- a/src/main.ts
+++ b/src/main.ts
@@ -354,7 +354,7 @@ export default class LLMWikiPlugin extends Plugin {
   // ==================== Ingestion ====================
 
   private async isAlreadyIngested(sourceFile: TFile): Promise<boolean> {
-    const slug = slugify(sourceFile.basename);
+    const slug = slugify(sourceFile.basename, this.settings.slugCase === 'preserve');
     const wikiPath = `${this.settings.wikiFolder}/sources/${slug}.md`;
 
     try {

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -55,6 +55,11 @@ export const DE_TEXTS = {
     maxTokensPerCallName: 'Kontextfenster',
     maxTokensPerCallDesc: 'Tokens an das Kontextfenster des Modells anpassen. 0 = kein Limit (Cloud).',
 
+    slugCaseName: 'Dateinamen-Schreibweise',
+    slugCaseDesc: "Legt fest, ob generierte Wiki-Dateinamen kleingeschrieben werden. 'Beibehalten' empfohlen fuer Sprachen, in denen Gross-/Kleinschreibung bedeutungsrelevant ist (z. B. deutsche Substantive).",
+    slugCaseLower: 'Kleinschreibung (Standard)',
+    slugCasePreserve: 'Schreibweise beibehalten',
+
     // Model Selection
     modelSection: 'Modellauswahl',
     fetchModelsName: 'Verfügbare Modelle abrufen',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -58,6 +58,12 @@ export const EN_TEXTS = {
     maxTokensPerCallName: 'Context Window',
     maxTokensPerCallDesc: 'Limit generation tokens to fit your model\'s context window. 0 = no cap (cloud default).',
 
+    // Issue #111: slug casing
+    slugCaseName: 'File Name Casing',
+    slugCaseDesc: 'Controls whether generated wiki filenames are lowercased. "Preserve" is recommended for languages where lowercase changes meaning (e.g. German nouns).',
+    slugCaseLower: 'Lowercase (default)',
+    slugCasePreserve: 'Preserve case',
+
     // Model Selection
     modelSection: 'Model Selection',
     fetchModelsName: 'Fetch Available Models',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -55,6 +55,11 @@ export const ES_TEXTS = {
     maxTokensPerCallName: 'Ventana de contexto',
     maxTokensPerCallDesc: 'Limitar tokens a la ventana de contexto del modelo. 0 = sin límite (cloud).',
 
+    slugCaseName: 'Mayúsculas en nombres de archivo',
+    slugCaseDesc: "Controla si los nombres de archivo Wiki generados se ponen en minúsculas. Se recomienda 'Conservar' para idiomas donde las mayúsculas son significativas (p. ej. sustantivos alemanes).",
+    slugCaseLower: 'Minúsculas (predeterminado)',
+    slugCasePreserve: 'Conservar mayúsculas',
+
     // Model Selection
     modelSection: 'Selección del modelo',
     fetchModelsName: 'Obtener modelos disponibles',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -55,6 +55,11 @@ export const FR_TEXTS = {
     maxTokensPerCallName: 'Fenêtre de contexte',
     maxTokensPerCallDesc: 'Limiter les tokens à la fenêtre de contexte du modèle. 0 = aucune limite (cloud).',
 
+    slugCaseName: 'Casse des noms de fichiers',
+    slugCaseDesc: "Contrôle si les noms de fichiers Wiki générés sont mis en minuscules. 'Conserver' recommandé pour les langues où la casse est significative (ex. noms allemands).",
+    slugCaseLower: 'Minuscules (défaut)',
+    slugCasePreserve: 'Conserver la casse',
+
     // Model Selection
     modelSection: 'Sélection du modèle',
     fetchModelsName: 'Récupérer les modèles disponibles',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -55,6 +55,11 @@ export const JA_TEXTS = {
     maxTokensPerCallName: 'コンテキストウィンドウ',
     maxTokensPerCallDesc: '生成Tokenをモデルのコンテキストウィンドウに制限。0 = 無制限（クラウドデフォルト）。',
 
+    slugCaseName: 'ファイル名の大文字小文字',
+    slugCaseDesc: '生成される Wiki ファイル名を小文字化するかどうかを制御します。大文字小文字に意味のある言語（ドイツ語の名詞など）では「保持」を推奨。',
+    slugCaseLower: '小文字（デフォルト）',
+    slugCasePreserve: '大文字小文字を保持',
+
     // Model Selection
     modelSection: 'モデル選択',
     fetchModelsName: '利用可能なモデルを取得',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -55,6 +55,11 @@ export const KO_TEXTS = {
     maxTokensPerCallName: '컨텍스트 창',
     maxTokensPerCallDesc: '컨텍스트 창에 맞게 토큰 제한. 0 = 제한 없음(클라우드 기본값).',
 
+    slugCaseName: '파일명 대소문자',
+    slugCaseDesc: '생성되는 Wiki 파일명을 소문자로 변환할지 제어합니다. 대소문자가 의미 있는 언어(예: 독일어 명사)는 "유지" 권장.',
+    slugCaseLower: '소문자(기본값)',
+    slugCasePreserve: '대소문자 유지',
+
     // Model Selection
     modelSection: '모델 선택',
     fetchModelsName: '사용 가능한 모델 가져오기',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -55,6 +55,11 @@ export const PT_TEXTS = {
     maxTokensPerCallName: 'Janela de contexto',
     maxTokensPerCallDesc: 'Limitar tokens à janela de contexto do modelo. 0 = sem limite (cloud).',
 
+    slugCaseName: 'Capitalização de nomes de arquivo',
+    slugCaseDesc: "Controla se os nomes de arquivo Wiki gerados são convertidos para minúsculas. Recomenda-se 'Preservar' para idiomas onde maiúsculas são significativas (ex. substantivos alemães).",
+    slugCaseLower: 'Minúsculas (padrão)',
+    slugCasePreserve: 'Preservar capitalização',
+
     // Model Selection
     modelSection: 'Seleção de modelo',
     fetchModelsName: 'Buscar modelos disponíveis',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -55,6 +55,11 @@ export const ZH_TEXTS = {
     maxTokensPerCallName: '上下文窗口',
     maxTokensPerCallDesc: '限制生成 Token 以适配模型上下文窗口。0 = 无限制（云端默认）。',
 
+    slugCaseName: '文件名大小写',
+    slugCaseDesc: '控制生成的 Wiki 文件名是否转为小写。对于大小写有语义的语言（如德语名词），建议选择“保留”。',
+    slugCaseLower: '小写（默认）',
+    slugCasePreserve: '保留大小写',
+
     // 模型选择
     modelSection: '模型选择',
     fetchModelsName: '获取可用模型',

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,12 @@ export interface LLMWikiSettings {
   // Issue #75: cap max_tokens per LLM call. 0 = no cap.
   // Recommended for local models with small context windows.
   maxTokensPerCall: number;
+
+  // Issue #111: slug casing for generated filenames.
+  // 'lower' preserves backwards-compatible all-lowercase filenames.
+  // 'preserve' keeps the casing the LLM produces — required for languages
+  // where lowercase is grammatically wrong (e.g. German nouns).
+  slugCase: 'lower' | 'preserve';
 }
 
 export interface QueryHistoryMessage {
@@ -473,4 +479,6 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   // wiring complete. Users with non-thinking models can leave true;
   // users with thinking models wanting CoT can set false.
   disableThinking: true,
+  // Issue #111: default to 'lower' for backwards compatibility.
+  slugCase: 'lower',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export interface LLMWikiSettings {
   // 'lower' preserves backwards-compatible all-lowercase filenames.
   // 'preserve' keeps the casing the LLM produces — required for languages
   // where lowercase is grammatically wrong (e.g. German nouns).
+  // Note: switching affects new files only — existing lowercase files keep their names.
   slugCase: 'lower' | 'preserve';
 }
 

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -465,6 +465,18 @@ export class LLMWikiSettingTab extends PluginSettingTab {
         .setValue(this.tempSettings.wikiFolder)
         .onChange((value) => { this.tempSettings.wikiFolder = value; }));
 
+    new Setting(containerEl)
+      .setName(this.getText('slugCaseName'))
+      .setDesc(this.getText('slugCaseDesc'))
+      .addDropdown(dropdown => {
+        dropdown.addOption('lower', this.getText('slugCaseLower'));
+        dropdown.addOption('preserve', this.getText('slugCasePreserve'));
+        dropdown.setValue(this.tempSettings.slugCase || 'lower');
+        dropdown.onChange((value: string) => {
+          this.tempSettings.slugCase = value as 'lower' | 'preserve';
+        });
+      });
+
     // Granularity setting with conditional custom inputs
     let customEntitySetting: Setting | null = null;
     let customConceptSetting: Setting | null = null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ export function getText<K extends keyof typeof TEXTS.en>(
   return text;
 }
 
-export function slugify(text: string): string {
+export function slugify(text: string, preserveCase = false): string {
   console.debug('slugify input:', text, 'length:', text?.length);
 
   if (!text || text.trim().length === 0) {
@@ -30,14 +30,15 @@ export function slugify(text: string): string {
     return 'untitled';
   }
 
-  return computeSlug(text);
+  return computeSlug(text, preserveCase);
 }
 
-// Pure slug computation — no debug logs. Used for batch operations like
-// matchExtractedToExisting where thousands of slugify calls would flood the log.
 // Pure slug computation — no debug logs on normal path. Used for batch operations
 // where thousands of silent calls are needed (e.g. matching 2141 existing pages).
-export function computeSlug(text: string): string {
+// preserveCase skips the final toLowerCase() for file creation (Issue #111).
+// All comparison/matching callers must NOT pass preserveCase so slugs stay
+// case-insensitively comparable regardless of the user's slugCase setting.
+export function computeSlug(text: string, preserveCase = false): string {
   if (!text || text.trim().length === 0) return 'untitled';
 
   const trimmed = text.trim();
@@ -62,7 +63,7 @@ export function computeSlug(text: string): string {
 
   if (finalSlug.length === 0) return 'untitled-' + Date.now();
 
-  return finalSlug.toLowerCase();
+  return preserveCase ? finalSlug : finalSlug.toLowerCase();
 }
 
 // Filter out aliases that are redundant against a page's own filename.

--- a/src/wiki/conversation-ingest.ts
+++ b/src/wiki/conversation-ingest.ts
@@ -182,17 +182,18 @@ CRITICAL RULES:
     this.ctx.onProgress?.('Creating summary page...');
     await this.orch.ensureWikiStructure();
 
-    const semanticSlug = slugify(parsed.source_title);
+    const preserveCase = this.ctx.settings.slugCase === 'preserve';
+    const semanticSlug = slugify(parsed.source_title, preserveCase);
     const summaryPath = `${this.ctx.settings.wikiFolder}/sources/${semanticSlug}.md`;
     console.debug('[Semantic file path]', summaryPath);
 
     // Build planned paths before summary so the LLM can reference them
     const convPlannedPaths: string[] = [summaryPath];
     for (const entity of parsed.entities) {
-      convPlannedPaths.push(`${this.ctx.settings.wikiFolder}/entities/${slugify(entity.name)}.md`);
+      convPlannedPaths.push(`${this.ctx.settings.wikiFolder}/entities/${slugify(entity.name, preserveCase)}.md`);
     }
     for (const concept of parsed.concepts) {
-      convPlannedPaths.push(`${this.ctx.settings.wikiFolder}/concepts/${slugify(concept.name)}.md`);
+      convPlannedPaths.push(`${this.ctx.settings.wikiFolder}/concepts/${slugify(concept.name, preserveCase)}.md`);
     }
 
     const createdPagesList = convPlannedPaths.length > 0

--- a/src/wiki/lint-fixes.ts
+++ b/src/wiki/lint-fixes.ts
@@ -212,7 +212,7 @@ export class LintFixer {
         concept: WIKI_SUBFOLDERS.concepts,
       };
       const stubDir = pluralMap[stubType] || `${stubType}s`;
-      const stubSlug = slugify(sanitizedTitle);
+      const stubSlug = slugify(sanitizedTitle, this.ctx.settings.slugCase === 'preserve');
       const stubPath = `${this.ctx.settings.wikiFolder}/${stubDir}/${stubSlug}.md`;
       const sourceRel = sourcePath
         .replace(this.ctx.settings.wikiFolder + '/', '')
@@ -289,7 +289,7 @@ tags: [${stubType === 'entity' ? 'other' : 'term'}]
         ? 'entity'
         : 'concept';
       const stubDir = stubType === 'entity' ? 'entities' : 'concepts';
-      const stubSlug = slugify(cleanBasename);
+      const stubSlug = slugify(cleanBasename, this.ctx.settings.slugCase === 'preserve');
       const stubPath = `${this.ctx.settings.wikiFolder}/${stubDir}/${stubSlug}.md`;
       const sourceRel = sourcePath
         .replace(this.ctx.settings.wikiFolder + '/', '')

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -95,7 +95,7 @@ export class PageFactory {
   ): Promise<PageCreationResult> {
     const folder = pageType === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
     const otherFolder = pageType === 'entity' ? WIKI_SUBFOLDERS.concepts : WIKI_SUBFOLDERS.entities;
-    const slug = slugify(name);
+    const slug = slugify(name, this.ctx.settings.slugCase === 'preserve');
     const slugPath = `${this.ctx.settings.wikiFolder}/${folder}/${slug}.md`;
 
     // Fast path: exact slug match (same type folder)

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -264,11 +264,12 @@ export class WikiEngine {
       let step = 1;
 
       const plannedPaths: string[] = [];
+      const preserveCase = this.settings.slugCase === 'preserve';
       for (const entity of analysis.entities) {
-        plannedPaths.push(normalizePath(`${this.settings.wikiFolder}/entities/${slugify(entity.name)}.md`));
+        plannedPaths.push(normalizePath(`${this.settings.wikiFolder}/entities/${slugify(entity.name, preserveCase)}.md`));
       }
       for (const concept of analysis.concepts) {
-        plannedPaths.push(normalizePath(`${this.settings.wikiFolder}/concepts/${slugify(concept.name)}.md`));
+        plannedPaths.push(normalizePath(`${this.settings.wikiFolder}/concepts/${slugify(concept.name, preserveCase)}.md`));
       }
 
       this.onProgress?.(`[${step}/${totalSteps}] Creating summary...`);
@@ -633,7 +634,8 @@ export class WikiEngine {
   }
 
   async createSummaryPage(file: TFile, analysis: SourceAnalysis, plannedPaths: string[] = []): Promise<string> {
-    const slug = slugify(file.basename);
+    const preserveCase = this.settings.slugCase === 'preserve';
+    const slug = slugify(file.basename, preserveCase);
     const path = normalizePath(`${this.settings.wikiFolder}/sources/${slug}.md`);
     const content = await this.app.vault.read(file);
 
@@ -662,9 +664,9 @@ export class WikiEngine {
           const name = relPath.split('/').pop() || relPath;
           return `- [[${relPath}|${name}]]`;
         }).join('\n')
-      : analysis.entities.map(e => `- [[entities/${slugify(e.name)}|${e.name}]]`).join('\n') +
+      : analysis.entities.map(e => `- [[entities/${slugify(e.name, preserveCase)}|${e.name}]]`).join('\n') +
         '\n' +
-        analysis.concepts.map(c => `- [[concepts/${slugify(c.name)}|${c.name}]]`).join('\n');
+        analysis.concepts.map(c => `- [[concepts/${slugify(c.name, preserveCase)}|${c.name}]]`).join('\n');
 
     const prompt = PROMPTS.generateSummaryPage
       .replace('{{source_title}}', analysis.source_title)


### PR DESCRIPTION
## Summary

Adds a `File Name Casing` setting (`lower` / `preserve`) that controls whether generated wiki filenames are lowercased.

**Motivation:** German (and other languages) capitalise nouns — `Mitochondrien`, `Insulinresistenz`, `Herzinsuffizienz`. The current forced lowercase produces grammatically wrong filenames. This was discovered while maintaining a German medical wiki with 400+ source notes, where every ingested page received lowercase filenames (`mitochondrien.md`, `insulinresistenz.md`).

## Changes

- **`src/types.ts`** — `slugCase: 'lower' | 'preserve'` added to `LLMWikiSettings`; default `'lower'` preserves backwards compatibility
- **`src/utils.ts`** — `preserveCase` optional param added to `computeSlug()` and `slugify()`; comparison/matching callers always pass `preserveCase=false` so slug equality checks remain case-insensitive regardless of user setting
- **`src/wiki/wiki-engine.ts`, `page-factory.ts`, `conversation-ingest.ts`, `lint-fixes.ts`, `main.ts`** — all file-creation call sites pass `settings.slugCase === 'preserve'`
- **`src/ui/settings.ts`** — dropdown added in the Wiki section, below the folder setting
- **All 8 language files** — `slugCaseName`, `slugCaseDesc`, `slugCaseLower`, `slugCasePreserve` keys added

## Design decisions

- `computeSlug()` for matching/deduplication is always lowercase internally — correct slug comparison is independent of the display/file-casing preference
- Default stays `'lower'` — zero behaviour change for existing users
- `preserveCase` propagated at call sites rather than via module-level state — keeps functions pure and testable

## Test plan

- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test` — 587/587 passed
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm build` — production build succeeds
- [ ] Manual: set `preserve`, ingest a German note → filenames retain capitalisation
- [ ] Manual: set `lower` (default) → filenames lowercased as before

Closes #111

🤖 Implemented with [Claude Code](https://claude.com/claude-code)