### PR TITLE
fix: hard-cap entities/concepts to customEntityLimit/customConceptLimit (#120)

### DIFF
--- a/src/__tests__/wiki/source-analyzer.test.ts
+++ b/src/__tests__/wiki/source-analyzer.test.ts
@@ -100,4 +100,40 @@ describe('SourceAnalyzer', () => {
     const result = await run(a, EMPTY_PATH);
     expect(result).not.toBeNull();
   });
+
+  it('hard-caps entities and concepts to customEntityLimit / customConceptLimit (#120)', async () => {
+    // LLM returns 5 entities and 5 concepts, but limits are set to 2/2.
+    // The hard cap must slice the accumulation before buildSourceAnalysis —
+    // the prompt instruction alone is not enough since LLMs may ignore it.
+    const { ctx } = createMockContext({
+      vaultFiles: { [DOC_PATH]: '# Dense\nMany organisms and pathways.' },
+      llmResponses: [JSON.stringify({
+        source_title: 'Dense',
+        summary: 'Many items.',
+        entities: [
+          { name: 'Alpha', type: 'other', summary: 'a', mentions_in_source: [] },
+          { name: 'Beta',  type: 'other', summary: 'b', mentions_in_source: [] },
+          { name: 'Gamma', type: 'other', summary: 'c', mentions_in_source: [] },
+          { name: 'Delta', type: 'other', summary: 'd', mentions_in_source: [] },
+          { name: 'Epsilon', type: 'other', summary: 'e', mentions_in_source: [] },
+        ],
+        concepts: [
+          { name: 'One',   type: 'term', summary: '1', mentions_in_source: [], related_concepts: [] },
+          { name: 'Two',   type: 'term', summary: '2', mentions_in_source: [], related_concepts: [] },
+          { name: 'Three', type: 'term', summary: '3', mentions_in_source: [], related_concepts: [] },
+          { name: 'Four',  type: 'term', summary: '4', mentions_in_source: [], related_concepts: [] },
+          { name: 'Five',  type: 'term', summary: '5', mentions_in_source: [], related_concepts: [] },
+        ],
+      })],
+      settings: { extractionGranularity: 'custom', customEntityLimit: 2, customConceptLimit: 2 },
+    });
+    const analyzer = new SourceAnalyzer(ctx);
+    // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+    const result = await analyzer.analyzeSource(createMockFile(DOC_PATH) as unknown as TFile);
+    expect(result).not.toBeNull();
+    expect(result!.entities).toHaveLength(2);
+    expect(result!.concepts).toHaveLength(2);
+    expect(result!.entities[0].name).toBe('Alpha');
+    expect(result!.concepts[0].name).toBe('One');
+  });
 });

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -389,6 +389,17 @@ export class SourceAnalyzer {
       }
     }
 
+    // Hard-cap accumulation to the configured custom limits (#120).
+    // The prompt instruction is a soft hint the LLM may exceed; the
+    // convergence detector only stops further batches. This slice ensures
+    // the user's limit is actually honoured regardless of LLM behaviour.
+    if (this.ctx.settings.extractionGranularity === 'custom') {
+      const eCap = this.ctx.settings.customEntityLimit ?? 5;
+      const cCap = this.ctx.settings.customConceptLimit ?? 5;
+      if (accumulation.entities.length > eCap) accumulation.entities = accumulation.entities.slice(0, eCap);
+      if (accumulation.concepts.length > cCap) accumulation.concepts = accumulation.concepts.slice(0, cCap);
+    }
+
     // Build final SourceAnalysis using pure function (Phase 3)
     const analysis = buildSourceAnalysis(
       file.path,


### PR DESCRIPTION
## Problem

`customEntityLimit` / `customConceptLimit` were not actually enforced. See Issue #120 for full root-cause analysis.

Two existing mechanisms are soft-only:
- **Prompt instruction** — "Extract at most N…" is routinely ignored by LLMs on dense sources
- **Convergence detector** — stops further batches once cumulative counts reach the cap, but never truncates within a batch. For single-batch notes (most notes) this never fires at all.

Result: a user with `customEntityLimit: 8` regularly gets 15–25 entity pages per note.

## Fix

After all batches are accumulated and immediately before `buildSourceAnalysis()`, slice both arrays to the configured limits:

```typescript
if (this.ctx.settings.extractionGranularity === 'custom') {
  const eCap = this.ctx.settings.customEntityLimit ?? 5;
  const cCap = this.ctx.settings.customConceptLimit ?? 5;
  if (accumulation.entities.length > eCap) accumulation.entities = accumulation.entities.slice(0, eCap);
  if (accumulation.concepts.length > cCap) accumulation.concepts = accumulation.concepts.slice(0, cCap);
}
```

The prompt instruction and convergence detector are preserved as complementary mechanisms (they guide the LLM and avoid unnecessary extra batches).

## Test

New test in `source-analyzer.test.ts`: LLM returns 5 entities + 5 concepts with limits set to 2/2 → result contains exactly 2 + 2, first items preserved in order.

## Test plan
- [x] `pnpm lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm test` — 660/660 passed
- [x] `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)