### PR TITLE
fix(#125): normalize sources field in the write path + slugify external remap

### DIFF
--- a/src/__tests__/core/sources-normalizer.test.ts
+++ b/src/__tests__/core/sources-normalizer.test.ts
@@ -55,6 +55,23 @@ describe('normalizeSourcePath', () => {
   it('handles custom wikiFolder', () => {
     expect(normalizeSourcePath('Notes/Foo.md', 'my-wiki')).toBe('sources/Foo');
   });
+
+  // Issue #125: external-path remap must slugify the filename so the resulting
+  // [[sources/X]] link resolves to the canonical (hyphenated) source page.
+  it('slugifies spaces in remapped external filenames', () => {
+    expect(normalizeSourcePath('[[Notizen/Autonome Dysregulation.md]]', WIKI))
+      .toBe('sources/Autonome-Dysregulation');
+  });
+
+  it('strips parentheses and slugifies remapped external filenames', () => {
+    expect(normalizeSourcePath('[[Notizen/AGEs (Advanced Glycation End Products).md]]', WIKI))
+      .toBe('sources/AGEs-Advanced-Glycation-End-Products');
+  });
+
+  it('lowercases the remapped slug when preserveCase is false', () => {
+    expect(normalizeSourcePath('Notizen/Autonome Dysregulation.md', WIKI, false))
+      .toBe('sources/autonome-dysregulation');
+  });
 });
 
 describe('normalizeSourcesField', () => {

--- a/src/core/sources-normalizer.ts
+++ b/src/core/sources-normalizer.ts
@@ -15,14 +15,17 @@
  * no alias pipe.
  */
 
+import { computeSlug } from '../utils';
+
 /**
  * Normalize a single raw source entry to its canonical form.
  *
  * @param raw - Raw string from frontmatter (may include `[[ ]]`, `.md`, `|alias`, or external path)
  * @param wikiFolder - User's wiki folder name (used to strip the prefix and detect internal paths)
+ * @param preserveCase - Match the user's slugCase setting when slugifying a remapped external filename
  * @returns Normalized relative path (e.g. `sources/Foo`), or empty string for unfixable inputs
  */
-export function normalizeSourcePath(raw: string, wikiFolder: string): string {
+export function normalizeSourcePath(raw: string, wikiFolder: string, preserveCase = true): string {
   let s = raw.trim();
   if (!s || s === '[[]]') return '';
 
@@ -53,9 +56,11 @@ export function normalizeSourcePath(raw: string, wikiFolder: string): string {
   ) {
     // Already canonical internal path
   } else {
-    // External: remap to sources/<filename>
+    // External: remap to sources/<filename>, slugified so the link resolves to the
+    // canonical source page (e.g. "Notizen/Autonome Dysregulation" → "sources/Autonome-Dysregulation",
+    // "AGEs (Advanced Glycation End Products)" → "sources/AGEs-Advanced-Glycation-End-Products").
     const filename = s.split('/').pop() || s;
-    s = `sources/${filename}`;
+    s = `sources/${computeSlug(filename, preserveCase)}`;
   }
 
   return s;
@@ -67,13 +72,14 @@ export function normalizeSourcePath(raw: string, wikiFolder: string): string {
  *
  * @param rawList - Array of raw source strings from frontmatter
  * @param wikiFolder - User's wiki folder name
+ * @param preserveCase - Match the user's slugCase setting when slugifying remapped external filenames
  * @returns Array of normalized wikilink strings `[[path]]` (no `.md`, no `|alias`)
  */
-export function normalizeSourcesField(rawList: string[], wikiFolder: string): string[] {
+export function normalizeSourcesField(rawList: string[], wikiFolder: string, preserveCase = true): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
   for (const raw of rawList) {
-    const normalized = normalizeSourcePath(String(raw), wikiFolder);
+    const normalized = normalizeSourcePath(String(raw), wikiFolder, preserveCase);
     if (!normalized) continue;
     if (seen.has(normalized)) continue;
     seen.add(normalized);
@@ -88,13 +94,14 @@ export function normalizeSourcesField(rawList: string[], wikiFolder: string): st
  *
  * @param content - File content (full markdown including frontmatter)
  * @param wikiFolder - User's wiki folder name
+ * @param preserveCase - Match the user's slugCase setting (must agree with fixPollutedSources)
  * @returns true if any sources entry would change
  */
-export function scanPollutedSources(content: string, wikiFolder: string): boolean {
+export function scanPollutedSources(content: string, wikiFolder: string, preserveCase = true): boolean {
   const entries = extractRawSourcesEntries(content);
   if (entries.length === 0) return false;
   return entries.some(e => {
-    const canonical = normalizeSourcePath(e, wikiFolder);
+    const canonical = normalizeSourcePath(e, wikiFolder, preserveCase);
     if (!canonical) return true; // empty link — pollution
     // Strip brackets to compare
     const stripped = e.replace(/^\[\[/, '').replace(/\]\]$/, '');
@@ -145,18 +152,20 @@ function extractRawSourcesEntries(content: string): string[] {
  *
  * @param content - File content (full markdown including frontmatter)
  * @param wikiFolder - User's wiki folder name
+ * @param preserveCase - Match the user's slugCase setting when slugifying remapped external filenames
  * @returns Object with `fixed` (number of changes made) and `content` (potentially modified)
  */
 export function fixPollutedSources(
   content: string,
-  wikiFolder: string
+  wikiFolder: string,
+  preserveCase = true
 ): { fixed: number; content: string } {
   const rawEntries = extractRawSourcesEntries(content);
   if (rawEntries.length === 0) return { fixed: 0, content };
   console.debug(`[fixPollutedSources] rawEntries (${rawEntries.length}): ${JSON.stringify(rawEntries)}`);
 
   // Compute the normalized entries
-  const normalized = normalizeSourcesField(rawEntries, wikiFolder);
+  const normalized = normalizeSourcesField(rawEntries, wikiFolder, preserveCase);
   console.debug(`[fixPollutedSources] normalized (${normalized.length}): ${JSON.stringify(normalized)}`);
 
   // Always perform the fix; the diff between before/after content is the truth.

--- a/src/schema/auto-maintain.ts
+++ b/src/schema/auto-maintain.ts
@@ -361,13 +361,14 @@ export class AutoMaintainManager {
       const wikiFiles = this.app.vault.getMarkdownFiles()
         .filter(f => f.path.startsWith(wikiFolder));
       console.debug(`[QuickFixes] Phase 2: scanning ${wikiFiles.length} files in "${wikiFolder}"`);
+      const sourcesPreserveCase = this.settings.slugCase === 'preserve';
       for (const file of wikiFiles) {
         sourcesFilesScanned += 1;
         const content = await this.app.vault.read(file);
-        if (!scanPollutedSources(content, wikiFolder)) continue;
+        if (!scanPollutedSources(content, wikiFolder, sourcesPreserveCase)) continue;
         sourcesFilesPolluted += 1;
         console.debug(`[QuickFixes] Polluted sources detected in ${file.path}`);
-        const { fixed, content: fixedContent } = fixPollutedSources(content, wikiFolder);
+        const { fixed, content: fixedContent } = fixPollutedSources(content, wikiFolder, sourcesPreserveCase);
         if (fixed > 0) {
           await this.app.vault.process(file, () => fixedContent);
           sourcesFilesCleaned += 1;

--- a/src/wiki/lint-controller.ts
+++ b/src/wiki/lint-controller.ts
@@ -117,11 +117,12 @@ export async function runLintWiki(ctx: LintContext, signal?: AbortSignal): Promi
     // ---- 0.5 Sources field normalize (programmatic, no LLM) — Issue #81 ----
     let sourcesNormalizedFiles = 0;
     let sourcesNormalizedEntries = 0;
+    const sourcesPreserveCase = ctx.settings.slugCase === 'preserve';
     for (const [path, info] of pageMap) {
-      if (!scanPollutedSources(info.content, ctx.settings.wikiFolder)) continue;
+      if (!scanPollutedSources(info.content, ctx.settings.wikiFolder, sourcesPreserveCase)) continue;
       const abstractFile = ctx.app.vault.getAbstractFileByPath(path);
       if (abstractFile instanceof TFile) {
-        const { fixed, content } = fixPollutedSources(info.content, ctx.settings.wikiFolder);
+        const { fixed, content } = fixPollutedSources(info.content, ctx.settings.wikiFolder, sourcesPreserveCase);
         if (fixed > 0) {
           await ctx.app.vault.process(abstractFile, () => content);
           sourcesNormalizedFiles += 1;

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -33,6 +33,7 @@ import {
   getExistingWikiPages,
 } from './lint-fixes';
 import { ContradictionManager } from './contradictions';
+import { fixPollutedSources } from '../core/sources-normalizer';
 import { UNIVERSAL_LINK_CONSTRAINTS } from './prompts/constraints';
 import { SourceAnalyzer } from './source-analyzer';
 import { TOKENS_PAGE_GENERATION, NOTICE_ABORT, NOTICE_RATE_LIMIT, NOTICE_NORMAL, PAGES_CACHE_TTL_MS } from '../constants';
@@ -732,6 +733,20 @@ export class WikiEngine {
           return `[[${folder}/${rest}${displayPart}]]`;
         }
       );
+    }
+
+    // Issue #125: normalize the `sources:` frontmatter field on every write.
+    // The LLM emits raw note paths ("[[Notizen/Autonome Dysregulation.md]]"),
+    // `.md` extensions, `|alias` pipes, and space/paren-containing titles. Left
+    // unfixed these become dead links that previously required a post-ingest
+    // cleanup script. normalizeSourcesField (Issue #81) already exists and is
+    // unit-tested but was only wired into the lint/auto-maintain paths — not the
+    // generation/merge write path that produces this pollution in the first place.
+    const preserveCase = this.settings.slugCase === 'preserve';
+    const sourcesFix = fixPollutedSources(content, this.settings.wikiFolder, preserveCase);
+    if (sourcesFix.fixed > 0) {
+      console.warn(`createOrUpdateFile: normalized polluted sources field in ${path}`);
+      content = sourcesFix.content;
     }
 
     for (let attempt = 0; attempt < 3; attempt++) {


### PR DESCRIPTION
Fixes #125.

## Problem

`normalizeSourcesField`/`fixPollutedSources` (Issue #81) already exist and are unit-tested, but they were only wired into the **lint** and **auto-maintain** paths — never the **generation/merge write path** that produces the pollution in the first place. As a result, every ingested/merged page persisted a polluted `sources:` frontmatter:

- raw external note paths: `"[[Notizen/Autonome Dysregulation.md]]"`
- `.md` extensions and `|alias` pipes
- duplicates

Additionally, the external-path remap in `normalizeSourcePath` did **not** slugify the remapped filename, so a title with spaces/parentheses produced a dead link:

```
[[Notizen/Autonome Dysregulation.md]]  →  [[sources/Autonome Dysregulation]]   ✗ dead
[[Notizen/AGEs (Advanced Glycation End Products).md]]  →  [[sources/AGEs (Advanced Glycation End Products)]]  ✗ dead
```

## Fix

1. **Wire `fixPollutedSources` into the write chokepoint.** `WikiEngine.createOrUpdateFile()` already centralises pollution detection for *all* writes (it documents itself as catching pollution "from page generation, stub expansion, dead link fixes, merges, etc."). Calling `fixPollutedSources` there normalises the `sources:` field on every persisted page — the single point that all generation/merge paths funnel through.

2. **Slugify the external remap.** `normalizeSourcePath` now runs the remapped filename through `computeSlug`, so the link resolves to the canonical source page:

```
[[Notizen/Autonome Dysregulation.md]]  →  [[sources/Autonome-Dysregulation]]            ✓
[[Notizen/AGEs (Advanced Glycation End Products).md]]  →  [[sources/AGEs-Advanced-Glycation-End-Products]]  ✓
```

   A `preserveCase` argument (default `true`, matching prior behaviour) is threaded through `normalizeSourcePath` / `normalizeSourcesField` / `scanPollutedSources` / `fixPollutedSources`, and the two existing callers (lint-controller, auto-maintain) now pass the user's `slugCase` setting so scan and fix stay in agreement.

## Tests

- 3 new cases in `sources-normalizer.test.ts` covering the space/paren slugify remap and the `preserveCase=false` (lowercase) variant.
- Full suite green: **688 passed**, eslint `--max-warnings=0` clean.

## Notes

- Default `preserveCase=true` keeps all pre-existing test expectations intact (the old remap preserved input case; it just never collapsed spaces/parens).
- Real-world impact: in one local ingest this eliminated raw-note-path pollution across **61** generated pages that previously required a post-ingest cleanup script.
