### PR TITLE
Skip no-op LLM regeneration of related pages (#131, Tier 1)

### DIFF
--- a/src/__tests__/__support__/engine-context.ts
+++ b/src/__tests__/__support__/engine-context.ts
@@ -17,6 +17,7 @@
 //     expect(result.entities).toHaveLength(1);
 //   });
 
+import { TFile } from 'obsidian'; // mocked in setup.ts
 import { EngineContext, LLMClient, LLMWikiSettings } from '../../types';
 
 // ── Mock File ────────────────────────────────────────────────────
@@ -131,6 +132,14 @@ export function createMockContext(opts: MockContextOptions = {}): { ctx: EngineC
           extension: 'md',
           parent: null,
         })),
+        getAbstractFileByPath: (path: string) => {
+          if (!vault.has(path)) return null;
+          return Object.assign(new TFile(), {
+            path,
+            basename: path.split('/').pop()?.replace('.md', '') || '',
+            extension: 'md',
+          });
+        },
       },
     } as unknown as EngineContext['app'],
     settings,

--- a/src/__tests__/wiki/page-factory.test.ts
+++ b/src/__tests__/wiki/page-factory.test.ts
@@ -1,6 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { createMockContext } from '../__support__/engine-context';
+import { describe, it, expect, vi } from 'vitest';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
 import { PageFactory } from '../../wiki/page-factory';
+import type { SourceAnalysis } from '../../types';
+
+function makeAnalysis(over: Partial<SourceAnalysis> = {}): SourceAnalysis {
+  return {
+    source_file: 'Notizen/New-Source.md',
+    source_title: 'New Source',
+    summary: '',
+    entities: [],
+    concepts: [],
+    contradictions: [],
+    related_pages: [],
+    key_points: [],
+    created_pages: [],
+    updated_pages: [],
+    ...over,
+  };
+}
 
 function makeFactory(vaultFiles: Record<string, string>) {
   const { ctx, vault } = createMockContext({ vaultFiles });
@@ -99,5 +116,54 @@ describe('PageFactory — buildPagesListForPrompt', () => {
 
   it('handles empty pages', async () => {
     expect('').toBe('');
+  });
+});
+
+describe('PageFactory — updateRelatedPage no-op skip (Issue #131)', () => {
+  it('skips the LLM call when the source extracted nothing matching the related page', async () => {
+    const { ctx, vault } = createMockContext({
+      vaultFiles: {
+        'wiki/concepts/Dysbiose.md':
+          '---\ntype: concept\nsources:\n  - "[[sources/Old]]"\n---\n\n## Description\nOriginal body, must stay verbatim.',
+      },
+    });
+    // Spy on the LLM client to assert it is never invoked.
+    const spy = vi.spyOn(ctx.getClient()!, 'createMessage');
+
+    const factory = new PageFactory(ctx);
+    // related_pages references Dysbiose, but it is not among extracted entities/concepts
+    const analysis = makeAnalysis({ related_pages: ['Dysbiose'] });
+    const sourceFile = createMockFile('Notizen/New-Source.md');
+
+    const result = await factory.updateRelatedPage('Dysbiose', analysis, sourceFile);
+
+    expect(spy).not.toHaveBeenCalled();  // LLM never invoked
+    expect(result).toBe(true);        // page still counts as updated
+    const content = vault.read('wiki/concepts/Dysbiose.md')!;
+    expect(content).toContain('Original body, must stay verbatim.');  // body untouched
+    expect(content).toContain('[[Notizen/New-Source.md]]');           // source recorded in frontmatter
+  });
+
+  it('still calls the LLM when the related page matches an extracted entity', async () => {
+    const { ctx, vault } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/Butyrat.md': '---\ntype: entity\n---\n\n## Description\nOld body.',
+      },
+      llmResponses: ['## Description\nNew merged body.'],
+    });
+    const spy = vi.spyOn(ctx.getClient()!, 'createMessage');
+
+    const factory = new PageFactory(ctx);
+    const analysis = makeAnalysis({
+      related_pages: ['Butyrat'],
+      entities: [{ name: 'Butyrat', type: 'other', summary: 'An SCFA', mentions_in_source: [] }],
+    });
+    const sourceFile = createMockFile('Notizen/New-Source.md');
+
+    const result = await factory.updateRelatedPage('Butyrat', analysis, sourceFile);
+
+    expect(spy).toHaveBeenCalledTimes(1);  // LLM invoked because there is new info
+    expect(result).toBe(true);
+    expect(vault.read('wiki/entities/Butyrat.md')!).toContain('New merged body.');
   });
 });

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -493,11 +493,24 @@ export class PageFactory {
     // 1. Programmatic frontmatter merge (sources + updated)
     const { frontmatter, body: existingBody } = mergeFrontmatter(existingContent, sourceFile.path);
 
+    // Issue #131: a "related page" is an existing page topically related to the
+    // source — a different set from the entities/concepts this source extracted.
+    // When the source extracted nothing matching this page, there is no new body
+    // content to weave in; the previous behaviour regenerated the whole body via
+    // the LLM anyway (a no-op rewrite that wastes a call and re-rolls verbatim
+    // text through the model, a known corruption vector). Skip the LLM entirely:
+    // record the new source in frontmatter and leave the body untouched.
+    const newInfo = analysis.entities.find(e => e.name === pageName) || analysis.concepts.find(c => c.name === pageName);
+    if (!newInfo) {
+      await this.ctx.createOrUpdateFile(page.path, `${frontmatter}\n\n${existingBody}`);
+      return true;
+    }
+
     const prompt = PROMPTS.updateRelatedPage
       .replace('{{page_name}}', pageName)
       .replace('{{existing_body}}', existingBody)
       .replace('{{source_basename}}', sourceFile.basename)
-      .replace('{{new_info}}', JSON.stringify(analysis.entities.find(e => e.name === pageName) || analysis.concepts.find(c => c.name === pageName) || 'No directly relevant information'))
+      .replace('{{new_info}}', JSON.stringify(newInfo))
       .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
 
     const client = this.ctx.getClient();


### PR DESCRIPTION
Measured over 15 ingests, roughly one third of related-page updates had no new information to add (the source extracted no entity/concept matching that page), yet `updateRelatedPage` still performed a full-body LLM regeneration. This wastes tokens for all providers (including cloud) and unnecessarily re-runs verbatim text through the model.

Fix: early-return when there is no matching new info — the new source is still recorded in frontmatter (programmatic merge, unchanged) and the body is left verbatim. The LLM is only invoked when there is genuinely something to integrate.

This is the low-risk part of #131 only; the larger Tier-2 change (deterministic assembly for the remaining updates) is left to you. 687 tests pass (2 new); `tsc` clean.
