### PR TITLE
Send per-task sampling temperature (#128)

### DIFF
--- a/src/__tests__/__support__/engine-context.ts
+++ b/src/__tests__/__support__/engine-context.ts
@@ -101,6 +101,8 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   customEntityTags: '',
   customConceptTags: '',
   slugCase: 'lower' as const,
+  extractionTemperature: 0.15,
+  chatTemperature: 0.7,
 };
 
 // ── Mock EngineContext ───────────────────────────────────────────

--- a/src/__tests__/root/llm-client.test.ts
+++ b/src/__tests__/root/llm-client.test.ts
@@ -147,6 +147,31 @@ describe('OpenAICompatibleClient.createMessage', () => {
     expect(mockRequestUrl).toHaveBeenCalledTimes(1);
   });
 
+  it('forwards temperature to the request body when set (#128)', async () => {
+    mockRequestUrl.mockResolvedValueOnce(makeOpenAIResponse('Hello world'));
+    const client = new OpenAICompatibleClient('key', 'https://api.openai.com');
+    await client.createMessage({
+      model: 'test-model',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0.15,
+    });
+    const body = JSON.parse((mockRequestUrl.mock.calls[0][0] as { body: string }).body) as { temperature?: number };
+    expect(body.temperature).toBe(0.15);
+  });
+
+  it('omits temperature from the request body when unset (#128)', async () => {
+    mockRequestUrl.mockResolvedValueOnce(makeOpenAIResponse('Hello world'));
+    const client = new OpenAICompatibleClient('key', 'https://api.openai.com');
+    await client.createMessage({
+      model: 'test-model',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    const body = JSON.parse((mockRequestUrl.mock.calls[0][0] as { body: string }).body) as { temperature?: number };
+    expect(body.temperature).toBeUndefined();
+  });
+
   it('detects truncation (finish_reason=length) and retries with doubled max_tokens', async () => {
     mockRequestUrl.mockResolvedValueOnce(makeOpenAIResponse('Hello', 'length'));
     mockRequestUrl.mockResolvedValueOnce(makeOpenAIResponse('Hello world'));

--- a/src/__tests__/root/utils.test.ts
+++ b/src/__tests__/root/utils.test.ts
@@ -912,6 +912,8 @@ describe('getGranularityInstruction', () => {
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('injects concrete entity and concept limits for custom mode', () => {
@@ -966,6 +968,8 @@ describe('appendGranularityToPrompt', () => {
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('appends granularity instruction to existing prompt', () => {
@@ -1017,6 +1021,8 @@ describe('getGranularityFixLimits', () => {
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('returns user-defined limits for custom mode', () => {
@@ -1673,6 +1679,8 @@ describe('buildActiveTagVocabularySection (Issue #85 v6 — prompt injection)', 
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('in default mode, lists the hardcoded VALID_ENTITY_TAGS', () => {
@@ -1749,6 +1757,8 @@ describe('appendTagVocabularyToPrompt (Issue #85 v6 — end-to-end prompt inject
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('appends active tag vocabulary section after the base prompt', () => {
@@ -1824,6 +1834,8 @@ describe('enforceFrontmatterConstraints (Issue #85 v6 — preserve LLM intent)',
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('retains out-of-vocab tags (does NOT silently drop them)', () => {
@@ -1932,6 +1944,8 @@ describe('getActiveSourceTags (Issue #85 v7)', () => {
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   it('returns the hardcoded VALID_SOURCE_TAGS list', () => {

--- a/src/__tests__/wiki/lint/scanners.test.ts
+++ b/src/__tests__/wiki/lint/scanners.test.ts
@@ -194,6 +194,8 @@ describe('scanTagViolations', () => {
     customEntityTags: '',
     customConceptTags: '',
     slugCase: 'lower' as const,
+    extractionTemperature: 0.15,
+    chatTemperature: 0.7,
   };
 
   function makeEntityPage(path: string, tags: string[] | string, withTitle = false): ScannerPage {

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -74,6 +74,7 @@ export class AnthropicCompatibleClient implements LLMClient {
   async createMessage(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128
     system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     response_format?: { type: 'json_object' };
@@ -83,6 +84,7 @@ export class AnthropicCompatibleClient implements LLMClient {
     const body: Record<string, unknown> = {
       model: params.model,
       max_tokens: params.max_tokens,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       messages: params.response_format?.type === 'json_object'
         ? [...params.messages, { role: 'assistant', content: '{' }]
         : params.messages
@@ -167,6 +169,7 @@ export class AnthropicCompatibleClient implements LLMClient {
         const fallbackBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
+          ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
           messages: params.system
             ? [{ role: 'system' as const, content: params.system }, ...params.messages]
             : params.messages,
@@ -183,6 +186,7 @@ export class AnthropicCompatibleClient implements LLMClient {
   async createMessageStream(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128
     system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     onChunk: (chunk: string) => void;
@@ -199,6 +203,7 @@ export class AnthropicCompatibleClient implements LLMClient {
     const body: Record<string, unknown> = {
       model: params.model,
       max_tokens: params.max_tokens,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       messages,
       stream: true
     };
@@ -292,6 +297,7 @@ export class AnthropicClient implements LLMClient {
   async createMessage(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128
     system?: string;
     messages: Array<{role: 'user' | 'assistant'; content: string}>;
     response_format?: { type: 'json_object' };
@@ -318,6 +324,7 @@ export class AnthropicClient implements LLMClient {
     const body: Record<string, unknown> = {
       model: params.model,
       max_tokens: params.max_tokens,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       messages,
     };
     if (params.system) body.system = params.system;
@@ -396,6 +403,7 @@ export class AnthropicClient implements LLMClient {
         const fallbackBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
+          ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
           messages: params.system
             ? [{ role: 'system' as const, content: params.system }, ...params.messages]
             : [...params.messages],
@@ -412,6 +420,7 @@ export class AnthropicClient implements LLMClient {
   async createMessageStream(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128
     system?: string;
     messages: Array<{role: 'user' | 'assistant'; content: string}>;
     onChunk: (chunk: string) => void;
@@ -430,6 +439,7 @@ export class AnthropicClient implements LLMClient {
     const streamBody: Record<string, unknown> = {
       model: params.model,
       max_tokens: params.max_tokens,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       messages: messagesWithLanguageHint,
       stream: true,
     };
@@ -503,6 +513,7 @@ export class OpenAICompatibleClient implements LLMClient {
   async createMessage(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128
     system?: string;
     messages: Array<{role: 'user' | 'assistant'; content: string}>;
     response_format?: { type: 'json_object' };
@@ -519,6 +530,7 @@ export class OpenAICompatibleClient implements LLMClient {
     const body: Record<string, unknown> = {
       model: params.model,
       max_tokens: params.max_tokens,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       messages
     };
     // Unified thinking control: use Anthropic-style `thinking.type` which
@@ -603,6 +615,7 @@ export class OpenAICompatibleClient implements LLMClient {
         const fallbackBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
+          ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
           messages: params.system
             ? [{ role: 'system' as const, content: params.system }, ...params.messages]
             : params.messages,
@@ -616,6 +629,7 @@ export class OpenAICompatibleClient implements LLMClient {
   async createMessageStream(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128
     system?: string;
     messages: Array<{role: 'user' | 'assistant'; content: string}>;
     onChunk: (chunk: string) => void;
@@ -634,6 +648,7 @@ export class OpenAICompatibleClient implements LLMClient {
     const body: Record<string, unknown> = {
       model: params.model,
       max_tokens: params.max_tokens,
+      ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
       messages,
       stream: true
     };
@@ -704,6 +719,7 @@ export class OpenAICompatibleClient implements LLMClient {
         const fallbackBody: Record<string, unknown> = {
           model: params.model,
           max_tokens: params.max_tokens,
+          ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
           messages,
           stream: true,
         };

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,17 +49,20 @@ function createLLMClient(settings: LLMWikiSettings): LLMClient {
     }
   }
 
-  // Issue #75: wrap createMessage with token cap when configured
-  if (settings.maxTokensPerCall > 0) {
-    const originalCreate = client.createMessage.bind(client) as (params: Parameters<typeof client.createMessage>[0]) => ReturnType<typeof client.createMessage>;
-    client.createMessage = async (params) => {
-      return originalCreate({
-        ...params,
-        max_tokens: capMaxTokens(params.max_tokens, settings),
-        maxTokensPerCall: settings.maxTokensPerCall,
-      });
-    };
-  }
+  // Issue #128: inject task-appropriate sampling temperature (default:
+  // extraction) when the caller didn't set one — chat call sites override
+  // by passing chatTemperature explicitly.
+  // Issue #75: cap max_tokens per call when configured.
+  const capTokens = settings.maxTokensPerCall > 0;
+  const originalCreate = client.createMessage.bind(client) as (params: Parameters<typeof client.createMessage>[0]) => ReturnType<typeof client.createMessage>;
+  client.createMessage = async (params) => {
+    return originalCreate({
+      ...params,
+      ...(params.temperature === undefined ? { temperature: settings.extractionTemperature } : {}),
+      ...(capTokens ? { max_tokens: capMaxTokens(params.max_tokens, settings), maxTokensPerCall: settings.maxTokensPerCall } : {}),
+    });
+  };
+
 
   return client;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,13 @@ export interface LLMWikiSettings {
   // Recommended for local models with small context windows.
   maxTokensPerCall: number;
 
+  // Issue #128: per-task sampling temperature sent with every request.
+  // Low for extraction (source analysis, verbatim Mentions) to maximize
+  // fidelity and avoid script-mixing corruption from sampling the logit
+  // tail; higher for chat answers. 0 = greedy.
+  extractionTemperature: number;
+  chatTemperature: number;
+
   // Issue #111: slug casing for generated filenames.
   // 'lower' preserves backwards-compatible all-lowercase filenames.
   // 'preserve' keeps the casing the LLM produces — required for languages
@@ -205,6 +212,7 @@ export interface LLMClient {
   createMessage(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128: per-request sampling temperature
     system?: string;
     messages: Array<{role: 'user' | 'assistant'; content: string}>;
     response_format?: { type: 'json_object' };
@@ -216,6 +224,7 @@ export interface LLMClient {
   createMessageStream?(params: {
     model: string;
     max_tokens: number;
+    temperature?: number;  // Issue #128: per-request sampling temperature
     system?: string;
     messages: Array<{role: 'user' | 'assistant'; content: string}>;
     onChunk: (chunk: string) => void;
@@ -472,6 +481,11 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   // Local model users can set this when the provider is Ollama, LM Studio,
   // custom, or anthropic-compatible.
   maxTokensPerCall: 0,
+
+  // Issue #128: default low extraction temp kills CJK/script-mixing in
+  // verbatim text; chat default keeps answers fluent.
+  extractionTemperature: 0.15,
+  chatTemperature: 0.7,
 
   // Issue #99 v2: default ON so thinking-capable models (Gemma 4,
   // DeepSeek-R1, QwQ) output final answer only — no mid-response CoT

--- a/src/wiki/query-engine.ts
+++ b/src/wiki/query-engine.ts
@@ -382,6 +382,7 @@ export class QueryModal extends Modal {
           fullResponse = await this.plugin.llmClient.createMessageStream({
             model: this.plugin.settings.model,
             max_tokens: TOKENS_QUERY_LLM_SELECT,
+            temperature: this.plugin.settings.chatTemperature,  // Issue #128
             system: wikiContext,
             messages: conversationMessages,
             onChunk: (chunk) => {
@@ -409,6 +410,7 @@ export class QueryModal extends Modal {
               fullResponse = await this.plugin.llmClient.createMessage({
                 model: this.plugin.settings.model,
                 max_tokens: TOKENS_QUERY_LLM_SELECT,
+                temperature: this.plugin.settings.chatTemperature,  // Issue #128
                 system: wikiContext,
                 messages: conversationMessages
               });


### PR DESCRIPTION
Split out from #132 per review — temperature is sent to **all** providers (including cloud), so its defaults warrant separate evaluation from the local-only params in #132.

## Problem
The plugin currently sends no `temperature`, so the backend uses its server default (1.0 on LM Studio). At temperature 1.0 the logit tail gets sampled, and on quantized local models (observed: Gemma 4 26B A4B QAT) this injects stray CJK/Devanagari characters mid-word into otherwise-clean extracted German text — corrupting verbatim Mentions.

## Change
Two settings, forwarded per-request to every client:
- **`extractionTemperature`** (default **0.15**) — source analysis, entity/concept generation, verbatim Mentions; low to maximize fidelity.
- **`chatTemperature`** (default **0.7**) — query answers.

The `createMessage` wrapper injects `extractionTemperature` when the caller passes none; query-engine call sites pass `chatTemperature` explicitly. `temperature` is omitted from the body when unset (no behavior change for callers that don't opt in).

## Note on defaults / cloud impact
Because temperature now goes to cloud providers too, the defaults (0.15 / 0.7) change their behavior vs. today's implicit 1.0. Happy to adjust the defaults or gate per-provider — flagging it explicitly since that was the reason to split this from #132.

687 tests green (incl. 2 new temperature-forwarding tests), tsc + eslint clean.