### PR TITLE
fix(frontmatter): dedup aliases in mergeFrontmatter (parity with enforceFrontmatterConstraints)

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -335,6 +335,20 @@ describe('mergeFrontmatter', () => {
     const result = mergeFrontmatter(input, 'sources/new');
     expect(result.frontmatter).toContain('[[sources/new]]');
   });
+
+  it('deduplicates repeated aliases (parity with enforceFrontmatterConstraints)', () => {
+    const input = '---\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\naliases:\n  - "UPF"\n  - "Ultra-processed food"\n  - "UPF"\n  - "Ultra-processed food"\n---\n\nBody';
+    const result = mergeFrontmatter(input, 'sources/new');
+    expect((result.frontmatter.match(/- "UPF"/g) || []).length).toBe(1);
+    expect((result.frontmatter.match(/- "Ultra-processed food"/g) || []).length).toBe(1);
+  });
+
+  it('drops empty-string aliases', () => {
+    const input = '---\ntype: concept\ncreated: 2026-01-01\nupdated: 2026-01-01\naliases:\n  - "Foo"\n  - ""\n---\n\nBody';
+    const result = mergeFrontmatter(input, 'sources/new');
+    expect(result.frontmatter).toContain('- "Foo"');
+    expect(result.frontmatter).not.toContain('- ""');
+  });
 });
 
 describe('preserveFrontmatterReviewTag', () => {

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -185,7 +185,11 @@ export function mergeFrontmatter(
   }
 
   if (Array.isArray(fm.aliases) && fm.aliases.length > 0) {
-    lines.push(`aliases:${yamlStringify(fm.aliases)}`);
+    // Dedup parity with enforceFrontmatterConstraints (keeps first occurrence, drops empties).
+    const dedupedAliases = fm.aliases.filter((v, i, a) => a.indexOf(v) === i && v);
+    if (dedupedAliases.length > 0) {
+      lines.push(`aliases:${yamlStringify(dedupedAliases)}`);
+    }
   }
 
   lines.push('---');


### PR DESCRIPTION
## Problem

`mergeFrontmatter` (`src/core/frontmatter.ts`) serializes `fm.aliases` verbatim. When a re-ingest **merges** into an existing page, any duplicate aliases already in the frontmatter are **preserved instead of cleaned up** — the function never self-heals frontmatter that has accumulated repeats over multiple ingests.

Its sibling `enforceFrontmatterConstraints` already dedups aliases:

```ts
const validAliases = collectedAliases.filter((v, i, a) => a.indexOf(v) === i && v);
```

`mergeFrontmatter` lacks that filter. This asymmetry is the gap: one serializer dedups, the other trusts its input.

## Reproduction (on v1.20.2)

```ts
const input = `---
type: concept
aliases:
  - "UPF"
  - "Ultra-processed food"
  - "UPF"
  - "Ultra-processed food"
---
Body`;

mergeFrontmatter(input, 'sources/new');
// → frontmatter still contains "UPF" twice (expected: once)
```

Observed in the field: pages that were re-ingested many times accumulated their full alias list repeated dozens of times (one real vault had a page with the alias block repeated ~15×, 86 duplicate lines).

## Fix

Apply the same order-preserving, empty-dropping filter at the `mergeFrontmatter` serialization site. First occurrence wins; output is byte-identical otherwise.

## Tests

Adds 2 regression tests (repeated aliases collapse to one; empty-string aliases dropped). Full suite: **781 passing**.