### PR TITLE
fix(wiki): respect reviewed:true in Stage-4 updateRelatedPage (parity with createOrUpdatePage)

### DIFF
--- a/src/__tests__/wiki/page-factory.test.ts
+++ b/src/__tests__/wiki/page-factory.test.ts
@@ -167,3 +167,31 @@ describe('PageFactory — updateRelatedPage no-op skip (Issue #131)', () => {
     expect(vault.read('wiki/entities/Butyrat.md')!).toContain('New merged body.');
   });
 });
+
+describe('PageFactory — updateRelatedPage reviewed guard (Stage 4)', () => {
+  it('preserves a reviewed page body instead of LLM-rewriting it when another source extracts it', async () => {
+    const { ctx, vault } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/Butyrat.md':
+          '---\ntype: entity\nreviewed: true\n---\n\n## Description\nCurated body, must stay verbatim.',
+      },
+      // Routed to appendToReviewedPage: NO_NEW_CONTENT => existing body preserved exactly.
+      // Without the guard, updateRelatedPage would write this string as the whole body.
+      llmResponses: ['NO_NEW_CONTENT'],
+    });
+
+    const factory = new PageFactory(ctx);
+    const analysis = makeAnalysis({
+      related_pages: ['Butyrat'],
+      entities: [{ name: 'Butyrat', type: 'other', summary: 'An SCFA', mentions_in_source: [] }],
+    });
+    const sourceFile = createMockFile('Notizen/New-Source.md');
+
+    const result = await factory.updateRelatedPage('Butyrat', analysis, sourceFile);
+
+    expect(result).toBe(true);
+    const content = vault.read('wiki/entities/Butyrat.md')!;
+    expect(content).toContain('Curated body, must stay verbatim.');  // curated body survives
+    expect(content).not.toContain('NO_NEW_CONTENT');                 // not the buggy full rewrite
+  });
+});

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -504,6 +504,15 @@ export class PageFactory {
       return true;
     }
 
+    // Parity with createOrUpdatePage: a `reviewed: true` page must never have its
+    // body LLM-rewritten — not even when a *different* source extracts it here in
+    // Stage 4. Route to the minimal append path so the curated body is preserved
+    // exactly and genuinely new content lands in the `## New Information` section.
+    if (parseFrontmatter(existingContent)?.reviewed === true) {
+      await this.appendToReviewedPage(newInfo, sourceFile, existingContent, page.path);
+      return true;
+    }
+
     const prompt = PROMPTS.updateRelatedPage
       .replace('{{page_name}}', pageName)
       .replace('{{existing_body}}', existingBody)


### PR DESCRIPTION
## Problem

`updateRelatedPage` (Stage 4 — where one ingested source updates a *different*, already-existing related page) rewrites the page body via the LLM **regardless of `reviewed: true`**. This is inconsistent with `createOrUpdatePage`, which routes reviewed pages to the minimal append path (`appendToReviewedPage`).

As a result, re-ingesting an unrelated note can silently overwrite a curated/locked page's body — the `reviewed` lock does not hold on the Stage-4 path.

## Fix

Add the same reviewed guard already present in `createOrUpdatePage`: when the related page is `reviewed: true`, route to `appendToReviewedPage` so the curated body is preserved exactly and only genuinely new content is appended.

```ts
if (parseFrontmatter(existingContent)?.reviewed === true) {
  await this.appendToReviewedPage(newInfo, sourceFile, existingContent, page.path);
  return true;
}
```

## Test

Adds a regression test: a `reviewed: true` page whose body is extracted by a *different* source. Without the guard the body is replaced by the LLM output; with it the curated body survives. The test fails on the unpatched code and passes with the fix. Full suite: **780/780 green**.
