### PR TITLE
fix(#187): deterministically correct sources/-prefixed related links

### DIFF
--- a/src/__tests__/core/related-link-corrector.test.ts
+++ b/src/__tests__/core/related-link-corrector.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
+
+describe('correctRelatedLinkPrefixes (root-cause fix for sources/-prefixed related links)', () => {
+  const ENT = 'Related Entities';
+  const CON = 'Related Concepts';
+
+  // --- Named regression cases: the two failure modes the (a)/(b) list-visibility
+  //     heuristic cannot cover, and that this post-pass exists to catch. ---
+
+  it('[truncated-existing-pages] re-types a link the model prefixed sources/ because the target fell outside the truncated existing_pages window', () => {
+    // The related entity exists in the vault but outside the MAX_PAGES window, so the
+    // model could not see its path and guessed the most salient prefix — sources/.
+    const c = ['## Related Entities', '- [[sources/Hippocampus|Hippocampus]]'].join('\n');
+    const r = correctRelatedLinkPrefixes(c, ['Hippocampus'], [], ENT, CON, true);
+    expect(r).toContain('[[entities/Hippocampus|Hippocampus]]');
+  });
+
+  it('[co-created-siblings] re-types a link to a sibling generated in the same run (never in existing_pages at any MAX_PAGES)', () => {
+    // Concept "Gedächtniskonsolidierung" co-created with related entity "Schlaf" in one
+    // ingest: the sibling does not exist when the prompt is built, so no list size could
+    // contain it. Raising MAX_PAGES can't reach it; the section type alone fixes the guess.
+    const c = ['## Related Entities', '- [[sources/Schlaf|Schlaf]]'].join('\n');
+    const r = correctRelatedLinkPrefixes(c, ['Schlaf'], [], ENT, CON, true);
+    expect(r).toContain('[[entities/Schlaf|Schlaf]]');
+  });
+
+  // --- Behavioural coverage ---
+
+  // A freshly-generated concept page where the model guessed `sources/` for the
+  // related links it could not place against the truncated existing-pages list.
+  const page = [
+    '## Description',
+    'It builds on [[sources/Langzeitgedächtnis|Langzeitgedächtnis]] in prose.',
+    '',
+    '## Related Concepts',
+    '- [[sources/Gedächtnis|Gedächtnis]]',
+    '- [[concepts/Abruf|Abruf]]',
+    '',
+    '## Related Entities',
+    '- [[sources/Hippocampus|Hippocampus]]',
+    '- [[sources/Schlaf|Schlaf]]',
+    '',
+    '## Mentions in Source',
+    '> **Source: [[sources/Gedächtnis|Gedächtnis]]**',
+    '> - "a verbatim quote"',
+  ].join('\n');
+
+  const out = correctRelatedLinkPrefixes(
+    page, ['Hippocampus', 'Schlaf'], ['Gedächtnis', 'Abruf'], ENT, CON, true,
+  );
+
+  it('re-types sources/-prefixed related concepts to concepts/', () => {
+    expect(out).toContain('- [[concepts/Gedächtnis|Gedächtnis]]');
+  });
+  it('re-types sources/-prefixed related entities to entities/', () => {
+    expect(out).toContain('- [[entities/Hippocampus|Hippocampus]]');
+    expect(out).toContain('- [[entities/Schlaf|Schlaf]]');
+  });
+  it('leaves already-correct related links untouched', () => {
+    expect(out).toContain('- [[concepts/Abruf|Abruf]]');
+  });
+  it('NEVER rewrites the source citation in Mentions, even when the source name is also a related concept', () => {
+    expect(out).toContain('> **Source: [[sources/Gedächtnis|Gedächtnis]]**');
+  });
+  it('does not touch prose links outside the Related sections', () => {
+    expect(out).toContain('[[sources/Langzeitgedächtnis|Langzeitgedächtnis]]');
+  });
+  it('resolves an ambiguous name (in both lists) via the section context', () => {
+    // In the Related Concepts section, the concept reading is meant.
+    const amb = ['## Related Concepts', '- [[sources/X|X]]'].join('\n');
+    expect(correctRelatedLinkPrefixes(amb, ['X'], ['X'], ENT, CON, true)).toContain('[[concepts/X|X]]');
+  });
+  it('section dictates the folder even when the link is not in the current related lists (self-heals merge-carried stale links)', () => {
+    // [[sources/Gedächtnis]] carried through a merge from the existing body, with
+    // "Gedächtnis" NOT in this ingest's related lists. Section-driven correction still
+    // fixes it; the name-map alone would not.
+    const c = '## Related Concepts\n- [[sources/Gedächtnis|Gedächtnis]]\n## Related Entities\n- [[sources/Hippocampus|Hippocampus]]';
+    const r = correctRelatedLinkPrefixes(c, [], [], ENT, CON, true);
+    expect(r).toContain('[[concepts/Gedächtnis|Gedächtnis]]');
+    expect(r).toContain('[[entities/Hippocampus|Hippocampus]]');
+  });
+  it('recognizes literal English headers on a non-English wiki (heals pages merged before the #188 fix)', () => {
+    // Pages merged before #188's merge.ts fix carry "## Related Concepts" literally
+    // regardless of wikiLanguage, while the caller passes the localized (German) labels.
+    const merged = [
+      '## Related Concepts',
+      '- [[sources/Gedächtnis|Gedächtnis]]',
+    ].join('\n');
+    const r = correctRelatedLinkPrefixes(
+      merged, [], ['Gedächtnis'], 'Verwandte Entitäten', 'Verwandte Konzepte', true,
+    );
+    expect(r).toContain('[[concepts/Gedächtnis|Gedächtnis]]');
+  });
+  it('matches inflection/spacing variants via slug (space vs hyphen)', () => {
+    const c = '## Related Concepts\n- [[sources/Exekutive-Funktionen|Exekutive Funktionen]]';
+    const r = correctRelatedLinkPrefixes(c, [], ['Exekutive Funktionen'], ENT, CON, true);
+    expect(r).toContain('[[concepts/Exekutive-Funktionen|Exekutive Funktionen]]');
+  });
+});

--- a/src/core/related-link-corrector.ts
+++ b/src/core/related-link-corrector.ts
@@ -1,0 +1,74 @@
+// Related-link prefix corrector — deterministic root-cause fix for `sources/`-prefixed
+// related links. Pure, no LLM, O(links).
+//
+// The Related Concepts / Related Entities sections are LLM-formatted, but the model
+// only ever sees a truncated (MAX_PAGES) existing-pages list, so it usually can't find
+// the target's path and defaults to the most salient prefix in the prompt — `sources/`
+// (which appears in the `sources:` frontmatter, the `## Source` section, and every
+// mention citation). Crucially, the worst case is a page and a related sibling
+// generated in the SAME run: the sibling is in the list at no MAX_PAGES, because it does
+// not exist yet when the prompt is built — so raising the cap can't reach it. The code
+// already KNOWS the type of every related name (`related_entities` are entities,
+// `related_concepts` are concepts), so re-assert it deterministically after generation
+// instead of trusting the guess.
+//
+// Scoped to the two Related sections by their header label, so the legitimate
+// `[[sources/<sourceSlug>]]` citations in "Mentions in Source" — whose names often
+// coincide with a related concept (e.g. the source "Gedächtnis" is also a related
+// concept) — are never rewritten. No false-merge risk.
+
+import { slugify } from './slug';
+
+export function correctRelatedLinkPrefixes(
+  content: string,
+  relatedEntities: string[] | undefined,
+  relatedConcepts: string[] | undefined,
+  relatedEntitiesLabel: string,
+  relatedConceptsLabel: string,
+  preserveCase: boolean
+): string {
+  // Name→type map from the typed related lists. Catches links mis-sectioned by
+  // the LLM (e.g. an entity listed under Related Concepts): the known type wins
+  // over the section's implied type. A name in BOTH lists is ambiguous → defer to
+  // the section context.
+  const folderBySlug = new Map<string, 'entities' | 'concepts'>();
+  const ambiguous = new Set<string>();
+  const index = (names: string[] | undefined, folder: 'entities' | 'concepts') => {
+    for (const n of names ?? []) {
+      const s = slugify(n, preserveCase);
+      if (!s) continue;
+      const prev = folderBySlug.get(s);
+      if (prev && prev !== folder) { ambiguous.add(s); continue; }
+      folderBySlug.set(s, folder);
+    }
+  };
+  index(relatedEntities, 'entities');
+  index(relatedConcepts, 'concepts');
+
+  // Section → implied folder. Match the localized headers AND the canonical
+  // English ones: pages merged before the #188 fix carry literal English headers
+  // regardless of wikiLanguage, so recognizing both also heals that backlog.
+  const sectionFolder = new Map<string, 'entities' | 'concepts'>();
+  for (const h of [relatedEntitiesLabel.trim(), 'Related Entities']) sectionFolder.set(h, 'entities');
+  for (const h of [relatedConceptsLabel.trim(), 'Related Concepts']) sectionFolder.set(h, 'concepts');
+
+  const linkRe = /\[\[(entities|concepts|sources)\/([^\]|]+)(\|[^\]]*)?\]\]/g;
+  let current: 'entities' | 'concepts' | undefined;
+  return content.split('\n').map(line => {
+    const header = /^#{1,6}\s+(.*?)\s*$/.exec(line);
+    if (header) {
+      current = sectionFolder.get(header[1].trim());
+      return line;
+    }
+    if (!current) return line;
+    return line.replace(linkRe, (full, folder: string, target: string, display?: string) => {
+      const s = slugify(target, preserveCase);
+      // Known type wins over section; otherwise the section dictates the folder
+      // (within "Related Concepts" every link is a concept, etc.). This also
+      // self-heals stale links carried through a merge from the existing body.
+      const correct = (!ambiguous.has(s) && folderBySlug.get(s)) || current;
+      if (correct === folder) return full;
+      return `[[${correct}/${target}${display ?? ''}]]`;
+    });
+  }).join('\n');
+}

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -14,13 +14,14 @@ import { ConflictResolver } from '../core/conflict-resolver';
 import { WIKI_SUBFOLDERS } from '../constants';
 import { TOKENS_DEDUP_RESOLUTION, TOKENS_PAGE_GENERATION, TOKENS_APPEND_REVIEWED } from '../constants';
 import { slugify, filterRedundantAliases } from '../core/slug';
+import { correctRelatedLinkPrefixes } from '../core/related-link-corrector';
 import { parseJsonResponse } from '../core/json';
 import { parseFrontmatter, mergeFrontmatter, enforceFrontmatterConstraints } from '../core/frontmatter';
 import { truncateMentions } from '../core/report';
 import { cleanMarkdownResponse } from '../core/markdown';
 import { normalizeLLMPath } from '../core/prompt-builders';
 import { UNIVERSAL_LINK_CONSTRAINTS } from './prompts/constraints';
-import { applySectionLabels, appendTagVocabularyToPrompt } from './system-prompts';
+import { applySectionLabels, appendTagVocabularyToPrompt, getSectionLabels } from './system-prompts';
 import { getExistingWikiPages } from './lint/get-existing-pages';
 
 // Wrap errors with entity/concept context for better diagnostics
@@ -367,7 +368,18 @@ export class PageFactory {
     const cleanedContent = cleanMarkdownResponse(pageContent);
     // Issue #85: pass settings so custom tag vocabulary is honored
     const enforcedContent = enforceFrontmatterConstraints(cleanedContent, pageType, this.ctx.settings);
-    await this.ctx.createOrUpdateFile(path, enforcedContent);
+    // Re-assert the known type of related links (deterministic; fixes the model's
+    // `sources/` guess against a truncated existing-pages list).
+    const labels = getSectionLabels(this.ctx.settings);
+    const correctedContent = correctRelatedLinkPrefixes(
+      enforcedContent,
+      info.related_entities,
+      info.related_concepts,
+      labels.related_entities,
+      labels.related_concepts,
+      this.ctx.settings.slugCase === 'preserve'
+    );
+    await this.ctx.createOrUpdateFile(path, correctedContent);
     return path;
     } catch (error) {
       throw contextualizeError(error, info.name, pageType);
@@ -423,8 +435,17 @@ export class PageFactory {
       return path;
     }
 
-    // 3. Assemble final content
-    const finalContent = `${frontmatter}\n\n${cleanedBody}`;
+    // 3. Assemble final content (re-assert related-link types deterministically)
+    const labels = getSectionLabels(this.ctx.settings);
+    const correctedBody = correctRelatedLinkPrefixes(
+      cleanedBody,
+      info.related_entities,
+      info.related_concepts,
+      labels.related_entities,
+      labels.related_concepts,
+      this.ctx.settings.slugCase === 'preserve'
+    );
+    const finalContent = `${frontmatter}\n\n${correctedBody}`;
     await this.ctx.createOrUpdateFile(path, finalContent);
     return path;
     } catch (error) {


### PR DESCRIPTION
Closes the root cause behind #187.

Per the discussion, this is the deterministic post-pass rather than a list-visibility heuristic. The Related Concepts / Related Entities sections are LLM-formatted against a truncated (`MAX_PAGES`) existing-pages list, so the model often can't place a target and defaults to the most salient prefix in the prompt — `sources/`. Raising the cap or splitting the list by type shrinks the problem but can't cover the worst case: a page and a related sibling generated in the **same run**, where the sibling exists in the list at no `MAX_PAGES` because it doesn't exist yet when the prompt is built.

The code already knows each related name's type, so we re-assert it after generation instead of trusting the guess.

## Shape

- New pure module `src/core/related-link-corrector.ts` (~75 LOC), `correctRelatedLinkPrefixes(content, relatedEntities, relatedConcepts, relatedEntitiesLabel, relatedConceptsLabel, preserveCase)`.
- Wired into `page-factory.ts` after `createNewPage` and `mergePage`.
- Section-scoped by header label, so the legitimate `[[sources/<slug>]]` citations in *Mentions in Source* (whose names often coincide with a related concept) are never rewritten.
- Section-driven, so it also self-heals stale `sources/`-links carried through a `mergePage` from the existing body — coverage the (a)/(b) path wouldn't have given.
- Recognizes the localized headers and the canonical English ones, so it also heals pages merged before the #188 fix (which carry literal English headers).
- No LLM, no false-merge risk, `O(links)`.

## Named regression tests

In `src/__tests__/core/related-link-corrector.test.ts`, the two cases the (a)/(b) heuristic misses are named test IDs so they'll catch any future regression of that choice:

- **`[truncated-existing-pages]`** — target exists but fell outside the `MAX_PAGES` window.
- **`[co-created-siblings]`** — sibling generated in the same run, never in `existing_pages` at any `MAX_PAGES`.

Plus behavioural coverage (Mentions citations untouched, prose untouched, ambiguity-via-section, merge-carried self-heal, inflection/spacing via slug). Full suite green (1017).

## Validation

Validated on a ~900-page medical vault: a 46-page bulk ingest produced **0 pages** with a `sources/`-prefixed related-link entry, vs the standing backlog this was diagnosed from.

---

Note on target: `feat/v1.22.1-patches` doesn't exist yet, so this opens against `main`. Happy to retarget to the patch branch once you create it — or rebase as you prefer.
