### PR TITLE
Add hub-retirement crystallization signal (core/hub-retirement.ts)

### DIFF
--- a/src/core/hub-retirement.test.ts
+++ b/src/core/hub-retirement.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  localClustering,
+  buildUndirectedAdjacency,
+  assessHubs,
+  type HubVerdict,
+} from './hub-retirement';
+
+// Build an undirected adjacency from an edge list (also exercises
+// buildUndirectedAdjacency, the integration entry point).
+function graph(edges: Array<[string, string]>): Map<string, Set<string>> {
+  const links = new Map<string, string[]>();
+  for (const [a, b] of edges) {
+    if (!links.has(a)) links.set(a, []);
+    links.get(a)!.push(b);
+  }
+  return buildUndirectedAdjacency(links);
+}
+
+// A hub with `degree` leaves and `internalEdges` edges among consecutive leaves.
+// clustering = 2 * internalEdges / (degree * (degree - 1)).
+function hubWith(name: string, degree: number, internalEdges: number): Array<[string, string]> {
+  const leaves = Array.from({ length: degree }, (_, i) => `${name}_n${i}`);
+  const e: Array<[string, string]> = leaves.map(l => [name, l]);
+  for (let i = 0; i < internalEdges; i++) e.push([leaves[i], leaves[i + 1]]);
+  return e;
+}
+
+const verdicts = (a: { verdict: HubVerdict }[]) => a.map(x => x.verdict);
+
+describe('Hub Retirement — Pure Functions', () => {
+  describe('localClustering', () => {
+    it('is 1 for a triangle (every neighbor pair connected)', () => {
+      const adj = graph([['a', 'b'], ['b', 'c'], ['a', 'c']]);
+      expect(localClustering('a', adj)).toEqual({ clustering: 1, degree: 2 });
+    });
+
+    it('is 0 for a star (no neighbor interconnects)', () => {
+      const adj = graph([['s', 'a'], ['s', 'b'], ['s', 'c'], ['s', 'd']]);
+      expect(localClustering('s', adj)).toEqual({ clustering: 0, degree: 4 });
+    });
+
+    it('counts the connected fraction of neighbor pairs', () => {
+      // x → {p,q,r}, only p-q connected: 1 of 3 possible pairs
+      const adj = graph([['x', 'p'], ['x', 'q'], ['x', 'r'], ['p', 'q']]);
+      const { clustering, degree } = localClustering('x', adj);
+      expect(degree).toBe(3);
+      expect(clustering).toBeCloseTo(1 / 3, 10);
+    });
+
+    it('is 0 below degree 2 and for unknown nodes', () => {
+      const adj = graph([['s', 'a']]);
+      expect(localClustering('s', adj)).toEqual({ clustering: 0, degree: 1 });
+      expect(localClustering('missing', adj)).toEqual({ clustering: 0, degree: 0 });
+    });
+  });
+
+  describe('buildUndirectedAdjacency', () => {
+    it('symmetrizes edges and drops self-loops', () => {
+      const adj = buildUndirectedAdjacency(new Map([
+        ['a', ['b', 'a']], // a→a self-loop dropped
+        ['b', ['c']],
+      ]));
+      expect(adj.get('a')).toEqual(new Set(['b']));
+      expect(adj.get('b')).toEqual(new Set(['a', 'c']));
+      expect(adj.get('c')).toEqual(new Set(['b']));
+    });
+  });
+
+  describe('assessHubs', () => {
+    // Three hubs, all with LOW absolute clustering (< 0.1, like the real graph),
+    // distinct ranks. degreeFloor lowered so the degree-10 fixtures qualify.
+    const lowGraph = graph([
+      ...hubWith('star', 10, 0),    // clustering 0
+      ...hubWith('mid', 10, 3),     // 6/90  = 0.067
+      ...hubWith('crystal', 10, 4), // 8/90  = 0.089
+    ]);
+    const hubs = ['star', 'mid', 'crystal'];
+
+    it('retires the relatively-most-crystallized hub even though clustering < 0.1', () => {
+      const out = assessHubs(lowGraph, hubs, { degreeFloor: 4 });
+      const byId = Object.fromEntries(out.map(a => [a.id, a]));
+      expect(byId.crystal.verdict).toBe('crystallized');
+      expect(byId.mid.verdict).toBe('transition');
+      expect(byId.star.verdict).toBe('star');
+      // The empirical point: the retired hub is below any absolute 0.10 cut.
+      expect(byId.crystal.clustering).toBeLessThan(0.1);
+    });
+
+    it('returns assessments sorted most-crystallized first', () => {
+      const out = assessHubs(lowGraph, hubs, { degreeFloor: 4 });
+      expect(out.map(a => a.id)).toEqual(['crystal', 'mid', 'star']);
+    });
+
+    it('treats a low-degree hub as building regardless of clustering', () => {
+      // 5-node clique hub: clustering 1, but degree 4 < default floor 30.
+      const adj = graph([
+        ['h', 'a'], ['h', 'b'], ['h', 'c'], ['h', 'd'],
+        ['a', 'b'], ['a', 'c'], ['a', 'd'], ['b', 'c'], ['b', 'd'], ['c', 'd'],
+      ]);
+      const [a] = assessHubs(adj, ['h']);
+      expect(a.clustering).toBe(1);
+      expect(a.verdict).toBe('building');
+    });
+
+    it('absoluteClusteringFloor blocks retirement in an all-star graph', () => {
+      const out = assessHubs(lowGraph, hubs, { degreeFloor: 4, absoluteClusteringFloor: 0.1 });
+      const crystal = out.find(a => a.id === 'crystal')!;
+      expect(crystal.verdict).toBe('transition'); // demoted: 0.089 < 0.1 floor
+    });
+
+    it('is magnitude-independent — verdict follows rank, not absolute clustering', () => {
+      // High-absolute-clustering graph with the same ordering as lowGraph.
+      // consecutive-pair scheme caps internal edges at degree-1 (= 5 here)
+      const highGraph = graph([
+        ...hubWith('s', 6, 0), // 0
+        ...hubWith('m', 6, 2), //  4/30 = 0.133
+        ...hubWith('c', 6, 5), // 10/30 = 0.333
+      ]);
+      const low = verdicts(assessHubs(lowGraph, hubs, { degreeFloor: 4 }));
+      const high = verdicts(assessHubs(highGraph, ['s', 'm', 'c'], { degreeFloor: 4 }));
+      expect(low).toEqual(['crystallized', 'transition', 'star']);
+      expect(high).toEqual(low);
+    });
+
+    it('keeps a single hub (no relative signal) as star, never crystallized', () => {
+      const [a] = assessHubs(lowGraph, ['crystal'], { degreeFloor: 4 });
+      expect(a.clusteringPercentile).toBe(0);
+      expect(a.verdict).toBe('star');
+    });
+
+    it('returns empty for no hubs', () => {
+      expect(assessHubs(lowGraph, [])).toEqual([]);
+    });
+  });
+});

--- a/src/core/hub-retirement.ts
+++ b/src/core/hub-retirement.ts
@@ -1,0 +1,175 @@
+// Hub Retirement — Pure functions for deciding whether a tagged hub has
+// "crystallized" and can have its hub status retired.
+//
+// Model (S15): a hub is a content-unspecific CRYSTALLIZATION POINT for a
+// developing domain. Its special status (hub-link suppression) is a DECAYING
+// developmental role. While the domain is a STAR — neighbors hang only off the
+// hub — the hub is load-bearing → keep. Once the neighbors interconnect
+// (crystallization) the hub is structurally redundant → retire the status.
+//
+// Metric = local clustering coefficient of the hub: edges among its neighbors
+// divided by possible neighbor pairs. Hubs have intrinsically LOW clustering, so
+// what carries signal is the RELATIVE rank within the hub set, not an absolute
+// cut. Measured across 4 independent graphs (prod + 3 experiment vaults,
+// 2026-06): no high-degree node crosses clustering 0.10, i.e. an absolute
+// crystallization cut never fires and the percentile rank is the only firing
+// signal. Hence the verdict is percentile-based by default, with an optional
+// absolute clustering floor as an escape hatch for all-star graphs.
+//
+// Zero side effects, fully unit-testable. The caller owns graph construction and
+// the actual tag write; this module only judges.
+
+export type HubVerdict = 'building' | 'star' | 'transition' | 'crystallized';
+
+export interface HubAssessment {
+  id: string;
+  degree: number;
+  clustering: number;
+  /** Rank of this hub's clustering within the assessed set, 0..1 (1 = most crystallized). */
+  clusteringPercentile: number;
+  verdict: HubVerdict;
+}
+
+export interface HubRetirementOptions {
+  /**
+   * Clustering percentile (0..1) at/above which a hub counts as crystallized.
+   * Relative to the assessed hub set. Default 0.75 (top quarter).
+   */
+  crystallizedPercentile?: number;
+  /**
+   * Clustering percentile (0..1) at/above which a hub is in transition.
+   * Default 0.50 (upper half).
+   */
+  transitionPercentile?: number;
+  /**
+   * Absolute degree below which clustering is treated as statistical noise and
+   * the hub is "building" regardless of rank. This is a noise guard, not a
+   * relative threshold: clustering variance scales with 1/degree, so a
+   * low-degree node's coefficient is unreliable in any graph. Default 30.
+   */
+  degreeFloor?: number;
+  /**
+   * Optional absolute clustering floor: a hub below this is never "crystallized"
+   * regardless of rank, so the tool does not mechanically retire the top of an
+   * all-star graph. Default 0 (off → pure relative verdict).
+   */
+  absoluteClusteringFloor?: number;
+}
+
+const DEFAULTS: Required<HubRetirementOptions> = {
+  crystallizedPercentile: 0.75,
+  transitionPercentile: 0.5,
+  degreeFloor: 30,
+  absoluteClusteringFloor: 0,
+};
+
+/**
+ * Local clustering coefficient of a node: existing edges among its neighbors
+ * divided by the number of possible neighbor pairs. Returns 0 for degree < 2.
+ *
+ * @param id - Node id
+ * @param adjacency - Undirected adjacency (symmetric neighbor sets)
+ *
+ * @example
+ * // triangle a-b-c: every neighbor pair is connected
+ * localClustering('a', new Map([
+ *   ['a', new Set(['b','c'])], ['b', new Set(['a','c'])], ['c', new Set(['a','b'])],
+ * ])) // => { clustering: 1, degree: 2 }
+ */
+export function localClustering(
+  id: string,
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): { clustering: number; degree: number } {
+  const neighbors = adjacency.get(id);
+  const degree = neighbors ? neighbors.size : 0;
+  if (degree < 2) return { clustering: 0, degree };
+  let edges = 0;
+  for (const u of neighbors!) {
+    const un = adjacency.get(u);
+    if (!un) continue;
+    for (const v of neighbors!) {
+      if (u < v && un.has(v)) edges++;
+    }
+  }
+  return { clustering: (2 * edges) / (degree * (degree - 1)), degree };
+}
+
+/**
+ * Build an undirected adjacency from a directed link map (each node → the nodes
+ * it links to). Self-loops are dropped; edges are symmetrized. Lets a caller
+ * feed the plugin's per-page outgoing-link sets directly.
+ *
+ * @param links - node id → ids it links to
+ */
+export function buildUndirectedAdjacency(
+  links: ReadonlyMap<string, Iterable<string>>,
+): Map<string, Set<string>> {
+  const adj = new Map<string, Set<string>>();
+  const touch = (n: string): Set<string> => {
+    let s = adj.get(n);
+    if (!s) { s = new Set<string>(); adj.set(n, s); }
+    return s;
+  };
+  for (const [src, targets] of links) {
+    for (const tgt of targets) {
+      if (tgt === src) continue;
+      touch(src).add(tgt);
+      touch(tgt).add(src);
+    }
+  }
+  return adj;
+}
+
+/** Fraction of values strictly less than `value`; 0 for the min, 1 for the max. */
+function percentileRank(value: number, sorted: readonly number[]): number {
+  const n = sorted.length;
+  if (n <= 1) return 0;
+  let below = 0;
+  for (const v of sorted) if (v < value) below++;
+  return below / (n - 1);
+}
+
+/**
+ * Assess each tagged hub and return a crystallization verdict. The verdict is
+ * relative to the supplied hub set (percentile of clustering), so it is
+ * vault-size invariant; `degreeFloor` and `absoluteClusteringFloor` are absolute
+ * guards layered on top.
+ *
+ * Returned assessments are sorted most-crystallized first.
+ *
+ * @param adjacency - Undirected graph adjacency (full graph, not just hubs)
+ * @param hubIds - Ids currently tagged as hubs
+ * @param options - Tunable thresholds (see HubRetirementOptions)
+ */
+export function assessHubs(
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+  hubIds: Iterable<string>,
+  options: HubRetirementOptions = {},
+): HubAssessment[] {
+  const o = { ...DEFAULTS, ...options };
+  const measured = [...hubIds].map(id => {
+    const { clustering, degree } = localClustering(id, adjacency);
+    return { id, clustering, degree };
+  });
+  const clusterings = measured.map(m => m.clustering).sort((a, b) => a - b);
+
+  const assessed = measured.map(({ id, clustering, degree }): HubAssessment => {
+    const clusteringPercentile = percentileRank(clustering, clusterings);
+    let verdict: HubVerdict;
+    if (degree < o.degreeFloor) {
+      verdict = 'building';
+    } else if (
+      clusteringPercentile >= o.crystallizedPercentile &&
+      clustering >= o.absoluteClusteringFloor
+    ) {
+      verdict = 'crystallized';
+    } else if (clusteringPercentile >= o.transitionPercentile) {
+      verdict = 'transition';
+    } else {
+      verdict = 'star';
+    }
+    return { id, degree, clustering, clusteringPercentile, verdict };
+  });
+
+  return assessed.sort((a, b) => b.clusteringPercentile - a.clusteringPercentile);
+}


### PR DESCRIPTION
The self-contained `core/hub-retirement.ts` we discussed in #198 — the hub-retirement signal as a small, standalone pure module, orthogonal to the PPR engine. It judges hubs; it does not touch the graph engine and writes no tags (the caller owns graph construction and the actual tag mutation).

## Model

A `Hub` tag is a *decaying developmental role*, not a permanent type. A hub is a content-unspecific crystallization point for a developing domain. While the domain is a **star** — neighbors hang off the hub but not off each other — the hub is load-bearing → keep. Once the neighbors **interconnect** (crystallization), the hub is structurally redundant → its status can be retired. The metric is the hub's local clustering coefficient.

## API

```ts
localClustering(id, adjacency)                 // { clustering, degree }
buildUndirectedAdjacency(directedLinks)        // symmetrize per-page link sets
assessHubs(adjacency, hubIds, options?)        // HubAssessment[], most-crystallized first
// verdict: 'building' | 'star' | 'transition' | 'crystallized'
```

## Why the verdict is relative (and the degree floor isn't)

Hubs cluster *intrinsically low* (high degree), so absolute clustering cuts are fragile. I ran the reference Python on **4 independent graphs** (one mature ~900-page vault + 3 controlled experiment vaults): **no high-degree hub crosses clustering 0.10 in any of them** — the whole high-degree mass sits at 0.04–0.10. An absolute crystallization cut therefore never fires; only the **percentile rank within the hub set** carries signal. So `assessHubs` decides crystallization by percentile (defaults: crystallized ≥ 0.75, transition ≥ 0.50), with an optional `absoluteClusteringFloor` as an escape hatch against mechanically retiring the top of an all-star graph.

The **degree floor stays absolute** (default 30) on purpose. It is a statistical noise guard — clustering variance scales with ~1/degree, an absolute property of degree, not a structural-position judgment. A percentile degree floor would mislabel mature-but-lower-degree hubs as "building" and, worse, protect *least* in small/young vaults where the noise is *worst* (it always lets the top 75% through regardless of absolute degree). All thresholds are tunable as `HubRetirementOptions` — treat the defaults as tuning priors.

## Scope / non-goals

- No graph-engine changes; `buildUndirectedAdjacency` lets you feed existing per-page link sets directly.
- No tag writes — the plugin owns mutation.
- 12 tests (incl. the "retire a hub whose clustering is still < 0.10" case and magnitude-independence). Lint/tsc clean against `main`.

Happy to adjust the threshold defaults or fold this into the v1.24.0 timeline however suits the PPR work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)