### PR TITLE
Consolidate frontmatter serialization into a single writer

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { LLMWikiSettings } from '../../types';
-import { enforceFrontmatterConstraints, isBlankSource, mergeFrontmatter, parseFrontmatter, preserveFrontmatterReviewTag, upsertFrontmatterField } from '../../core/frontmatter';
+import { enforceFrontmatterConstraints, isBlankSource, mergeFrontmatter, parseFrontmatter, preserveFrontmatterReviewTag, serializeFrontmatter, upsertFrontmatterField } from '../../core/frontmatter';
 
 describe('isBlankSource', () => {
   it('is true for empty or whitespace-only content', () => {
@@ -297,6 +297,52 @@ describe('enforceFrontmatterConstraints', () => {
     const today = new Date().toISOString().split('T')[0];
     expect(result).toContain(`created: ${today}`);
     expect(result).toContain(`updated: ${today}`);
+  });
+});
+
+describe('serializeFrontmatter', () => {
+  it('emits fields in canonical order: type, created, updated, passthrough, sources, tags, reviewed, aliases', () => {
+    const block = serializeFrontmatter(
+      {
+        type: 'entity',
+        created: '2026-01-01',
+        updated: '2026-07-04',
+        sources: ['[[sources/a]]'],
+        tags: ['person'],
+        reviewed: true,
+        aliases: ['Alt'],
+      },
+      { passthroughLines: ['supersedes: "[[sources/old]]"'], tagStyle: 'block' }
+    );
+    const order = ['type:', 'created:', 'updated:', 'supersedes:', 'sources:', 'tags:', 'reviewed:', 'aliases:']
+      .map(k => block.indexOf(k));
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(order.every(i => i !== -1)).toBe(true);
+  });
+
+  it('block vs inline tag style', () => {
+    const fm = { created: '2026-01-01', updated: '2026-07-04', tags: ['method', 'theory'] };
+    expect(serializeFrontmatter(fm, { tagStyle: 'block' })).toContain('tags:\n  - "method"\n  - "theory"');
+    expect(serializeFrontmatter(fm, { tagStyle: 'inline' })).toContain('tags: [method, theory]');
+  });
+
+  it('emits a bare tags: line only when emitEmptyTags is set', () => {
+    const fm = { created: '2026-01-01', updated: '2026-07-04', tags: [] as string[] };
+    expect(serializeFrontmatter(fm, { emitEmptyTags: true })).toContain('\ntags:\n');
+    expect(serializeFrontmatter(fm, { emitEmptyTags: false })).not.toMatch(/\ntags:/);
+  });
+
+  it('dedups aliases, keeping first occurrence and dropping empties', () => {
+    const block = serializeFrontmatter({
+      created: '2026-01-01', updated: '2026-07-04', aliases: ['A', 'A', '', 'B'],
+    });
+    expect(block.match(/- "A"/g)?.length).toBe(1);
+    expect(block).toContain('- "B"');
+  });
+
+  it('omits sources/tags/aliases when absent, and omits type when undefined', () => {
+    const block = serializeFrontmatter({ created: '2026-01-01', updated: '2026-07-04' });
+    expect(block).toBe('---\ncreated: 2026-01-01\nupdated: 2026-07-04\n---');
   });
 });
 

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -168,6 +168,72 @@ export function upsertFrontmatterField(content: string, key: string, value: stri
   return `---\n${line}\n---\n\n${content}`;
 }
 
+export interface SerializeFrontmatterOptions {
+  /**
+   * Verbatim frontmatter lines for non-canonical fields (e.g. a future
+   * `supersedes:` flag), emitted after `updated:` and before `sources:`.
+   * Callers that intentionally drop unknown fields pass none; callers that
+   * preserve them (enforceFrontmatterConstraints) pass their collected lines.
+   */
+  passthroughLines?: string[];
+  /** `'block'` → `tags:\n  - x`; `'inline'` → `tags: [x, y]`. Default `'block'`. */
+  tagStyle?: 'inline' | 'block';
+  /** When there are no tags, emit a bare `tags:` line instead of omitting the field. */
+  emitEmptyTags?: boolean;
+}
+
+/**
+ * Canonical v6 frontmatter serializer — the single source of truth for the
+ * field ORDER and YAML SHAPE of type/created/updated/sources/tags/reviewed/aliases.
+ * mergeFrontmatter, enforceFrontmatterConstraints, and mergeDuplicatePages all
+ * delegate here, so a new field (or a fix) is added in exactly one place rather
+ * than three divergent hand-rolled writers. Returns the frontmatter block only
+ * (`---\n…\n---`), without the body; the caller joins body as needed.
+ *
+ * The tag STYLE is parameterized rather than unified: `fix-runners.ts` rewrites
+ * tags with an inline-only regex, so enforce must keep emitting inline tags while
+ * merge keeps block tags. Only the duplicated ordering/serialization logic is
+ * consolidated; observable output is unchanged.
+ */
+export function serializeFrontmatter(
+  fm: FrontmatterData,
+  opts: SerializeFrontmatterOptions = {}
+): string {
+  const { passthroughLines = [], tagStyle = 'block', emitEmptyTags = false } = opts;
+  const lines: string[] = ['---'];
+
+  if (fm.type) lines.push(`type: ${fm.type}`);
+  if (fm.created) lines.push(`created: ${fm.created}`);
+  if (fm.updated) lines.push(`updated: ${fm.updated}`);
+
+  for (const line of passthroughLines) lines.push(line);
+
+  if (Array.isArray(fm.sources) && fm.sources.length > 0) {
+    lines.push(`sources:${yamlStringify(fm.sources)}`);
+  }
+
+  if (Array.isArray(fm.tags) && fm.tags.length > 0) {
+    lines.push(tagStyle === 'inline'
+      ? `tags: [${fm.tags.join(', ')}]`
+      : `tags:${yamlStringify(fm.tags)}`);
+  } else if (emitEmptyTags) {
+    lines.push('tags:');
+  }
+
+  if (fm.reviewed) lines.push('reviewed: true');
+
+  if (Array.isArray(fm.aliases)) {
+    // Dedup: keep first occurrence, drop empties (parity across all writers).
+    const dedupedAliases = fm.aliases.filter((v, i, a) => a.indexOf(v) === i && v);
+    if (dedupedAliases.length > 0) {
+      lines.push(`aliases:${yamlStringify(dedupedAliases)}`);
+    }
+  }
+
+  lines.push('---');
+  return lines.join('\n');
+}
+
 export function mergeFrontmatter(
   existingContent: string,
   newSourcePath: string
@@ -201,41 +267,21 @@ export function mergeFrontmatter(
   const created = fm.created || new Date().toISOString().split('T')[0];
   const updated = new Date().toISOString().split('T')[0];
 
-  const lines: string[] = ['---'];
+  // Always emit a `tags:` line (bare when empty) to preserve prior behavior.
+  const frontmatter = serializeFrontmatter(
+    {
+      type: fm.type,
+      created,
+      updated,
+      sources: mergedSources,
+      tags: Array.isArray(fm.tags) ? fm.tags : [],
+      reviewed: fm.reviewed,
+      aliases: Array.isArray(fm.aliases) ? fm.aliases : undefined,
+    },
+    { tagStyle: 'block', emitEmptyTags: true }
+  );
 
-  if (fm.type) lines.push(`type: ${fm.type}`);
-  lines.push(`created: ${created}`);
-  lines.push(`updated: ${updated}`);
-
-  if (mergedSources.length > 0) {
-    lines.push(`sources:${yamlStringify(mergedSources)}`);
-  }
-
-  if (Array.isArray(fm.tags) && fm.tags.length > 0) {
-    lines.push(`tags:${yamlStringify(fm.tags)}`);
-  } else {
-    lines.push('tags:');
-  }
-
-  if (fm.reviewed) {
-    lines.push('reviewed: true');
-  }
-
-  if (Array.isArray(fm.aliases) && fm.aliases.length > 0) {
-    // Dedup parity with enforceFrontmatterConstraints (keeps first occurrence, drops empties).
-    const dedupedAliases = fm.aliases.filter((v, i, a) => a.indexOf(v) === i && v);
-    if (dedupedAliases.length > 0) {
-      lines.push(`aliases:${yamlStringify(dedupedAliases)}`);
-    }
-  }
-
-  lines.push('---');
-
-  return {
-    frontmatter: lines.join('\n'),
-    body,
-    wasMerged: true
-  };
+  return { frontmatter, body, wasMerged: true };
 }
 
 export function preserveFrontmatterReviewTag(originalContent: string, newContent: string): string {
@@ -275,7 +321,6 @@ export function enforceFrontmatterConstraints(
 
   const lines = fmText.split('\n');
   const newLines: string[] = [];
-  let typeLine = '';
   let collectedTags: string[] = [];
   let foundType = false;
   let foundTags = false;
@@ -298,7 +343,6 @@ export function enforceFrontmatterConstraints(
     if (line.startsWith('type:')) {
       foundType = true;
       const currentType = line.substring(5).trim();
-      typeLine = `type: ${pageType}`;
       if ((pageType === 'entity' || pageType === 'concept') && currentType && currentType !== 'entity' && currentType !== 'concept' && currentType !== pageType) {
         collectedTags.push(currentType);
       }
@@ -339,23 +383,16 @@ export function enforceFrontmatterConstraints(
     }
   }
 
-  const result: string[] = ['---'];
+  // Non-canonical fields (unknown keys) are passed through verbatim, preserving
+  // prior enforce behavior. newLines already excludes type/tags/aliases/created/
+  // updated and list items by construction; the filter is defensive.
+  const passthroughLines = newLines.filter(line =>
+    !line.startsWith('type:') && !line.startsWith('tags:') && !line.startsWith('aliases:') &&
+    !line.startsWith('created:') && !line.startsWith('updated:'));
 
-  if (foundType) {
-    result.push(typeLine);
-  }
-
-  result.push(`created: ${createdValue || today}`);
-  result.push(`updated: ${today}`);
-
-  for (const line of newLines) {
-    if (!line.startsWith('type:') && !line.startsWith('tags:') && !line.startsWith('aliases:') &&
-        !line.startsWith('created:') && !line.startsWith('updated:')) {
-      result.push(line);
-    }
-  }
-
-  if (foundTags || collectedTags.length > 0) {
+  const hasTags = foundTags || collectedTags.length > 0;
+  const dedupedTags: string[] = [];
+  if (hasTags) {
     const validSubtypes: readonly string[] = pageType === 'entity'
       ? (settings ? getActiveEntityTags(settings) : VALID_ENTITY_TAGS)
       : pageType === 'concept'
@@ -363,7 +400,6 @@ export function enforceFrontmatterConstraints(
         : pageType === 'source'
           ? (settings ? getActiveSourceTags(settings) : VALID_SOURCE_TAGS)
           : [];
-    const dedupedTags: string[] = [];
     const outOfVocab: string[] = [];
     for (const tag of collectedTags) {
       if (!tag || tag === pageType) continue;
@@ -377,21 +413,18 @@ export function enforceFrontmatterConstraints(
         outOfVocab
       );
     }
-    if (dedupedTags.length > 0) {
-      result.push(`tags: [${dedupedTags.join(', ')}]`);
-    } else {
-      result.push('tags:');
-    }
   }
 
-  if (foundAliases || collectedAliases.length > 0) {
-    const validAliases = collectedAliases.filter((v, i, a) => a.indexOf(v) === i && v);
-    if (validAliases.length > 0) {
-      result.push(`aliases:${yamlStringify(validAliases)}`);
-    }
-  }
+  const frontmatter = serializeFrontmatter(
+    {
+      type: foundType ? pageType : undefined,
+      created: createdValue || today,
+      updated: today,
+      tags: dedupedTags,
+      aliases: (foundAliases || collectedAliases.length > 0) ? collectedAliases : undefined,
+    },
+    { passthroughLines, tagStyle: 'inline', emitEmptyTags: hasTags }
+  );
 
-  result.push('---');
-
-  return result.join('\n') + '\n\n' + body;
+  return frontmatter + '\n\n' + body;
 }

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -2,7 +2,7 @@ import { EngineContext } from '../../types';
 import { PROMPTS } from '../../prompts';
 import { TOKENS_LINT_PAGE_FIX, WIKI_SUBFOLDERS } from '../../constants';
 import { buildSystemPrompt } from '../system-prompts';
-import { parseFrontmatter, enforceFrontmatterConstraints } from '../../core/frontmatter';
+import { parseFrontmatter, enforceFrontmatterConstraints, serializeFrontmatter } from '../../core/frontmatter';
 import { parseJsonResponse } from '../../core/json';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { escapeRegex } from './utils';
@@ -136,27 +136,18 @@ export async function mergeDuplicatePages(
   }
 
   const today = new Date().toISOString().split('T')[0];
-  const fmLines: string[] = ['---'];
-  if (targetFm?.type) fmLines.push(`type: ${targetFm.type}`);
-  fmLines.push(`created: ${targetFm?.created || today}`);
-  fmLines.push(`updated: ${today}`);
-  if (mergedSourcesList.length > 0) {
-    fmLines.push(`${WIKI_SUBFOLDERS.sources}:`);
-    for (const s of mergedSourcesList) fmLines.push(`  - "${s}"`);
-  }
-  const tags = Array.isArray(targetFm?.tags) ? targetFm.tags : [];
-  if (tags.length > 0) {
-    fmLines.push('tags:');
-    for (const t of tags) fmLines.push(`  - ${t}`);
-  }
-  if (targetFm?.reviewed) fmLines.push('reviewed: true');
-  if (dedupedAliases.length > 0) {
-    fmLines.push('aliases:');
-    for (const a of dedupedAliases) fmLines.push(`  - "${a}"`);
-  }
-  fmLines.push('---');
-
-  const newContent = fmLines.join('\n') + '\n\n' + mergedBody;
+  const newContent = serializeFrontmatter(
+    {
+      type: targetFm?.type,
+      created: targetFm?.created || today,
+      updated: today,
+      sources: mergedSourcesList,
+      tags: Array.isArray(targetFm?.tags) ? targetFm.tags : [],
+      reviewed: targetFm?.reviewed,
+      aliases: dedupedAliases,
+    },
+    { tagStyle: 'block' }
+  ) + '\n\n' + mergedBody;
   const pageType = targetPath.includes(`/${WIKI_SUBFOLDERS.entities}/`)
     ? 'entity'
     : targetPath.includes(`/${WIKI_SUBFOLDERS.concepts}/`)


### PR DESCRIPTION
Three sites currently rebuild the v6 frontmatter block field-by-field, each with its own copy of the ordering + YAML logic: `mergeFrontmatter`, `enforceFrontmatterConstraints`, and `mergeDuplicatePages` (which hand-rolls the block and then re-runs it through `enforceFrontmatterConstraints`). They've already drifted — only `mergeFrontmatter` handles `sources:`, only `enforceFrontmatterConstraints` validates the tag vocabulary and passes through unknown fields.

Since v1.24.0's Tier 1 (#220) adds a `supersedes:` frontmatter flag, and `mergeFrontmatter` currently drops any field it doesn't explicitly enumerate, I figured it was worth unifying these *before* that lands rather than after — otherwise the new field has to be threaded through three writers, and forgetting one silently drops provenance on the next merge.

This extracts `serializeFrontmatter(fm, opts)` as the single source of truth for field order and YAML shape; the three callers delegate to it. Tag style stays parameterized (`enforce` keeps inline tags, since `fix-runners` rewrites them with an inline-only regex) so observable output is unchanged — the full suite passes without test edits. Adds unit coverage for the new function.
