### PR TITLE
feat: semantic progress notifications + query turn indicator (#219, #221)

### DIFF
--- a/src/__tests__/core/progress-notification.test.ts
+++ b/src/__tests__/core/progress-notification.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { decideProgressDisplay, ProgressScope } from '../../core/progress-notification';
+
+describe('decideProgressDisplay', () => {
+  it('shows notice+status for manual user-triggered short operations', () => {
+    const result = decideProgressDisplay(ProgressScope.IngestManual, false, true);
+    expect(result.display).toBe('notice+status-bar');
+  });
+
+  it('shows notice+status for manual user-triggered long operations', () => {
+    const result = decideProgressDisplay(ProgressScope.IngestManual, true, true);
+    expect(result.display).toBe('notice+status-bar');
+  });
+
+  it('shows status-only for watch-mode auto-ingest', () => {
+    const result = decideProgressDisplay(ProgressScope.IngestAutoWatch, false, false);
+    expect(result.display).toBe('status-bar-only');
+  });
+
+  it('shows status-only for periodic lint', () => {
+    const result = decideProgressDisplay(ProgressScope.LintPeriodic, false, false);
+    expect(result.display).toBe('status-bar-only');
+  });
+
+  it('shows notice+status for manual lint', () => {
+    const result = decideProgressDisplay(ProgressScope.LintManual, false, true);
+    expect(result.display).toBe('notice+status-bar');
+  });
+
+  it('shows notice+status for manual smart fix', () => {
+    const result = decideProgressDisplay(ProgressScope.SmartFixManual, false, true);
+    expect(result.display).toBe('notice+status-bar');
+  });
+
+  it('shows status-only for startup auto-maintenance', () => {
+    const result = decideProgressDisplay(ProgressScope.AutoMaintenance, false, false);
+    expect(result.display).toBe('status-bar-only');
+  });
+
+  it('flags unknown long user ops for notice+status', () => {
+    const result = decideProgressDisplay('unknown' as ProgressScope, true, true);
+    expect(result.display).toBe('notice+status-bar');
+  });
+});

--- a/src/__tests__/wiki/turn-indicator.test.ts
+++ b/src/__tests__/wiki/turn-indicator.test.ts
@@ -1,0 +1,101 @@
+// v1.23.2: vertical turn indicator (Variant 2 only).
+//
+// ChatGPT/Grok-style right-edge dots. Each dot maps to a conversation
+// turn (user + assistant pair). IntersectionObserver highlights the
+// dot whose turn is currently visible. Clicking a dot scrolls that
+// turn to the top of the history container.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+// We can't easily import QueryView without a lot of scaffolding, so we
+// test the helper logic directly and verify DOM mutations through a
+// small harness that mirrors the implementation.
+import {
+  buildTurnIndicator,
+  findTurnElements,
+  scrollTurnToStart,
+  updateActiveDot,
+} from '../../wiki/turn-indicator';
+
+beforeEach(() => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  // eslint-disable-next-line obsidianmd/no-global-this
+  globalThis.document = dom.window.document;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  (globalThis as Record<string, unknown>).activeDocument = dom.window.document;
+});
+
+afterEach(() => {
+  // eslint-disable-next-line obsidianmd/no-global-this
+  delete (globalThis as Record<string, unknown>).document;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  delete (globalThis as Record<string, unknown>).activeDocument;
+});
+
+function makeHistoryContainer(): HTMLElement {
+  // eslint-disable-next-line obsidianmd/no-global-this
+  const doc = globalThis.document;
+  const container = doc.createElement('div');
+  container.className = 'llm-wiki-query-history';
+  // Three turns
+  for (let i = 0; i < 3; i++) {
+    const user = doc.createElement('div');
+    user.className = 'llm-wiki-query-message-wrapper llm-wiki-query-message-user';
+    user.dataset.turn = String(i);
+    container.appendChild(user);
+
+    const assistant = doc.createElement('div');
+    assistant.className = 'llm-wiki-query-message-wrapper llm-wiki-query-message-assistant';
+    assistant.dataset.turn = String(i);
+    container.appendChild(assistant);
+  }
+  return container;
+}
+
+describe('turn-indicator helpers', () => {
+  it('finds all unique turns in order', () => {
+    const container = makeHistoryContainer();
+    const turns = findTurnElements(container);
+    expect(turns.length).toBe(3);
+    expect(turns[0].dataset.turn).toBe('0');
+    expect(turns[2].dataset.turn).toBe('2');
+  });
+
+  it('builds an indicator with one dot per turn', () => {
+    const container = makeHistoryContainer();
+    const indicator = buildTurnIndicator(container, 0, () => {});
+    const dots = indicator.querySelectorAll('.llm-wiki-turn-dot');
+    expect(dots.length).toBe(3);
+    expect(indicator.classList.contains('llm-wiki-turn-indicator')).toBe(true);
+  });
+
+  it('updates the active dot class based on visible turn', () => {
+    const container = makeHistoryContainer();
+    const indicator = buildTurnIndicator(container, 0, () => {});
+    const dots = indicator.querySelectorAll('.llm-wiki-turn-dot');
+
+    updateActiveDot(indicator, 1);
+    expect(dots[1].classList.contains('llm-wiki-turn-dot-active')).toBe(true);
+    expect(dots[0].classList.contains('llm-wiki-turn-dot-active')).toBe(false);
+
+    updateActiveDot(indicator, 2);
+    expect(dots[2].classList.contains('llm-wiki-turn-dot-active')).toBe(true);
+    expect(dots[1].classList.contains('llm-wiki-turn-dot-active')).toBe(false);
+  });
+
+  it('scrolls the selected turn to start via scrollIntoView mock', () => {
+    const container = makeHistoryContainer();
+    const turns = findTurnElements(container);
+    const called: { turn: string; options: ScrollIntoViewOptions }[] = [];
+
+    scrollTurnToStart(turns[1], (opts: ScrollIntoViewOptions) => {
+      called.push({ turn: turns[1].dataset.turn ?? '', options: opts });
+    });
+
+    expect(called.length).toBe(1);
+    expect(called[0].turn).toBe('1');
+    expect(called[0].options.block).toBe('start');
+    expect(called[0].options.behavior).toBe('smooth');
+  });
+});

--- a/src/__tests__/wiki/turn-indicator.test.ts
+++ b/src/__tests__/wiki/turn-indicator.test.ts
@@ -64,15 +64,47 @@ describe('turn-indicator helpers', () => {
 
   it('builds an indicator with one dot per turn', () => {
     const container = makeHistoryContainer();
-    const indicator = buildTurnIndicator(container, 0, () => {});
+    const indicator = buildTurnIndicator(container, 0, ['q1', 'q2', 'q3'], () => {});
     const dots = indicator.querySelectorAll('.llm-wiki-turn-dot');
     expect(dots.length).toBe(3);
     expect(indicator.classList.contains('llm-wiki-turn-indicator')).toBe(true);
   });
 
+  it('creates tooltip elements with question text on hover', () => {
+    const container = makeHistoryContainer();
+    const indicator = buildTurnIndicator(container, 0, ['first question', 'second question', 'third'], () => {});
+    const tooltips = indicator.querySelectorAll('.llm-wiki-turn-dot-tooltip');
+    expect(tooltips.length).toBe(3);
+    expect(tooltips[0].textContent).toBe('first question');
+    expect(tooltips[1].textContent).toBe('second question');
+    expect(tooltips[2].textContent).toBe('third');
+  });
+
+  it('wraps each dot in a .llm-wiki-turn-dot-wrapper', () => {
+    const container = makeHistoryContainer();
+    const indicator = buildTurnIndicator(container, 0, ['a', 'b', 'c'], () => {});
+    const wrappers = indicator.querySelectorAll('.llm-wiki-turn-dot-wrapper');
+    expect(wrappers.length).toBe(3);
+    // Each wrapper contains a dot and a tooltip
+    wrappers.forEach(w => {
+      expect(w.querySelector('.llm-wiki-turn-dot')).toBeTruthy();
+    });
+  });
+
+  it('always creates tooltip element with label or fallback', () => {
+    const container = makeHistoryContainer();
+    const indicator = buildTurnIndicator(container, 0, ['question', '', 'three'], () => {});
+    const tooltips = indicator.querySelectorAll('.llm-wiki-turn-dot-tooltip');
+    expect(tooltips.length).toBe(3);
+    expect(tooltips[0].textContent).toBe('question');
+    // Empty label falls back to "Turn N"
+    expect(tooltips[1].textContent).toMatch(/Turn \d+/);
+    expect(tooltips[2].textContent).toBe('three');
+  });
+
   it('updates the active dot class based on visible turn', () => {
     const container = makeHistoryContainer();
-    const indicator = buildTurnIndicator(container, 0, () => {});
+    const indicator = buildTurnIndicator(container, 0, ['q1', 'q2', 'q3'], () => {});
     const dots = indicator.querySelectorAll('.llm-wiki-turn-dot');
 
     updateActiveDot(indicator, 1);

--- a/src/core/progress-notification.ts
+++ b/src/core/progress-notification.ts
@@ -1,0 +1,60 @@
+/**
+ * Semantic progress-notification channel selection.
+ *
+ * No user-facing setting. The decision is driven by the operation type,
+ * whether the user explicitly triggered it, and whether it is long-running.
+ *
+ * Display channels:
+ * - 'notice+status-bar' → persistent Notice + status bar. For user-triggered
+ *   short ops (manual ingest, manual lint, manual smart-fix). User expects
+ *   feedback because they clicked a button / ran a command.
+ * - 'status-bar-only'   → status bar only. For background ops (watch-mode
+ *   auto-ingest, periodic lint, startup auto-maintenance). No blocking Notice
+ *   because the user did not initiate the action.
+ */
+
+export enum ProgressScope {
+  IngestManual = 'ingest-manual',
+  IngestAutoWatch = 'ingest-auto-watch',
+  LintManual = 'lint-manual',
+  LintPeriodic = 'lint-periodic',
+  SmartFixManual = 'smart-fix-manual',
+  AutoMaintenance = 'auto-maintenance',
+}
+
+export interface ProgressDisplayDecision {
+  display: 'notice+status-bar' | 'status-bar-only';
+  reason: string;
+}
+
+const BACKGROUND_SCOPES = new Set<string>([
+  ProgressScope.IngestAutoWatch,
+  ProgressScope.LintPeriodic,
+  ProgressScope.AutoMaintenance,
+]);
+
+export function decideProgressDisplay(
+  scope: ProgressScope,
+  isLong: boolean,
+  hasUserAction: boolean,
+): ProgressDisplayDecision {
+  if (BACKGROUND_SCOPES.has(scope)) {
+    return {
+      display: 'status-bar-only',
+      reason: `${scope} is background/auto-triggered; do not show persistent Notice`,
+    };
+  }
+
+  if (!hasUserAction) {
+    return {
+      display: 'status-bar-only',
+      reason: `operation was not triggered by user; stay in status bar`,
+    };
+  }
+
+  const longHint = isLong ? ' long-running' : '';
+  return {
+    display: 'notice+status-bar',
+    reason: `user-triggered${longHint} operation; show persistent Notice + status bar`,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ import { applySettingsMigrations } from './core/settings-migrations';
 import { normalizeVocabularyCsv } from './core/tag-vocab';
 import { buildIngestStatusBarText, BatchProgress } from './core/status-bar';
 import { IngestQueue } from './core/ingest-queue';
+import { decideProgressDisplay, ProgressScope } from './core/progress-notification';
 import { LLMWikiSettingTab } from './ui/settings';
 import { WikiEngine } from './wiki/wiki-engine';
 import { QueryView, VIEW_TYPE_QUERY } from './wiki/query-engine';
@@ -114,7 +115,7 @@ export default class LLMWikiPlugin extends Plugin {
       // this callback (during file writes), autoMaintainManager is guaranteed
       // to exist. This is intentional — reordering the assignments would break it.
       (path: string) => this.autoMaintainManager.watchWrite(path),
-      (msg: string) => this.showProgress(msg),
+      (msg: string) => this.showProgressFor(ProgressScope.IngestAutoWatch, msg),
       // v1.22.6 #204: Dispatch based on report.trigger so watch-mode
       // auto-ingest goes through onAutoIngestDone (Notice) while
       // manual ingest keeps the legacy IngestReportModal behavior.
@@ -438,11 +439,20 @@ export default class LLMWikiPlugin extends Plugin {
   }
 
   private showProgress(msg: string): void {
-    if (this.progressNotice) {
-      this.progressNotice.setMessage(msg);
-    } else {
-      this.progressNotice = new Notice(msg, 0);
+    // Backward-compatible alias: callers without a scope default to manual ingest.
+    this.showProgressFor(ProgressScope.IngestManual, msg);
+  }
+
+  private showProgressFor(scope: ProgressScope, msg: string): void {
+    const decision = decideProgressDisplay(scope, false, true);
+    if (decision.display === 'notice+status-bar') {
+      if (this.progressNotice) {
+        this.progressNotice.setMessage(msg);
+      } else {
+        this.progressNotice = new Notice(msg, 0);
+      }
     }
+    this.ingestStatusBar?.removeClass('llm-wiki-status-bar-hidden');
   }
 
   private dismissProgress(): void {
@@ -527,7 +537,7 @@ export default class LLMWikiPlugin extends Plugin {
     }
 
     new FileSuggestModal(this.app, this.settings.wikiFolder, (file) => {
-      this.showProgress(`Ingesting: ${file.basename}`);
+      this.showProgressFor(ProgressScope.IngestManual, `Ingesting: ${file.basename}`);
       this.wikiEngine.ingestSource(file, { interactive: true }).catch(e => {
         console.error('Single ingest failed:', e);
         const errMsg = e instanceof Error ? e.message : String(e);
@@ -552,7 +562,7 @@ export default class LLMWikiPlugin extends Plugin {
     // File-type validation is handled centrally by the ingest gate (#164),
     // which accepts the text allowlist (.md, .txt, …) and shows a localized
     // notice for anything else.
-    this.showProgress(`Ingesting: ${activeFile.basename}`);
+    this.showProgressFor(ProgressScope.IngestManual, `Ingesting: ${activeFile.basename}`);
     this.wikiEngine.ingestSource(activeFile, { interactive: true }).catch(e => {
       console.error('Ingest active file failed:', e);
       const errMsg = e instanceof Error ? e.message : String(e);
@@ -643,7 +653,7 @@ export default class LLMWikiPlugin extends Plugin {
    * workaround).
    */
   private async runBatchIngest(files: TFile[], jobIds: string[], sourceLabel: string): Promise<void> {
-    this.showProgress('Checking for already-ingested files...');
+    this.showProgressFor(ProgressScope.IngestManual, 'Checking for already-ingested files...');
     const alreadyIngestedFiles: TFile[] = [];
     const newFiles: TFile[] = [];
     // Aligned with `files` by index — only entries whose id is in
@@ -692,7 +702,7 @@ export default class LLMWikiPlugin extends Plugin {
     });
 
     const texts = TEXTS[this.settings.language];
-    this.showProgress(texts.batchIngestStarting
+    this.showProgressFor(ProgressScope.IngestManual, texts.batchIngestStarting
       .replace('{count}', String(ingestCount))
       .replace('{folder}', sourceLabel));
 
@@ -745,7 +755,7 @@ export default class LLMWikiPlugin extends Plugin {
           );
         }
         this.batchProgress = { current: i + 1, total: ingestCount };
-        this.showProgress(`[${i + 1}/${ingestCount}] ${file.basename}`);
+        this.showProgressFor(ProgressScope.IngestManual, `[${i + 1}/${ingestCount}] ${file.basename}`);
         console.debug(`(${i + 1}/${ingestCount}) ingesting: ${file.path}`);
         await this.wikiEngine.ingestSource(file, { batchCtx });
         if (this.wikiEngine.wasCancelled) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {
   LLMClient,
   IngestReport
 } from './types';
-import { TOKENS_QUERY_MODEL_DETECT, NOTICE_NORMAL, NOTICE_ERROR, NOTICE_ABORT, COMPATIBLE_SOURCE_EXTENSIONS } from './constants';
+import { TOKENS_QUERY_MODEL_DETECT, NOTICE_NORMAL, NOTICE_ERROR, NOTICE_ABORT, NOTICE_RATE_LIMIT, COMPATIBLE_SOURCE_EXTENSIONS } from './constants';
 import { wrapWithAdvancedSettings } from './llm-client-wrapper';
 import { createLLMClientFromSettingsSync, preloadLLMClientModules } from './llm-sdk/create-llm-client';
 import { runSchemaAnalyze } from './schema/analyze';
@@ -304,16 +304,31 @@ export default class LLMWikiPlugin extends Plugin {
     );
 
     this.wikiEngine.setLintCallbacks(
-      () => {
+      (filename?: string) => {
         const label = getText(this.settings.language, 'lintStatusBar');
         if (this.ingestStatusBar) {
-          this.ingestStatusBar.setText(label);
+          const text = filename
+            ? `${filename} · ${label}`
+            : label;
+          this.ingestStatusBar.setText(text);
           this.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
         }
       },
       () => {
         if (this.ingestStatusBar) {
           this.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
+        }
+      }
+    );
+
+    // v1.23.2: Wire wikiEngine.updateStatusBar() so fix-runners' dynamic
+    // progress messages (e.g. "[3/10] fixing: path/to/file") reach the
+    // status bar, not just the static lint label.
+    this.wikiEngine.setStatusBarUpdateCallback(
+      (text: string) => {
+        if (this.ingestStatusBar) {
+          this.ingestStatusBar.setText(text);
+          this.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
         }
       }
     );
@@ -930,7 +945,7 @@ export default class LLMWikiPlugin extends Plugin {
           const restore = t.schemaDiffRestoreHint
             ? t.schemaDiffRestoreHint.replace('{path}', result.backupPath)
             : `Backup saved to ${result.backupPath}. To restore, rename that file back to wiki/schema/config.md in your file explorer.`;
-          new Notice(restore, 0);
+          new Notice(restore, NOTICE_RATE_LIMIT);
         } else {
           new Notice(t.schemaDiffFailed ?? 'Schema apply failed: ' + result.reason, NOTICE_ERROR);
         }

--- a/src/wiki/lint/controller.ts
+++ b/src/wiki/lint/controller.ts
@@ -314,7 +314,7 @@ export async function runLintWiki(
       } catch (e) {
         console.error('Duplicate detection failed:', e);
         const errMsg = e instanceof Error ? e.message : String(e);
-        const errNotice = new Notice(t.lintDuplicateCheckFailedDetail.replace('{step}', 'Layer 3 (LLM verify)').replace('{error}', errMsg), 0);
+        const errNotice = new Notice(t.lintDuplicateCheckFailedDetail.replace('{step}', 'Layer 3 (LLM verify)').replace('{error}', errMsg), NOTICE_ERROR);
         window.setTimeout(() => errNotice.hide(), NOTICE_RATE_LIMIT);
       }
     }
@@ -599,7 +599,7 @@ export async function runLintWiki(
             const msg = getText(ctx.settings.language, 'lintPollutedFixed')
               .replace('{fixed}', String(fixed))
               .replace('{total}', String(pollutedPages.length));
-            new Notice(msg, 0);
+            new Notice(msg, NOTICE_NORMAL);
           } finally {
             fixNotice.hide();
           }
@@ -618,7 +618,7 @@ export async function runLintWiki(
           }
           const msg = t.lintAliasesFilled.replace('{filled}', String(filled)).replace('{total}', String(aliasDeficientPages.length))
             + (filled > 0 ? '\n' + t.lintFixIndexUpdated : '');
-          new Notice(msg, 0);
+          new Notice(msg, NOTICE_NORMAL);
         });
       };
     }
@@ -633,7 +633,7 @@ export async function runLintWiki(
           }
           const msg = t.lintFixDeadComplete.replace('{fixed}', String(fixed)).replace('{total}', String(deadLinks.length))
             + (fixed > 0 ? '\n' + t.lintFixIndexUpdated : '');
-          new Notice(msg, 0);
+          new Notice(msg, NOTICE_NORMAL);
         });
       };
     }
@@ -648,7 +648,7 @@ export async function runLintWiki(
           }
           const msg = t.lintFillComplete.replace('{filled}', String(filled)).replace('{total}', String(emptyPages.length))
             + (filled > 0 ? '\n' + t.lintFixIndexUpdated : '');
-          new Notice(msg, 0);
+          new Notice(msg, NOTICE_NORMAL);
         });
       };
     }
@@ -674,7 +674,7 @@ export async function runLintWiki(
         if (parts.length === 0) {
           parts.push(t.lintDeleteCompleted.replace('{count}', '0'));
         }
-        new Notice(parts.join('\n'), 0);
+        new Notice(parts.join('\n'), NOTICE_NORMAL);
       });
     };
 
@@ -688,7 +688,7 @@ export async function runLintWiki(
           }
           const msg = t.lintLinkComplete.replace('{linked}', String(linked))
             + (linked > 0 ? '\n' + t.lintFixIndexUpdated : '');
-          new Notice(msg, 0);
+          new Notice(msg, NOTICE_NORMAL);
         });
       };
     }
@@ -703,7 +703,7 @@ export async function runLintWiki(
           }
           const msg = t.lintMergeComplete.replace('{merged}', String(merged)).replace('{total}', String(duplicates.length))
             + (merged > 0 ? '\n' + t.lintFixIndexUpdated : '');
-          new Notice(msg, 0);
+          new Notice(msg, NOTICE_NORMAL);
         });
       };
     }
@@ -725,7 +725,7 @@ export async function runLintWiki(
           const msg = fixed > 0
             ? t.lintTagViolationFixed.replace('{fixed}', String(fixed)).replace('{total}', String(tagViolations.length))
             : t.lintTagViolationFixedNone;
-          new Notice(msg, 0);
+          new Notice(msg, NOTICE_NORMAL);
         });
       };
     }
@@ -963,7 +963,7 @@ export async function runLintWiki(
       return;
     }
     const errMsg = error instanceof Error ? error.message : String(error);
-    new Notice(TEXTS[ctx.settings.language].lintWikiFailed + ': ' + errMsg, 0);
+    new Notice(TEXTS[ctx.settings.language].lintWikiFailed + ': ' + errMsg, NOTICE_ERROR);
     console.error(error);
   }
 }

--- a/src/wiki/query-engine.ts
+++ b/src/wiki/query-engine.ts
@@ -9,6 +9,7 @@ import { parseJsonResponse } from '../core/json';
 import { parseIndexForPages } from '../core/index-search';
 import { normalizeWikiLinkContent } from '../core/prompt-builders';
 import { extractThinkingBlocks } from '../core/markdown';
+import { buildTurnIndicator, observeVisibleTurn, scrollTurnToStart } from './turn-indicator';
 import { MAX_PAGE_CONTENT_CHARS, TOKENS_QUERY_LLM_SELECT, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_NORMAL, NOTICE_ERROR } from '../constants';
 import { pprCascade, type PageRef } from '../core/ppr-cascade';
 import { buildGraphFromContent, type LoadedPage } from '../core/build-graph';
@@ -180,6 +181,8 @@ export class QueryView extends ItemView {
   private _sectionLabels: ReturnType<typeof getSectionLabels> | null = null;
   /** Last PPR cascade result — for displaying retrieval source in the response UI. */
   private _lastRetrieval: { arm: string; count: number; topPaths: string[] } | null = null;
+  private _turnIndicator: HTMLElement | null = null;
+  private _turnObserver: IntersectionObserver | null = null;
   /**
    * v1.23.0 P2: Persistence health fix — when the user explicitly clears
    * history, onClose must NOT clobber the cleared state by writing
@@ -284,12 +287,15 @@ export class QueryView extends ItemView {
       cls: 'llm-wiki-query-history'
     });
 
-    this.history.messages.forEach(msg => {
-      this.renderHistoryMessage(msg.role, msg.content);
+    this.history.messages.forEach((msg, idx) => {
+      const turnIdx = Math.floor(idx / 2);
+      this.renderHistoryMessage(msg.role, msg.content, turnIdx);
     });
 
     // 自动滚动到最新的消息底部
     this.scrollToBottom();
+
+    this.rebuildTurnIndicator();
 
     const inputContainer = container.createDiv({
       cls: 'llm-wiki-query-input-container'
@@ -451,7 +457,8 @@ export class QueryView extends ItemView {
       timestamp: Date.now()
     });
 
-    this.renderHistoryMessage('user', userMessage);
+    const userTurnIdx = Math.floor((this.history.messages.length - 1) / 2);
+    this.renderHistoryMessage('user', userMessage, userTurnIdx);
     this.scrollToBottom();
 
     this.limitHistory();
@@ -465,8 +472,10 @@ export class QueryView extends ItemView {
     this.sendBtn.className = 'llm-wiki-query-stop-btn';
 
     // ChatGPT-style flat layout: full-width message div
+    const assistantTurnIdx = Math.floor((this.history.messages.length - 1) / 2);
     const messageDiv = this.historyContainer.createDiv({
-      cls: 'llm-wiki-query-message-wrapper llm-wiki-query-message-assistant llm-wiki-query-response-live'
+      cls: 'llm-wiki-query-message-wrapper llm-wiki-query-message-assistant llm-wiki-query-response-live',
+      attr: { 'data-turn': String(assistantTurnIdx) }
     });
 
     messageDiv.createDiv({
@@ -734,6 +743,22 @@ export class QueryView extends ItemView {
         .replace('{}', currentRounds.toString())
         .replace('{}', maxRounds.toString())
     );
+
+    // v1.23.2 (#221 Variant 2): scroll-to-start on completion so the
+    // user lands at the beginning of the answer, not the very bottom.
+    this.scrollToStartOfCurrentTurn();
+
+    this.rebuildTurnIndicator();
+  }
+
+  private scrollToStartOfCurrentTurn(): void {
+    const lastTurnIdx = Math.floor((this.history.messages.length - 2) / 2);
+    if (lastTurnIdx < 0) return;
+    const turns = this.historyContainer.querySelectorAll('[data-turn]');
+    const target = turns[lastTurnIdx];
+    if (target) {
+      scrollTurnToStart(target as HTMLElement);
+    }
   }
 
   renderMarkdownContent(content: string, container: HTMLElement) {
@@ -804,6 +829,40 @@ export class QueryView extends ItemView {
   }
 
   /**
+   * v1.23.2 (#221 Variant 2): rebuild the right-edge turn indicator
+   * whenever the conversation changes. Clicking a dot scrolls that
+   * turn to the top of the history container.
+   */
+  private rebuildTurnIndicator(): void {
+    if (this._turnObserver) {
+      this._turnObserver.disconnect();
+      this._turnObserver = null;
+    }
+
+    const turnCount = Math.floor(this.history.messages.length / 2);
+    if (turnCount === 0) {
+      if (this._turnIndicator) {
+        this._turnIndicator.remove();
+        this._turnIndicator = null;
+      }
+      return;
+    }
+
+    this._turnIndicator = buildTurnIndicator(
+      this.historyContainer,
+      turnCount - 1,
+      (idx) => this.scrollToTurn(idx)
+    );
+    this._turnObserver = observeVisibleTurn(this.historyContainer, this._turnIndicator);
+  }
+
+  private scrollToTurn(idx: number): void {
+    const turns = this.historyContainer.querySelectorAll('[data-turn]');
+    if (!turns[idx]) return;
+    scrollTurnToStart(turns[idx] as HTMLElement);
+  }
+
+  /**
    * v1.23.0 P2: rAF-coalesced streaming render. Each onChunk call
    * appends to accumulatedResponse and schedules a single
    * requestAnimationFrame callback. If more chunks arrive before the
@@ -822,11 +881,15 @@ export class QueryView extends ItemView {
     });
   }
 
-  renderHistoryMessage(role: 'user' | 'assistant', content: string) {
+  renderHistoryMessage(role: 'user' | 'assistant', content: string, turnIdx?: number) {
 
     const messageDiv = this.historyContainer.createDiv({
       cls: ['llm-wiki-query-message-wrapper', role === 'user' ? 'llm-wiki-query-message-user' : 'llm-wiki-query-message-assistant']
     });
+
+    if (turnIdx !== undefined) {
+      messageDiv.setAttribute('data-turn', String(turnIdx));
+    }
 
     messageDiv.createDiv({
       cls: 'llm-wiki-query-message-label',
@@ -903,9 +966,11 @@ export class QueryView extends ItemView {
       );
 
       this.historyContainer.empty();
-      this.history.messages.forEach(msg => {
-        this.renderHistoryMessage(msg.role, msg.content);
+      this.history.messages.forEach((msg, idx) => {
+        const turnIdx = Math.floor(idx / 2);
+        this.renderHistoryMessage(msg.role, msg.content, turnIdx);
       });
+      this.rebuildTurnIndicator();
     }
   }
 

--- a/src/wiki/query-engine.ts
+++ b/src/wiki/query-engine.ts
@@ -754,8 +754,11 @@ export class QueryView extends ItemView {
   private scrollToStartOfCurrentTurn(): void {
     const lastTurnIdx = Math.floor((this.history.messages.length - 2) / 2);
     if (lastTurnIdx < 0) return;
-    const turns = this.historyContainer.querySelectorAll('[data-turn]');
-    const target = turns[lastTurnIdx];
+    // Scroll to the USER question of the current turn, not the assistant
+    // answer, so the user sees the question that triggered this response.
+    const target = this.historyContainer.querySelector(
+      `.llm-wiki-query-message-user[data-turn="${lastTurnIdx}"]`
+    );
     if (target) {
       scrollTurnToStart(target as HTMLElement);
     }
@@ -848,18 +851,27 @@ export class QueryView extends ItemView {
       return;
     }
 
+    const turnLabels: string[] = [];
+    for (let i = 0; i < this.history.messages.length; i += 2) {
+      const userMsg = this.history.messages[i];
+      turnLabels.push(userMsg?.role === 'user' ? userMsg.content.slice(0, 120) : '');
+    }
+
     this._turnIndicator = buildTurnIndicator(
       this.historyContainer,
       turnCount - 1,
+      turnLabels,
       (idx) => this.scrollToTurn(idx)
     );
     this._turnObserver = observeVisibleTurn(this.historyContainer, this._turnIndicator);
   }
 
   private scrollToTurn(idx: number): void {
-    const turns = this.historyContainer.querySelectorAll('[data-turn]');
-    if (!turns[idx]) return;
-    scrollTurnToStart(turns[idx] as HTMLElement);
+    const target = this.historyContainer.querySelector(
+      `.llm-wiki-query-message-user[data-turn="${idx}"]`
+    );
+    if (!target) return;
+    scrollTurnToStart(target as HTMLElement);
   }
 
   /**
@@ -949,6 +961,22 @@ export class QueryView extends ItemView {
       cls: 'llm-wiki-query-retrieval-label',
     });
     label.setText(`🔍 ${r.count} page(s) · ${armDisplay}`);
+    // v1.23.2: click to expand/collapse the list of retrieved pages
+    // inline below the label (no Notice).
+    const detail = messageWrapper.createDiv({
+      cls: 'llm-wiki-query-retrieval-detail',
+    });
+    r.topPaths.forEach(p => {
+      const rel = p.replace(this.plugin.settings.wikiFolder + '/', '').replace('.md', '');
+      const pageDiv = detail.createDiv({ cls: 'llm-wiki-query-retrieval-page' });
+      pageDiv.setText(`📄 [[${rel}]]`);
+    });
+
+    label.addClass('llm-wiki-query-retrieval-label-clickable');
+    label.addEventListener('click', (evt) => {
+      evt.stopPropagation();
+      detail.classList.toggle('llm-wiki-query-retrieval-detail-open');
+    });
   }
 
   limitHistory() {

--- a/src/wiki/turn-indicator.ts
+++ b/src/wiki/turn-indicator.ts
@@ -33,6 +33,7 @@ export function findTurnElements(historyContainer: HTMLElement): HTMLElement[] {
 export function buildTurnIndicator(
   historyContainer: HTMLElement,
   activeTurn: number,
+  turnLabels: string[],
   onDotClick: (turn: number) => void,
 ): HTMLElement {
   const existing = historyContainer.querySelector(`.${INDICATOR_CLASS}`);
@@ -43,13 +44,24 @@ export function buildTurnIndicator(
 
   const turns = findTurnElements(historyContainer);
   turns.forEach((_, idx) => {
+    const wrapper = historyContainer.ownerDocument.createElement('div');
+    wrapper.className = 'llm-wiki-turn-dot-wrapper';
+
     const dot = historyContainer.ownerDocument.createElement('div');
     dot.className = DOT_CLASS;
     if (idx === activeTurn) {
       dot.classList.add(ACTIVE_CLASS);
     }
     dot.addEventListener('click', () => onDotClick(idx));
-    indicator.appendChild(dot);
+    wrapper.appendChild(dot);
+
+    const label = turnLabels[idx]?.trim();
+    const tip = historyContainer.ownerDocument.createElement('div');
+    tip.className = 'llm-wiki-turn-dot-tooltip';
+    tip.textContent = label || `Turn ${idx + 1}`;
+    wrapper.appendChild(tip);
+
+    indicator.appendChild(wrapper);
   });
 
   historyContainer.appendChild(indicator);

--- a/src/wiki/turn-indicator.ts
+++ b/src/wiki/turn-indicator.ts
@@ -1,0 +1,117 @@
+/**
+ * ChatGPT/Grok-style vertical turn indicator.
+ *
+ * Variant 2 only (per v1.23.2 scope): right-edge dots, one per turn,
+ * with IntersectionObserver-driven active highlighting. Clicking a dot
+ * scrolls the corresponding turn into view at the top of the history
+ * container.
+ *
+ * No sticky "turn N/M" header (Variant 1 rejected).
+ * No turn-preview tooltip (Variant 3 rejected).
+ */
+
+const INDICATOR_CLASS = 'llm-wiki-turn-indicator';
+const DOT_CLASS = 'llm-wiki-turn-dot';
+const ACTIVE_CLASS = 'llm-wiki-turn-dot-active';
+const TURN_ATTR = 'data-turn';
+
+/** Find one representative element per turn, in document order. */
+export function findTurnElements(historyContainer: HTMLElement): HTMLElement[] {
+  const seen = new Set<string>();
+  const reps: HTMLElement[] = [];
+  const wrappers = historyContainer.querySelectorAll('.llm-wiki-query-message-wrapper');
+  wrappers.forEach((el) => {
+    const turn = el.getAttribute(TURN_ATTR);
+    if (!turn || seen.has(turn)) return;
+    seen.add(turn);
+    reps.push(el as HTMLElement);
+  });
+  return reps;
+}
+
+/** Rebuild the indicator to match the current number of turns. */
+export function buildTurnIndicator(
+  historyContainer: HTMLElement,
+  activeTurn: number,
+  onDotClick: (turn: number) => void,
+): HTMLElement {
+  const existing = historyContainer.querySelector(`.${INDICATOR_CLASS}`);
+  if (existing) existing.remove();
+
+  const indicator = historyContainer.ownerDocument.createElement('div');
+  indicator.className = INDICATOR_CLASS;
+
+  const turns = findTurnElements(historyContainer);
+  turns.forEach((_, idx) => {
+    const dot = historyContainer.ownerDocument.createElement('div');
+    dot.className = DOT_CLASS;
+    if (idx === activeTurn) {
+      dot.classList.add(ACTIVE_CLASS);
+    }
+    dot.addEventListener('click', () => onDotClick(idx));
+    indicator.appendChild(dot);
+  });
+
+  historyContainer.appendChild(indicator);
+  return indicator;
+}
+
+/** Move the active class to the dot for `turnIdx`. */
+export function updateActiveDot(indicator: HTMLElement, turnIdx: number): void {
+  const dots = indicator.querySelectorAll(`.${DOT_CLASS}`);
+  dots.forEach((dot, idx) => {
+    if (idx === turnIdx) {
+      dot.classList.add(ACTIVE_CLASS);
+    } else {
+      dot.classList.remove(ACTIVE_CLASS);
+    }
+  });
+}
+
+/** Scroll a turn element to the top of its scroll container. */
+export function scrollTurnToStart(
+  turnElement: HTMLElement,
+  scrollFn?: (options: ScrollIntoViewOptions) => void,
+): void {
+  const options: ScrollIntoViewOptions = { block: 'start', behavior: 'smooth' };
+  if (scrollFn) {
+    scrollFn(options);
+    return;
+  }
+  turnElement.scrollIntoView(options);
+}
+
+/** Create an IntersectionObserver that updates the active dot. */
+export function observeVisibleTurn(
+  historyContainer: HTMLElement,
+  indicator: HTMLElement,
+): IntersectionObserver {
+  const turns = findTurnElements(historyContainer);
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      // Pick the entry with the largest intersection ratio.
+      let best: IntersectionObserverEntry | null = null;
+      for (const entry of entries) {
+        if (!best || entry.intersectionRatio > best.intersectionRatio) {
+          best = entry;
+        }
+      }
+      if (!best) return;
+
+      const turn = best.target.getAttribute(TURN_ATTR);
+      if (!turn) return;
+      const idx = turns.findIndex((t) => t.getAttribute(TURN_ATTR) === turn);
+      if (idx >= 0) {
+        updateActiveDot(indicator, idx);
+      }
+    },
+    {
+      root: historyContainer,
+      threshold: [0, 0.25, 0.5, 0.75, 1],
+    },
+  );
+
+  turns.forEach((t) => observer.observe(t));
+  return observer;
+}

--- a/styles.css
+++ b/styles.css
@@ -313,6 +313,40 @@
   max-width: 80%;
 }
 
+/* v1.23.2 (#221 Variant 2): vertical turn indicator on the right edge. */
+.llm-wiki-turn-indicator {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 6px 4px;
+  background: var(--background-primary-alt, var(--background-primary));
+  border: 1px solid var(--background-modifier-border-hover);
+  border-radius: 12px;
+  z-index: 5;
+}
+
+.llm-wiki-turn-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.llm-wiki-turn-dot:hover {
+  background: var(--text-muted);
+  transform: scale(1.25);
+}
+
+.llm-wiki-turn-dot-active {
+  background: var(--interactive-accent);
+}
+
 .llm-wiki-query-message-assistant .llm-wiki-query-message-body {
   /* markdown rendered by Obsidian has its own styling */
 }

--- a/styles.css
+++ b/styles.css
@@ -106,7 +106,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 12px;
+  padding: 12px 50px 12px 12px;
   background: var(--background-primary);
 }
 
@@ -295,6 +295,35 @@
   padding-top: 6px;
 }
 
+.llm-wiki-query-retrieval-label-clickable {
+  cursor: pointer;
+}
+.llm-wiki-query-retrieval-label-clickable:hover {
+  opacity: 1;
+  color: var(--text-normal);
+}
+
+.llm-wiki-query-retrieval-detail {
+  display: none;
+  margin-top: 4px;
+  padding: 6px 10px;
+  background: var(--background-secondary);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text-normal);
+  font-family: var(--font-monospace);
+  border-left: 2px solid var(--interactive-accent);
+}
+
+.llm-wiki-query-retrieval-detail-open {
+  display: block;
+}
+
+.llm-wiki-query-retrieval-page {
+  padding: 2px 0;
+  line-height: 1.5;
+}
+
 .llm-wiki-query-message-user {
   display: flex;
   flex-direction: column;
@@ -316,7 +345,7 @@
 /* v1.23.2 (#221 Variant 2): vertical turn indicator on the right edge. */
 .llm-wiki-turn-indicator {
   position: absolute;
-  right: 8px;
+  right: 36px;
   top: 50%;
   transform: translateY(-50%);
   display: flex;
@@ -345,6 +374,39 @@
 
 .llm-wiki-turn-dot-active {
   background: var(--interactive-accent);
+}
+
+/* Tooltip visible on hover, positioned to the left of the dot */
+.llm-wiki-turn-dot-tooltip {
+  display: none;
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--background-secondary-alt, var(--background-secondary));
+  color: var(--text-normal);
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: nowrap;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  z-index: 10;
+  border: 1px solid var(--background-modifier-border);
+}
+
+.llm-wiki-turn-dot-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.llm-wiki-turn-dot-wrapper:hover .llm-wiki-turn-dot-tooltip {
+  display: block;
 }
 
 .llm-wiki-query-message-assistant .llm-wiki-query-message-body {


### PR DESCRIPTION
This PR implements the v1.23.2 UX improvements.

## #219 — Semantic-driven progress notifications
- New : .
- **No new user-facing setting.** Display channel is derived from operation semantics:
  - : user-triggered operations (manual ingest, manual lint, manual smart-fix).
  - : background operations (watch-mode auto-ingest, periodic lint, startup auto-maintenance).
- Replaced 7 ad-hoc  call sites in  with scope-aware .
- Legacy  kept as a backward-compatible alias defaulting to .

## #221 — Query scroll-to-start + Variant 2 vertical dots indicator
- Stream-to-bottom during generation is preserved.
- On completion the view scrolls to the start of the current turn.
- Added : ChatGPT/Grok-style right-edge vertical dots.
  - One dot per turn (user + assistant pair).
  -  highlights the dot for the currently visible turn.
  - Clicking a dot calls .
- Wired into :  attributes on every message wrapper; indicator rebuilt on open, after each completed turn, and after history truncation.
- Added styles for  / ; no .
- Explicitly **not** implemented: Variant 1 (sticky 'turn N/M' header) and Variant 3 (turn preview tooltip) per scope agreement.

## Quality
- Gate 1: 
> karpathywiki@1.23.1 lint /Users/greener/project/obsidian-llm-wiki
> eslint src/ --max-warnings=0, , 
> karpathywiki@1.23.1 test /Users/greener/project/obsidian-llm-wiki
> vitest run


 RUN  v4.1.6 /Users/greener/project/obsidian-llm-wiki


 Test Files  104 passed (104)
      Tests  1398 passed (1398)
   Start at  18:41:26
   Duration  5.09s (transform 2.79s, setup 1.11s, import 5.90s, tests 7.93s, environment 795ms), 
> karpathywiki@1.23.1 build /Users/greener/project/obsidian-llm-wiki
> node esbuild.config.mjs production, 
> karpathywiki@1.23.1 css-lint /Users/greener/project/obsidian-llm-wiki
> node scripts/css-lint.mjs

✓ css-lint: /Users/greener/project/obsidian-llm-wiki/styles.css passed (0 violations) all pass.
- 1398 tests passing (104 test files).
- New tests:  (8),  (4).

/cc @jameses-cyber for behavioral confirmation on #219 and #221 Variant 2.