### PR TITLE
fix: canonicalize LLM-garbled section headers on write

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizeSectionHeaders } from '../../core/section-header-canonicalizer';
+
+describe('canonicalizeSectionHeaders (deterministic repair of LLM-garbled section headers)', () => {
+  // The de labels the model is handed and expected to copy verbatim.
+  const DE = [
+    'Grundlegende Informationen', 'Beschreibung', 'Verwandte Inhalte',
+    'Erwähnungen in der Quelle', 'Neue Informationen', 'Definition',
+    'Hauptmerkmale', 'Anwendungen', 'Verwandte Konzepte', 'Verwandte Entitäten',
+    'Quelle', 'Kerninhalt', 'Wichtige Entitäten', 'Wichtige Konzepte',
+    'Hauptpunkte', 'Aufgelöste Widersprüche', 'Neue Behauptung',
+    'Bestehendes Wissen', 'Lösungsvorschlag', 'Quellseite',
+    'Verwandte Seiten', 'Aktualisiert',
+  ];
+
+  // --- Named regression cases: the four real garbles from the S29 clean re-ingest. ---
+  it.each([
+    ['Erwägungen in der Quelle'],
+    ['Erwurnungen in der Quelle'],
+    ['Erwährungen in der Quelle'],
+    ['Erwnungen in der Quelle'],
+  ])('[garbled-mentions-header] snaps "## %s" back to the canonical label', (garbled) => {
+    const r = canonicalizeSectionHeaders(`## ${garbled}`, DE);
+    expect(r).toBe('## Erwähnungen in der Quelle');
+  });
+
+  // --- Negative coverage: it must never rewrite a correct or unrelated header. ---
+
+  it('[exact-label] leaves an exact canonical label untouched', () => {
+    const c = ['## Verwandte Entitäten', '## Erwähnungen in der Quelle'].join('\n');
+    expect(canonicalizeSectionHeaders(c, DE)).toBe(c);
+  });
+
+  it('[distinct-content-header] does not snap a genuine content header that is far from every label', () => {
+    const c = '## Pathophysiologie und klinische Relevanz';
+    expect(canonicalizeSectionHeaders(c, DE)).toBe(c);
+  });
+
+  it('[h1-and-frontmatter-safe] never touches the H1 title or non-H2 lines', () => {
+    const c = ['# Erwägungen', '### Erwägungen', 'Erwägungen in der Quelle'].join('\n');
+    expect(canonicalizeSectionHeaders(c, DE)).toBe(c);
+  });
+
+  it('[bounded] does not snap a header beyond MAX_DISTANCE edits from any label', () => {
+    // "Verwandte Publikationen" is >3 edits from "Verwandte Konzepte"/"Verwandte Seiten".
+    const c = '## Verwandte Publikationen';
+    expect(canonicalizeSectionHeaders(c, DE)).toBe(c);
+  });
+
+  it('preserves the rest of the page verbatim while fixing only the garbled header', () => {
+    const page = [
+      '# Apoptose',
+      '',
+      '## Verwandte Entitäten',
+      '- [[entities/Caspase|Caspase]]',
+      '',
+      '## Erwägungen in der Quelle',
+      '- "a verbatim quote" — [[sources/Biochemie-Signalwege]]',
+    ].join('\n');
+    const r = canonicalizeSectionHeaders(page, DE);
+    expect(r).toContain('## Erwähnungen in der Quelle');
+    expect(r).not.toContain('Erwägungen');
+    expect(r).toContain('- [[entities/Caspase|Caspase]]');
+  });
+});

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -1,0 +1,63 @@
+// Section-header canonicalizer — deterministic repair of LLM-garbled section headers.
+// Pure, no LLM, O(lines × labels).
+//
+// The generation/merge prompts hand the model the exact section labels
+// (`## {{section_...}}` resolved via applySectionLabels) and it is expected to copy
+// them verbatim into the page. A local model occasionally garbles one on the way
+// out — observed on the longest, rarest label under `wikiLanguage: de`:
+// `## Erwähnungen in der Quelle` came back as `## Erwägungen…`, `## Erwurnungen…`,
+// `## Erwährungen…`, `## Erwnungen…`. This is not a sampling artifact — at extraction
+// temperature the correct token dominates by a wide logprob margin and neither
+// repetition_penalty nor temperature moves it; it surfaces only under full-length
+// generation. The parser (`getSectionLabels` consumers: query-engine, page-factory,
+// contradictions) matches labels EXACTLY, so a garbled header silently drops that
+// section from Tier-B retrieval.
+//
+// The label is a known structural fact, so re-assert it after generation rather than
+// trusting the copy — the same move `correctRelatedLinkPrefixes` makes for link folders.
+// Bounded so it only heals genuine near-misses and never rewrites a real content header:
+// a header is snapped only when it is within MAX_DISTANCE edits of exactly one canonical
+// label AND strictly closer to it than to any other (the smallest distance between two
+// canonical labels is 4, so the window is unambiguous). Exact labels short-circuit.
+
+const MAX_DISTANCE = 3;
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const cur = [i];
+    for (let j = 1; j <= b.length; j++) {
+      cur[j] = Math.min(
+        prev[j] + 1,
+        cur[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      );
+    }
+    prev = cur;
+  }
+  return prev[b.length];
+}
+
+export function canonicalizeSectionHeaders(content: string, canonicalLabels: string[]): string {
+  const canonical = new Set(canonicalLabels);
+
+  const snap = (header: string): string | null => {
+    if (canonical.has(header)) return null; // exact — leave untouched
+    let best = Infinity, second = Infinity, bestLabel: string | null = null;
+    for (const label of canonicalLabels) {
+      const d = levenshtein(header, label);
+      if (d < best) { second = best; best = d; bestLabel = label; }
+      else if (d < second) { second = d; }
+    }
+    if (bestLabel !== null && best <= MAX_DISTANCE && best < second) return bestLabel;
+    return null; // too far, or ambiguous
+  };
+
+  return content.split('\n').map(line => {
+    const m = /^(##\s+)(.+?)\s*$/.exec(line);
+    if (!m) return line;
+    const target = snap(m[2]);
+    return target ? `${m[1]}${target}` : line;
+  }).join('\n');
+}

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -15,6 +15,7 @@ import { WIKI_SUBFOLDERS } from '../constants';
 import { TOKENS_DEDUP_RESOLUTION, TOKENS_PAGE_GENERATION, TOKENS_APPEND_REVIEWED } from '../constants';
 import { slugify, filterRedundantAliases } from '../core/slug';
 import { correctRelatedLinkPrefixes } from '../core/related-link-corrector';
+import { canonicalizeSectionHeaders } from '../core/section-header-canonicalizer';
 import { parseJsonResponse } from '../core/json';
 import { parseFrontmatter, mergeFrontmatter, enforceFrontmatterConstraints } from '../core/frontmatter';
 import { truncateMentions } from '../core/report';
@@ -371,8 +372,11 @@ export class PageFactory {
     // Re-assert the known type of related links (deterministic; fixes the model's
     // `sources/` guess against a truncated existing-pages list).
     const labels = getSectionLabels(this.ctx.settings);
+    // Re-assert the known section labels before the link corrector runs, so a garbled
+    // `## Verwandte …` header still resolves its section for prefix correction.
+    const canonicalizedContent = canonicalizeSectionHeaders(enforcedContent, Object.values(labels));
     const correctedContent = correctRelatedLinkPrefixes(
-      enforcedContent,
+      canonicalizedContent,
       info.related_entities,
       info.related_concepts,
       labels.related_entities,
@@ -437,8 +441,9 @@ export class PageFactory {
 
     // 3. Assemble final content (re-assert related-link types deterministically)
     const labels = getSectionLabels(this.ctx.settings);
+    const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
     const correctedBody = correctRelatedLinkPrefixes(
-      cleanedBody,
+      canonicalizedBody,
       info.related_entities,
       info.related_concepts,
       labels.related_entities,


### PR DESCRIPTION
## Problem

A local model occasionally garbles a section label as it writes a page. Under
`wikiLanguage: de`, the longest and rarest label — `## Erwähnungen in der Quelle`
— came back in four different corrupted forms across a single clean re-ingest:
`## Erwägungen…`, `## Erwurnungen…`, `## Erwährungen…`, `## Erwnungen…`.

Because the `getSectionLabels` consumers (query-engine, page-factory,
contradictions) match section labels exactly, a garbled header silently drops
that section from Tier-B retrieval — the content is written but unreachable.

## Fix

The label is a known structural fact, handed to the model in the prompt via
`applySectionLabels`. So re-assert it after generation rather than trusting the
copy — exactly as `correctRelatedLinkPrefixes` already re-asserts link folders.

`canonicalizeSectionHeaders` (new, pure, no LLM) snaps a `##` header to a
canonical label only when it is within a bounded edit distance (≤3) of exactly
one label and strictly closer to it than to any other. The smallest distance
between two canonical labels is 4, so the window is unambiguous; exact labels
and genuine content headers are never rewritten. Wired on both the create and
merge paths, before the link corrector so a garbled `## Verwandte …` header
still resolves its own section for prefix repair.

## Not a sampling knob

Ruled out before writing the corrector: at extraction temperature the correct
header token dominates by a wide logprob margin, and sweeping `repeat_penalty`
1.0→1.3 and temperature leaves it unmoved — the garble only surfaces under
full-length generation. An on-write re-assertion is therefore the reliable fix,
not a sampling-config tweak.

## The minimal fix, not the root one

On-write re-assertion is the low-risk step, matching the existing
`correctRelatedLinkPrefixes` pattern. The root fix is to not hand the label to
the model at all: the section labels — and the verbatim quotes the prompt
already tells it to copy `as-is` from the structured `mentions_in_source` input
— are deterministic scaffolding that could be assembled in code, leaving the
model only the prose and the links. Happy to open that as its own issue if
it's worth pursuing.

## Tests

9 new cases (the four real garbles + exact-label / content-header / H1 /
bounded-distance negatives), full suite green (1395), `tsc` clean.
