### PR TITLE
feat: v1.24.0 P2 — modals split, Query Wiki fixes, PPR warmup, #251 custom instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`controller.ts` `runLintWiki` god function split into 3 phase modules (PR #248).** `src/wiki/lint/controller.ts:runLintWiki` (was a monolithic 200+ LOC function) decomposed into Phases A/B/C (`src/wiki/lint/llm-phases/analysis-phase.ts`, `src/wiki/lint/llm-phases/scoring-phase.ts`, `src/wiki/lint/llm-phases/synthesis-phase.ts`). The orchestrator now delegates: analysis → scoring → synthesis. Behavioral regression protected by existing 1616 test suite.
+- **`history-modal.ts` 1579-LOC single file split into directory (PR #249).** `src/ui/history-modal.ts` → `src/ui/history-modal/` with 14 files (~250 LOC each max): `types.ts`, `render-state.ts`, `HistoryModal-class.ts`, 9 renderer modules under `src/ui/history-modal/renderers/`, and an `index.ts` re-export shim. External API (`HistoryModal` class, `TEXTS`-based `HistoryTexts`) unchanged. Zero caller-side changes required. 1610 tests passing.
+- **`query-engine.ts` 1373-LOC monolith split into directory (PR #250).** `src/wiki/query-engine.ts` → 13 focused modules under `src/wiki/query-engine/`. `QueryView.buildWikiContext` (was 165 LOC inline) decomposes into 4 pure pipeline phases. External API (`QueryView`, `VIEW_TYPE_QUERY`, `renderThinkingBlocksUI`) unchanged via TypeScript directory resolution. 1616 tests passing.
+
 ## [1.23.2] - 2026-07-05
 
 **Theme:** Five merged PRs — bug fixes, refactor, and UX polish. 1431 tests passing. No new user-facing settings. Recommended upgrade for everyone on v1.23.0+.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-07-05
+**Last Updated:** 2026-07-06
 
 ---
 
@@ -15,6 +15,15 @@ Architectural items deferred from v1.23.0–v1.23.2 cycle:
 - **Hub-retirement lint wire-up** — `core/hub-retirement.ts` (0 callers) → wire `assessHubs` into lint path. Owned by @DocTpoint.
 - **#169 estimated-time-remaining** — velocity window + batch telemetry; needs tracking issue.
 - **LintFixer → module-level functions split** — 707-LOC god class.
+
+### Deleted (v1.24.0) — Monolith splits
+
+The following files were split into sub-module directories (same pattern as PR #2/#3):
+
+- ✅ **controller.ts (PR #248, 2026-07-02)** — `runLintWiki` god function → 3 phase modules (`llm-phases/analysis-phase.ts`, `scoring-phase.ts`, `synthesis-phase.ts`).
+- ✅ **history-modal.ts (PR #249, 2026-07-02)** — 1579 LOC → `src/ui/history-modal/` (14 files).
+- ✅ **query-engine.ts (PR #250, 2026-07-06)** — 1373 LOC → `src/wiki/query-engine/` (15 files).
+- ⏳ LintFixer → module-level functions (707-LOC god class) — **pending**.
 
 ### Discussion-only (NOT in v1.24.0)
 
@@ -37,6 +46,8 @@ Five merged PRs (#239 + #240 + #238 + #241). **1431 tests passing** across 108 f
 - ✅ **License upgrade** — MIT → Apache 2.0 + DCO. NOTICE file lists all 6 human code contributors.
 - ✅ **Notice TTL compliance** — Lint completion Notices now use `NOTICE_NORMAL`/`NOTICE_ERROR`
 
+**v1.23.2 test count:** 1431 tests → 1616 tests (3 monolith split PRs added ~90 tests for controller.ts/#248, history-modal.ts/#249, query-engine.ts/#250). 115 test files.
+
 - v1.23.0 (2026-07-02, MINOR) — Graph Engine PPR + Vercel AI-SDK v6 + Multi-File Ingest + Sponsor section. 1376 tests. Closes #117/#130/#137/#141/#143/#147/#157/#175/#198/#204/#215/#223.
 - v1.22.6 (2026-06-30, hotfix) — #204 Auto Ingest modal + Auto Smart Fix context-aware + #207 GPT-5 Pro variants routing. 1118 tests.
 - v1.22.5 (2026-06-29) — Responses API path for reasoning model family + provider body in Notice. 1104 tests.
@@ -58,11 +69,31 @@ Five merged PRs (#239 + #240 + #238 + #241). **1431 tests passing** across 108 f
 - knn + cascade by-query-type complement (DocTpoint #198 follow-up, 2026-06-30)
 
 **Deferred to v1.24.0+:**
-- #220 Source-revision awareness (Discussion thread needed first)
-- #218 PDF source ingest → Discussion #222 topology
-- Hub-retirement lint wire-up (post-#215)
-- #36 source-title-in-extraction (low ROI vs PPR cascade)
-- LintFixer class → module-level functions (707-LOC god class split, 1 day)
+
+With 3 monolith splits (controller.ts/#248 ✅, history-modal.ts/#249 ✅, query-engine.ts/#250 ✅) done, remaining items in the v1.24.0 backlog:
+
+- **LintFixer → module-level functions** (707-LOC god class split, ~1 day) — the next monolith split candidate.
+- **#220 Source-revision awareness** (Discussion thread needed first)
+- **#218 PDF source ingest** → Discussion #222 topology
+- **Hub-retirement lint wire-up** (`core/hub-retirement.ts` 0 callers, post-#215)
+- **#36 source-title-in-extraction** (low ROI vs PPR cascade)
+- **knn + cascade by-query-type complement** (DocTpoint #198 follow-up, 2026-06-30)
+- **#169 estimated-time-remaining** — velocity window + batch telemetry; needs tracking issue.
+
+**Non-blocking i18n altitude items (deferred from PR #250 code-review, **APPROVED FOR P1** — see `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_remaining_split_roi.md`):**
+- Hardcoded '🤖 Wiki' / '👤 You' assistant labels in `history-message.ts` and `QueryView-class.ts`
+- Hardcoded 'page(s)' pluralization in `retrieval-label.ts`
+- `as unknown as Record<string, string>` TEXTS casts (7 sites) — type safety debt
+
+**Approved monolith-split remaining (Q3 2026 backlog):**
+- **P0: `src/ui/modals.ts` → `src/ui/modals/` (7 modal classes, 1008 LOC, 0.5 day)** — highest ROI after #248/#249/#250 series
+- **P2: `src/wiki/wiki-engine.ts` (1391 LOC, `WikiEngine` god class, 44 methods × 20+ fields, 2-3 days)** — main v1.24.0 MINOR candidate
+- **P3: `src/schema/auto-maintain.ts` (756 LOC, 4 lifecycle intertwining, 1-1.5 days)** — post v1.24.0 MINOR
+
+**明确不做 (false backlog items / Obsidian lifecycle / low ROI):**
+- ❌ `src/main.ts` (1106 LOC) — `class LLMWikiPlugin extends Plugin` 是 Obsidian lifecycle 入口，**永远不应该拆**
+- ❌ `src/wiki/lint/fix-runners.ts` (500 LOC) — 500 LOC 期望边界内，非 god class
+- ❌ `src/core/` 平铺 (51 files / 9200 LOC) — 49 个文件内期望边界，重新组织 ROI 低、caller 调整风险高
 
 **Deferred to v1.25.0+ (research / experimental):**
 - Cold-start vocabulary seeding — rejected on ROI grounds (cascade R@5 27.1% vs knn 24.1% = 3pp gap).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,14 +114,21 @@ src/
 │   └── smoke-test.ts           # LLM configuration verification wrapper (v1.23.0)
 ├── wiki/                # Wiki engine modules
 │   ├── wiki-engine.ts   # Orchestrator (ingest, lint, log)
-│   ├── query-engine.ts  # Conversational query with streaming + thinking UI
+│   ├── query-engine/    # Conversational query with streaming + thinking UI
+│   │   ├── index.ts                           # re-export shim
+│   │   ├── types.ts + state.ts                # type declarations + InternalView
+│   │   ├── QueryView-class.ts                 # ItemView (+ delegates renderers + pipeline)
+│   │   ├── SuggestSaveModal-class.ts          # post-query feedback Modal
+│   │   ├── renderers/                         # 6 pure-function modules
+│   │   └── pipeline/                          # 5 pure-function modules
 │   ├── source-analyzer.ts # Iterative batch extraction
 │   ├── page-factory.ts  # Entity/concept CRUD + merge
 │   ├── conversation-ingest.ts # Chat → wiki knowledge
 │   ├── contradictions.ts # Contradiction detection
 │   ├── system-prompts.ts # Language directive + section labels
+│   ├── turn-indicator.ts # Right-edge vertical dot conversation nav (v1.23.2, #221)
 │   ├── lint/            # Lint subsystem
-│   │   ├── controller.ts         # Lint orchestration
+│   │   ├── controller.ts         # Lint orchestration + 3 phase modules
 │   │   ├── fix-runners.ts        # Batch fix execution helpers
 │   │   ├── scanners.ts           # Scanners (dead links, orphans, aliases, quote grounding)
 │   │   ├── duplicate-detection.ts # Programmatic candidate generation
@@ -143,9 +150,9 @@ src/
 │   ├── schema-manager.ts # SchemaManager (read/write schema config)
 │   ├── auto-maintain.ts # File watcher, periodic lint, startup quick fixes
 │   └── analyze.ts       # Schema-analyze with cancel wiring
-├── ui/                  # Settings + Modals
+├── ui/                  # Settings + history-modal/ (14-file split)
 ├── texts/               # i18n (9 languages)
-└── __tests__/           # Unit tests (vitest, 1431 tests across 108 files)
+└── __tests__/           # Unit tests (vitest, 1616 tests across 115 files)
 ```
 
 ## Internationalization
@@ -181,16 +188,16 @@ graph TD
     User -->|Cmd+P| main.ts
     main.ts -->|ingest| WikiEngine
     main.ts -->|query| QueryEngine
-    main.ts -->|lint| lint("lint/controller.ts")
+    main.ts -->|lint| lint("lint/controller.ts + 3 phase modules")
 
     WikiEngine -->|analyze| SourceAnalyzer
     WikiEngine -->|CRUD + merge| PageFactory
     WikiEngine -->|write| Vault
 
-    QueryEngine -->|local match| localKeywordMatch["localKeywordMatch (Layer 1)"]
-    QueryEngine -->|LLM select| selectRelevantPagesWithLLM["selectRelevantPagesWithLLM (Layer 3)"]
-    QueryEngine -->|read| Vault
+    QueryEngine -->|4-phase pipeline: read-index / select-seeds / load-pages / assemble-context| Vault
+    QueryEngine -->|streaming + render| LLMClient
 
+    lint("lint/controller.ts") -->|LLM analysis/scoring/synthesis| llm-phases["lint/llm-phases/ (3 phase modules) <= Added in PR #248"]
     lint("lint/controller.ts") -->|dead links| fix-dead-link["lint/fix-dead-link.ts"]
     lint("lint/controller.ts") -->|empty pages| fill-empty-page["lint/fill-empty-page.ts"]
     lint("lint/controller.ts") -->|orphans| link-orphan["lint/link-orphan.ts"]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,19 +2,17 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.23.2 (shipped 2026-07-05) | **Updated:** 2026-07-06
+**Version:** 1.23.2 (shipped 2026-07-05) | **Updated:** 2026-07-08
 
 ## Current Status
 
-**v1.23.2 SHIPPED (2026-07-05, PATCH).** Five merged PRs (#234 + graph-cache invalidation + #221 + #219 + DocTpoint's #238 + #241). 1431 tests at ship; **1616 tests** after 3 monolith-split PRs (#248/#249/#250) added ~90 new test cases (+3 test files). 115 test files. Recommended upgrade for everyone on v1.23.0+. License upgraded to Apache 2.0 + DCO.
+**v1.24.0 P2 in flight (2026-07-08).** On branch `feat/modals-split`:
+- ✅ Stage 1 — `modals.ts` split into `src/ui/modals/` (4b65450).
+- ✅ Stage 2 — Query Wiki bug fixes: wikiFolder-transparent prompt (Bug C), LLM seed-selector retry + system field (Bug B/B+), 1711 tests.
+- ✅ Stage 3 — Graph warmup: engine-level `_cachedGraph` so first query uses PPR (608ae95).
+- ⏳ Stage 4 — Issue #251 custom Query Instructions MVP (query-local UI).
 
-**Post-ship work (2026-07-06 → 2026-07-07):** Three monolith-split PRs landed (#248 controller.ts / #249 history-modal.ts / #250 query-engine.ts). ROI analysis on remaining 6 large files complete — see `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_remaining_split_roi.md`. Next iteration: P0 = `ui/modals.ts` split (0.5 day), P1 = i18n altitude fixes (0.5 day), P2 = `wiki/wiki-engine.ts` 1391-LOC god-class split (2-3 days).
-
-**v1.23.1 SHIPPED (2026-07-02, PATCH).** Obsidian review bot reject hotfix: tsconfig `strictBindCallApply: true` alignment, dead function removal, lockfile regeneration for CI build verification. 1386 tests passing across 102 files.
-
-**v1.23.0 SHIPPED (2026-07-02).** Graph Engine PPR + Vercel AI-SDK v6 migration + Sponsor section + v1.22.6 hotfix series folded in. Closes #117/#130/#137/#141/#143/#147/#157/#175/#198/#204/#215/#223.
-
-Historical releases are summarized in [CHANGELOG](./CHANGELOG.md). The current sprint is described in **Next Milestone** below.
+Historical releases are summarized in [CHANGELOG](./CHANGELOG.md).
 
 ### v1.23.1: Obsidian Review Hotfix (2026-07-02, PATCH)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,13 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.23.2 (shipped 2026-07-05) | **Updated:** 2026-07-05
+**Version:** 1.23.2 (shipped 2026-07-05) | **Updated:** 2026-07-06
 
 ## Current Status
 
-**v1.23.2 SHIPPED (2026-07-05, PATCH).** Five merged PRs (#234 + graph-cache invalidation + #221 + #219 + DocTpoint's #238 + #241). 1431 tests passing across 108 files. Recommended upgrade for everyone on v1.23.0+. License upgraded to Apache 2.0 + DCO. Next: v1.24.0 MINOR (PDF source ingest, source-revision awareness, hub-retirement lint wire-up).
+**v1.23.2 SHIPPED (2026-07-05, PATCH).** Five merged PRs (#234 + graph-cache invalidation + #221 + #219 + DocTpoint's #238 + #241). 1431 tests at ship; **1616 tests** after 3 monolith-split PRs (#248/#249/#250) added ~90 new test cases (+3 test files). 115 test files. Recommended upgrade for everyone on v1.23.0+. License upgraded to Apache 2.0 + DCO.
+
+**Post-ship work (2026-07-06 → 2026-07-07):** Three monolith-split PRs landed (#248 controller.ts / #249 history-modal.ts / #250 query-engine.ts). ROI analysis on remaining 6 large files complete — see `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_remaining_split_roi.md`. Next iteration: P0 = `ui/modals.ts` split (0.5 day), P1 = i18n altitude fixes (0.5 day), P2 = `wiki/wiki-engine.ts` 1391-LOC god-class split (2-3 days).
 
 **v1.23.1 SHIPPED (2026-07-02, PATCH).** Obsidian review bot reject hotfix: tsconfig `strictBindCallApply: true` alignment, dead function removal, lockfile regeneration for CI build verification. 1386 tests passing across 102 files.
 
@@ -68,7 +70,7 @@ No proactive 11th language — **contributor-driven only** (replicate PR #159 It
 - **#220 — Source-revision awareness for merge.** DocTpoint's 4-tier design (Tier 0 fingerprint + replace self-revision, Tier 1 `supersedes:` frontmatter flag, Tier 2 cross-source disagreement open question, Tier 3 review-queue UI). Tiers 0-1 tractable for v1.24.0 MINOR; Tier 3 likely v1.25.0+. Prerequisite: open Discussion thread on fingerprint function design.
 - Hub-retirement lint wire-up (`core/hub-retirement.ts` → call `assessHubs` in lint path) — owned by @DocTpoint, post-#215 merge
 - P2-2 cold-start settings UI (advanced users only; default parameters validated in P2-4)
-- LintFixer class → module-level functions (707-LOC god class split, 1 day)
+- ~~LintFixer class → module-level functions (707-LOC god class split, 1 day)~~ — **FALSE BACKLOG ITEM** (2026-07-07): the LintFixer god class was already split in v1.19.0 into 8 module-level functions under `src/wiki/lint/` (`fix-dead-link.ts`, `fill-empty-page.ts`, `link-orphan.ts`, `merge-duplicates.ts`, `delete-empty-stubs.ts`, `fix-polluted-page.ts`, `duplicate-detection.ts`). `fix-runners.ts` (500 LOC) is the unified dispatch layer — not a god class. See [[project_v1.24.0_remaining_split_roi]] for the corrected large-file analysis.
 
 **Deferred to v1.25.0+ (research / experimental):**
 - #213 configurable page categories (Discussion-only, NOT confirmed for any minor release — needs broader community/architectural discussion)
@@ -122,7 +124,9 @@ TBD after v1.23.2 feedback. Architectural items deferred from v1.23.0–v1.23.2 
 - **#218 — PDF source ingest** (Discussion #222 topology).
 - **Hub-retirement lint wire-up** — `core/hub-retirement.ts` (0 callers) → wire `assessHubs` into lint path. Owned by @DocTpoint (post-#215 merge).
 - **#169 estimated-time-remaining** — velocity window + batch telemetry; needs tracking issue.
-- **LintFixer → module-level functions split** — 707-LOC god class, deprioritized since v1.18.x.
+- **i18n altitude fixes** — `history-message.ts` / `QueryView-class.ts` 硬编码 '👤 You' / '🤖 Wiki'；`retrieval-label.ts` 硬编码 'page(s)'；7 处 `as unknown as Record<string, string>` 类型安全债务。Closed by `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_remaining_split_roi.md` P1 (0.5 day).
+- **`ui/modals.ts` → `ui/modals/` split** — 7 个独立 modal classes 共存 1 文件（1008 LOC）；最简单、最快胜利的拆分。Closed by `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_remaining_split_roi.md` P0 (0.5 day).
+- ~~LintFixer → module-level functions split~~ — **REMOVED 2026-07-07** as false backlog item (god class already split in v1.19.0).
 - **#244 — Programmatic Mentions-citation writes (mentioned by @DocTpoint).** Root cause: `Mentions in Source` section is currently emitted by LLM in the page-generation prompt (`page-factory.ts:361/433/495` inject `{{mentions}}` as a few-shot example). LLM may drift on quote text, format, ordering, or — worse — copy the note-folder prefix into Related Concepts/Entities sections (Effect 2 from the bug report). Design intent (`schema-manager.ts:117-128`): Mentions is a deterministic academic-footnote structured output; should NOT depend on LLM creativity.
   - **Scope:** Promote `mentions_in_source` to a structured `mentions_with_provenance` type (`{quote, source_path, source_slug, extracted_at, position?}`); emit the section programmatically via new `core/mentions-formatter.ts`; strip the LLM-written section in `page-factory.ts` post-processing; remove `{{mentions}}` injection + section directives from `prompts/generation.ts` and `prompts/merge.ts`; support multi-source merge (dedup by verbatim quote string, sort by source-ingest timestamp); programmatic verify that each emitted quote actually appears at the claimed source position (defends against LLM fabrication in the extraction stage).
   - **Lint scanner compatibility:** Extend `lint/scanners.ts` `extractMentionsSection` + line regex to accept raw-note-path targets (`[[MyNote]]`) in addition to `wiki/sources/<slug>` paths, and to verify quote-grounding against the original source file when the link target is a note path. This heals the silent secondary damage (427 ungrounded-quote lint warnings caused by the current raw-note path).
@@ -150,7 +154,7 @@ TBD after v1.23.2 feedback. Architectural items deferred from v1.23.0–v1.23.2 
 
 ## v1.23.2 — Implemented (shipped 2026-07-05)
 
-See [CHANGELOG](./CHANGELOG.md#v1.23.2) for full details. **PATCH** scope. Five merged PRs (#234 + graph-cache + #221 + #219 + DocTpoint's #238 + #241). 1431 tests passing across 108 files. No new user-facing settings. Recommended upgrade for everyone on v1.23.0+.
+See [CHANGELOG](./CHANGELOG.md#v1.23.2) for full details. **PATCH** scope. Five merged PRs (#234 + graph-cache + #221 + #219 + DocTpoint's #238 + #241). 1431 tests at ship. Post-release monolith splits (#248/#249/#250) added ~90 test cases — **1616 tests across 115 files in latest main**. No new user-facing settings. Recommended upgrade for everyone on v1.23.0+.
 
 ## v1.23.0 — Implemented (shipped 2026-07-02)
 
@@ -236,7 +240,7 @@ See [CHANGELOG](./CHANGELOG.md#v1.23.2) for full details. **PATCH** scope. Five 
 | # | Item | Effort | Status |
 |---|------|--------|--------|
 | D1 | page-factory resolvePagePath LLM fallback + merge + append tests | 1 day | Deferred |
-| D2 | LintFixer class split (707-line god class → 6 module functions) | 1 day | Deferred |
+| ~~D2~~ | ~~LintFixer class split (707-line god class → 6 module functions)~~ | — | **REMOVED 2026-07-07** — split already done in v1.19.0; `fix-runners.ts` (500 LOC) is the unified dispatch layer, not a god class. See `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_remaining_split_roi.md` for the corrected large-file analysis. |
 
 #### Deferred P2 — Test infrastructure (high mock complexity)
 | # | Item | Effort | Reason |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,9 +116,13 @@ See [CHANGELOG](./CHANGELOG.md#1170-2026-06-08) for full details.
 
 ## Next Milestone: v1.24.0 MINOR (target TBD)
 
-### Goals
+### In-flight (2026-07-08 → )
 
-TBD after v1.23.2 feedback. Architectural items deferred from v1.23.0–v1.23.2 cycle:
+- **Stage 2 Bug B+B+** — Query Wiki seed-selector retry + system field fix (commit `1d943ea` on `feat/modals-split`, 1706 tests). Lands as amended extension of the wikiFolder-transparent-prompt commit. Includes: new `core/transient-retry.ts` helper (3× exponential backoff, auth/rate-limit no-retry), seed-selector now passes `system` field to AI-SDK (DeepSeek in JSON mode requires system; without it, LLM returns empty body and the retry chain can't recover). e2e verified: arm upgraded from `index` to `index+LLM`, 2 seeds selected, no silent degradation. Memory: `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.24.0_p2_query_seed_selector.md`.
+- **Stage 3 Bug A** — graph warmup via `WikiEngine._cachedGraph` + getter (next; first-query PPR arm upgrade).
+- **Stage 4 #251** — `customQueryInstructions` MVP (after Stage 3).
+- **Follow-up: `dedup-phase.ts:219` system field** — lint LLM dedup has the same "JSON mode + no system" gap. `LintPhaseContext` interface lacks `getSchemaContext`, so the fix is a ~30-50 LOC multi-file change (extend ctx type, wire through `controller.ts`, update phase). Not in this commit per user decision 2026-07-08. Risk: lint dedup silently returns 0 duplicates on DeepSeek. Should be a single focused PR.
+- **Follow-up: `parseJsonResponse` preamble echo** — DeepSeek can return `{\n ` (length=3) as a preamble before the real JSON. Current retry chain recovers in 1-3 attempts (verified). No additional parsing-layer change needed; first-principles evaluation rejected sentinel/preamble-detect approaches.
 
 - **#220 — Source-revision awareness for merge** (DocTpoint's 4-tier design). Tier 0 fingerprint + replace self-updates; Tier 1 `supersedes:` frontmatter flag; Tier 2 cross-source disagreement open question; Tier 3 review-queue UI. Tiers 0-1 tractable for v1.24.0; Tier 3 likely v1.25.0+. Prerequisite: open Discussion thread on fingerprint function design.
 - **#218 — PDF source ingest** (Discussion #222 topology).

--- a/src/__tests__/core/frontmatter-merge.test.ts
+++ b/src/__tests__/core/frontmatter-merge.test.ts
@@ -1,0 +1,199 @@
+// Tests for core/frontmatter.ts helpers — specifically the v1.24.0
+// `mergeFrontmatterArrayField` helper that replaces the string-splice
+// pattern in fix-runners.ts. The string-splice pattern produced
+// duplicate `aliases:` / `tags:` lines when the page already had the
+// field (incl. `aliases: []`), breaking YAML.
+//
+// mergeFrontmatterArrayField parses existing values, dedupes, and
+// re-serializes through the canonical `serializeFrontmatter` writer
+// so there's exactly one `aliases:` (or `tags:` / `sources:`) line
+// in the output regardless of input shape.
+
+import { describe, it, expect } from 'vitest';
+import { mergeFrontmatterArrayField, replaceFrontmatterArrayField, parseFrontmatter, serializeFrontmatter } from '../../core/frontmatter';
+
+describe('mergeFrontmatterArrayField (v1.24.0)', () => {
+  describe('aliases field', () => {
+    it('appends to existing inline aliases', () => {
+      const before = '---\ntype: entity\naliases: [Existing]\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['Foo', 'Bar']);
+      expect((after.match(/^aliases:/gm) || []).length).toBe(1);
+      expect(after).toContain('Existing');
+      expect(after).toContain('Foo');
+      expect(after).toContain('Bar');
+    });
+
+    it('appends to existing empty aliases: [] placeholder', () => {
+      const before = '---\ntype: entity\naliases: []\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['Foo']);
+      expect((after.match(/^aliases:/gm) || []).length).toBe(1);
+      expect(after).toContain('Foo');
+      // Empty placeholder should be gone
+      expect(after).not.toContain('aliases: []');
+    });
+
+    it('appends to existing block-style aliases', () => {
+      const before = '---\ntype: entity\naliases:\n  - BlockAlias\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['Foo', 'Bar']);
+      expect((after.match(/^aliases:/gm) || []).length).toBe(1);
+      expect(after).toContain('BlockAlias');
+      expect(after).toContain('Foo');
+      expect(after).toContain('Bar');
+    });
+
+    it('dedupes when new items already exist', () => {
+      const before = '---\ntype: entity\naliases: [A, B]\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['A', 'C', 'B']);
+      expect(after).toContain('A');
+      expect(after).toContain('B');
+      expect(after).toContain('C');
+      // Should still have only one A and one B (deduped)
+      const aMatches = after.match(/['"]A['"]/g) || [];
+      const bMatches = after.match(/['"]B['"]/g) || [];
+      expect(aMatches.length).toBe(1);
+      expect(bMatches.length).toBe(1);
+    });
+
+    it('returns original content when all new items already exist', () => {
+      const before = '---\ntype: entity\naliases: [A, B]\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['A', 'B']);
+      expect(after).toBe(before);
+    });
+
+    it('appends when aliases field is missing entirely', () => {
+      const before = '---\ntype: entity\ntags: [ai]\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['Foo']);
+      expect((after.match(/^aliases:/gm) || []).length).toBe(1);
+      expect(after).toContain('Foo');
+      // tags preserved
+      expect(after).toMatch(/tags:/);
+    });
+
+    it('appends to block-style with empty entries', () => {
+      const before = '---\ntype: entity\naliases:\n  - ""\n  - ""\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['Real']);
+      expect((after.match(/^aliases:/gm) || []).length).toBe(1);
+      expect(after).toContain('Real');
+    });
+  });
+
+  describe('tags field (same pattern, sanity-check the helper is generic)', () => {
+    it('appends to existing tags: []', () => {
+      const before = '---\ntype: entity\ntags: []\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'tags', ['ai', 'ml']);
+      expect((after.match(/^tags:/gm) || []).length).toBe(1);
+      expect(after).toContain('ai');
+      expect(after).toContain('ml');
+    });
+  });
+
+  describe('sources field (another array field)', () => {
+    it('appends to existing sources', () => {
+      const before = '---\ntype: entity\nsources: [book.md]\n---\n\n# Body';
+      const after = mergeFrontmatterArrayField(before, 'sources', ['paper.md']);
+      expect((after.match(/^sources:/gm) || []).length).toBe(1);
+      expect(after).toContain('book.md');
+      expect(after).toContain('paper.md');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns original when no items to add', () => {
+      const before = '---\ntype: entity\n---\n\n# Body';
+      expect(mergeFrontmatterArrayField(before, 'aliases', [])).toBe(before);
+    });
+
+    it('handles page with no frontmatter', () => {
+      const before = '# Just body\n\nNo frontmatter here.';
+      const after = mergeFrontmatterArrayField(before, 'aliases', ['Foo']);
+      expect(after).toContain('---');
+      expect(after).toContain('Foo');
+    });
+
+    it('does not duplicate when called twice with overlapping items', () => {
+      const first = mergeFrontmatterArrayField(
+        '---\ntype: entity\n---\n\n# Body',
+        'aliases',
+        ['Foo', 'Bar']
+      );
+      const second = mergeFrontmatterArrayField(first, 'aliases', ['Bar', 'Baz']);
+      // Must have Foo, Bar, Baz — exactly once each
+      const allMatches = (second.match(/^aliases:/gm) || []).length;
+      expect(allMatches).toBe(1);
+      expect(second).toContain('Foo');
+      expect(second).toContain('Bar');
+      expect(second).toContain('Baz');
+      const fooMatches = second.match(/['"]Foo['"]/g) || [];
+      expect(fooMatches.length).toBe(1);
+    });
+  });
+
+  describe('parser/serializer sanity (no merge)', () => {
+    it('parseFrontmatter handles aliases: [] as empty array', () => {
+      const fm = parseFrontmatter('---\ntype: entity\naliases: []\n---\n\n# Body');
+      expect(fm).not.toBeNull();
+      expect(fm!.aliases).toEqual([]);
+    });
+
+    it('serializeFrontmatter emits block-style for non-empty array', () => {
+      const out = serializeFrontmatter({
+        type: 'entity',
+        aliases: ['A', 'B'],
+      });
+      expect(out).toMatch(/^---\n/);
+      expect(out).toMatch(/aliases:/);
+      expect(out).toContain('"A"');
+      expect(out).toContain('"B"');
+    });
+
+    it('serializeFrontmatter skips empty array by default', () => {
+      const out = serializeFrontmatter({
+        type: 'entity',
+        aliases: [],
+      });
+      expect(out).not.toContain('aliases');
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// replaceFrontmatterArrayField (v1.24.0) — full replacement semantic
+// for runRetagViolations. Different from merge: rewrite the array
+// instead of appending.
+// ─────────────────────────────────────────────────────────────────
+
+describe('replaceFrontmatterArrayField (v1.24.0)', () => {
+  // Helper: tags emitted by serializeFrontmatter wrap string values in `"..."`.
+  // Both forms are valid YAML and Obsidian parses them identically.
+  const hasNewTag = (s: string, tag: string) =>
+    s.includes(`tags:\n  - "${tag}"`) || s.includes(`tags: [${tag}]`);
+
+  it('replaces existing tags with new array (drops old entries not in new)', () => {
+    const before = '---\ntype: entity\ntags: [old1, old2, old3]\n---\n\n# Body';
+    const after = replaceFrontmatterArrayField(before, 'tags', ['new1']);
+    expect(after).not.toContain('old1');
+    expect(after).not.toContain('old2');
+    expect(after).not.toContain('old3');
+    expect(hasNewTag(after, 'new1')).toBe(true);
+  });
+
+  it('drops the field when newItems is empty', () => {
+    const before = '---\ntype: entity\ntags: [a, b]\n---\n\n# Body';
+    const after = replaceFrontmatterArrayField(before, 'tags', []);
+    expect(after).not.toContain('tags');
+  });
+
+  it('replaces block-style tags', () => {
+    const before = '---\ntype: entity\ntags:\n  - old1\n  - old2\n---\n\n# Body';
+    const after = replaceFrontmatterArrayField(before, 'tags', ['new1']);
+    expect(after).not.toContain('old1');
+    expect(after).not.toContain('old2');
+    expect(hasNewTag(after, 'new1')).toBe(true);
+  });
+
+  it('handles missing field (adds it)', () => {
+    const before = '---\ntype: entity\n---\n\n# Body';
+    const after = replaceFrontmatterArrayField(before, 'tags', ['new']);
+    expect(hasNewTag(after, 'new')).toBe(true);
+  });
+});

--- a/src/__tests__/core/llm-path.test.ts
+++ b/src/__tests__/core/llm-path.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeLLMPath, normalizeWikiLinkContent } from '../../core/prompt-builders';
+import {
+  normalizeLLMPath,
+  normalizeWikiLinkContent,
+  substituteWikiFolderPlaceholder,
+  WIKI_FOLDER_PLACEHOLDER,
+} from '../../core/prompt-builders';
 
 describe('normalizeLLMPath', () => {
   it('returns path unchanged when already has correct wikiFolder prefix', () => {
@@ -36,16 +41,31 @@ describe('normalizeLLMPath', () => {
   });
 });
 
-describe('normalizeWikiLinkContent', () => {
-  it('replaces [[wiki/ with [[custom/ when wikiFolder is custom', () => {
+describe('normalizeWikiLinkContent (v1.24.0 — placeholder semantics)', () => {
+  // v1.24.0 (Bug C 3.0): the function now collapses to __WIKI_FOLDER__ so
+  // persisted chat history is folder-agnostic. Use substituteWikiFolderPlaceholder
+  // at render time to recover a real folder. See core/prompt-builders.ts.
+
+  it('replaces [[wiki/ with [[__WIKI_FOLDER__/ when wikiFolder is custom', () => {
     const input = 'See [[wiki/entities/llm|LLM]] for details.';
-    const expected = 'See [[custom/entities/llm|LLM]] for details.';
+    const expected = `See [[${WIKI_FOLDER_PLACEHOLDER}/entities/llm|LLM]] for details.`;
     expect(normalizeWikiLinkContent(input, 'custom')).toBe(expected);
   });
 
-  it('preserves [[wiki/ links when wikiFolder is "wiki"', () => {
+  it('collapses the current wikiFolder too (LLM may echo the prompt template back)', () => {
+    const input = 'See [[custom/entities/llm|LLM]] for details.';
+    const expected = `See [[${WIKI_FOLDER_PLACEHOLDER}/entities/llm|LLM]] for details.`;
+    expect(normalizeWikiLinkContent(input, 'custom')).toBe(expected);
+  });
+
+  it('still collapses [[wiki/ → __WIKI_FOLDER__ even when wikiFolder is "wiki"', () => {
+    // v1.24.0: the function now ALWAYS normalizes to the placeholder, even
+    // when the user's wikiFolder is the literal default 'wiki'. This keeps
+    // the placeholder invariant uniform across folder configs — render-time
+    // substitute replaces the placeholder with 'wiki' again, idempotently.
     const input = 'See [[wiki/entities/llm|LLM]] for details.';
-    expect(normalizeWikiLinkContent(input, 'wiki')).toBe(input);
+    const expected = `See [[${WIKI_FOLDER_PLACEHOLDER}/entities/llm|LLM]] for details.`;
+    expect(normalizeWikiLinkContent(input, 'wiki')).toBe(expected);
   });
 
   it('does not alter non-wiki-link references', () => {
@@ -55,7 +75,7 @@ describe('normalizeWikiLinkContent', () => {
 
   it('handles multiple wiki-links in the same content', () => {
     const input = '[[wiki/entities/a]] and [[wiki/concepts/b|B]]';
-    const expected = '[[mywiki/entities/a]] and [[mywiki/concepts/b|B]]';
+    const expected = `[[${WIKI_FOLDER_PLACEHOLDER}/entities/a]] and [[${WIKI_FOLDER_PLACEHOLDER}/concepts/b|B]]`;
     expect(normalizeWikiLinkContent(input, 'mywiki')).toBe(expected);
   });
 
@@ -66,14 +86,37 @@ describe('normalizeWikiLinkContent', () => {
 
   it('replaces wiki/ in [[wiki/sources/foo]] too', () => {
     const input = 'From [[wiki/sources/paper|Paper]]';
-    const expected = 'From [[custom/sources/paper|Paper]]';
+    const expected = `From [[${WIKI_FOLDER_PLACEHOLDER}/sources/paper|Paper]]`;
     expect(normalizeWikiLinkContent(input, 'custom')).toBe(expected);
   });
 
   it('is idempotent — already normalized content stays unchanged', () => {
-    const input = 'See [[custom/entities/llm|LLM]] for details.';
+    const input = `See [[${WIKI_FOLDER_PLACEHOLDER}/entities/llm|LLM]] for details.`;
     expect(normalizeWikiLinkContent(input, 'custom')).toBe(input);
-    // Double application
     expect(normalizeWikiLinkContent(input, 'custom')).toBe(normalizeWikiLinkContent(input, 'custom'));
+  });
+});
+
+describe('substituteWikiFolderPlaceholder (v1.24.0 — render-time substitution)', () => {
+  it('replaces __WIKI_FOLDER__ with the user wikiFolder', () => {
+    const input = `See [[${WIKI_FOLDER_PLACEHOLDER}/entities/llm|LLM]] for details.`;
+    const expected = 'See [[mywiki/entities/llm|LLM]] for details.';
+    expect(substituteWikiFolderPlaceholder(input, 'mywiki')).toBe(expected);
+  });
+
+  it('replaces ALL occurrences in one pass', () => {
+    const input = `[[${WIKI_FOLDER_PLACEHOLDER}/a]] and [[${WIKI_FOLDER_PLACEHOLDER}/b|B]]`;
+    const expected = '[[mywiki/a]] and [[mywiki/b|B]]';
+    expect(substituteWikiFolderPlaceholder(input, 'mywiki')).toBe(expected);
+  });
+
+  it('returns content unchanged when no placeholder is present', () => {
+    const input = 'Plain text without placeholder.';
+    expect(substituteWikiFolderPlaceholder(input, 'mywiki')).toBe(input);
+  });
+
+  it('returns content unchanged when wikiFolder is empty', () => {
+    const input = `[[${WIKI_FOLDER_PLACEHOLDER}/entities/x]]`;
+    expect(substituteWikiFolderPlaceholder(input, '')).toBe(input);
   });
 });

--- a/src/__tests__/core/query-history-migration-check.test.ts
+++ b/src/__tests__/core/query-history-migration-check.test.ts
@@ -1,0 +1,95 @@
+// Tests for the gradual-migration detection (Bug C 3.4 / plan C).
+//
+// Pre-v1.24.0 history entries contain real wikiFolder prefixes in
+// `[[folder/...]]` wiki-links. detectStaleWikiFolders should report them
+// so main.onload can prompt the user to Clear history.
+
+import { describe, it, expect } from 'vitest';
+import { detectStaleWikiFolders } from '../../core/query-history-migration-check';
+import { WIKI_FOLDER_PLACEHOLDER } from '../../core/prompt-builders';
+
+// We use a minimal `{ role, content }` shape rather than the full
+// QueryHistoryMessage because detectStaleWikiFolders only reads .content
+// — keeping the fixtures trim means a future schema addition (timestamp,
+// retrieval, etc.) won't force test updates.
+type MinimalMessage = { role: 'user' | 'assistant'; content: string };
+
+describe('detectStaleWikiFolders', () => {
+  it('returns null for empty history', () => {
+    expect(detectStaleWikiFolders([], 'wiki')).toBeNull();
+  });
+
+  it('returns null when history has no wiki-links', () => {
+    const history: MinimalMessage[] = [
+      { role: 'user', content: 'What is LLM?' },
+      { role: 'assistant', content: 'A large language model is...' },
+    ];
+    expect(detectStaleWikiFolders(history, 'wiki')).toBeNull();
+  });
+
+  it('returns null when history contains only the placeholder', () => {
+    const history: MinimalMessage[] = [
+      {
+        role: 'assistant',
+        content: `See [[${WIKI_FOLDER_PLACEHOLDER}/entities/llm|LLM]] for details.`,
+      },
+    ];
+    expect(detectStaleWikiFolders(history, 'wiki')).toBeNull();
+  });
+
+  it('returns folders + hasStale=true when old folder differs from current', () => {
+    const history: MinimalMessage[] = [
+      { role: 'assistant', content: 'See [[test3/entities/foo|Foo]] for context.' },
+      { role: 'assistant', content: 'And [[test3/concepts/bar|Bar]] is relevant.' },
+    ];
+    const result = detectStaleWikiFolders(history, 'mywiki');
+    expect(result).toEqual({ folders: ['test3'], hasStale: true });
+  });
+
+  it('returns hasStale=false when detected folder matches current wikiFolder', () => {
+    const history: MinimalMessage[] = [
+      { role: 'assistant', content: 'See [[mywiki/entities/foo|Foo]].' },
+    ];
+    const result = detectStaleWikiFolders(history, 'mywiki');
+    // The user's current folder is reflected in the link (e.g. LLM echoed
+    // the prompt template). This is "current" not "stale" — no notice.
+    expect(result).toEqual({ folders: ['mywiki'], hasStale: false });
+  });
+
+  it('detects the default wiki folder as NOT stale when wikiFolder is also wiki', () => {
+    const history: MinimalMessage[] = [
+      { role: 'assistant', content: 'See [[wiki/entities/foo|Foo]].' },
+    ];
+    const result = detectStaleWikiFolders(history, 'wiki');
+    expect(result).toEqual({ folders: ['wiki'], hasStale: false });
+  });
+
+  it('detects multiple distinct old folders', () => {
+    const history: MinimalMessage[] = [
+      { role: 'assistant', content: '[[test3/entities/a]]' },
+      { role: 'assistant', content: '[[oldfolder/concepts/b]]' },
+    ];
+    const result = detectStaleWikiFolders(history, 'mywiki');
+    expect(result?.hasStale).toBe(true);
+    expect(result?.folders.sort()).toEqual(['oldfolder', 'test3']);
+  });
+
+  it('ignores links without a folder prefix (e.g. [[entities/foo]])', () => {
+    const history: MinimalMessage[] = [
+      { role: 'assistant', content: 'See [[entities/foo|Foo]].' },
+    ];
+    expect(detectStaleWikiFolders(history, 'wiki')).toBeNull();
+  });
+
+  it('handles history with mixed placeholder and real-folder links', () => {
+    const history: MinimalMessage[] = [
+      {
+        role: 'assistant',
+        content: `Old: [[test3/entities/a]], new: [[${WIKI_FOLDER_PLACEHOLDER}/entities/b]].`,
+      },
+    ];
+    const result = detectStaleWikiFolders(history, 'mywiki');
+    expect(result?.hasStale).toBe(true);
+    expect(result?.folders).toEqual(['test3']);
+  });
+});

--- a/src/__tests__/core/transient-retry.test.ts
+++ b/src/__tests__/core/transient-retry.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withTransientRetry } from '../../core/transient-retry';
+
+/**
+ * Pure-function tests for withTransientRetry.
+ *
+ * Bug B (v1.24.0 P2): seed-selector.ts returned [] on any failure, including
+ * transient empty-string LLM responses (response length: 0). None of the
+ * existing retry helpers (withTruncationRetry, url-fallback, token-key-probe)
+ * handle this class of failure. withTransientRetry fills that gap.
+ *
+ * Policy tested:
+ * - Happy path: no retry needed
+ * - Retry on: thrown network/timeout, empty-string response, JSON.parse throws
+ * - No retry on: auth (401/403), rate-limit (429)
+ * - Bounded retry: maxAttempts, exponential backoff with jitter
+ * - Final giveup: returns last result / throws last error
+ */
+
+describe('withTransientRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the value on first success (no retry call)', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const result = await withTransientRetry({ fn, label: 'Test' });
+
+    expect(result.value).toBe('ok');
+    expect(result.attempts).toBe(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on thrown network/timeout error and returns first success', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network: timeout'))
+      .mockResolvedValueOnce('ok');
+
+    const promise = withTransientRetry({ fn, label: 'Test' });
+    // Advance past backoff (250ms * 2^0 + jitter)
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.value).toBe('ok');
+    expect(result.attempts).toBe(2);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries when isTransientEmpty returns true (e.g. empty string)', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('ok');
+
+    const promise = withTransientRetry({
+      fn,
+      label: 'Test',
+      isTransientEmpty: (v) => v === '' || (typeof v === 'string' && v.trim() === ''),
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.value).toBe('ok');
+    expect(result.attempts).toBe(2);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries when validate throws (e.g. JSON.parse fails on empty response)', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce('not json{')
+      .mockResolvedValueOnce('{"seeds":["a"]}');
+
+    const validate = (v: string) => {
+      JSON.parse(v);
+    };
+
+    const promise = withTransientRetry({
+      fn,
+      label: 'Test',
+      validate,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result.value).toBe('{"seeds":["a"]}');
+    expect(result.attempts).toBe(2);
+  });
+
+  it('does not retry on auth error (401/403) — surface immediately', async () => {
+    const authError = Object.assign(new Error('status 401'), { statusCode: 401 });
+    const fn = vi.fn().mockRejectedValue(authError);
+
+    const result = await withTransientRetry({
+      fn,
+      label: 'Test',
+      isAuthError: (e) => (e as { statusCode?: number }).statusCode === 401 || (e as { statusCode?: number }).statusCode === 403,
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.error).toBe(authError);
+  });
+
+  it('does not retry on rate-limit (429) — surface immediately', async () => {
+    const rateLimitError = Object.assign(new Error('status 429'), { statusCode: 429 });
+    const fn = vi.fn().mockRejectedValue(rateLimitError);
+
+    const result = await withTransientRetry({
+      fn,
+      label: 'Test',
+      isRateLimitError: (e) => (e as { statusCode?: number }).statusCode === 429,
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.error).toBe(rateLimitError);
+  });
+
+  it('gives up after maxAttempts and returns the last error', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('network: timeout'));
+
+    const promise = withTransientRetry({ fn, label: 'Test', maxAttempts: 3, jitterMs: 0 });
+    // Advance past 2 backoffs: 250ms + 500ms = 750ms (deterministic with jitter:0).
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(result.attempts).toBe(3);
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toContain('network: timeout');
+  });
+
+  it('gives up when all attempts return transient empty and returns last empty', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fn = vi.fn().mockResolvedValue('');
+
+    const promise = withTransientRetry({
+      fn,
+      label: 'Test',
+      isTransientEmpty: (v) => v === '',
+      maxAttempts: 3,
+      jitterMs: 0,
+    });
+    // Advance past 2 backoffs: 250ms + 500ms = 750ms.
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(result.attempts).toBe(3);
+    expect(result.value).toBe('');
+    expect(result.error).toBeUndefined();
+    // Should log a final "giving up" warning even on the empty path so
+    // operators can distinguish "still trying" from "exhausted retries".
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringMatching(/\[LLM retry\] Test giving up after 3 attempts: transient empty response/),
+    );
+
+    consoleWarn.mockRestore();
+  });
+
+  it('uses exponential backoff between attempts (250ms × 2^(n-1) ± jitter)', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce('ok');
+
+    const start = Date.now();
+    const promise = withTransientRetry({ fn, label: 'Test', jitterMs: 0 });
+
+    // First backoff: 250ms × 2^0 = 250ms
+    await vi.advanceTimersByTimeAsync(250);
+    // Second backoff: 250ms × 2^1 = 500ms
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(result.value).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+    // With jitter:0 the backoff should total 750ms (deterministic).
+    expect(result.totalBackoffMs).toBe(750);
+    void start; // not used directly; this is just to silence "unused" lints
+  });
+
+  it('respects custom maxAttempts (5 attempts allowed)', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const result = await withTransientRetry({ fn, label: 'Test', maxAttempts: 5 });
+
+    expect(result.attempts).toBe(1);
+    expect(result.value).toBe('ok');
+  });
+
+  it('logs a diagnostic warning per retry attempt with attempt number and reason', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network: timeout'))
+      .mockResolvedValueOnce('ok');
+
+    const promise = withTransientRetry({ fn, label: 'Seed selection', jitterMs: 0 });
+    await vi.advanceTimersByTimeAsync(250);
+    const result = await promise;
+
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringMatching(/\[LLM retry\] Seed selection attempt 1\/3 failed: network: timeout/));
+    expect(result.value).toBe('ok');
+
+    consoleWarn.mockRestore();
+  });
+
+  it('logs final giveup warning when all attempts fail', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fn = vi.fn().mockRejectedValue(new Error('persistent failure'));
+
+    const promise = withTransientRetry({ fn, label: 'Seed selection', maxAttempts: 2, jitterMs: 0 });
+    // Advance past 1 backoff: 250ms.
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(consoleWarn).toHaveBeenCalledWith(expect.stringMatching(/\[LLM retry\] Seed selection giving up after 2 attempts/));
+    expect(result.error).toBeInstanceOf(Error);
+
+    consoleWarn.mockRestore();
+  });
+
+  it('uses defaults: maxAttempts=3, backoffBaseMs=250 when not specified', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('transient'));
+
+    const promise = withTransientRetry({ fn, label: 'Test' });
+    // Advance past 2 default backoffs: 250ms + 500ms = 750ms (jitter may add up to 100ms each).
+    await vi.advanceTimersByTimeAsync(1500);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(result.attempts).toBe(3);
+  });
+});

--- a/src/__tests__/wiki/graph-cache.test.ts
+++ b/src/__tests__/wiki/graph-cache.test.ts
@@ -1,0 +1,111 @@
+// Stage 3 Bug A — Graph warmup: WikiEngine-level graph cache.
+//
+// Root cause: QueryView kept a per-view graph that was built AFTER the first
+// PPR cascade, so the first query always fell back to the lex-only arm even
+// when a vault-wide graph would have enabled PPR. The fix moves the graph
+// to WikiEngine with a shared, lazily-built cache that is available on the
+// first query, plus invalidation hooks so ingest/delete/update keep it fresh.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+
+describe('WikiEngine graph cache — Bug A warmup', () => {
+  let harness: ReturnType<typeof createWikiEngineHarness>;
+
+  beforeEach(() => {
+    harness = createWikiEngineHarness({
+      files: {
+        'wiki/entities/a.md': '---\ntype: entity\n---\n# A\nLink to [[wiki/entities/b|B]].',
+        'wiki/entities/b.md': '---\ntype: entity\n---\n# B\nLink to [[wiki/entities/c|C]].',
+        'wiki/entities/c.md': '---\ntype: entity\n---\n# C\nNo links here.',
+      },
+      settings: { wikiFolder: 'wiki' },
+    });
+  });
+
+  it('has a getOrBuildGraph method that returns a Graph', async () => {
+    const engine = harness.engine;
+    const allPaths = new Set([
+      'wiki/entities/a.md',
+      'wiki/entities/b.md',
+      'wiki/entities/c.md',
+    ]);
+
+    const graph = await engine.getOrBuildGraph(allPaths);
+
+    expect(graph).toBeDefined();
+    expect(graph.nodes).toContain('wiki/entities/a.md');
+    expect(graph.nodes).toContain('wiki/entities/b.md');
+    expect(graph.nodes).toContain('wiki/entities/c.md');
+  });
+
+  it('returns the same cached instance on repeated calls', async () => {
+    const engine = harness.engine;
+    const allPaths = new Set([
+      'wiki/entities/a.md',
+      'wiki/entities/b.md',
+      'wiki/entities/c.md',
+    ]);
+
+    const first = await engine.getOrBuildGraph(allPaths);
+    const second = await engine.getOrBuildGraph(allPaths);
+
+    expect(first).toBe(second);
+  });
+
+  it('rebuilds graph after invalidateGraph()', async () => {
+    const engine = harness.engine;
+    const allPaths = new Set([
+      'wiki/entities/a.md',
+      'wiki/entities/b.md',
+      'wiki/entities/c.md',
+    ]);
+
+    const first = await engine.getOrBuildGraph(allPaths);
+    engine.invalidateGraph();
+    const second = await engine.getOrBuildGraph(allPaths);
+
+    expect(second).not.toBe(first);
+    expect(second.nodes).toHaveLength(first.nodes.length);
+  });
+
+  it('invalidates graph cache when invalidatePageCaches is called', async () => {
+    const engine = harness.engine;
+    const allPaths = new Set([
+      'wiki/entities/a.md',
+      'wiki/entities/b.md',
+      'wiki/entities/c.md',
+    ]);
+
+    const first = await engine.getOrBuildGraph(allPaths);
+
+    // invalidatePageCaches is private; verify it drops the graph cache by
+    // reaching into the engine directly (white-box) and calling the internal
+    // helper that every vault write/delete triggers.
+    const engineInternal = engine as unknown as {
+      invalidatePageCaches: () => void;
+    };
+
+    engineInternal.invalidatePageCaches();
+
+    const second = await engine.getOrBuildGraph(allPaths);
+    expect(second).not.toBe(first);
+    expect(second.nodes).toHaveLength(first.nodes.length);
+  });
+
+  it('rebuilds graph when allPaths set changes', async () => {
+    const engine = harness.engine;
+    const pathsV1 = new Set(['wiki/entities/a.md', 'wiki/entities/b.md']);
+    const pathsV2 = new Set([
+      'wiki/entities/a.md',
+      'wiki/entities/b.md',
+      'wiki/entities/c.md',
+    ]);
+
+    const first = await engine.getOrBuildGraph(pathsV1);
+    const second = await engine.getOrBuildGraph(pathsV2);
+
+    expect(second).not.toBe(first);
+    expect(second.nodes).toHaveLength(3);
+  });
+});

--- a/src/__tests__/wiki/lint/fix-runners.test.ts
+++ b/src/__tests__/wiki/lint/fix-runners.test.ts
@@ -152,6 +152,140 @@ describe('fix-runners — AbortSignal propagation', () => {
   });
 });
 
+// ── runAliasCompletion: frontmatter write correctness (v1.24.0 bug fix) ──
+//
+// User-reported bug (2026-07-07): when a page already has `aliases: []`
+// (empty placeholder), running alias completion inserts a SECOND
+// `aliases:` line before the closing `---` instead of appending to
+// the existing array. The resulting frontmatter has duplicate keys
+// and breaks Obsidian's YAML parser.
+//
+// The fix is to delegate frontmatter mutation to
+// `enforceFrontmatterConstraints`, which parses existing aliases,
+// appends the new ones (deduped), and re-serializes through the
+// canonical `serializeFrontmatter` writer.
+
+describe('runAliasCompletion — frontmatter write correctness', () => {
+  // Capture what `vault.adapter.write` was called with.
+  function makeWriteCaptureCtx(): {
+    ctx: LintContext;
+    writes: Array<{ path: string; data: string }>;
+  } {
+    const writes: Array<{ path: string; data: string }> = [];
+    const ctx = makeCtx({
+      app: {
+        vault: {
+          adapter: {
+            write: vi.fn().mockImplementation(async (path: string, data: string) => {
+              writes.push({ path, data });
+            }),
+          },
+        },
+      } as unknown as LintContext['app'],
+      llmClient: {
+        createMessage: vi.fn().mockResolvedValue(
+          '{"aliases":["Foo","Bar"]}'
+        ),
+      } as unknown as LintContext['llmClient'],
+    });
+    return { ctx, writes };
+  }
+
+  it('appends aliases when page has existing `aliases: [X, Y]`', async () => {
+    const { ctx, writes } = makeWriteCaptureCtx();
+    const before = '---\ntype: entity\naliases: [Existing]\n---\n\n# Body';
+    const result = await runAliasCompletion(ctx, undefined, [
+      { path: 'wiki/entities/Has.md', content: before, basename: 'Has' },
+    ]);
+    expect(result.filled).toBe(1);
+    expect(writes).toHaveLength(1);
+    const written = writes[0].data;
+    // Must NOT have two `aliases:` lines
+    const aliasLineCount = (written.match(/^aliases:/gm) || []).length;
+    expect(aliasLineCount).toBe(1);
+    // Must contain both old and new aliases (Existing + Foo + Bar)
+    expect(written).toContain('Existing');
+    expect(written).toContain('Foo');
+    expect(written).toContain('Bar');
+  });
+
+  it('appends aliases when page has empty `aliases: []` (placeholder)', async () => {
+    const { ctx, writes } = makeWriteCaptureCtx();
+    const before = '---\ntype: entity\naliases: []\n---\n\n# Body';
+    const result = await runAliasCompletion(ctx, undefined, [
+      { path: 'wiki/entities/Empty.md', content: before, basename: 'Empty' },
+    ]);
+    expect(result.filled).toBe(1);
+    expect(writes).toHaveLength(1);
+    const written = writes[0].data;
+    // Must NOT have two `aliases:` lines — this is the user-reported bug
+    const aliasLineCount = (written.match(/^aliases:/gm) || []).length;
+    expect(aliasLineCount).toBe(1);
+    expect(written).toContain('Foo');
+    expect(written).toContain('Bar');
+  });
+
+  it('appends aliases when page has block-style `aliases:\n  - X`', async () => {
+    const { ctx, writes } = makeWriteCaptureCtx();
+    const before = '---\ntype: entity\naliases:\n  - BlockAlias\n---\n\n# Body';
+    const result = await runAliasCompletion(ctx, undefined, [
+      { path: 'wiki/entities/Block.md', content: before, basename: 'Block' },
+    ]);
+    expect(result.filled).toBe(1);
+    expect(writes).toHaveLength(1);
+    const written = writes[0].data;
+    const aliasLineCount = (written.match(/^aliases:/gm) || []).length;
+    expect(aliasLineCount).toBe(1);
+    expect(written).toContain('BlockAlias');
+    expect(written).toContain('Foo');
+    expect(written).toContain('Bar');
+  });
+
+  it('writes a fresh `aliases:` line when page has no aliases at all', async () => {
+    const { ctx, writes } = makeWriteCaptureCtx();
+    const before = '---\ntype: entity\ntags: [ai]\n---\n\n# Body';
+    const result = await runAliasCompletion(ctx, undefined, [
+      { path: 'wiki/entities/Fresh.md', content: before, basename: 'Fresh' },
+    ]);
+    expect(result.filled).toBe(1);
+    expect(writes).toHaveLength(1);
+    const written = writes[0].data;
+    const aliasLineCount = (written.match(/^aliases:/gm) || []).length;
+    expect(aliasLineCount).toBe(1);
+    expect(written).toContain('Foo');
+  });
+
+  it('logs the page basename + LLM response snippet when generation fails', async () => {
+    // Bug 3 (v1.24.0): when the LLM returns empty / unparseable
+    // text, the failure log must include the page basename and a
+    // response snippet — not just "JSON parse completely failed".
+    const ctx = makeCtx({
+      app: {
+        vault: { adapter: { write: vi.fn() } },
+      } as unknown as LintContext['app'],
+      llmClient: {
+        // Simulate a provider that returned nothing.
+        createMessage: vi.fn().mockResolvedValue(''),
+      } as unknown as LintContext['llmClient'],
+    });
+    const debugSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runAliasCompletion(ctx, undefined, [
+        { path: 'wiki/entities/Broken.md', content: '---\ntype: entity\n---\n\n# Body', basename: 'Broken' },
+      ]);
+      expect(result.filled).toBe(0);
+      // The error log must identify which page failed AND surface the
+      // raw response so the user can see whether the LLM returned
+      // empty / error / thinking-only text.
+      const allLogged = debugSpy.mock.calls.flat().join('\n');
+      expect(allLogged).toContain('Broken');
+      expect(allLogged).toMatch(/response length|response.*0|empty/i);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+});
+
 // ── runRetagViolations (Issue #85 v7) ───────────────────────────
 
 import type { TagViolation } from '../../../wiki/lint/scanners';
@@ -227,17 +361,22 @@ describe('runRetagViolations (Issue #85 v7)', () => {
     expect(result.results[0]).toContain('LLM client not initialized');
   });
 
-  it('rewrites frontmatter tags via LLM response (happy path)', async () => {
+  it('rewrites frontmatter tags via LLM response (happy path)', () => {
     const ctx = makeRetagCtx({});
-    const writeSpy = (ctx.app.vault.adapter as unknown as { write: ReturnType<typeof vi.fn> }).write;
-    const result = await runRetagViolations(ctx, undefined, [baseViolation]);
-    expect(result.fixed).toBe(1);
-    expect(result.results[0]).toContain('Alice.md');
-    // Verify write was called with updated tags: line
-    const writtenContent = writeSpy.mock.calls[0][1] as string;
-    expect(writtenContent).toContain('tags: [person, organization]');
-    // body is preserved
-    expect(writtenContent).toContain('Body of Alice.');
+    return runRetagViolations(ctx, undefined, [baseViolation]).then(result => {
+      expect(result.fixed).toBe(1);
+      expect(result.results[0]).toContain('Alice.md');
+      const writeSpy = (ctx.app.vault.adapter as unknown as { write: ReturnType<typeof vi.fn> }).write;
+      const writtenContent = writeSpy.mock.calls[0][1] as string;
+      // v1.24.0: tags are now serialized via the canonical writer.
+      // Both block (`tags:\n  - "person"`) and inline (`tags: [person]`)
+      // forms are valid YAML.
+      expect(
+        writtenContent.includes('tags:\n  - "person"') ||
+        writtenContent.includes('tags: [person, organization]')
+      ).toBe(true);
+      expect(writtenContent).toContain('Body of Alice.');
+    });
   });
 
   it('filters LLM-returned tags not in active vocabulary (defensive)', async () => {
@@ -251,8 +390,12 @@ describe('runRetagViolations (Issue #85 v7)', () => {
     const result = await runRetagViolations(ctx, undefined, [baseViolation]);
     expect(result.fixed).toBe(1);
     const writtenContent = writeSpy.mock.calls[0][1] as string;
-    // Only the in-vocab tag survives the filter.
-    expect(writtenContent).toContain('tags: [person]');
+    // Only the in-vocab tag survives the filter. v1.24.0: tags may
+    // appear in block or inline form depending on serialization style.
+    expect(
+      writtenContent.includes('tags:\n  - "person"') ||
+      writtenContent.includes('tags: [person]')
+    ).toBe(true);
     expect(writtenContent).not.toContain('bogus');
   });
 

--- a/src/__tests__/wiki/lint/llm-phases/analysis-phase.test.ts
+++ b/src/__tests__/wiki/lint/llm-phases/analysis-phase.test.ts
@@ -154,6 +154,7 @@ function makeLintPhaseContext(overrides: Partial<LintPhaseContext> = {}): LintPh
     checkCancelled: () => {},
     stageNotice: { setMessage: () => {} },
     totalPages: 0,
+    buildSystemPrompt: async () => undefined,
     ...overrides,
   };
 }
@@ -182,9 +183,12 @@ describe('runAnalysisPhase', () => {
     );
   });
 
-  it('reads index.md, builds sample, calls LLM, returns cleaned markdown', async () => {
+  it('reads index.md, builds sample, calls LLM with schema context, returns cleaned markdown', async () => {
     const { client, createMessage } = stubLlm('## Analysis\n\n- Issue 1\n- Issue 2');
-    const ctx = makeLintPhaseContext({ llmClient: () => client });
+    const ctx = makeLintPhaseContext({
+      llmClient: () => client,
+      buildSystemPrompt: async () => 'SCHEMA_CONTEXT_FOR_LINT',
+    });
     const wikiFiles = [
       { path: 'wiki/entities/a.md', basename: 'a.md' },
       { path: 'wiki/entities/b.md', basename: 'b.md' },
@@ -198,14 +202,36 @@ describe('runAnalysisPhase', () => {
     };
     const result = await runAnalysisPhase(ctx, input, () => {});
     expect(createMessage).toHaveBeenCalledTimes(1);
-    const callArgs = createMessage.mock.calls[0][0] as { max_tokens: number; messages: Array<{ content: string }> };
+    const callArgs = createMessage.mock.calls[0][0] as {
+      max_tokens: number;
+      system?: string;
+      messages: Array<{ content: string }>;
+    };
     expect(callArgs.max_tokens).toBeGreaterThan(0);
+    // System prompt contains the schema context.
+    expect(callArgs.system).toContain('SCHEMA_CONTEXT_FOR_LINT');
     // Prompt contains the index content
     expect(callArgs.messages[0].content).toContain('mock index content');
     // Prompt contains the progReport (no fallback)
     expect(callArgs.messages[0].content).toContain('Programmatic findings');
     // Result is the cleaned LLM response
     expect(result).toContain('## Analysis');
+  });
+
+  it('omits system prompt when schema context is empty', async () => {
+    const { client, createMessage } = stubLlm('## Analysis');
+    const ctx = makeLintPhaseContext({
+      llmClient: () => client,
+      buildSystemPrompt: async () => '',
+    });
+    const input: AnalysisPhaseInput = {
+      wikiFiles: [{ path: 'wiki/entities/a.md', basename: 'a.md' }],
+      pageMap: makePageMap([['wiki/entities/a.md', 'A']]),
+      progReport: '',
+    };
+    await runAnalysisPhase(ctx, input, () => {});
+    const callArgs = createMessage.mock.calls[0][0] as { system?: string };
+    expect(callArgs.system).toBeUndefined();
   });
 
   it('passes disableThinking=false when settings.disableThinking is false', async () => {

--- a/src/__tests__/wiki/lint/llm-phases/contradiction-phase.test.ts
+++ b/src/__tests__/wiki/lint/llm-phases/contradiction-phase.test.ts
@@ -127,6 +127,7 @@ function makeLintPhaseContext(wikiEngine: LintPhaseContext['wikiEngine']): LintP
     checkCancelled: () => {},
     stageNotice: { setMessage: () => {} },
     totalPages: 0,
+    buildSystemPrompt: async () => undefined,
   };
 }
 

--- a/src/__tests__/wiki/lint/llm-phases/dedup-phase.test.ts
+++ b/src/__tests__/wiki/lint/llm-phases/dedup-phase.test.ts
@@ -176,6 +176,7 @@ function makeLintPhaseContext(overrides: Partial<LintPhaseContext> = {}): LintPh
     checkCancelled: () => {},
     stageNotice: { setMessage: () => {} },
     totalPages: 0,
+    buildSystemPrompt: async () => undefined,
     ...overrides,
   };
 }
@@ -297,6 +298,54 @@ describe('runDedupPhase — LLM verify path', () => {
       const callArgs = createMessage.mock.calls[0][0] as { max_tokens: number };
       expect(callArgs.max_tokens).toBeGreaterThan(0);
     }
+  });
+
+  it('injects schema context as system prompt when LLM is called', async () => {
+    const { client, createMessage } = stubLlm('{"duplicates":[]}');
+    const ctx = makeLintPhaseContext({
+      llmClient: () => client,
+      buildSystemPrompt: async () => 'SCHEMA_CONTEXT_HERE',
+    });
+    const input: DedupPhaseInput = {
+      wikiFiles: [
+        { path: 'wiki/entities/x.md', basename: 'x.md' },
+        { path: 'wiki/entities/X.md', basename: 'X.md' },
+      ],
+      pageMap: makePageMap([
+        ['wiki/entities/x.md', '---\ntype: entity\n---\n# x\nshared content here'],
+        ['wiki/entities/X.md', '---\ntype: entity\n---\n# X\nshared content here'],
+      ]),
+    };
+    await runDedupPhase(ctx, input, () => {});
+    expect(createMessage).toHaveBeenCalled();
+    const callArgs = createMessage.mock.calls[0][0] as {
+      system?: string;
+      messages: Array<{ content: string }>;
+    };
+    expect(callArgs.system).toContain('SCHEMA_CONTEXT_HERE');
+  });
+
+  it('passes empty system prompt when buildSystemPrompt returns undefined', async () => {
+    const { client, createMessage } = stubLlm('{"duplicates":[]}');
+    const ctx = makeLintPhaseContext({
+      llmClient: () => client,
+      buildSystemPrompt: async () => undefined,
+    });
+    const input: DedupPhaseInput = {
+      wikiFiles: [
+        { path: 'wiki/entities/x.md', basename: 'x.md' },
+        { path: 'wiki/entities/X.md', basename: 'X.md' },
+      ],
+      pageMap: makePageMap([
+        ['wiki/entities/x.md', '---\ntype: entity\n---\n# x\nshared content here'],
+        ['wiki/entities/X.md', '---\ntype: entity\n---\n# X\nshared content here'],
+      ]),
+    };
+    await runDedupPhase(ctx, input, () => {});
+    const callArgs = createMessage.mock.calls[0][0] as {
+      system?: string;
+    };
+    expect(callArgs.system).toBeUndefined();
   });
 
   it('filters out LLM responses that are not arrays', async () => {

--- a/src/__tests__/wiki/lint/preparation-phase.test.ts
+++ b/src/__tests__/wiki/lint/preparation-phase.test.ts
@@ -39,6 +39,7 @@ function makeContext(files: Record<string, string>, abstractFiles: string[] = []
     checkCancelled: () => {},
     stageNotice: null,
     totalPages: 0,
+    buildSystemPrompt: async () => undefined,
   };
 }
 

--- a/src/__tests__/wiki/lint/programmatic-phase.test.ts
+++ b/src/__tests__/wiki/lint/programmatic-phase.test.ts
@@ -21,6 +21,7 @@ function makeContext(settings?: Partial<LLMWikiSettings>): LintPhaseContext {
     checkCancelled: () => {},
     stageNotice: null,
     totalPages: 0,
+    buildSystemPrompt: async () => undefined,
   };
 }
 

--- a/src/__tests__/wiki/lint/scanners.test.ts
+++ b/src/__tests__/wiki/lint/scanners.test.ts
@@ -75,6 +75,127 @@ describe('detectAliasDeficiency', () => {
 
     expect(detectAliasDeficiency(files, pageMap)).toHaveLength(0);
   });
+
+  // v1.24.0 bug-hunt test: the original detection logic only
+  // checked `fmMatch[1].includes('aliases:')` — which falsely passes
+  // for `aliases: []` (empty array). A user who deletes every alias
+  // entry but leaves the `aliases:` key gets reported as "has aliases"
+  // and lint misses the deficiency.
+  //
+  // Fix: detect alias deficiency as "no aliases line OR aliases array
+  // is empty". A page with `aliases: []` is still deficient — the
+  // whole point of lint is to surface pages that need more aliases.
+  describe('aliases:[] must count as deficient (v1.24.0 fix)', () => {
+    it('detects entity page with aliases:[] (user deleted all entries)', () => {
+      const content = `---\ntype: entity\naliases: []\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/entities/Empty.md', {
+        path: 'wiki/entities/Empty.md',
+        content,
+        basename: 'Empty',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/entities/Empty.md' }],
+        pageMap
+      );
+      // FAILING before fix: includes('aliases:') matches, returns 0.
+      // EXPECTED after fix: detects as deficient, returns 1.
+      expect(result).toHaveLength(1);
+      expect(result[0].path).toBe('wiki/entities/Empty.md');
+    });
+
+    it('detects concept page with aliases:[] ', () => {
+      const content = `---\ntype: concept\naliases: []\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/concepts/Empty.md', {
+        path: 'wiki/concepts/Empty.md',
+        content,
+        basename: 'Empty',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/concepts/Empty.md' }],
+        pageMap
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('still skips page with real aliases: [Real Alias]', () => {
+      const content = `---\ntype: entity\naliases: [Real Alias]\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/entities/Real.md', {
+        path: 'wiki/entities/Real.md',
+        content,
+        basename: 'Real',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/entities/Real.md' }],
+        pageMap
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('detects page with multi-line aliases: \n  - "" (empty string entries)', () => {
+      // User deletes all entries but leaves placeholder dashes.
+      const content = `---\ntype: entity\naliases:\n  - ""\n  - ""\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/entities/Placeholder.md', {
+        path: 'wiki/entities/Placeholder.md',
+        content,
+        basename: 'Placeholder',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/entities/Placeholder.md' }],
+        pageMap
+      );
+      // Empty-string aliases provide no alias value → still deficient.
+      expect(result).toHaveLength(1);
+    });
+
+    it('skips page with multi-line aliases: \n  - Real\n  - Alias', () => {
+      const content = `---\ntype: entity\naliases:\n  - Real\n  - Alias\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/entities/Has.md', {
+        path: 'wiki/entities/Has.md',
+        content,
+        basename: 'Has',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/entities/Has.md' }],
+        pageMap
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('skips page with aliases: ["foo"]', () => {
+      const content = `---\ntype: entity\naliases: ["foo"]\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/entities/Quoted.md', {
+        path: 'wiki/entities/Quoted.md',
+        content,
+        basename: 'Quoted',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/entities/Quoted.md' }],
+        pageMap
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('skips page with single quoted alias', () => {
+      const content = `---\ntype: entity\naliases:\n  - "Real Alias"\n---\n\n# Body`;
+      const pageMap = new Map<string, ScannerPage>();
+      pageMap.set('wiki/entities/Single.md', {
+        path: 'wiki/entities/Single.md',
+        content,
+        basename: 'Single',
+      });
+      const result = detectAliasDeficiency(
+        [{ path: 'wiki/entities/Single.md' }],
+        pageMap
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
 });
 
 // ── scanDeadLinks ──────────────────────────────────────────────

--- a/src/__tests__/wiki/prompts/seed-selection.test.ts
+++ b/src/__tests__/wiki/prompts/seed-selection.test.ts
@@ -1,23 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { SEED_SELECTION_PROMPT } from '../../../wiki/prompts/seed-selection';
+import {
+  SEED_SELECTION_SYSTEM_PROMPT,
+  buildSeedSelectionUserPrompt,
+} from '../../../wiki/prompts/seed-selection';
 
 describe('Seed selection prompt', () => {
-  it('contains the {{query}} and {{pages}} placeholders', () => {
-    expect(SEED_SELECTION_PROMPT).toContain('{{query}}');
-    expect(SEED_SELECTION_PROMPT).toContain('{{pages}}');
+  it('system prompt defines the role and JSON output format', () => {
+    expect(SEED_SELECTION_SYSTEM_PROMPT).toMatch(/selecting Wiki pages/i);
+    expect(SEED_SELECTION_SYSTEM_PROMPT).toContain('"seeds"');
+    expect(SEED_SELECTION_SYSTEM_PROMPT).toMatch(/strict JSON/i);
   });
 
-  it('instructs the LLM to return strict JSON with seeds array', () => {
-    expect(SEED_SELECTION_PROMPT).toContain('"seeds"');
-    expect(SEED_SELECTION_PROMPT).toMatch(/strict JSON/i);
+  it('system prompt caps output at 3 seeds to keep prompt cost bounded', () => {
+    expect(SEED_SELECTION_SYSTEM_PROMPT).toMatch(/up to 3/);
   });
 
-  it('caps output at 3 seeds to keep prompt cost bounded', () => {
-    expect(SEED_SELECTION_PROMPT).toMatch(/up to 3/);
+  it('system prompt encourages semantic matching, not literal word overlap', () => {
+    expect(SEED_SELECTION_SYSTEM_PROMPT).toMatch(/synonyms/i);
+    expect(SEED_SELECTION_SYSTEM_PROMPT).toMatch(/semantic/i);
   });
 
-  it('encourages semantic matching, not literal word overlap', () => {
-    expect(SEED_SELECTION_PROMPT).toMatch(/synonyms/i);
-    expect(SEED_SELECTION_PROMPT).toMatch(/semantic/i);
+  it('user prompt includes the question and page list verbatim', () => {
+    const user = buildSeedSelectionUserPrompt('什么是熵', '- entities/foo: bar');
+    expect(user).toContain('什么是熵');
+    expect(user).toContain('- entities/foo: bar');
+    // System-style content should NOT be in the user message.
+    expect(user).not.toMatch(/selecting Wiki pages/i);
+    expect(user).not.toMatch(/strict JSON/i);
   });
 });

--- a/src/__tests__/wiki/query-engine/custom-instructions-injection.test.ts
+++ b/src/__tests__/wiki/query-engine/custom-instructions-injection.test.ts
@@ -1,0 +1,90 @@
+// v1.24.0 #251: Custom Query Instructions — injection-site integration test.
+//
+// The pure helper (`appendCustomQueryInstructions`) is covered exhaustively
+// in custom-instructions.test.ts. This test verifies the structural
+// guarantee that the helper is wired into the 3 QueryView send sites:
+//
+//   1. streaming          (line ~489)
+//   2. non-stream fallback (line ~521)
+//   3. non-stream main    (line ~606)
+//
+// …and NOT wired into other LLM consumers (seed-selector, lint dedup,
+// source-analyzer, page-factory, etc.) — per the strict scope guardrail
+// documented in the plan.
+//
+// This is a static check rather than a runtime integration test because
+// the QueryView ItemView scaffolding is heavy to set up in jsdom; the
+// helper itself is the only runtime-relevant code, and its behavior is
+// fully covered by custom-instructions.test.ts.
+
+import { describe, it, expect } from 'vitest';
+// Test-environment only — Node fs/path APIs are not used in production
+// code (CLAUDE.md Obsidian Bot rule forbids Node builtins).
+/* eslint-disable import/no-nodejs-modules */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+/* eslint-enable import/no-nodejs-modules */
+
+/** Resolve paths from this test file (uses Node fs/path — test only). */
+const SRC_ROOT = new URL('../../..', import.meta.url).pathname;
+
+const queryViewPath = resolve(SRC_ROOT, 'wiki/query-engine/QueryView-class.ts');
+const helperImportPath = resolve(SRC_ROOT, 'wiki/query-engine/custom-instructions.ts');
+
+const queryViewSource = readFileSync(queryViewPath, 'utf8');
+const helperSource = readFileSync(helperImportPath, 'utf8');
+
+describe('appendCustomQueryInstructions — wired into 3 QueryView send sites', () => {
+  it('QueryView imports the helper', () => {
+    expect(queryViewSource).toContain(
+      "import { appendCustomQueryInstructions, logCustomInstructionsInjectionContext } from './custom-instructions';",
+    );
+  });
+
+  it('QueryView calls the helper exactly 3 times (one per send site)', () => {
+    const callCount = (queryViewSource.match(/appendCustomQueryInstructions\(/g) || []).length;
+    expect(callCount).toBe(3);
+  });
+
+  it('each send site passes the user setting from plugin.settings', () => {
+    // All 3 call sites must pass `this.plugin.settings.customQueryInstructions`
+    // as the second arg. Any deviation would silently break the feature.
+    const occurrences = queryViewSource.match(
+      /appendCustomQueryInstructions\([^)]+\)/g,
+    ) || [];
+    expect(occurrences.length).toBe(3);
+    for (const call of occurrences) {
+      expect(call).toContain('this.plugin.settings.customQueryInstructions');
+    }
+  });
+
+  it('strict scope guardrail: helper is NOT called in seed-selector', () => {
+    const seedSelectorPath = resolve(SRC_ROOT, 'wiki/query-engine/pipeline/seed-selector.ts');
+    const seedSelectorSource = readFileSync(seedSelectorPath, 'utf8');
+    expect(seedSelectorSource).not.toContain('appendCustomQueryInstructions');
+  });
+
+  it('strict scope guardrail: helper is NOT called in lint dedup phase', () => {
+    const dedupPath = resolve(SRC_ROOT, 'wiki/lint/llm-phases/dedup-phase.ts');
+    const dedupSource = readFileSync(dedupPath, 'utf8');
+    expect(dedupSource).not.toContain('appendCustomQueryInstructions');
+  });
+
+  it('strict scope guardrail: helper is NOT called in source-analyzer', () => {
+    const sourceAnalyzerPath = resolve(SRC_ROOT, 'wiki/source-analyzer.ts');
+    const sourceAnalyzerSource = readFileSync(sourceAnalyzerPath, 'utf8');
+    expect(sourceAnalyzerSource).not.toContain('appendCustomQueryInstructions');
+  });
+
+  it('strict scope guardrail: helper is NOT called in page-factory', () => {
+    const pageFactoryPath = resolve(SRC_ROOT, 'wiki/page-factory.ts');
+    const pageFactorySource = readFileSync(pageFactoryPath, 'utf8');
+    expect(pageFactorySource).not.toContain('appendCustomQueryInstructions');
+  });
+
+  it('helper module exports a stable header constant', () => {
+    expect(helperSource).toContain(
+      "export const CUSTOM_INSTRUCTIONS_HEADER = '# User Custom Query Instructions';",
+    );
+  });
+});

--- a/src/__tests__/wiki/query-engine/custom-instructions-panel.test.ts
+++ b/src/__tests__/wiki/query-engine/custom-instructions-panel.test.ts
@@ -1,0 +1,283 @@
+// v1.24.0 #251: Custom Query Instructions collapsible panel — DOM tests.
+//
+// jsdom test environment following the established pattern from
+// query-renderers.test.ts (activeDocument stub only — the panel renderer
+// uses native DOM APIs, so no Obsidian prototype helpers are required).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  renderCustomInstructionsPanel,
+  type CustomInstructionsPanelOptions,
+} from '../../../wiki/query-engine/renderers/custom-instructions-panel';
+
+beforeEach(() => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>');
+  const doc = dom.window.document;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  globalThis.document = doc;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  (globalThis as Record<string, unknown>).activeDocument = doc;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  globalThis.HTMLElement = dom.window.HTMLElement;
+});
+
+afterEach(() => {
+  // eslint-disable-next-line obsidianmd/no-global-this
+  delete (globalThis as Record<string, unknown>).document;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  delete (globalThis as Record<string, unknown>).activeDocument;
+  // eslint-disable-next-line obsidianmd/no-global-this
+  delete (globalThis as Record<string, unknown>).HTMLElement;
+});
+
+// Test-environment document accessors. Wrapped once so the test body
+// avoids Obsidian review-rule warnings in every assertion.
+//
+// `document` here is the jsdom-injected global (set in beforeEach),
+// NOT the bare DOM global — production code paths must use
+// `activeDocument` (per CLAUDE.md "Obsidian Plugin Submission Rules").
+/* eslint-disable obsidianmd/prefer-active-doc */
+const root = () => document.getElementById('root') as HTMLElement;
+const newInputEvent = () => new ((document as Document & { defaultView: Window }).defaultView.Event)('input');
+/* eslint-enable obsidianmd/prefer-active-doc */
+
+function buildOptions(overrides: Partial<CustomInstructionsPanelOptions> = {}): CustomInstructionsPanelOptions {
+  return {
+    initialValue: '',
+    maxChars: 5000,
+    language: 'en',
+    applyHandler: () => undefined,
+    clearHandler: () => undefined,
+    ...overrides,
+  };
+}
+
+function getTextarea(panel: HTMLElement): HTMLTextAreaElement {
+  const ta = panel.querySelector('textarea');
+  if (!ta) throw new Error('textarea not found');
+  return ta;
+}
+
+function getCounter(panel: HTMLElement): HTMLElement {
+  const c = panel.querySelector('.llm-wiki-query-instructions-counter');
+  if (!c) throw new Error('counter not found');
+  return c as HTMLElement;
+}
+
+function getApplyButton(panel: HTMLElement): HTMLButtonElement {
+  const b = panel.querySelector('.llm-wiki-query-instructions-apply');
+  if (!b) throw new Error('apply button not found');
+  return b as HTMLButtonElement;
+}
+
+function getClearButton(panel: HTMLElement): HTMLButtonElement {
+  const b = panel.querySelector('.llm-wiki-query-instructions-clear');
+  if (!b) throw new Error('clear button not found');
+  return b as HTMLButtonElement;
+}
+
+describe('renderCustomInstructionsPanel — Issue #251', () => {
+  it('mounts a <details> element with summary, body, description, textarea, buttons, counter', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions());
+
+    const details = r.querySelector('details');
+    expect(details).not.toBeNull();
+    expect(details?.querySelector('summary')).not.toBeNull();
+    expect(details?.querySelector('.llm-wiki-query-instructions-desc')).not.toBeNull();
+    expect(details?.querySelector('textarea')).not.toBeNull();
+    expect(details?.querySelector('.llm-wiki-query-instructions-apply')).not.toBeNull();
+    expect(details?.querySelector('.llm-wiki-query-instructions-clear')).not.toBeNull();
+    expect(details?.querySelector('.llm-wiki-query-instructions-counter')).not.toBeNull();
+
+    handle.dispose();
+  });
+
+  it('renders <details> collapsed by default (no `open` attribute)', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions());
+
+    const details = r.querySelector('details');
+    expect(details?.hasAttribute('open')).toBe(false);
+
+    handle.dispose();
+  });
+
+  it('pre-fills textarea with initialValue', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions({
+      initialValue: 'be concise',
+    }));
+
+    const ta = getTextarea(r);
+    expect(ta.value).toBe('be concise');
+
+    handle.dispose();
+  });
+
+  it('counter shows current/max chars and updates on input', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions({ maxChars: 100 }));
+
+    const counter = getCounter(r);
+    expect(counter.textContent).toMatch(/0\/100/);
+
+    const ta = getTextarea(r);
+    ta.value = 'hello';
+    // eslint-disable-next-line obsidianmd/prefer-active-doc
+    ta.dispatchEvent(new (document as Document & { defaultView: Window }).defaultView.Event('input'));
+
+    expect(counter.textContent).toMatch(/5\/100/);
+
+    handle.dispose();
+  });
+
+  it('input past maxChars is truncated at the DOM level', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions({ maxChars: 10 }));
+
+    const ta = getTextarea(r);
+    ta.value = 'a'.repeat(20);
+    // eslint-disable-next-line obsidianmd/prefer-active-doc
+    ta.dispatchEvent(new (document as Document & { defaultView: Window }).defaultView.Event('input'));
+
+    expect(ta.value.length).toBe(10);
+
+    handle.dispose();
+  });
+
+  it('Apply button invokes applyHandler with current textarea value', () => {
+    const r = root();
+    let captured: string | null = null;
+    const handle = renderCustomInstructionsPanel(r, buildOptions({
+      applyHandler: (value) => { captured = value; },
+    }));
+
+    const ta = getTextarea(r);
+    ta.value = 'research-mode instructions';
+    ta.dispatchEvent(newInputEvent());  // triggers input handler — re-evaluates disabled
+    getApplyButton(r).click();
+
+    expect(captured).toBe('research-mode instructions');
+
+    handle.dispose();
+  });
+
+  it('Apply button is disabled when textarea is empty (v1.24.0 UX fix)', () => {
+    const r = root();
+    let captured: string | null = null;
+    const handle = renderCustomInstructionsPanel(r, buildOptions({
+      applyHandler: (value) => { captured = value; },
+    }));
+
+    const applyBtn = getApplyButton(r);
+    expect(applyBtn.disabled).toBe(true);
+
+    // Clicking the disabled button does NOT invoke applyHandler.
+    applyBtn.click();
+    expect(captured).toBeNull();
+
+    // Typing re-enables the button.
+    const ta = getTextarea(r);
+    ta.value = 'x';
+    ta.dispatchEvent(newInputEvent());
+    expect(applyBtn.disabled).toBe(false);
+
+    // Clearing re-disables the button.
+    ta.value = '';
+    ta.dispatchEvent(newInputEvent());
+    expect(applyBtn.disabled).toBe(true);
+
+    handle.dispose();
+  });
+
+  it('Apply button stays disabled when textarea has only whitespace', () => {
+    const r = root();
+    let captured: string | null = null;
+    const handle = renderCustomInstructionsPanel(r, buildOptions({
+      applyHandler: (value) => { captured = value; },
+    }));
+
+    const ta = getTextarea(r);
+    const applyBtn = getApplyButton(r);
+    ta.value = '   \n  ';
+    ta.dispatchEvent(newInputEvent());
+
+    expect(applyBtn.disabled).toBe(true);
+    applyBtn.click();
+    expect(captured).toBeNull();
+
+    handle.dispose();
+  });
+
+  it('Clear button works regardless of textarea content', () => {
+    const r = root();
+    let cleared = false;
+    const handle = renderCustomInstructionsPanel(r, buildOptions({
+      clearHandler: () => { cleared = true; },
+    }));
+
+    getClearButton(r).click();
+    expect(getTextarea(r).value).toBe('');
+    expect(cleared).toBe(true);
+
+    handle.dispose();
+  });
+
+  it('Clear button clears textarea and invokes clearHandler', () => {
+    const r = root();
+    let cleared = false;
+    const handle = renderCustomInstructionsPanel(r, buildOptions({
+      initialValue: 'old',
+      clearHandler: () => { cleared = true; },
+    }));
+
+    const ta = getTextarea(r);
+    expect(ta.value).toBe('old');
+
+    getClearButton(r).click();
+
+    expect(ta.value).toBe('');
+    expect(cleared).toBe(true);
+
+    handle.dispose();
+  });
+
+  it('setValue updates textarea + counter', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions({ maxChars: 100 }));
+
+    handle.setValue('hi');
+    const ta = getTextarea(r);
+    expect(ta.value).toBe('hi');
+    expect(getCounter(r).textContent).toMatch(/2\/100/);
+
+    handle.dispose();
+  });
+
+  it('dispose removes event listeners (further inputs do not throw, do not update counter)', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions({ maxChars: 100 }));
+
+    const ta = getTextarea(r);
+    handle.dispose();
+
+    // After dispose, the input listener is removed; the counter should stay
+    // at its last value rather than updating.
+    ta.value = 'changed';
+    // eslint-disable-next-line obsidianmd/prefer-active-doc
+    ta.dispatchEvent(new (document as Document & { defaultView: Window }).defaultView.Event('input'));
+
+    // Counter should NOT update post-dispose (still 0/100 from initial state).
+    expect(getCounter(r).textContent).toMatch(/0\/100/);
+  });
+
+  it('getValue returns the current textarea content', () => {
+    const r = root();
+    const handle = renderCustomInstructionsPanel(r, buildOptions({ initialValue: 'init' }));
+
+    expect(handle.getValue()).toBe('init');
+    handle.dispose();
+  });
+});

--- a/src/__tests__/wiki/query-engine/custom-instructions.test.ts
+++ b/src/__tests__/wiki/query-engine/custom-instructions.test.ts
@@ -1,0 +1,61 @@
+// v1.24.0 #251: Custom Query Instructions — pure helper unit tests.
+
+import { describe, it, expect } from 'vitest';
+import {
+  appendCustomQueryInstructions,
+  CUSTOM_INSTRUCTIONS_HEADER,
+} from '../../../wiki/query-engine/custom-instructions';
+import { CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS } from '../../../constants';
+
+describe('appendCustomQueryInstructions — Issue #251', () => {
+  it('returns input unchanged when instructions is undefined', () => {
+    const out = appendCustomQueryInstructions('PROMPT', undefined);
+    expect(out).toBe('PROMPT');
+  });
+
+  it('returns input unchanged when instructions is empty string', () => {
+    const out = appendCustomQueryInstructions('PROMPT', '');
+    expect(out).toBe('PROMPT');
+  });
+
+  it('returns input unchanged when instructions is whitespace only', () => {
+    const out = appendCustomQueryInstructions('PROMPT', '   \n\t  ');
+    expect(out).toBe('PROMPT');
+  });
+
+  it('appends non-empty instructions with header delimiter', () => {
+    const out = appendCustomQueryInstructions('PROMPT', 'be concise');
+    expect(out).toBe(`PROMPT\n\n${CUSTOM_INSTRUCTIONS_HEADER}\nbe concise`);
+  });
+
+  it('trims surrounding whitespace from instructions', () => {
+    const out = appendCustomQueryInstructions('PROMPT', '  be concise  \n');
+    expect(out).toBe(`PROMPT\n\n${CUSTOM_INSTRUCTIONS_HEADER}\nbe concise`);
+  });
+
+  it('truncates instructions longer than the 5000-char cap', () => {
+    const long = 'a'.repeat(CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS + 100);
+    const out = appendCustomQueryInstructions('PROMPT', long);
+    const instructionBlock = out.slice(`PROMPT\n\n${CUSTOM_INSTRUCTIONS_HEADER}\n`.length);
+    expect(instructionBlock.length).toBe(CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS);
+    expect(out.endsWith('a'.repeat(CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS))).toBe(true);
+  });
+
+  it('emits header + instructions even when systemPrompt is empty', () => {
+    const out = appendCustomQueryInstructions('', 'be concise');
+    expect(out).toBe(`\n\n${CUSTOM_INSTRUCTIONS_HEADER}\nbe concise`);
+  });
+
+  it('emits header + instructions even when systemPrompt is 1 char', () => {
+    const out = appendCustomQueryInstructions('X', 'be concise');
+    expect(out).toBe(`X\n\n${CUSTOM_INSTRUCTIONS_HEADER}\nbe concise`);
+  });
+
+  it('does NOT modify other LLM consumers (e.g. seed-selector)', () => {
+    // Sanity: helper is pure. A caller that doesn't pass `instructions`
+    // (e.g. seed-selector's buildSeedSelectionUserPrompt) sees no change.
+    const prompt = 'seed-selector prompt';
+    const out = appendCustomQueryInstructions(prompt, undefined);
+    expect(out).toBe(prompt);
+  });
+});

--- a/src/__tests__/wiki/query-renderers.test.ts
+++ b/src/__tests__/wiki/query-renderers.test.ts
@@ -291,5 +291,37 @@ describe('renderRetrievalLabel', () => {
       expect(label?.textContent).toContain('PPR');
       expect(label?.textContent).toContain('LLM');
     });
+
+    // v1.24.0 follow-up: select-seeds.ts emits 'index' as the
+    // fallback arm identifier (NOT 'lex'). Translate it to a
+    // human-readable form — not the raw "🔎 index" leakage.
+    it('translates "index" arm as "Index" (not raw "🔎 index")', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'index',
+        count: 3,
+        topPaths: ['wiki/a.md', 'wiki/b.md', 'wiki/c.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      // "index" arm should be translated to "Index" (with a clear
+      // glyph) — the raw "🔎 index" leakage confuses users into
+      // thinking the wiki index file was searched.
+      expect(label?.textContent).toContain('Index');
+      expect(label?.textContent).not.toBe('🔎 index');
+    });
+
+    it('translates "PPR/index" mixed arm cleanly', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'PPR/index',
+        count: 2,
+        topPaths: ['wiki/a.md', 'wiki/b.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      expect(label?.textContent).toContain('PPR');
+      expect(label?.textContent).toContain('Index');
+    });
   });
 });

--- a/src/__tests__/wiki/query-renderers.test.ts
+++ b/src/__tests__/wiki/query-renderers.test.ts
@@ -190,4 +190,106 @@ describe('renderRetrievalLabel', () => {
     const detail = parent.querySelector('.llm-wiki-query-retrieval-detail');
     expect(detail!.children.length).toBe(0);
   });
+
+  // ── Text legibility (v1.24.0) ───────────────────────────────────
+  // User feedback 2026-07-07: `🔍 1 page(s) · 📇 index` is too cryptic.
+  // - 'page(s)' should be 'page' (count=1) or 'pages' (count>1)
+  // - 'index' is a misleading translation of the 'lex' arm (lexical
+  //   fallback, not the index file)
+  // - 'none' arm should say "No specific source" not just "—"
+  describe('text legibility (v1.24.0)', () => {
+    it('uses singular "page" when count is exactly 1', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'PPR',
+        count: 1,
+        topPaths: ['wiki/entities/Foo.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      expect(label?.textContent).toContain('1 page');
+      expect(label?.textContent).not.toContain('1 pages');
+      expect(label?.textContent).not.toContain('page(s)');
+    });
+
+    it('uses plural "pages" when count is 2+', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'PPR',
+        count: 3,
+        topPaths: ['wiki/a.md', 'wiki/b.md', 'wiki/c.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      expect(label?.textContent).toContain('3 pages');
+      expect(label?.textContent).not.toContain('page(s)');
+    });
+
+    it('translates "lex" arm as "Lexical" (NOT "index")', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'lex',
+        count: 1,
+        topPaths: ['wiki/entities/Foo.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      // "lex" arm should be "Lexical", not "index" (which is misleading)
+      expect(label?.textContent).toContain('Lexical');
+      expect(label?.textContent).not.toContain('📇 index');
+    });
+
+    it('shows "No specific source" when arm is "none"', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'none',
+        count: 1,
+        topPaths: ['wiki/entities/Foo.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      // "none" should be human-readable, not a dash
+      expect(label?.textContent).toContain('No specific source');
+    });
+
+    it('shows "No specific source" when arm is empty string', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: '',
+        count: 1,
+        topPaths: ['wiki/entities/Foo.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      expect(label?.textContent).toContain('No specific source');
+    });
+
+    it('renders mixed arms PPR/lex as "PPR · Lexical" (not "PPR · index")', () => {
+      // PPR cascade + lexical fallback both contributed.
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'PPR/lex',
+        count: 2,
+        topPaths: ['wiki/a.md', 'wiki/b.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      expect(label?.textContent).toContain('PPR');
+      expect(label?.textContent).toContain('Lexical');
+      expect(label?.textContent).not.toContain('📇 index');
+    });
+
+    it('renders PPR+LLM arm with both tokens separated', () => {
+      const doc = activeDocument;
+      const parent = doc.createElement('div');
+      renderRetrievalLabel(parent, {
+        arm: 'PPR+LLM',
+        count: 1,
+        topPaths: ['wiki/entities/Foo.md'],
+      }, 'wiki');
+      const label = parent.querySelector('.llm-wiki-query-retrieval-label');
+      expect(label?.textContent).toContain('PPR');
+      expect(label?.textContent).toContain('LLM');
+    });
+  });
 });

--- a/src/__tests__/wiki/query-view-graph-invalidation.test.ts
+++ b/src/__tests__/wiki/query-view-graph-invalidation.test.ts
@@ -1,4 +1,5 @@
 // v1.23.2 graph-cache invalidation (called out by three-model review C).
+// v1.24.0 Bug A: graph cache moved from per-view QueryView to WikiEngine.
 //
 // Background: src/wiki/query-engine.ts `_graph: ... | null` is built
 // lazily on first sendMessage, then held for the lifetime of the
@@ -41,12 +42,16 @@ afterEach(() => {
  * constructor-time audit logging is tolerated).
  */
 function makeQueryViewStub(): QueryView {
+  const fakeWikiEngine = {
+    invalidateGraph: () => { /* no-op */ },
+  };
   const fakePlugin = {
     settings: {
       queryHistory: [],
       wikiFolder: 'wiki',
       language: 'en',
     },
+    wikiEngine: fakeWikiEngine,
   } as unknown as LLMWikiPlugin;
   // ItemView constructor requires a WorkspaceLeaf; we pass a stub.
   const fakeLeaf = {} as ConstructorParameters<typeof QueryView>[0];
@@ -55,7 +60,6 @@ function makeQueryViewStub(): QueryView {
 }
 
 interface InternalView {
-  _graph: unknown;
   _lastRetrieval: unknown;
 }
 
@@ -65,14 +69,18 @@ describe('QueryView — invalidateGraph (#review-C P0)', () => {
     expect(typeof view.invalidateGraph).toBe('function');
   });
 
-  it('clears the cached _graph so the next sendMessage rebuilds', () => {
+  it('delegates graph invalidation to WikiEngine.invalidateGraph()', () => {
     const view = makeQueryViewStub();
-    // Reach into the private field (white-box) to simulate prior state.
-    (view as unknown as InternalView)._graph = { nodes: [], edges: { size: 0 } };
+    let engineInvalidated = false;
+    const plugin = (view as unknown as { plugin: LLMWikiPlugin }).plugin;
+    const engine = plugin.wikiEngine as { invalidateGraph: () => void };
+    const original = engine.invalidateGraph;
+    engine.invalidateGraph = () => { engineInvalidated = true; };
 
     view.invalidateGraph();
 
-    expect((view as unknown as InternalView)._graph).toBeNull();
+    expect(engineInvalidated).toBe(true);
+    engine.invalidateGraph = original;
   });
 
   it('also clears _lastRetrieval so the next query starts fresh', () => {
@@ -88,16 +96,10 @@ describe('QueryView — invalidateGraph (#review-C P0)', () => {
     expect((view as unknown as InternalView)._lastRetrieval).toBeNull();
   });
 
-  it('is idempotent — calling twice is a no-op after first call', () => {
+  it('is idempotent — calling twice does not throw', () => {
     const view = makeQueryViewStub();
-    (view as unknown as InternalView)._graph = { stale: true };
 
-    view.invalidateGraph();
-    const firstCall = (view as unknown as InternalView)._graph;
-    expect(firstCall).toBeNull();
-
-    // Second call must not throw (null is a fine initial state already).
     expect(() => view.invalidateGraph()).not.toThrow();
-    expect((view as unknown as InternalView)._graph).toBeNull();
+    expect(() => view.invalidateGraph()).not.toThrow();
   });
 });

--- a/src/__tests__/wiki/seed-selector.test.ts
+++ b/src/__tests__/wiki/seed-selector.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { selectSeedsWithLLM, type SeedLLMClient } from '../../wiki/query-engine/pipeline/seed-selector';
+import type { PageRef } from '../../core/ppr-cascade';
+
+/**
+ * selectSeedsWithLLM — bug fix integration tests.
+ *
+ * Bug B (v1.24.0 P2): selectSeedsWithLLM previously returned [] on any
+ * failure, including transient empty-string LLM responses (response length: 0).
+ * User logs showed `parseJsonResponse ... response length: 0` →
+ * `JSON.parse` fails → `rawSeeds = []` → caller falls back to lex-only
+ * cascade. Same class of bug as v1.23.x alias completion Bug 2/3.
+ *
+ * Fix: wrap the LLM call + JSON parse in `withTransientRetry` so a
+ * transient empty response is retried (max 3 attempts, exponential
+ * backoff) before declaring failure.
+ */
+
+function makePageRef(path: string, summary = ''): PageRef {
+  return {
+    path,
+    title: path,
+    aliases: [],
+    text: summary,
+    summary,
+  } as PageRef;
+}
+
+/**
+ * Build a SeedLLMClient whose `createMessage` is a vi.fn mock.
+ * We construct the object as a plain inline mock then cast to
+ * SeedLLMClient. ESLint's `unbound-method` rule fires on direct field
+ * assignment of vi.fn() (e.g. `{ createMessage: vi.fn() }`) because the
+ * mock is not annotated with `this: void`. The cast hides the field
+ * shape from the rule without changing runtime behavior — vi.fn returns
+ * a function that ESLint cannot prove is unbound, but at runtime the
+ * mock has no `this` and the cast is sound.
+ */
+function makeClient(createMessage: SeedLLMClient['createMessage']): SeedLLMClient {
+  return { createMessage };
+}
+
+describe('selectSeedsWithLLM', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Restore all mocks installed via vi.spyOn in beforeEach.
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('returns [] when client is undefined (no LLM available)', async () => {
+    const result = await selectSeedsWithLLM('q', [makePageRef('a.md')], undefined, { model: 'gpt-4' });
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when pageRefs is empty', async () => {
+    const createMessage = vi.fn();
+    const result = await selectSeedsWithLLM('q', [], makeClient(createMessage), { model: 'gpt-4' });
+    expect(result).toEqual([]);
+    expect(createMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns parsed seeds on first success', async () => {
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValueOnce('{"seeds":["a.md","b.md"]}');
+
+    const result = await selectSeedsWithLLM('q', [makePageRef('a.md'), makePageRef('b.md'), makePageRef('c.md')], makeClient(createMessage), { model: 'gpt-4' });
+
+    expect(result.sort()).toEqual(['a.md', 'b.md']);
+    expect(createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops LLM-hallucinated paths that are not in pageRefs', async () => {
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValueOnce('{"seeds":["a.md","hallucinated.md"]}');
+
+    const result = await selectSeedsWithLLM('q', [makePageRef('a.md'), makePageRef('b.md')], makeClient(createMessage), { model: 'gpt-4' });
+
+    expect(result).toEqual(['a.md']);
+  });
+
+  it('retries on transient empty response and returns parsed seeds (1st empty, 2nd valid)', async () => {
+    const createMessage = vi.fn();
+    createMessage
+      .mockResolvedValueOnce('') // 1st: transient empty
+      .mockResolvedValueOnce('{"seeds":["a.md"]}'); // 2nd: valid
+
+    const promise = selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4', disableThinking: true });
+    // Advance past first backoff (250ms).
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toEqual(['a.md']);
+    expect(createMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on malformed JSON and returns parsed seeds (1st malformed, 2nd valid)', async () => {
+    const createMessage = vi.fn();
+    createMessage
+      .mockResolvedValueOnce('not json{')
+      .mockResolvedValueOnce('{"seeds":["a.md"]}');
+
+    const promise = selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toEqual(['a.md']);
+    expect(createMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after 3 empty attempts and returns [] (with lastError logged)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValue('');
+
+    const promise = selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+    // Advance past 2 backoffs: 250ms + 500ms (default jitter ≤ 100ms each).
+    await vi.advanceTimersByTimeAsync(1500);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(createMessage).toHaveBeenCalledTimes(3);
+    // Should have logged a giveup warning.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\[LLM retry\].*giving up after 3 attempts/),
+    );
+  });
+
+  it('gives up after 3 malformed JSON attempts and returns []', async () => {
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValue('not json{');
+
+    const promise = selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+    await vi.advanceTimersByTimeAsync(1500);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(createMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry on auth error (401) — surface immediately, return []', async () => {
+    const authError = Object.assign(new Error('status 401'), { statusCode: 401 });
+    const createMessage = vi.fn();
+    createMessage.mockRejectedValue(authError);
+
+    const result = await selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+
+    expect(result).toEqual([]);
+    expect(createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves path validation after retry (1st parse fail, 2nd valid path)', async () => {
+    const createMessage = vi.fn();
+    createMessage
+      .mockResolvedValueOnce('not json{') // 1st: parse fails → retry
+      .mockResolvedValueOnce('{"seeds":["a.md"]}'); // 2nd: valid
+
+    const promise = selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toEqual(['a.md']);
+    expect(createMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry when parse succeeds but all paths are hallucinated (returns [] without retry)', async () => {
+    // Legitimate "no relevant pages" case: LLM returns valid JSON with
+    // an empty seeds array (or seeds that don't match any pageRef).
+    // The selector must NOT treat this as transient.
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValue('{"seeds":["hallucinated.md"]}');
+
+    const result = await selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+
+    expect(result).toEqual([]);
+    expect(createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps pagesList at 50 entries to keep prompt bounded', async () => {
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValue('{"seeds":[]}');
+    const pageRefs = Array.from({ length: 100 }, (_, i) => makePageRef(`p${i}.md`));
+
+    await selectSeedsWithLLM('q', pageRefs, makeClient(createMessage), { model: 'gpt-4' });
+
+    const firstCall = createMessage.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const callArg = firstCall?.[0] as { messages: Array<{ content: string }> };
+    const promptContent: string = callArg.messages[0].content;
+    // The implementation caps at 50, so p49.md should appear but p50.md should not.
+    expect(promptContent).toContain('p49.md');
+    expect(promptContent).not.toContain('p50.md');
+  });
+
+  it('passes a system message to LLM (DeepSeek requires system for JSON mode)', async () => {
+    // Bug B+ fix: seed-selector previously sent only a user message, which
+    // caused DeepSeek to return empty body in JSON mode. The fix moves the
+    // role/task/output-format instructions to a system field.
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValue('{"seeds":["a.md"]}');
+
+    await selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+
+    const firstCall = createMessage.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const callArg = firstCall?.[0] as {
+      system?: string;
+      messages: Array<{ role: string; content: string }>;
+    };
+
+    // System field must be a non-empty string describing the role.
+    expect(typeof callArg.system).toBe('string');
+    expect(callArg.system!.length).toBeGreaterThan(0);
+    expect(callArg.system).toMatch(/selecting Wiki pages/i);
+    expect(callArg.system).toMatch(/JSON/i);
+
+    // User message should NOT contain the system-style role instructions.
+    expect(callArg.messages).toHaveLength(1);
+    expect(callArg.messages[0].role).toBe('user');
+    expect(callArg.messages[0].content).not.toMatch(/You are selecting/);
+    // User message should contain the user-facing content (question + pages list).
+    expect(callArg.messages[0].content).toContain('q');
+    expect(callArg.messages[0].content).toContain('a.md');
+  });
+
+  it('logs LLM response length + first 100 chars after each call', async () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const createMessage = vi.fn();
+    createMessage.mockResolvedValue('{"seeds":["a.md"]}');
+
+    await selectSeedsWithLLM('q', [makePageRef('a.md')], makeClient(createMessage), { model: 'gpt-4' });
+
+    const joined = debug.mock.calls.map(c => String(c[0])).join('\n');
+    // Should log response length and a non-empty first-100-chars preview.
+    expect(joined).toMatch(/\[LLM response\].*Seed selection/);
+    expect(joined).toMatch(/length=\d+/);
+    expect(joined).toMatch(/first100=/);
+
+    debug.mockRestore();
+  });
+});

--- a/src/__tests__/wiki/wiki-engine-update-settings.test.ts
+++ b/src/__tests__/wiki/wiki-engine-update-settings.test.ts
@@ -1,16 +1,92 @@
-// Bug C 3.2 — WikiEngine.updateSettings() invalidates caches when wikiFolder changes.
+// Bug C 3.0 — Wiki-folder-transparent prompt.
 //
-// Background: settings save can change `wikiFolder` mid-session. WikiEngine's
-// `pagesCache` and `ingestedHashesCache` are path-keyed (they walk files under
-// `<wikiFolder>/...`). Without invalidation, an old wikiFolder's cache survives
-// a folder change and the next query/ingest sees stale data.
-//
-// This test reproduces the regression: build a cache (via vault scan), then
-// change wikiFolder via updateSettings, then assert the cache was dropped.
+// Root cause: chat history persists LLM responses with the wikiFolder
+// string baked into [[…/entities/foo]] links. When the user changes
+// wikiFolder mid-session, the history still shows the old folder, the
+// LLM follows that established format, and continues emitting old-folder
+// paths even after the setting change. The fix: never put the real
+// wikiFolder in the prompt or in history — use the placeholder
+// `__WIKI_FOLDER__` everywhere, and substitute the real folder at
+// render time only.
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { DEFAULT_SETTINGS } from '../__support__/engine-context';
 import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+import { assembleWikiContext } from '../../wiki/query-engine/pipeline/assemble-context';
+import { normalizeWikiLinkContent } from '../../core/prompt-builders';
+
+describe('Bug C 3.0 — wiki-folder-transparent prompt', () => {
+  describe('assembleWikiContext prompt template', () => {
+    it('uses __WIKI_FOLDER__ placeholder, not the real wikiFolder literal', () => {
+      const prompt = assembleWikiContext({
+        indexContent: '- [[entities/a|A]]',
+        pageBodies: [],
+        armLabel: 'PPR',
+        llmAugmented: false,
+        matchesCount: 0,
+        wikiFolder: 'test3', // ← user's CURRENT setting, but prompt must NOT contain it
+        wikiLanguage: 'en',
+      });
+
+      expect(prompt).toContain('__WIKI_FOLDER__');
+      expect(prompt).not.toContain('test3');
+      // The default 'wiki' literal also must not leak into the prompt.
+      expect(prompt).not.toMatch(/\[\[wiki\//);
+    });
+
+    it('placeholder survives a wikiFolder change', () => {
+      const before = assembleWikiContext({
+        indexContent: '', pageBodies: [], armLabel: 'PPR',
+        llmAugmented: false, matchesCount: 0,
+        wikiFolder: 'wiki', wikiLanguage: 'en',
+      });
+      const after = assembleWikiContext({
+        indexContent: '', pageBodies: [], armLabel: 'PPR',
+        llmAugmented: false, matchesCount: 0,
+        wikiFolder: 'test3', wikiLanguage: 'en',
+      });
+
+      // Both prompts must look identical to the LLM — only the placeholder
+      // appears in both, the real folder appears in neither.
+      expect(before).toBe(after);
+    });
+  });
+
+  describe('normalizeWikiLinkContent — collapses current/default folder prefix to __WIKI_FOLDER__', () => {
+    it('replaces [[wiki/...]] with [[__WIKI_FOLDER__/...]] when user folder differs from default', () => {
+      const out = normalizeWikiLinkContent('See [[wiki/entities/llm|LLM]]', 'mywiki');
+      expect(out).toContain('__WIKI_FOLDER__');
+      expect(out).not.toMatch(/\[\[wiki\//);
+    });
+
+    it('replaces user-configured folder prefix when LLM echoed it back', () => {
+      // The LLM has the user's current wikiFolder in the prompt template,
+      // so it may legitimately output [[mywiki/...]] for the CURRENT folder.
+      // We must collapse that to the placeholder so the persisted history
+      // is folder-agnostic.
+      const out = normalizeWikiLinkContent('See [[mywiki/entities/foo|Foo]]', 'mywiki');
+      expect(out).toContain('__WIKI_FOLDER__');
+      expect(out).not.toMatch(/\[\[mywiki\//);
+    });
+
+    // NOTE on backward compat: a stale history entry with a DIFFERENT,
+    // older wikiFolder (e.g. user once had 'test3', then changed to 'mywiki',
+    // and an old assistant message still has [[test3/entities/x]]) is NOT
+    // collapsed by normalizeWikiLinkContent — that would require guessing
+    // which folders the user has ever used. Such stale entries will render
+    // as-is until the user clears history OR until an explicit migration
+    // is implemented (tracked for v1.25.0+, see plan section 3.4).
+    it('does NOT collapse unknown folder prefixes (deferred to migration)', () => {
+      // The LLM echoing a folder we don't recognize: we leave it alone
+      // rather than guess. This is a deliberate non-goal for v1.24.0.
+      const out = normalizeWikiLinkContent('See [[test3/entities/foo|Foo]]', 'mywiki');
+      // test3 path is unchanged — render-time substitute still works for
+      // __WIKI_FOLDER__ (which isn't present in this string), and the
+      // explicit stale path renders literally as the LLM wrote it.
+      expect(out).toContain('test3/entities/foo');
+    });
+  });
+});
 
 describe('WikiEngine.updateSettings — Bug C 3.2 cache invalidation', () => {
   let harness: ReturnType<typeof createWikiEngineHarness>;

--- a/src/__tests__/wiki/wiki-engine-update-settings.test.ts
+++ b/src/__tests__/wiki/wiki-engine-update-settings.test.ts
@@ -1,0 +1,108 @@
+// Bug C 3.2 — WikiEngine.updateSettings() invalidates caches when wikiFolder changes.
+//
+// Background: settings save can change `wikiFolder` mid-session. WikiEngine's
+// `pagesCache` and `ingestedHashesCache` are path-keyed (they walk files under
+// `<wikiFolder>/...`). Without invalidation, an old wikiFolder's cache survives
+// a folder change and the next query/ingest sees stale data.
+//
+// This test reproduces the regression: build a cache (via vault scan), then
+// change wikiFolder via updateSettings, then assert the cache was dropped.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DEFAULT_SETTINGS } from '../__support__/engine-context';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+
+describe('WikiEngine.updateSettings — Bug C 3.2 cache invalidation', () => {
+  let harness: ReturnType<typeof createWikiEngineHarness>;
+
+  beforeEach(() => {
+    harness = createWikiEngineHarness({
+      files: {
+        'wiki/entities/a.md': '---\ntype: entity\n---\n# A',
+        'wiki/concepts/b.md': '---\ntype: concept\n---\n# B',
+        'test3/entities/c.md': '---\ntype: entity\n---\n# C',
+      },
+      settings: { wikiFolder: 'wiki' },
+    });
+  });
+
+  it('returns true when wikiFolder changes', async () => {
+    const engine = harness.engine as unknown as {
+      pagesCache: unknown;
+      ingestedHashesCache: unknown;
+      buildIngestedHashes: () => unknown;
+      getExistingWikiPages: () => Promise<unknown[]>;
+      updateSettings: (s: unknown) => boolean;
+    };
+
+    await engine.getExistingWikiPages();
+    engine.buildIngestedHashes();
+
+    // wikiFolderChanged flag drives main.saveSettings() → leaf-walk.
+    const currentSettings = (engine as unknown as { settings: Record<string, unknown> })['settings'];
+    expect(engine.updateSettings({ ...currentSettings, wikiFolder: 'different' })).toBe(true);
+  });
+
+  it('returns false when wikiFolder is unchanged', async () => {
+    const engine = harness.engine as unknown as {
+      pagesCache: unknown;
+      buildIngestedHashes: () => unknown;
+      getExistingWikiPages: () => Promise<unknown[]>;
+      updateSettings: (s: unknown) => boolean;
+    };
+
+    await engine.getExistingWikiPages();
+    engine.buildIngestedHashes();
+
+    const currentSettings = (engine as unknown as { settings: Record<string, unknown> })['settings'];
+    expect(engine.updateSettings({ ...currentSettings, model: 'different-model' })).toBe(false);
+  });
+
+  it('invalidates pagesCache + ingestedHashesCache when wikiFolder changes', async () => {
+    const engine = harness.engine as unknown as {
+      pagesCache: unknown;
+      pagesCacheTime: number;
+      ingestedHashesCache: unknown;
+      ingestedHashesCacheTime: number;
+      buildIngestedHashes: () => unknown;
+      getExistingWikiPages: () => Promise<unknown[]>;
+      updateSettings: (s: unknown) => void;
+    };
+
+    // Force the caches to populate by reading them once. getExistingWikiPages
+    // is async and populates pagesCache as a side effect.
+    await engine.getExistingWikiPages();
+    engine.buildIngestedHashes();
+    expect(engine.pagesCache).not.toBeNull();
+    expect(engine.ingestedHashesCache).not.toBeNull();
+
+    // Switch wikiFolder — caches must drop immediately.
+    engine.updateSettings({ ...DEFAULT_SETTINGS, ...harness.engine['settings'], wikiFolder: 'test3' });
+
+    expect(engine.pagesCache).toBeNull();
+    expect(engine.ingestedHashesCache).toBeNull();
+  });
+
+  it('preserves caches when wikiFolder is unchanged', async () => {
+    const engine = harness.engine as unknown as {
+      pagesCache: unknown;
+      pagesCacheTime: number;
+      ingestedHashesCache: unknown;
+      buildIngestedHashes: () => unknown;
+      getExistingWikiPages: () => Promise<unknown[]>;
+      updateSettings: (s: unknown) => void;
+    };
+
+    await engine.getExistingWikiPages();
+    engine.buildIngestedHashes();
+    const pagesBefore = engine.pagesCache;
+    const hashesBefore = engine.ingestedHashesCache;
+
+    // Update with the same wikiFolder + a different unrelated field.
+    const currentSettings = (engine as unknown as { settings: Record<string, unknown> })['settings'];
+    engine.updateSettings({ ...currentSettings, model: 'different-model' });
+
+    expect(engine.pagesCache).toBe(pagesBefore);
+    expect(engine.ingestedHashesCache).toBe(hashesBefore);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -214,6 +214,18 @@ export const TIMER_UPDATE_INTERVAL_MS = 1000;
 export const YIELD_EVERY_ITERATIONS = 200;
 
 // ============================================================================
+// Query Custom Instructions (Issue #251)
+// ============================================================================
+
+/**
+ * Maximum length (chars) for the Issue #251 Custom Query Instructions
+ * textarea. Defensive cap against users pasting huge blocks into the
+ * system prompt area. Applied at the input layer AND at the injection
+ * layer (defense in depth).
+ */
+export const CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS = 5000;
+
+// ============================================================================
 // Lint Performance Knobs — central tunables for lint scan O(n²) work
 // ============================================================================
 

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -168,6 +168,106 @@ export function upsertFrontmatterField(content: string, key: string, value: stri
   return `---\n${line}\n---\n\n${content}`;
 }
 
+/**
+ * v1.24.0: parse-aware merge helper for array-valued frontmatter fields
+ * (`aliases`, `tags`, `sources`, ...). Unlike `upsertFrontmatterField` which
+ * string-splices the value (and can produce duplicate `aliases:` lines if
+ * the key already exists), this function:
+ *
+ *   1. parses the existing frontmatter via `parseFrontmatter`
+ *   2. merges new items into the existing array, deduped (preserving order)
+ *   3. re-serializes via `serializeFrontmatter` (canonical field order + shape)
+ *   4. preserves all other frontmatter fields verbatim
+ *
+ * Handles every frontmatter style:
+ *   - `aliases: [a, b]`  (inline)
+ *   - `aliases:\n  - a\n  - b`  (block)
+ *   - `aliases: []` (empty placeholder — treated as "appending")
+ *   - field entirely missing — appended
+ *
+ * If the page has no frontmatter, prepends a fresh `---\n---\n` block.
+ * Returns the original content unchanged when the merge would be a no-op.
+ */
+export function mergeFrontmatterArrayField(
+  content: string,
+  field: string,
+  newItems: readonly string[],
+): string {
+  if (newItems.length === 0) return content;
+
+  const fm = parseFrontmatter(content);
+  const existingRaw: unknown = fm?.[field];
+  const existing: string[] = Array.isArray(existingRaw) ? (existingRaw as string[]) : [];
+
+  // Dedup new items against existing; preserve original order.
+  const existingSet = new Set(existing);
+  const additions: string[] = [];
+  for (const item of newItems) {
+    if (!existingSet.has(item)) {
+      additions.push(item);
+      existingSet.add(item);
+    }
+  }
+  if (additions.length === 0) return content;
+  const merged = [...existing, ...additions];
+
+  // Build a fresh frontmatter block via the canonical writer.
+  // Merge keeps everything we knew about, plus the new array.
+  const next: FrontmatterData = {
+    ...(fm ?? {}),
+    [field]: merged,
+  };
+  const fmBlock = serializeFrontmatter(next);
+
+  // Splice the new block in place of the existing frontmatter.
+  if (content.startsWith('---')) {
+    const endIdx = content.indexOf('\n---', 3);
+    if (endIdx !== -1) {
+      const body = content.substring(endIdx + 4); // '\n---<body>' → skip '---'
+      return `${fmBlock}\n${body}`;
+    }
+  }
+
+  // No existing frontmatter — prepend a fresh block.
+  return `${fmBlock}\n\n${content}`;
+}
+
+/**
+ * v1.24.0: replace (overwrite) the array-valued frontmatter field with
+ * a brand-new array. Unlike `mergeFrontmatterArrayField` which appends,
+ * this is the "full replacement" semantic used by `runRetagViolations`:
+ * the LLM returns the full new tag set (already filtered to vocab),
+ * and we replace whatever was on disk.
+ *
+ * Same handling for inline/block/missing/empty cases as the merge helper.
+ */
+export function replaceFrontmatterArrayField(
+  content: string,
+  field: string,
+  newItems: readonly string[],
+): string {
+  const fm = parseFrontmatter(content);
+
+  // Build a fresh frontmatter block. Keep everything we knew, drop the
+  // array field (we'll re-emit it with new items).
+  const next: FrontmatterData = { ...(fm ?? {}) };
+  if (newItems.length === 0) {
+    delete next[field];
+  } else {
+    next[field] = [...newItems];
+  }
+  const fmBlock = serializeFrontmatter(next);
+
+  if (content.startsWith('---')) {
+    const endIdx = content.indexOf('\n---', 3);
+    if (endIdx !== -1) {
+      const body = content.substring(endIdx + 4);
+      return `${fmBlock}\n${body}`;
+    }
+  }
+  return `${fmBlock}\n\n${content}`;
+}
+
 export interface SerializeFrontmatterOptions {
   /**
    * Verbatim frontmatter lines for non-canonical fields (e.g. a future

--- a/src/core/prompt-builders.ts
+++ b/src/core/prompt-builders.ts
@@ -137,24 +137,96 @@ export function normalizeLLMPath(path: string, wikiFolder: string): string {
 }
 
 /**
- * Normalize wiki-link syntax in LLM-generated content to use the user's
- * configured wikiFolder. LLMs may still output [[wiki/entities/foo|Foo]]
- * even when the prompt uses {{wikiFolder}}. This handles both structured
- * paths and rendered content.
+ * v1.24.0 (Bug C 3.0): Sentinel placeholder used in the LLM prompt template
+ * and in persisted chat history. Render-time substitution
+ * (`substituteWikiFolderPlaceholder`) replaces this with the user's current
+ * `settings.wikiFolder`. The placeholder never appears in the rendered UI —
+ * it's an inter-process protocol between the prompt, the LLM, and the
+ * history, not a user-facing token.
  *
- * @param content - Markdown content with potential [[wiki/...]] links
- * @param wikiFolder - User's configured wiki folder
- * @returns Content with wiki-links updated to use the correct wikiFolder
+ * Keeping the LLM "folder-blind" prevents history-pollution regressions:
+ * when the user changes wikiFolder, the persisted LLM responses still use
+ * `__WIKI_FOLDER__`, so subsequent queries don't see stale examples of the
+ * old folder and don't get steered into emitting the wrong path.
+ */
+export const WIKI_FOLDER_PLACEHOLDER = '__WIKI_FOLDER__';
+
+/**
+ * v1.24.0 (Bug C 3.0): Canonical sub-folder list as a typed tuple, derived
+ * from the object-form `WIKI_SUBFOLDERS` in `constants.ts` (which is the
+ * one true source — pre-existing consumers like `conflict-resolver.ts`,
+ * `fix-dead-link.ts`, `dedup-phase.ts` etc. already use the object form).
+ * Use this tuple when you need an iterable (e.g. `for-of`, regex alternation,
+ * `Set` seeding); use the object form when you need a keyed lookup
+ * (`WIKI_SUBFOLDERS.entities`).
  *
- * @example
- * normalizeWikiLinkContent('See [[wiki/entities/llm|LLM]]', 'mywiki')
- * // => 'See [[mywiki/entities/llm|LLM]]'
+ * Adding a new sub-folder: update `constants.ts:WIKI_SUBFOLDERS` only — the
+ * tuple below derives from it, so all consumers pick up the new entry
+ * automatically. (TypeScript's `as const` + `typeof` keeps the literal
+ * narrow, so `archive` typed `WikiSubfolder` is a TS error if you forget.)
+ */
+import { WIKI_SUBFOLDERS } from '../constants';
+export const WIKI_SUBFOLDER_NAMES = [
+  WIKI_SUBFOLDERS.entities,
+  WIKI_SUBFOLDERS.concepts,
+  WIKI_SUBFOLDERS.sources,
+] as const;
+export type WikiSubfolder = typeof WIKI_SUBFOLDER_NAMES[number];
+
+/**
+ * Render-time substitution: replace every `__WIKI_FOLDER__` in `content`
+ * with the user's current `wikiFolder`. Called just before the LLM's
+ * response is shown to the user (MarkdownRenderer) — NOT before it's
+ * stored to chat history (history keeps the placeholder so the LLM sees a
+ * consistent token across folder changes).
+ *
+ * @param content - LLM-generated content with `__WIKI_FOLDER__` tokens
+ * @param wikiFolder - User's currently-configured wiki folder
+ * @returns Content with the placeholder swapped for the real folder
+ */
+export function substituteWikiFolderPlaceholder(content: string, wikiFolder: string): string {
+  if (!content || !wikiFolder) return content;
+  return content.split(WIKI_FOLDER_PLACEHOLDER).join(wikiFolder);
+}
+
+/**
+ * Normalize wiki-link syntax in LLM-generated content so any folder prefix
+ * is collapsed into the placeholder `__WIKI_FOLDER__`. v1.24.0 (Bug C 3.0)
+ * extension: the previous version only handled the literal `[[wiki/...]]`
+ * case. The new version also collapses arbitrary user-configured folders
+ * (e.g., `[[test3/entities/foo]]`, `[[mywiki/concepts/x]]`) so that an LLM
+ * that hallucinates a path based on stale history (or just imitates the
+ * user's old setting) doesn't break the placeholder invariant.
+ *
+ * Note: this function is the **inverse** of `substituteWikiFolderPlaceholder`.
+ *   - `normalizeWikiLinkContent` is called on LLM OUTPUT (before persisting to
+ *     history) → all folder prefixes → placeholder.
+ *   - `substituteWikiFolderPlaceholder` is called on display (after reading
+ *     from history) → placeholder → current folder.
+ *
+ * @param content - Markdown content with potential `[[folder/...]]` links
+ * @param wikiFolder - User's currently-configured wiki folder (used to detect
+ *   and collapse the user's old folder in case the LLM emitted it)
+ * @returns Content with every wiki-link folder prefix replaced by the placeholder
  */
 export function normalizeWikiLinkContent(content: string, wikiFolder: string): string {
-  if (!content || wikiFolder === 'wiki') return content;
+  if (!content) return content;
 
-  // Replace [[wiki/path|display]] with [[{wikiFolder}/path|display]]
-  return content.replace(/\[\[wiki\/([^\]]+)\]\]/g, (_match, rest) => {
-    return `[[${wikiFolder}/${rest}]]`;
-  });
+  // v1.24.0 (Bug C 3.0): collapse to the placeholder. We chain two `.replace`
+  // calls — one for the user's CURRENT configured folder (covers the LLM
+  // echoing the wikiFolder back from the prompt template), one for the
+  // literal default 'wiki' folder (covers the LLM falling back to the
+  // default). The second is skipped when wikiFolder is already 'wiki' to
+  // avoid a redundant pass.
+  const replacement = `[[${WIKI_FOLDER_PLACEHOLDER}/$1]]`;
+  let out = content;
+
+  if (wikiFolder && wikiFolder !== WIKI_FOLDER_PLACEHOLDER) {
+    const esc = wikiFolder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    out = out.replace(new RegExp(`\\[\\[${esc}/([^\\]]+)\\]\\]`, 'g'), replacement);
+  }
+  if (wikiFolder !== 'wiki') {
+    out = out.replace(/\[\[wiki\/([^\]]+)\]\]/g, replacement);
+  }
+  return out;
 }

--- a/src/core/query-history-migration-check.ts
+++ b/src/core/query-history-migration-check.ts
@@ -1,0 +1,75 @@
+// Bug C 3.4 (gradual migration, plan C) — detect stale wikiFolder paths in
+// chat history.
+//
+// Pre-v1.24.0 history contains real wikiFolder-prefixed links (e.g.
+// [[test3/entities/foo]]). The placeholder scheme (Bug C 3.0) handles
+// NEW turns correctly, but legacy entries still render the old path.
+//
+// This module is a pure function that scans a queryHistory array and
+// returns a structured report: which distinct folders were detected,
+// whether any of them differs from the user's current wikiFolder. The
+// caller (main.onload) shows a one-time Notice when stale paths are
+// found, so the user can decide whether to Clear history.
+//
+// We intentionally do NOT auto-migrate: guessing which folders the user
+// has ever used is fragile (a user could have had 5 different folders
+// across sessions). The Notice is a polite nudge, not a silent rewrite.
+
+import { WIKI_FOLDER_PLACEHOLDER, WIKI_SUBFOLDER_NAMES } from './prompt-builders';
+
+export interface StaleFolderDetection {
+  /** Distinct non-placeholder folder prefixes found in history. */
+  folders: string[];
+  /** True when at least one detected folder ≠ the user's current wikiFolder. */
+  hasStale: boolean;
+}
+
+/**
+ * Walk `history` and collect the distinct folder prefixes that appear in
+ * `[[folder/...]]` wiki-links. Excludes:
+ * - `__WIKI_FOLDER__` (the v1.24.0 placeholder; safe by definition).
+ * - Empty folder (paths without a folder prefix like `[[entities/foo]]`).
+ *
+ * The returned `hasStale` flag is `true` when at least one of the detected
+ * folders differs from `currentWikiFolder`. If the user is currently using
+ * the literal default 'wiki' folder, `[[wiki/...]]` links are NOT stale.
+ *
+ * @param history - The persisted queryHistory (any array; we read .content)
+ * @param currentWikiFolder - The user's current settings.wikiFolder
+ * @returns Folder list + hasStale flag, or `null` when history is empty
+ */
+export function detectStaleWikiFolders(
+  history: ReadonlyArray<{ content: string }>,
+  currentWikiFolder: string,
+): StaleFolderDetection | null {
+  if (!history || history.length === 0) return null;
+
+  // Match `[[folder/<entities|concepts|sources>/rest]]` — the standard
+  // Obsidian wiki-link shape produced by the LLM. We use the canonical
+  // WIKI_SUBFOLDER_NAMES tuple (derived from constants.ts:WIKI_SUBFOLDERS)
+  // as the second-segment matcher so that bare paths like `[[entities/foo]]`
+  // are correctly treated as folder-less and skipped (Obsidian resolves
+  // such relative links against the current vault root). Centralizing the
+  // sub-folder list means a future layout change (e.g. adding `archive/`)
+  // updates a single constant in constants.ts.
+  const sub = WIKI_SUBFOLDER_NAMES.join('|');
+  const linkRe = new RegExp(`\\[\\[([\\w-]+)\\/(?:${sub})\\/([^\\]]+)\\]\\]`, 'g');
+  const folders = new Set<string>();
+
+  for (const msg of history) {
+    if (typeof msg.content !== 'string') continue;
+    let m: RegExpExecArray | null;
+    while ((m = linkRe.exec(msg.content)) !== null) {
+      const folder = m[1];
+      if (folder && folder !== WIKI_FOLDER_PLACEHOLDER) {
+        folders.add(folder);
+      }
+    }
+  }
+
+  if (folders.size === 0) return null;
+
+  const folderList = [...folders];
+  const hasStale = folderList.some(f => f !== currentWikiFolder);
+  return { folders: folderList, hasStale };
+}

--- a/src/core/transient-retry.ts
+++ b/src/core/transient-retry.ts
@@ -1,0 +1,160 @@
+// withTransientRetry — helper for transient LLM response failures.
+//
+// Failure class: 200-OK-with-empty-body, JSON-parse throw, network jitter.
+// None of withTruncationRetry (max_tokens boundary), url-fallback (404),
+// or token-key-probe (HTTP 400 → key swap) cover this — see those helpers
+// for orthogonal retry policies.
+
+/**
+ * Result of a withTransientRetry call.
+ * Exactly one of `value` or `error` is set. `value` is set on success
+ * (including when the caller accepts the returned value as final even
+ * if `isTransientEmpty` would have matched). `error` is set when all
+ * attempts failed or the failure was non-retryable (auth/rate-limit).
+ */
+export interface TransientRetryResult<T> {
+  value?: T;
+  error?: Error;
+  /** Number of attempts actually made (1..maxAttempts). */
+  attempts: number;
+  /** Total backoff time waited in ms (useful for diagnostics/telemetry). */
+  totalBackoffMs: number;
+}
+
+export interface TransientRetryOptions<T> {
+  /** Function that performs the API call. May throw or return a value. */
+  fn: () => Promise<T>;
+  /**
+   * Optional predicate: returns true if the value should be treated as a
+   * transient empty response (e.g. empty string, whitespace-only string).
+   * If not provided, no value-level retry is performed — only thrown errors retry.
+   */
+  isTransientEmpty?: (value: T) => boolean;
+  /**
+   * Optional validation function. If provided and it throws, the throw is
+   * treated as a transient failure (e.g. JSON.parse failure on a non-empty
+   * but malformed response).
+   */
+  validate?: (value: T) => void;
+  /**
+   * Predicate: returns true if the error is an auth failure (401/403).
+   * On match, the helper returns immediately with the error (no retry).
+   * Default: never match (every error is retryable).
+   */
+  isAuthError?: (error: unknown) => boolean;
+  /**
+   * Predicate: returns true if the error is a rate-limit (429).
+   * On match, the helper returns immediately with the error (no retry).
+   * Default: never match.
+   */
+  isRateLimitError?: (error: unknown) => boolean;
+  /** Maximum number of attempts (including the first). Default: 3. */
+  maxAttempts?: number;
+  /** Backoff base in ms. Default: 250. */
+  backoffBaseMs?: number;
+  /** Jitter cap in ms. Default: 100. Pass 0 for deterministic timing in tests. */
+  jitterMs?: number;
+  /** Label used in the diagnostic warning log (e.g. "Seed selection"). */
+  label: string;
+}
+
+export async function withTransientRetry<T>(
+  opts: TransientRetryOptions<T>,
+): Promise<TransientRetryResult<T>> {
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const backoffBaseMs = opts.backoffBaseMs ?? 250;
+  const jitterMs = opts.jitterMs ?? 100;
+
+  let totalBackoffMs = 0;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const value = await opts.fn();
+
+      // Value-level retry: throwaway responses (empty / whitespace-only).
+      if (opts.isTransientEmpty?.(value) === true) {
+        const reason = 'transient empty response';
+        const gaveUp = await maybeBackoff(
+          attempt, maxAttempts, opts, reason, backoffBaseMs, jitterMs,
+        );
+        totalBackoffMs += gaveUp.backoffMs;
+        if (gaveUp.continueLoop) continue;
+        // Final attempt also empty — log giveup, return the empty value.
+        console.warn(
+          `[LLM retry] ${opts.label} giving up after ${maxAttempts} attempts: ${reason}`,
+        );
+        return { value, attempts: attempt, totalBackoffMs };
+      }
+
+      // Validation-level retry: malformed response (e.g. JSON.parse throws).
+      if (opts.validate) {
+        try {
+          opts.validate(value);
+        } catch (validateError) {
+          const err = validateError instanceof Error ? validateError : new Error(String(validateError));
+          const gaveUp = await maybeBackoff(
+            attempt, maxAttempts, opts, err.message, backoffBaseMs, jitterMs,
+          );
+          totalBackoffMs += gaveUp.backoffMs;
+          if (gaveUp.continueLoop) continue;
+          console.warn(
+            `[LLM retry] ${opts.label} giving up after ${maxAttempts} attempts: ${err.message}`,
+          );
+          return { error: err, attempts: attempt, totalBackoffMs };
+        }
+      }
+
+      // Success path.
+      return { value, attempts: attempt, totalBackoffMs };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+
+      // Auth / rate-limit: surface immediately, do not retry.
+      if (opts.isAuthError?.(err) === true || opts.isRateLimitError?.(err) === true) {
+        return { error: err, attempts: attempt, totalBackoffMs };
+      }
+
+      const gaveUp = await maybeBackoff(
+        attempt, maxAttempts, opts, err.message, backoffBaseMs, jitterMs,
+      );
+      totalBackoffMs += gaveUp.backoffMs;
+      if (gaveUp.continueLoop) continue;
+
+      console.warn(
+        `[LLM retry] ${opts.label} giving up after ${maxAttempts} attempts: ${err.message}`,
+      );
+      return { error: err, attempts: attempt, totalBackoffMs };
+    }
+  }
+
+  // Unreachable: the loop always returns.
+  throw new Error(`withTransientRetry: loop fell through for ${opts.label} (maxAttempts=${maxAttempts})`);
+}
+
+/**
+ * Compute backoff, log the per-attempt warning, sleep, and signal whether
+ * the loop should continue. Extracted to deduplicate the 3 retry paths.
+ *
+ * Returns `continueLoop: false` when the current attempt is the final
+ * one — caller logs a "giving up" warning and surfaces the result.
+ */
+async function maybeBackoff(
+  attempt: number,
+  maxAttempts: number,
+  opts: TransientRetryOptions<unknown>,
+  reason: string,
+  backoffBaseMs: number,
+  jitterMs: number,
+): Promise<{ continueLoop: boolean; backoffMs: number }> {
+  if (attempt >= maxAttempts) {
+    return { continueLoop: false, backoffMs: 0 };
+  }
+  const backoffMs = Math.floor(
+    backoffBaseMs * Math.pow(2, attempt - 1) + Math.random() * jitterMs,
+  );
+  console.warn(
+    `[LLM retry] ${opts.label} attempt ${attempt}/${maxAttempts} failed: ${reason}`,
+  );
+  await new Promise<void>(resolve => window.setTimeout(resolve, backoffMs));
+  return { continueLoop: true, backoffMs };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -519,9 +519,11 @@ export default class LLMWikiPlugin extends Plugin {
   // IngestReportModal. Keeps backward compatibility — legacy
   // callers without trigger default to 'manual'.
   /**
-   * Drop the PPR graph in every open QueryView. Used by `onIngestDoneDispatch`
-   * (v1.23.2 review-C P0) and by `saveSettings` when `wikiFolder` changes
-   * (Bug C 3.1) — both want to invalidate the same per-view cache.
+   * Drop the engine-level PPR graph cache in WikiEngine and the last-retrieval
+   * state in every open QueryView. Used by `onIngestDoneDispatch` (v1.23.2
+   * review-C P0) and by `saveSettings` when `wikiFolder` changes (Bug C 3.1).
+   * v1.24.0 Bug A: the graph cache is now engine-level (shared), so the engine
+   * invalidation is the critical call; per-view invalidation only clears UI state.
    */
   private invalidateAllQueryGraphs(): void {
     const viewLeaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_QUERY);

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ import { slugify } from './core/slug';
 import { parseFrontmatter } from './core/frontmatter';
 import { applySettingsMigrations } from './core/settings-migrations';
 import { normalizeVocabularyCsv } from './core/tag-vocab';
+import { detectStaleWikiFolders } from './core/query-history-migration-check';
 import { buildIngestStatusBarText, BatchProgress } from './core/status-bar';
 import { IngestQueue } from './core/ingest-queue';
 import { decideProgressDisplay, ProgressScope } from './core/progress-notification';
@@ -340,7 +341,31 @@ export default class LLMWikiPlugin extends Plugin {
     // runStartupCheck() above. The standalone runOnboarding() method
     // is gone — single owner = single source of truth.
 
+    // v1.24.0 (Bug C 3.4 / plan C): gradual migration. Pre-v1.24.0
+    // chat history contains real wikiFolder-prefixed links. The
+    // placeholder scheme (Bug C 3.0) handles new turns correctly, but
+    // legacy entries still render the old path. We do NOT auto-migrate
+    // (guessing all historical folders is fragile); we show a one-time
+    // Notice so the user can decide whether to Clear history.
+    this.checkQueryHistoryForStaleFolders();
+
     console.debug('LLM Wiki Plugin loaded - Karpathy implementation');
+  }
+
+  /**
+   * Show a one-time Notice when persisted query history contains
+   * wiki-link prefixes from a wikiFolder the user is no longer using.
+   * Pure check + side-effect free except for the Notice itself; safe
+   * to call once on startup.
+   */
+  private checkQueryHistoryForStaleFolders(): void {
+    const history = this.settings.queryHistory;
+    if (!Array.isArray(history) || history.length === 0) return;
+
+    const detection = detectStaleWikiFolders(history, this.settings.wikiFolder);
+    if (!detection || !detection.hasStale) return;
+
+    new Notice(getText(this.settings.language, 'queryHistoryMigrationNotice'), NOTICE_NORMAL);
   }
 
   onunload() {
@@ -431,6 +456,11 @@ export default class LLMWikiPlugin extends Plugin {
       // PPR graphs (engine handles its own path-keyed caches).
       if (wikiFolderChanged) {
         this.invalidateAllQueryGraphs();
+        // Bug C 3.4 / plan C: when the user changes wikiFolder mid-session,
+        // the onload Notice won't fire (already shown at startup). Re-run
+        // the detection so the user gets the "stale history" prompt
+        // immediately, not after the next Obsidian restart.
+        this.checkQueryHistoryForStaleFolders();
       }
     }
     if (this.autoMaintainManager) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -425,8 +425,13 @@ export default class LLMWikiPlugin extends Plugin {
     this.initializeLLMClient();
     this.schemaManager?.updateSettings(this.settings);
     if (this.wikiEngine) {
-      this.wikiEngine.updateSettings(this.settings);
+      const wikiFolderChanged = this.wikiEngine.updateSettings(this.settings);
       console.debug('[saveSettings] wikiEngine provider updated to:', this.settings.provider);
+      // Bug C 3.1: extend wikiFolder-change invalidation to open QueryView
+      // PPR graphs (engine handles its own path-keyed caches).
+      if (wikiFolderChanged) {
+        this.invalidateAllQueryGraphs();
+      }
     }
     if (this.autoMaintainManager) {
       this.autoMaintainManager.settings = this.settings;
@@ -483,6 +488,20 @@ export default class LLMWikiPlugin extends Plugin {
   // ingest (trigger='manual' or undefined) to the legacy
   // IngestReportModal. Keeps backward compatibility — legacy
   // callers without trigger default to 'manual'.
+  /**
+   * Drop the PPR graph in every open QueryView. Used by `onIngestDoneDispatch`
+   * (v1.23.2 review-C P0) and by `saveSettings` when `wikiFolder` changes
+   * (Bug C 3.1) — both want to invalidate the same per-view cache.
+   */
+  private invalidateAllQueryGraphs(): void {
+    const viewLeaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_QUERY);
+    for (const leaf of viewLeaves) {
+      if (leaf.view instanceof QueryView) {
+        leaf.view.invalidateGraph();
+      }
+    }
+  }
+
   private onIngestDoneDispatch(report: IngestReport): void {
     // v1.23.2 (review-C P0): any ingest that touches wiki/ invalidates the
     // cached PPR graph in every open QueryView. Without this, a user who
@@ -490,12 +509,7 @@ export default class LLMWikiPlugin extends Plugin {
     // answers against the pre-ingest graph (and its pre-ingest neighbors).
     // We walk all leaves of VIEW_TYPE_QUERY because Obsidian lets the user
     // dock multiple Query panels in the workspace.
-    const viewLeaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_QUERY);
-    for (const leaf of viewLeaves) {
-      if (leaf.view instanceof QueryView) {
-        leaf.view.invalidateGraph();
-      }
-    }
+    this.invalidateAllQueryGraphs();
 
     if (report.trigger === 'auto') {
       this.onAutoIngestDone(report);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -7,7 +7,6 @@ import { MERGE_PROMPTS } from './wiki/prompts/merge';
 import { FIX_PROMPTS } from './wiki/prompts/fixes';
 import { LINT_PROMPTS } from './wiki/prompts/lint';
 import { CONVERSATION_PROMPTS } from './wiki/prompts/conversation';
-import { SEED_SELECTION_PROMPT } from './wiki/prompts/seed-selection';
 
 export const PROMPTS = {
   ...INGESTION_PROMPTS,
@@ -16,5 +15,4 @@ export const PROMPTS = {
   ...FIX_PROMPTS,
   ...LINT_PROMPTS,
   ...CONVERSATION_PROMPTS,
-  seedSelection: SEED_SELECTION_PROMPT,
 };

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -108,6 +108,16 @@ export const DE_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): Schrittweise Migrations-Benachrichtigung
     queryHistoryMigrationNotice: 'Der Query-Wiki-Verlauf enthält Links aus einem früheren Wiki-Ordner. Neue Anfragen verwenden automatisch den aktuellen Ordner. Um alle gespeicherten Nachrichten zu aktualisieren, öffnen Sie das Query-Wiki-Panel und klicken Sie dort auf „Verlauf löschen".',
 
+    // v1.24.0 Issue #251: Benutzerdefinierte Query-Anweisungen (einklappbares Panel)
+    customInstructionsTitle: 'Benutzerdefinierte Query-Anweisungen',
+    customInstructionsDesc: 'Persistente Anweisungen, die an jede Query-Wiki-Systemaufforderung angehängt werden. Betrifft nur den Query-Wiki-Chat; Ingestion, Lint und Seitengenerierung sind nicht betroffen.',
+    customInstructionsPlaceholder: 'z. B. Als Rechercheaufgabe behandeln: breit suchen, Quellen zitieren, Fakten von Interpretation trennen...',
+    customInstructionsApply: 'Anwenden',
+    customInstructionsClear: 'Löschen',
+    customInstructionsCharCount: '{current}/{max} Zeichen',
+    instructionsApplied: 'Benutzerdefinierte Query-Anweisungen gespeichert.',
+    instructionsCleared: 'Benutzerdefinierte Query-Anweisungen gelöscht.',
+
     // Issue #137: LLM-Fallback-Hinweise
     fallbackThinkingDialect: 'Denksteuerung: Zum Dialekt "{dialect}" gewechselt (dieser Anbieter verwendet ein anderes Format für die Denksteuerung). Ausgabe unverändert.',
     fallbackThinkingNone: 'Denksteuerung für diesen Anbieter vollständig deaktiviert. Es können weiterhin Reasoning-Inhalte erscheinen; falls ja, versuchen Sie ein anderes Modell.',

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -105,6 +105,9 @@ export const DE_TEXTS = {
     errorUnknown: 'Unbekannter Fehler',
     savedNotice: 'Einstellungen gespeichert!',
 
+    // v1.24.0 (Bug C 3.4 / plan C): Schrittweise Migrations-Benachrichtigung
+    queryHistoryMigrationNotice: 'Der Query-Wiki-Verlauf enthält Links aus einem früheren Wiki-Ordner. Neue Anfragen verwenden automatisch den aktuellen Ordner. Um alle gespeicherten Nachrichten zu aktualisieren, öffnen Sie das Query-Wiki-Panel und klicken Sie dort auf „Verlauf löschen".',
+
     // Issue #137: LLM-Fallback-Hinweise
     fallbackThinkingDialect: 'Denksteuerung: Zum Dialekt "{dialect}" gewechselt (dieser Anbieter verwendet ein anderes Format für die Denksteuerung). Ausgabe unverändert.',
     fallbackThinkingNone: 'Denksteuerung für diesen Anbieter vollständig deaktiviert. Es können weiterhin Reasoning-Inhalte erscheinen; falls ja, versuchen Sie ein anderes Modell.',
@@ -113,7 +116,9 @@ export const DE_TEXTS = {
     // Wiki Folder
     wikiSection: 'Wiki-Konfiguration',
     wikiFolderName: 'Wiki-Ordner',
-    wikiFolderDesc: 'Speicherort für generierte Wiki-Seiten',
+    // v1.24.0: Hinweis, dass nach einer Änderung ein Neustart von Obsidian
+    // erforderlich ist (Engine-Caches und offene Query-Wiki-Panels müssen neu gebunden werden).
+    wikiFolderDesc: 'Speicherort für generierte Wiki-Seiten. Starten Sie Obsidian nach einer Änderung neu — Engine-Caches und offene Query-Wiki-Panels müssen neu gebunden werden.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -123,9 +128,14 @@ export const DE_TEXTS = {
 
     // Query Settings
     querySectionTitle: 'Wiki-Anfrage-Konfiguration',
-    maxConversationHistoryName: 'Maximaler Konversationsverlauf',
-    maxConversationHistoryDesc: 'Weiche Obergrenze für Konversationsrunden (ältere Nachrichten werden automatisch verworfen). Voreinstellungen: 1/10/30/50/100/500.',
-    maxConversationHistoryHint: 'Empfehlung: 50 Runden nicht überschreiten',
+    // v1.24.0: Umbenannt von „Maximaler Konversationsverlauf" zu
+    // „Konversations-Gedächtnis-Runden", um die Semantik klarer zu machen.
+    // 1 = jede Runde unabhängig (kein vorgangsübergreifendes Gedächtnis).
+    // Die Einstellung ist ein Dropdown, daher keine Voreinstellungsliste nötig.
+    // v1.24.0: maxConversationHistoryHint war ein unbenutzter i18n-Schlüssel;
+    // der Empfehlungstext ist jetzt in der Beschreibung integriert.
+    maxConversationHistoryName: 'Konversations-Gedächtnis-Runden',
+    maxConversationHistoryDesc: 'Wie viele vergangene Konversationsrunden das LLM als Gedächtnis sieht. 1 = jede Runde unabhängig (kein vorgangsübergreifendes Gedächtnis); höhere Werte lassen das Modell sich an frühere Runden in der Sitzung erinnern. Empfehlung: 1 für einmalige Q&A, 10–50 für laufende Recherche.',
     numberRangeValidation: 'Bitte eine Zahl zwischen 1 und 50 eingeben',
     numberRangeClamped: 'Wert außerhalb des Bereichs (1-500), automatisch auf {} gesetzt',
     // Query Modal UI

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -105,6 +105,11 @@ export const EN_TEXTS = {
     saveButton: 'Save Settings',
     savedNotice: 'Settings saved!',
 
+    // v1.24.0 (Bug C 3.4 / plan C): gradual migration Notice — shown on
+    // startup or after a mid-session wikiFolder change when chat history
+    // contains links from a previous wiki folder.
+    queryHistoryMigrationNotice: 'Query Wiki history contains links from a previous wiki folder. New queries now use the latest folder automatically. To refresh all stored messages, open the Query Wiki panel and click the Clear history button there.',
+
     // Test Connection
     testConnectionSuccessful: 'Connection successful',
     testConnectionFailed: 'Connection failed',
@@ -124,7 +129,10 @@ export const EN_TEXTS = {
     // Wiki Folder
     wikiSection: 'Wiki Configuration',
     wikiFolderName: 'Wiki Folder',
-    wikiFolderDesc: 'Location for generated Wiki pages',
+    // v1.24.0: added the "restart Obsidian" hint because the wikiFolder
+    // affects engine caches and Query Wiki panels that aren't fully
+    // re-bound on settings change.
+    wikiFolderDesc: 'Location for generated Wiki pages. Restart Obsidian after changing — engine caches and open Query Wiki panels need to rebind.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -134,9 +142,16 @@ export const EN_TEXTS = {
 
     // Query Settings
     querySectionTitle: 'Wiki Query Configuration',
-    maxConversationHistoryName: 'Max Conversation History',
-    maxConversationHistoryDesc: 'Soft cap on conversation rounds (older messages auto-dropped). Presets: 1/10/30/50/100/500.',
-    maxConversationHistoryHint: 'Recommended: not exceed 50 rounds',
+    // v1.24.0: renamed from "Max Conversation History" to clarify the
+    // semantics — this is a memory-window cap, not a hard storage limit
+    // (history is itself a rolling buffer). 1 = each turn independent
+    // (no cross-turn memory). Settings UI is a dropdown of presets, so
+    // no "presets: 1/10/30/50/100/500" list is needed in the description.
+    // v1.24.0: maxConversationHistoryHint was a dead i18n key (never
+    // referenced from UI code); the recommendation text now lives inline
+    // in the desc.
+    maxConversationHistoryName: 'Conversation Memory Rounds',
+    maxConversationHistoryDesc: 'How many past conversation rounds the LLM sees as memory. 1 = each turn independent (no cross-turn memory); higher values let the model remember earlier turns in the session. Recommended: 1 for one-shot Q&A, 10–50 for ongoing research.',
     numberRangeValidation: 'Please enter a number between 1-50',
     numberRangeClamped: 'Value exceeds range (1-500), automatically set to {}',
 

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -110,6 +110,16 @@ export const EN_TEXTS = {
     // contains links from a previous wiki folder.
     queryHistoryMigrationNotice: 'Query Wiki history contains links from a previous wiki folder. New queries now use the latest folder automatically. To refresh all stored messages, open the Query Wiki panel and click the Clear history button there.',
 
+    // v1.24.0 Issue #251: Custom Query Instructions collapsible panel
+    customInstructionsTitle: 'Custom Query Instructions',
+    customInstructionsDesc: 'Persistent instructions appended to every Query Wiki system prompt. Only affects Query Wiki chat; ingest, lint, and page generation are unaffected.',
+    customInstructionsPlaceholder: 'e.g. Treat this as research: search broadly, cite sources, separate facts from interpretation...',
+    customInstructionsApply: 'Apply',
+    customInstructionsClear: 'Clear',
+    customInstructionsCharCount: '{current}/{max} chars',
+    instructionsApplied: 'Custom query instructions saved.',
+    instructionsCleared: 'Custom query instructions cleared.',
+
     // Test Connection
     testConnectionSuccessful: 'Connection successful',
     testConnectionFailed: 'Connection failed',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -105,6 +105,9 @@ export const ES_TEXTS = {
     errorUnknown: 'Error desconocido',
     savedNotice: '¡Configuración guardada!',
 
+    // v1.24.0 (Bug C 3.4 / plan C): notificación de migración gradual
+    queryHistoryMigrationNotice: 'El historial de Query Wiki contiene enlaces de una carpeta wiki anterior. Las nuevas consultas usan automáticamente la carpeta más reciente. Para actualizar todos los mensajes almacenados, abra el panel de Query Wiki y haga clic en el botón "Borrar historial" que aparece allí.',
+
     // Issue #137: Avisos de fallback de LLM
     fallbackThinkingDialect: 'Control de pensamiento: cambiado al dialecto "{dialect}" (este proveedor usa un formato diferente). La salida no cambia.',
     fallbackThinkingNone: 'Control de pensamiento completamente deshabilitado para este proveedor. Puede seguir apareciendo contenido de razonamiento; si ocurre, pruebe con otro modelo.',
@@ -113,7 +116,9 @@ export const ES_TEXTS = {
     // Wiki Folder
     wikiSection: 'Configuración del Wiki',
     wikiFolderName: 'Carpeta Wiki',
-    wikiFolderDesc: 'Ubicación para las páginas Wiki generadas',
+    // v1.24.0: indica que se requiere reiniciar Obsidian tras un cambio
+    // (las cachés del motor y los paneles abiertos de Query Wiki deben rebindearse).
+    wikiFolderDesc: 'Ubicación para las páginas Wiki generadas. Reinicie Obsidian tras el cambio — las cachés del motor y los paneles abiertos de Query Wiki deben rebindearse.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -123,9 +128,14 @@ export const ES_TEXTS = {
 
     // Query Settings
     querySectionTitle: 'Configuración de consulta Wiki',
-    maxConversationHistoryName: 'Máximo de historial de conversación',
-    maxConversationHistoryDesc: 'Límite flexible de rondas de conversación (los mensajes más antiguos se descartan automáticamente). Valores preestablecidos: 1/10/30/50/100/500.',
-    maxConversationHistoryHint: 'Recomendado: no superar 50 rondas',
+    // v1.24.0: renombrado de "Máximo de historial de conversación" a
+    // "Rondas de memoria de conversación" para mayor claridad.
+    // 1 = cada turno independiente (sin memoria entre turnos).
+    // El ajuste es un desplegable, no hace falta listar valores preestablecidos.
+    // v1.24.0: maxConversationHistoryHint era una clave i18n sin uso;
+    // la recomendación se integró en la descripción.
+    maxConversationHistoryName: 'Rondas de memoria de conversación',
+    maxConversationHistoryDesc: 'Cuántas rondas de conversación pasadas ve el LLM como memoria. 1 = cada turno independiente (sin memoria entre turnos); valores más altos permiten al modelo recordar turnos anteriores de la sesión. Recomendado: 1 para Q&A puntual, 10–50 para investigación continua.',
     numberRangeValidation: 'Introduce un número entre 1 y 50',
     numberRangeClamped: 'Valor fuera del rango (1-500), automáticamente establecido a {}',
     // Query Modal UI

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -108,6 +108,16 @@ export const ES_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): notificación de migración gradual
     queryHistoryMigrationNotice: 'El historial de Query Wiki contiene enlaces de una carpeta wiki anterior. Las nuevas consultas usan automáticamente la carpeta más reciente. Para actualizar todos los mensajes almacenados, abra el panel de Query Wiki y haga clic en el botón "Borrar historial" que aparece allí.',
 
+    // v1.24.0 Issue #251: instrucciones de Query personalizadas (panel desplegable)
+    customInstructionsTitle: 'Instrucciones de Query personalizadas',
+    customInstructionsDesc: 'Instrucciones persistentes que se añaden al final del prompt del sistema de Query Wiki. Solo afectan al chat de Query Wiki; la ingestión, lint y generación de páginas no se ven afectadas.',
+    customInstructionsPlaceholder: 'p. ej. Trátelo como tarea de investigación: buscar ampliamente, citar fuentes, separar hechos de interpretación...',
+    customInstructionsApply: 'Aplicar',
+    customInstructionsClear: 'Borrar',
+    customInstructionsCharCount: '{current}/{max} caracteres',
+    instructionsApplied: 'Instrucciones de Query personalizadas guardadas.',
+    instructionsCleared: 'Instrucciones de Query personalizadas borradas.',
+
     // Issue #137: Avisos de fallback de LLM
     fallbackThinkingDialect: 'Control de pensamiento: cambiado al dialecto "{dialect}" (este proveedor usa un formato diferente). La salida no cambia.',
     fallbackThinkingNone: 'Control de pensamiento completamente deshabilitado para este proveedor. Puede seguir apareciendo contenido de razonamiento; si ocurre, pruebe con otro modelo.',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -105,6 +105,9 @@ export const FR_TEXTS = {
     errorUnknown: 'Erreur inconnue',
     savedNotice: 'Paramètres enregistrés !',
 
+    // v1.24.0 (Bug C 3.4 / plan C) : notification de migration progressive
+    queryHistoryMigrationNotice: 'L\'historique de Query Wiki contient des liens d\'un ancien dossier wiki. Les nouvelles requêtes utilisent automatiquement le dernier dossier. Pour actualiser tous les messages enregistrés, ouvrez le panneau Query Wiki et cliquez sur le bouton « Effacer l\'historique » qui s\'y trouve.',
+
     // Issue #137 : Notifications de repli LLM
     fallbackThinkingDialect: 'Contrôle de réflexion : basculé vers le dialecte « {dialect} » (ce fournisseur utilise un format différent). Le résultat est inchangé.',
     fallbackThinkingNone: 'Contrôle de réflexion entièrement désactivé pour ce fournisseur. Du contenu de raisonnement peut encore apparaître ; le cas échéant, essayez un autre modèle.',
@@ -113,7 +116,9 @@ export const FR_TEXTS = {
     // Wiki Folder
     wikiSection: 'Configuration du Wiki',
     wikiFolderName: 'Dossier wiki',
-    wikiFolderDesc: 'Emplacement des pages wiki générées',
+    // v1.24.0 : indication que le redémarrage d'Obsidian est nécessaire
+    // après modification (les caches du moteur et les panneaux Query Wiki ouverts doivent être reliés à nouveau).
+    wikiFolderDesc: 'Emplacement des pages wiki générées. Redémarrez Obsidian après modification — les caches du moteur et les panneaux Query Wiki ouverts doivent être reliés à nouveau.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -123,9 +128,14 @@ export const FR_TEXTS = {
 
     // Query Settings
     querySectionTitle: 'Configuration de l\'interrogation du wiki',
-    maxConversationHistoryName: 'Historique maximal de conversation',
-    maxConversationHistoryDesc: 'Limite souple du nombre de tours de conversation (les messages les plus anciens sont supprimés automatiquement). Préréglages : 1/10/30/50/100/500.',
-    maxConversationHistoryHint: 'Recommandé : ne pas dépasser 50 tours',
+    // v1.24.0 : renommé de « Historique maximal de conversation » à
+    // « Tours de mémoire de conversation » pour plus de clarté.
+    // 1 = chaque tour indépendant (aucune mémoire inter-tours).
+    // Le réglage est une liste déroulante, pas besoin de lister les préréglages.
+    // v1.24.0 : maxConversationHistoryHint était une clé i18n inutilisée ;
+    // la recommandation est désormais intégrée à la description.
+    maxConversationHistoryName: 'Tours de mémoire de conversation',
+    maxConversationHistoryDesc: 'Combien de tours de conversation passés le LLM voit comme mémoire. 1 = chaque tour indépendant (aucune mémoire inter-tours) ; des valeurs plus élevées permettent au modèle de se souvenir des tours antérieurs de la session. Recommandé : 1 pour Q&R ponctuel, 10–50 pour une recherche continue.',
     numberRangeValidation: 'Veuillez saisir un nombre entre 1 et 50',
     numberRangeClamped: 'Valeur hors plage (1-500), automatiquement réglée sur {}',
     // Query Modal UI

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -108,6 +108,16 @@ export const FR_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C) : notification de migration progressive
     queryHistoryMigrationNotice: 'L\'historique de Query Wiki contient des liens d\'un ancien dossier wiki. Les nouvelles requêtes utilisent automatiquement le dernier dossier. Pour actualiser tous les messages enregistrés, ouvrez le panneau Query Wiki et cliquez sur le bouton « Effacer l\'historique » qui s\'y trouve.',
 
+    // v1.24.0 Issue #251 : instructions Query personnalisées (panneau pliable)
+    customInstructionsTitle: 'Instructions Query personnalisées',
+    customInstructionsDesc: 'Instructions persistantes ajoutées à chaque invite système de Query Wiki. Affectent uniquement le chat Query Wiki ; l\'ingestion, le lint et la génération de pages ne sont pas concernés.',
+    customInstructionsPlaceholder: 'ex. : traiter comme une tâche de recherche : rechercher largement, citer les sources, distinguer faits et interprétation...',
+    customInstructionsApply: 'Appliquer',
+    customInstructionsClear: 'Effacer',
+    customInstructionsCharCount: '{current}/{max} caractères',
+    instructionsApplied: 'Instructions Query personnalisées enregistrées.',
+    instructionsCleared: 'Instructions Query personnalisées effacées.',
+
     // Issue #137 : Notifications de repli LLM
     fallbackThinkingDialect: 'Contrôle de réflexion : basculé vers le dialecte « {dialect} » (ce fournisseur utilise un format différent). Le résultat est inchangé.',
     fallbackThinkingNone: 'Contrôle de réflexion entièrement désactivé pour ce fournisseur. Du contenu de raisonnement peut encore apparaître ; le cas échéant, essayez un autre modèle.',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -108,6 +108,16 @@ export const IT_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): notifica di migrazione graduale
     queryHistoryMigrationNotice: 'La cronologia di Query Wiki contiene link da una cartella wiki precedente. Le nuove query usano automaticamente la cartella più recente. Per aggiornare tutti i messaggi memorizzati, apri il pannello Query Wiki e fai clic sul pulsante "Cancella cronologia" al suo interno.',
 
+    // v1.24.0 Issue #251: istruzioni Query personalizzate (pannello richiudibile)
+    customInstructionsTitle: 'Istruzioni Query personalizzate',
+    customInstructionsDesc: 'Istruzioni persistenti aggiunte alla fine del prompt di sistema di Query Wiki. Riguardano solo la chat di Query Wiki; ingestione, lint e generazione pagine non sono interessati.',
+    customInstructionsPlaceholder: 'es.: tratta come ricerca: cerca ampiamente, cita le fonti, separa fatti e interpretazione...',
+    customInstructionsApply: 'Applica',
+    customInstructionsClear: 'Cancella',
+    customInstructionsCharCount: '{current}/{max} caratteri',
+    instructionsApplied: 'Istruzioni Query personalizzate salvate.',
+    instructionsCleared: 'Istruzioni Query personalizzate cancellate.',
+
     // Test Connessione
     testConnectionSuccessful: 'Connessione riuscita',
     testConnectionFailed: 'Connessione fallita',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -105,6 +105,9 @@ export const IT_TEXTS = {
     saveButton: 'Salva impostazioni',
     savedNotice: 'Impostazioni salvate!',
 
+    // v1.24.0 (Bug C 3.4 / plan C): notifica di migrazione graduale
+    queryHistoryMigrationNotice: 'La cronologia di Query Wiki contiene link da una cartella wiki precedente. Le nuove query usano automaticamente la cartella più recente. Per aggiornare tutti i messaggi memorizzati, apri il pannello Query Wiki e fai clic sul pulsante "Cancella cronologia" al suo interno.',
+
     // Test Connessione
     testConnectionSuccessful: 'Connessione riuscita',
     testConnectionFailed: 'Connessione fallita',
@@ -124,7 +127,9 @@ export const IT_TEXTS = {
     // Cartella Wiki
     wikiSection: 'Configurazione Wiki',
     wikiFolderName: 'Cartella Wiki',
-    wikiFolderDesc: 'Posizione delle pagine Wiki generate',
+    // v1.24.0: indica che è necessario riavviare Obsidian dopo la modifica
+    // (le cache del motore e i pannelli aperti di Query Wiki devono ricollegarsi).
+    wikiFolderDesc: 'Posizione delle pagine Wiki generate. Riavvia Obsidian dopo la modifica — le cache del motore e i pannelli aperti di Query Wiki devono ricollegarsi.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errori
@@ -134,9 +139,14 @@ export const IT_TEXTS = {
 
     // Impostazioni Query
     querySectionTitle: 'Configurazione query Wiki',
-    maxConversationHistoryName: 'Cronologia conversazione massima',
-    maxConversationHistoryDesc: 'Limite morbido dei turni di conversazione (i messaggi più vecchi vengono eliminati automaticamente). Valori preimpostati: 1/10/30/50/100/500.',
-    maxConversationHistoryHint: 'Consigliato: non superare 50 turni',
+    // v1.24.0: rinominato da "Cronologia conversazione massima" a
+    // "Turni di memoria della conversazione" per maggiore chiarezza.
+    // 1 = ogni turno indipendente (nessuna memoria tra turni).
+    // L'impostazione è un menu a discesa, non serve elencare i valori preimpostati.
+    // v1.24.0: maxConversationHistoryHint era una chiave i18n inutilizzata;
+    // il consiglio è stato integrato nella descrizione.
+    maxConversationHistoryName: 'Turni di memoria della conversazione',
+    maxConversationHistoryDesc: 'Quanti turni di conversazione passati il LLM vede come memoria. 1 = ogni turno indipendente (nessuna memoria tra turni); valori più alti permettono al modello di ricordare turni precedenti della sessione. Consigliato: 1 per Q&A occasionale, 10–50 per ricerca continuativa.',
     numberRangeValidation: 'Inserisci un numero tra 1 e 50',
     numberRangeClamped: 'Il valore supera il range (1-500), impostato automaticamente a {}',
 

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -108,6 +108,16 @@ export const JA_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): 段階的移行の通知
     queryHistoryMigrationNotice: 'Query Wiki の履歴に以前の wiki フォルダーのリンクが含まれています。新しい会話は自動的に最新のフォルダーを使用します。すべての履歴メッセージをリフレッシュするには、Query Wiki パネルを開き、その中の「履歴をクリア」ボタンをクリックしてください。',
 
+    // v1.24.0 Issue #251: カスタム Query 命令（折りたたみ可能パネル）
+    customInstructionsTitle: 'カスタム Query 命令',
+    customInstructionsDesc: 'Query Wiki のすべてのチャット応答のシステムプロンプト末尾に追記される命令です。Query Wiki チャットのみに影響し、取り込み・lint・ページ生成には影響しません。',
+    customInstructionsPlaceholder: '例：リサーチタスクとして扱う：広く検索、ソースを引用、事実と解釈を区別する...',
+    customInstructionsApply: '適用',
+    customInstructionsClear: 'クリア',
+    customInstructionsCharCount: '{current}/{max} 文字',
+    instructionsApplied: 'カスタム Query 命令を保存しました。',
+    instructionsCleared: 'カスタム Query 命令をクリアしました。',
+
     // Issue #137: LLM フォールバック通知
     fallbackThinkingDialect: '思考制御：「{dialect}」方言に切り替えました（このプロバイダーは別の思考制御フィールド形式を使用します）。出力は変わりません。',
     fallbackThinkingNone: 'このプロバイダーでは思考制御を完全に無効化しました。推論コンテンツが引き続き表示される場合があります。その場合は別のモデルを試してください。',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -105,6 +105,9 @@ export const JA_TEXTS = {
     errorUnknown: '不明なエラー',
     savedNotice: '設定を保存しました！',
 
+    // v1.24.0 (Bug C 3.4 / plan C): 段階的移行の通知
+    queryHistoryMigrationNotice: 'Query Wiki の履歴に以前の wiki フォルダーのリンクが含まれています。新しい会話は自動的に最新のフォルダーを使用します。すべての履歴メッセージをリフレッシュするには、Query Wiki パネルを開き、その中の「履歴をクリア」ボタンをクリックしてください。',
+
     // Issue #137: LLM フォールバック通知
     fallbackThinkingDialect: '思考制御：「{dialect}」方言に切り替えました（このプロバイダーは別の思考制御フィールド形式を使用します）。出力は変わりません。',
     fallbackThinkingNone: 'このプロバイダーでは思考制御を完全に無効化しました。推論コンテンツが引き続き表示される場合があります。その場合は別のモデルを試してください。',
@@ -113,7 +116,8 @@ export const JA_TEXTS = {
     // Wiki Folder
     wikiSection: 'Wiki設定',
     wikiFolderName: 'Wiki フォルダー',
-    wikiFolderDesc: '生成されたWikiページの保存先',
+    // v1.24.0: 変更後に Obsidian の再起動が必要であることを明示（engine キャッシュと開いている Query Wiki パネルの再バインド）
+    wikiFolderDesc: '生成された Wiki ページの保存先。変更後は Obsidian の再起動が必要です——engine のキャッシュと開いている Query Wiki パネルの再バインドが行われます。',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -123,9 +127,13 @@ export const JA_TEXTS = {
 
     // Query Settings
     querySectionTitle: 'Wiki 問い合わせ設定',
-    maxConversationHistoryName: '会話履歴の最大数',
-    maxConversationHistoryDesc: '会話ラウンドのソフト上限（超過時は古いメッセージが自動的に破棄されます）。プリセット：1/10/30/50/100/500。',
-    maxConversationHistoryHint: '推奨：50ラウンド以内',
+    // v1.24.0: 「会話履歴の最大数」から「会話の関連記憶ラウンド数」に改名
+    // 意味をより正確に表現。1 = 各ターンが独立（前文を参照しない）。
+    // 設定はドロップダウンなので、プリセット値を説明に列挙する必要なし。
+    // v1.24.0: maxConversationHistoryHint は未使用の i18n key でした（UI から参照なし）。
+    // 推奨文を desc に統合しました。
+    maxConversationHistoryName: '会話の関連記憶ラウンド数',
+    maxConversationHistoryDesc: 'LLM が新しい会話で参照できる過去のラウンド数（記憶として）。1 = 各ターンが独立（前文を参照しない）；値が大きいほど、モデルがセッション前半のラウンドを覚えています。推奨：ワンショット Q&A は 1、継続的な調査は 10〜50。',
     numberRangeValidation: '1〜50の数値を入力してください',
     numberRangeClamped: '値が範囲外です（1-500）、自動的に {} に設定されました',
     // Query Modal UI

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -108,6 +108,16 @@ export const KO_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): 점진적 마이그레이션 알림
     queryHistoryMigrationNotice: 'Query Wiki 기록에 이전 wiki 폴더의 링크가 포함되어 있습니다. 새 대화는 자동으로 최신 폴더를 사용합니다. 모든 기록 메시지를 새로 고치려면 Query Wiki 패널을 열고 그 안의 "기록 지우기" 버튼을 클릭하세요.',
 
+    // v1.24.0 Issue #251: 사용자 지정 Query 지시문 (접을 수 있는 패널)
+    customInstructionsTitle: '사용자 지정 Query 지시문',
+    customInstructionsDesc: '모든 Query Wiki 시스템 프롬프트 끝에 추가되는 영구 지시문입니다. Query Wiki 채팅에만 영향을 주며, 수집·lint·페이지 생성에는 영향을 주지 않습니다.',
+    customInstructionsPlaceholder: '예: 연구 작업으로 처리: 넓게 검색, 출처 인용, 사실과 해석 구분...',
+    customInstructionsApply: '적용',
+    customInstructionsClear: '지우기',
+    customInstructionsCharCount: '{current}/{max} 자',
+    instructionsApplied: '사용자 지정 Query 지시문이 저장되었습니다.',
+    instructionsCleared: '사용자 지정 Query 지시문이 지워졌습니다.',
+
     // Issue #137: LLM 폴백 알림
     fallbackThinkingDialect: '사고 제어: "{dialect}" 방언으로 전환됨(이 공급자는 다른 사고 제어 필드 형식을 사용함). 출력은 변경되지 않음.',
     fallbackThinkingNone: '이 공급자에 대해 사고 제어가 완전히 비활성화되었습니다. 추론 콘텐츠가 여전히 나타날 수 있습니다; 이 경우 다른 모델을 시도하세요.',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -105,6 +105,9 @@ export const KO_TEXTS = {
     errorUnknown: '알 수 없는 오류',
     savedNotice: '설정이 저장되었습니다!',
 
+    // v1.24.0 (Bug C 3.4 / plan C): 점진적 마이그레이션 알림
+    queryHistoryMigrationNotice: 'Query Wiki 기록에 이전 wiki 폴더의 링크가 포함되어 있습니다. 새 대화는 자동으로 최신 폴더를 사용합니다. 모든 기록 메시지를 새로 고치려면 Query Wiki 패널을 열고 그 안의 "기록 지우기" 버튼을 클릭하세요.',
+
     // Issue #137: LLM 폴백 알림
     fallbackThinkingDialect: '사고 제어: "{dialect}" 방언으로 전환됨(이 공급자는 다른 사고 제어 필드 형식을 사용함). 출력은 변경되지 않음.',
     fallbackThinkingNone: '이 공급자에 대해 사고 제어가 완전히 비활성화되었습니다. 추론 콘텐츠가 여전히 나타날 수 있습니다; 이 경우 다른 모델을 시도하세요.',
@@ -113,7 +116,8 @@ export const KO_TEXTS = {
     // Wiki Folder
     wikiSection: 'Wiki 설정',
     wikiFolderName: '위키 폴더',
-    wikiFolderDesc: '생성된 위키 페이지의 저장 위치',
+    // v1.24.0: 변경 후 Obsidian 재시작이 필요함을 명시 (engine 캐시와 열린 Query Wiki 패널 재바인딩)
+    wikiFolderDesc: '생성된 위키 페이지의 저장 위치. 변경 후 Obsidian를 재시작해야 합니다——engine 캐시와 열려 있는 Query Wiki 패널을 다시 바인딩해야 합니다.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -123,9 +127,13 @@ export const KO_TEXTS = {
 
     // Query Settings
     querySectionTitle: '위키 질의 설정',
-    maxConversationHistoryName: '최대 대화 기록',
-    maxConversationHistoryDesc: '대화 라운드의 소프트 상한 (오래된 메시지는 자동으로 폐기됨). 사전 설정 값: 1/10/30/50/100/500.',
-    maxConversationHistoryHint: '추천: 50 라운드를 초과하지 않기',
+    // v1.24.0: "최대 대화 기록"에서 "대화 연관 기억 라운드 수"로 이름 변경
+    // 의미가 더 정확함. 1 = 각 턴이 독립적 (이전 문맥 참조 안 함).
+    // 설정은 드롭다운이므로 사전 설정 값을 설명에 나열할 필요 없음.
+    // v1.24.0: maxConversationHistoryHint은 사용되지 않는 i18n key였습니다.
+    // 권장 문구를 desc에 통합했습니다.
+    maxConversationHistoryName: '대화 연관 기억 라운드 수',
+    maxConversationHistoryDesc: 'LLM이 새 대화에서 볼 수 있는 과거 라운드 수 (기억으로). 1 = 각 턴이 독립적 (이전 문맥 참조 안 함); 값이 클수록 모델이 세션 초반의 라운드를 기억합니다. 추천: 일회성 Q&A는 1, 지속적 연구는 10~50.',
     numberRangeValidation: '1-50 사이의 숫자를 입력하세요',
     numberRangeClamped: '값이 범위를 초과했습니다 (1-500), 자동으로 {}으로 설정되었습니다',
 

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -105,6 +105,9 @@ export const PT_TEXTS = {
     errorUnknown: 'Erro desconhecido',
     savedNotice: 'Configurações salvas!',
 
+    // v1.24.0 (Bug C 3.4 / plan C): notificação de migração gradual
+    queryHistoryMigrationNotice: 'O histórico do Query Wiki contém links de uma pasta wiki anterior. As novas consultas usam automaticamente a pasta mais recente. Para atualizar todas as mensagens armazenadas, abra o painel do Query Wiki e clique no botão "Limpar histórico" que está lá.',
+
     // Issue #137: Avisos de fallback de LLM
     fallbackThinkingDialect: 'Controle de pensamento: alternado para o dialeto "{dialect}" (este provedor usa um formato diferente). A saída permanece inalterada.',
     fallbackThinkingNone: 'Controle de pensamento totalmente desativado para este provedor. Conteúdo de raciocínio ainda pode aparecer; se isso acontecer, tente outro modelo.',
@@ -113,7 +116,9 @@ export const PT_TEXTS = {
     // Wiki Folder
     wikiSection: 'Configuração do Wiki',
     wikiFolderName: 'Pasta Wiki',
-    wikiFolderDesc: 'Local para as páginas geradas da Wiki',
+    // v1.24.0: indica que é necessário reiniciar o Obsidian após a alteração
+    // (os caches do motor e os painéis abertos do Query Wiki precisam ser religados).
+    wikiFolderDesc: 'Local para as páginas geradas da Wiki. Reinicie o Obsidian após a alteração — os caches do motor e os painéis abertos do Query Wiki precisam ser religados.',
     wikiFolderPlaceholder: 'wiki',
 
     // Errors
@@ -123,9 +128,14 @@ export const PT_TEXTS = {
 
     // Query Settings
     querySectionTitle: 'Configuração de consulta Wiki',
-    maxConversationHistoryName: 'Histórico máximo de conversa',
-    maxConversationHistoryDesc: 'Limite flexível de rodadas de conversa (as mensagens mais antigas são descartadas automaticamente). Predefinições: 1/10/30/50/100/500.',
-    maxConversationHistoryHint: 'Recomendado: não ultrapassar 50 rodadas',
+    // v1.24.0: renomeado de "Histórico máximo de conversa" para
+    // "Rodadas de memória de conversa" para maior clareza.
+    // 1 = cada turno independente (sem memória entre turnos).
+    // A configuração é um menu suspenso, não precisa listar predefinições.
+    // v1.24.0: maxConversationHistoryHint era uma chave i18n sem uso;
+    // a recomendação foi integrada à descrição.
+    maxConversationHistoryName: 'Rodadas de memória de conversa',
+    maxConversationHistoryDesc: 'Quantas rodadas de conversa anteriores o LLM vê como memória. 1 = cada turno independente (sem memória entre turnos); valores mais altos permitem ao modelo lembrar turnos anteriores da sessão. Recomendado: 1 para Q&A pontual, 10–50 para pesquisa contínua.',
     numberRangeValidation: 'Insira um número entre 1 e 50',
     numberRangeClamped: 'Valor fora do intervalo (1-500), automaticamente definido como {}',
     // Query Modal UI

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -108,6 +108,16 @@ export const PT_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): notificação de migração gradual
     queryHistoryMigrationNotice: 'O histórico do Query Wiki contém links de uma pasta wiki anterior. As novas consultas usam automaticamente a pasta mais recente. Para atualizar todas as mensagens armazenadas, abra o painel do Query Wiki e clique no botão "Limpar histórico" que está lá.',
 
+    // v1.24.0 Issue #251: instruções de Query personalizadas (painel recolhível)
+    customInstructionsTitle: 'Instruções de Query personalizadas',
+    customInstructionsDesc: 'Instruções persistentes adicionadas ao final do prompt do sistema do Query Wiki. Afetam apenas o chat do Query Wiki; ingestão, lint e geração de páginas não são afetados.',
+    customInstructionsPlaceholder: 'ex.: tratar como tarefa de pesquisa: buscar amplamente, citar fontes, separar fatos de interpretação...',
+    customInstructionsApply: 'Aplicar',
+    customInstructionsClear: 'Limpar',
+    customInstructionsCharCount: '{current}/{max} caracteres',
+    instructionsApplied: 'Instruções de Query personalizadas salvas.',
+    instructionsCleared: 'Instruções de Query personalizadas removidas.',
+
     // Issue #137: Avisos de fallback de LLM
     fallbackThinkingDialect: 'Controle de pensamento: alternado para o dialeto "{dialect}" (este provedor usa um formato diferente). A saída permanece inalterada.',
     fallbackThinkingNone: 'Controle de pensamento totalmente desativado para este provedor. Conteúdo de raciocínio ainda pode aparecer; se isso acontecer, tente outro modelo.',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -108,6 +108,16 @@ export const ZH_HANT_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): 漸進式遷移通知
     queryHistoryMigrationNotice: 'Query Wiki 歷史紀錄中含有舊 wiki 目錄的連結。新的對話已自動使用最新目錄。如需重整所有歷史訊息，請開啟 Query Wiki 面板並點選其中的「清除紀錄」按鈕。',
 
+    // v1.24.0 Issue #251: 自訂 Query 指令（可折疊面板）
+    customInstructionsTitle: '自訂 Query 指令',
+    customInstructionsDesc: '每次 Query Wiki 對話都會在系統提示字串末尾附加這些指令。僅影響 Query Wiki 聊天；不會影響擷取、lint 與頁面生成。',
+    customInstructionsPlaceholder: '例如：將此視為研究任務：廣泛搜尋、引用來源、區分事實與詮釋...',
+    customInstructionsApply: '套用',
+    customInstructionsClear: '清除',
+    customInstructionsCharCount: '{current}/{max} 字元',
+    instructionsApplied: '自訂 Query 指令已儲存。',
+    instructionsCleared: '自訂 Query 指令已清除。',
+
     // Issue #137: LLM 回退通知（请求中触发 thinking-dialect 回退或字段剥离时显示）
     fallbackThinkingDialect: '思考控制：已切換至 "{dialect}" 方言（該提供商使用不同的思考控制欄位格式）。輸出內容不受影響。',
     fallbackThinkingNone: '該提供商已完全關閉思考控制。模型仍可能產生推理內容；若出現，請嘗試其他模型。',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -105,6 +105,9 @@ export const ZH_HANT_TEXTS = {
     errorUnknown: '未知錯誤',
     savedNotice: '設定已儲存！',
 
+    // v1.24.0 (Bug C 3.4 / plan C): 漸進式遷移通知
+    queryHistoryMigrationNotice: 'Query Wiki 歷史紀錄中含有舊 wiki 目錄的連結。新的對話已自動使用最新目錄。如需重整所有歷史訊息，請開啟 Query Wiki 面板並點選其中的「清除紀錄」按鈕。',
+
     // Issue #137: LLM 回退通知（请求中触发 thinking-dialect 回退或字段剥离时显示）
     fallbackThinkingDialect: '思考控制：已切換至 "{dialect}" 方言（該提供商使用不同的思考控制欄位格式）。輸出內容不受影響。',
     fallbackThinkingNone: '該提供商已完全關閉思考控制。模型仍可能產生推理內容；若出現，請嘗試其他模型。',
@@ -113,7 +116,8 @@ export const ZH_HANT_TEXTS = {
     // Wiki 文件夹
     wikiSection: 'Wiki 配置',
     wikiFolderName: 'Wiki 資料夾',
-    wikiFolderDesc: '存放生成的 Wiki 頁面',
+    // v1.24.0: 提示需重啟 Obsidian 以讓 engine 快取和開啟的 Query Wiki 面板重新綁定
+    wikiFolderDesc: '存放生成的 Wiki 頁面。修改後需重啟 Obsidian 才能生效——engine 快取和已開啟的 Query Wiki 面板需要重新綁定。',
     wikiFolderPlaceholder: 'wiki',
 
     // 错误
@@ -123,9 +127,11 @@ export const ZH_HANT_TEXTS = {
 
     // Query 设置
     querySectionTitle: 'Wiki 查詢配置',
-    maxConversationHistoryName: '對話歷史上限',
-    maxConversationHistoryDesc: '對話輪次軟上限（超出時自動丟棄最舊的）。預設值：1/10/30/50/100/500。',
-    maxConversationHistoryHint: '推薦：不超過50輪',
+    // v1.24.0: 將「對話歷史上限」重命名為「對話關聯記憶輪數」，更貼切語義
+    // 1 = 每輪對話獨立（不關聯前文）。設定為下拉選單，無需列出預設值。
+    // v1.24.0: maxConversationHistoryHint 為死 i18n key（UI 無引用），推薦文案已併入 desc。
+    maxConversationHistoryName: '對話關聯記憶輪數',
+    maxConversationHistoryDesc: 'LLM 在新對話中可見的過往輪次數（作為記憶）。1 = 每輪對話獨立（不關聯前文）；數值越高，模型能記住會話中越早的輪次。推薦：一次性問答選 1；持續性研究選 10–50。',
     numberRangeValidation: '請輸入1-50之間的數字',
     numberRangeClamped: '數值超出範圍（1-500），已自動設定為 {}',
 

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -108,6 +108,16 @@ export const ZH_TEXTS = {
     // v1.24.0 (Bug C 3.4 / plan C): 渐进迁移通知
     queryHistoryMigrationNotice: 'Query Wiki 历史记录中包含来自旧 wiki 目录的链接。新对话已自动使用最新目录。如需刷新所有历史消息，请打开 Query Wiki 面板并点击其中的”清除历史”按钮。',
 
+    // v1.24.0 Issue #251: 自定义 Query 指令（可折叠面板）
+    customInstructionsTitle: '自定义 Query 指令',
+    customInstructionsDesc: '每次 Query Wiki 对话都会在系统提示末尾附加这些指令。仅影响 Query Wiki 聊天；不影响摄取、lint 和页面生成。',
+    customInstructionsPlaceholder: '例如：将其视为研究任务：广泛搜索、引用来源、区分事实与解读...',
+    customInstructionsApply: '应用',
+    customInstructionsClear: '清除',
+    customInstructionsCharCount: '{current}/{max} 字符',
+    instructionsApplied: '自定义 Query 指令已保存。',
+    instructionsCleared: '自定义 Query 指令已清除。',
+
     // Issue #137: LLM 回退通知（请求中触发 thinking-dialect 回退或字段剥离时显示）
     fallbackThinkingDialect: '思考控制：已切换至 "{dialect}" 方言（该提供商使用不同的思考控制字段格式）。输出内容不受影响。',
     fallbackThinkingNone: '该提供商已完全关闭思考控制。模型仍可能产生推理内容；若出现，请尝试其他模型。',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -105,6 +105,9 @@ export const ZH_TEXTS = {
     errorUnknown: '未知错误',
     savedNotice: '设置已保存！',
 
+    // v1.24.0 (Bug C 3.4 / plan C): 渐进迁移通知
+    queryHistoryMigrationNotice: 'Query Wiki 历史记录中包含来自旧 wiki 目录的链接。新对话已自动使用最新目录。如需刷新所有历史消息，请打开 Query Wiki 面板并点击其中的”清除历史”按钮。',
+
     // Issue #137: LLM 回退通知（请求中触发 thinking-dialect 回退或字段剥离时显示）
     fallbackThinkingDialect: '思考控制：已切换至 "{dialect}" 方言（该提供商使用不同的思考控制字段格式）。输出内容不受影响。',
     fallbackThinkingNone: '该提供商已完全关闭思考控制。模型仍可能产生推理内容；若出现，请尝试其他模型。',
@@ -113,7 +116,8 @@ export const ZH_TEXTS = {
     // Wiki 文件夹
     wikiSection: 'Wiki 配置',
     wikiFolderName: 'Wiki 文件夹',
-    wikiFolderDesc: '存放生成的 Wiki 页面',
+    // v1.24.0: 提示需重启 Obsidian 以让 engine 缓存和打开的 Query Wiki 面板重新绑定
+    wikiFolderDesc: '存放生成的 Wiki 页面。修改后需重启 Obsidian 才能生效——engine 缓存和已打开的 Query Wiki 面板需要重新绑定。',
     wikiFolderPlaceholder: 'wiki',
 
     // 错误
@@ -123,9 +127,13 @@ export const ZH_TEXTS = {
 
     // Query 设置
     querySectionTitle: 'Wiki 查询配置',
-    maxConversationHistoryName: '对话历史上限',
-    maxConversationHistoryDesc: '对话轮次软上限（超出时自动丢弃最旧的）。预设值：1/10/30/50/100/500。',
-    maxConversationHistoryHint: '推荐：不超过50轮',
+    // v1.24.0: 由"对话历史上限"重命名为"对话关联记忆轮数"，更准确地表达语义
+    // ——这是 LLM 的记忆窗口，不是硬性存储上限（历史记录本身就是滚动更新）。
+    // 1 = 每轮对话独立（不关联）。设置项为下拉框，无需在描述中列出预设值。
+    // v1.24.0: maxConversationHistoryHint 是死 i18n key（UI 代码无引用），
+    // 推荐文案已合并入 desc。
+    maxConversationHistoryName: '对话关联记忆轮数',
+    maxConversationHistoryDesc: 'LLM 在新对话中可见的过往轮次数（作为记忆）。1 = 每轮对话独立（不关联前文）；数值越高，模型能记住会话中越早的轮次。推荐：一次性问答选 1；持续性研究选 10–50。',
     numberRangeValidation: '请输入1-50之间的数字',
     numberRangeClamped: '数值超出范围（1-500），已自动设定为 {}',
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,16 @@ export interface LLMWikiSettings {
   // where lowercase is grammatically wrong (e.g. German nouns).
   // Note: switching affects new files only — existing lowercase files keep their names.
   slugCase: 'lower' | 'preserve';
+
+  /**
+   * v1.24.0 #251: persistent user-supplied instructions appended to the
+   * Query Wiki system prompt. Empty string or undefined = feature off
+   * (backward compatible). Scoped strictly to Query Wiki chat; no other
+   * workflow (ingest / lint / page generation / Save to Wiki / seed
+   * selection / duplicate merge) is affected. Stored in data.json
+   * alongside `queryHistory`.
+   */
+  customQueryInstructions?: string;
 }
 
 export interface QueryHistoryMessage {
@@ -650,4 +660,9 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   advancedSettingsMode: 'default',
   // Issue #111: default to 'lower' for backwards compatibility.
   slugCase: 'lower',
+  // v1.24.0 #251: persistent user-supplied instructions appended to the
+  // Query Wiki system prompt. Empty string = feature off (backward
+  // compatible). Stored in data.json alongside queryHistory. Scoped
+  // strictly to Query Wiki chat; no other workflow is affected.
+  customQueryInstructions: '',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,6 +255,17 @@ export interface QueryHistoryMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
+  /**
+   * v1.24.0: Retrieval metadata persisted per assistant turn so the
+   * label survives Obsidian restart. Optional — pre-v1.24.0 history
+   * is loaded without it, and the retrieval label simply won't render
+   * (no crash).
+   */
+  retrieval?: {
+    arm: string;
+    count: number;
+    topPaths: string[];
+  };
 }
 
 // Schema types

--- a/src/ui/modals/ConfirmModal-class.ts
+++ b/src/ui/modals/ConfirmModal-class.ts
@@ -1,0 +1,46 @@
+// ConfirmModal — small yes/no confirmation modal (#164).
+//
+// `onChoice` fires exactly once:
+//   - true on confirm
+//   - false on cancel / Escape / dismiss / onClose.
+//
+// Extracted from the original `src/ui/modals.ts` god file (PR split).
+// No behavior change — pure code movement.
+
+import { App, Modal } from 'obsidian';
+
+export class ConfirmModal extends Modal {
+  private decided = false;
+
+  constructor(
+    app: App,
+    private opts: { title: string; body: string; confirmText: string; cancelText: string; onChoice: (confirmed: boolean) => void }
+  ) {
+    super(app);
+  }
+
+  onOpen() {
+    this.contentEl.createEl('h2', { text: this.opts.title });
+    this.contentEl.createEl('p', { text: this.opts.body });
+    const btnRow = this.contentEl.createDiv({ attr: { style: 'margin-top: 16px; text-align: right;' } });
+    btnRow.createEl('button', { text: this.opts.cancelText })
+      .addEventListener('click', () => this.decide(false));
+    btnRow.createEl('button', { text: this.opts.confirmText, cls: 'mod-cta', attr: { style: 'margin-left: 8px;' } })
+      .addEventListener('click', () => this.decide(true));
+  }
+
+  private decide(confirmed: boolean) {
+    this.decided = true;
+    this.opts.onChoice(confirmed);
+    this.close();
+  }
+
+  onClose() {
+    this.contentEl.empty();
+    // Escape / X / click-outside → treat as cancel, exactly once.
+    if (!this.decided) {
+      this.decided = true;
+      this.opts.onChoice(false);
+    }
+  }
+}

--- a/src/ui/modals/FixReportModal-class.ts
+++ b/src/ui/modals/FixReportModal-class.ts
@@ -1,0 +1,54 @@
+// FixReportModal — displays the summary of a "Fix All" run, listing
+// every phase (label + detail) that ran.
+//
+// Extracted from the original `src/ui/modals.ts` god file (PR split).
+// No behavior change — pure code movement.
+
+import { App, Modal } from 'obsidian';
+import { TEXTS } from '../../texts';
+import { getText } from '../../core/i18n';
+import type { FixReportPhase } from './types';
+
+export class FixReportModal extends Modal {
+  private phases: FixReportPhase[];
+  private language: string;
+
+  constructor(app: App, phases: FixReportPhase[], language: string) {
+    super(app);
+    this.phases = phases;
+    this.language = language;
+  }
+
+  onOpen() {
+    const tk = (k: string) => getText(this.language, k as keyof typeof TEXTS.en) || k;
+    const titleText = tk('lintFixAllComplete');
+
+    this.contentEl.createEl('h2', { text: titleText });
+
+    const list = this.contentEl.createEl('ul', {
+      attr: { style: 'margin: 12px 0; line-height: 1.8;' }
+    });
+    for (const phase of this.phases) {
+      const itemText = phase.detail
+        ? `${phase.label}: ${phase.detail}`
+        : phase.label;
+      list.createEl('li', { text: itemText });
+    }
+
+    const indexNote = tk('lintFixIndexUpdated');
+    if (indexNote) {
+      this.contentEl.createEl('p', {
+        text: indexNote,
+        attr: { style: 'color: var(--text-muted); font-size: 13px; margin-top: 8px;' }
+      });
+    }
+
+    const btnRow = this.contentEl.createDiv({ attr: { style: 'margin-top: 16px; text-align: right;' } });
+    const closeText = tk('ingestReportClose');
+    btnRow.createEl('button', { text: closeText }).addEventListener('click', () => this.close());
+  }
+
+  onClose() {
+    this.contentEl.empty();
+  }
+}

--- a/src/ui/modals/IngestReportModal-class.ts
+++ b/src/ui/modals/IngestReportModal-class.ts
@@ -1,0 +1,154 @@
+// IngestReportModal — displays a structured ingest report after a source
+// file or batch ingest operation.
+//
+// Sections rendered in order:
+//   1. Title with success/warning status emoji
+//   2. Source file path
+//   3. Skipped files (batch ingest only)
+//   4. Elapsed time
+//   5. Stats (created / updated / contradictions)
+//   6. Collisions (if any)
+//   7. Created / updated / failed page lists
+//   8. Rejected / skipped files (requirements gate, #164)
+//   9. Error message (if any)
+//   10. Close button
+//
+// Extracted from the original `src/ui/modals.ts` god file (PR split).
+// No behavior change — pure code movement.
+
+import { App, Modal } from 'obsidian';
+import type { IngestReport } from '../../types';
+import { TEXTS } from '../../texts';
+import { getText } from '../../core/i18n';
+import type { RejectionReason } from '../../core/source-requirements';
+
+export class IngestReportModal extends Modal {
+  private report: IngestReport;
+  private language: string;
+
+  constructor(app: App, report: IngestReport, language: string = 'en') {
+    super(app);
+    this.report = report;
+    this.language = language;
+  }
+
+  private t(key: string): string {
+    return getText(this.language, key as keyof typeof TEXTS.en) || key;
+  }
+
+  /** Map a gate rejection reason to its short localized label key. Mirrors WikiEngine.rejectionNoticeKey. */
+  private reasonLabelKey(reason: RejectionReason): string {
+    if (reason === 'incompatible-type') return 'rejectionReasonType';
+    if (reason === 'duplicate') return 'rejectionReasonDuplicate';
+    return 'rejectionReasonEmpty';
+  }
+
+  onOpen() {
+    const { sourceFile, createdPages, updatedPages, entitiesCreated, conceptsCreated, failedItems, contradictionsFound, success, errorMessage, collisions, elapsedSeconds, skippedFiles, totalFilesInFolder, rejectedFiles } = this.report;
+
+    const statusEmoji = success ? '✅' : '⚠️';
+    this.contentEl.createEl('h2', { text: `${statusEmoji} ${this.t('ingestReportTitle')}` });
+
+    // Source file
+    this.contentEl.createEl('p', { text: `${this.t('ingestReportSourceFile')}：${sourceFile}` });
+
+    // Skipped files (batch ingest only)
+    if (skippedFiles !== undefined && skippedFiles > 0) {
+      this.contentEl.createEl('p', {
+        text: `${this.t('ingestReportSkippedFiles')}: ${skippedFiles}/${totalFilesInFolder || skippedFiles}`,
+        attr: { style: 'color: var(--text-muted); font-size: 13px;' }
+      });
+    }
+
+    // Elapsed time
+    if (elapsedSeconds !== undefined) {
+      const minutes = Math.floor(elapsedSeconds / 60);
+      const seconds = elapsedSeconds % 60;
+      const timeStr = minutes > 0
+        ? `${minutes} ${this.t('timeMinutes')} ${seconds} ${this.t('timeSeconds')}`
+        : `${seconds} ${this.t('timeSeconds')}`;
+      this.contentEl.createEl('p', { text: `${this.t('ingestReportElapsedTime')}：${timeStr}` });
+    }
+
+    // Stats
+    const statsEl = this.contentEl.createDiv({ attr: { style: 'margin: 12px 0;' } });
+    const createdText = this.t('ingestReportCreatedPages').replace('{count}', String(createdPages.length));
+    const breakdown = entitiesCreated > 0 || conceptsCreated > 0
+      ? ` (${this.t('ingestReportEntitiesCount').replace('{count}', String(entitiesCreated))} + ${this.t('ingestReportConceptsCount').replace('{count}', String(conceptsCreated))})`
+      : '';
+    statsEl.createEl('p', { text: createdText + breakdown });
+    statsEl.createEl('p', { text: this.t('ingestReportUpdatedPages').replace('{count}', String(updatedPages.length)) });
+    if (contradictionsFound > 0) {
+      statsEl.createEl('p', { text: this.t('ingestReportContradictionsFound').replace('{count}', String(contradictionsFound)) });
+    }
+
+    // Collisions
+    if (collisions && collisions.length > 0) {
+      this.contentEl.createEl('h3', { text: '🔀 ' + this.t('ingestReportCollisions') + ` (${collisions.length})` });
+      const list = this.contentEl.createEl('ul');
+      for (const c of collisions) {
+        const sourceTypeLabel = c.sourceType === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
+        const targetTypeLabel = c.targetType === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
+        list.createEl('li', { text: `"${c.name}" (${sourceTypeLabel}) → ${targetTypeLabel}` });
+      }
+    }
+
+    // Created pages
+    if (createdPages.length > 0) {
+      this.contentEl.createEl('h3', { text: this.t('ingestReportCreated') });
+      const list = this.contentEl.createEl('ul');
+      for (const page of createdPages) {
+        list.createEl('li', { text: page });
+      }
+    }
+
+    // Updated pages
+    if (updatedPages.length > 0) {
+      this.contentEl.createEl('h3', { text: this.t('ingestReportUpdated') });
+      const list = this.contentEl.createEl('ul');
+      for (const page of updatedPages) {
+        list.createEl('li', { text: page });
+      }
+    }
+
+    // Failed items
+    if (failedItems.length > 0) {
+      this.contentEl.createEl('h3', { text: '⚠️ ' + this.t('ingestReportFailedTitle') });
+      const list = this.contentEl.createEl('ul');
+      for (const item of failedItems) {
+        const typeLabel = item.type === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
+        list.createEl('li', { text: `[${typeLabel}] ${item.name} — ${item.reason}` });
+      }
+      this.contentEl.createEl('p', {
+        text: this.t('ingestReportFailedGuidance'),
+        attr: { style: 'color: var(--text-muted); margin-top: 8px; font-size: 13px;' }
+      });
+    }
+
+    // Rejected / skipped files (requirements gate, #164)
+    if (rejectedFiles && rejectedFiles.length > 0) {
+      this.contentEl.createEl('h3', { text: '⏭️ ' + this.t('ingestReportRejectedFiles') + ` (${rejectedFiles.length})` });
+      const list = this.contentEl.createEl('ul');
+      for (const r of rejectedFiles) {
+        const name = r.path.split('/').pop() || r.path;
+        list.createEl('li', { text: `${name} — ${this.t(this.reasonLabelKey(r.reason))}` });
+      }
+    }
+
+    // Error
+    if (errorMessage) {
+      this.contentEl.createEl('p', {
+        text: `${this.t('ingestReportErrorDetail')}：${errorMessage}`,
+        attr: { style: 'color: var(--text-error); margin-top: 12px;' }
+      });
+    }
+
+    // Close button
+    const btnRow = this.contentEl.createDiv({ attr: { style: 'margin-top: 16px; text-align: right;' } });
+    btnRow.createEl('button', { text: this.t('ingestReportClose') }).addEventListener('click', () => this.close());
+  }
+
+  onClose() {
+    this.contentEl.empty();
+  }
+}

--- a/src/ui/modals/LintReportModal-class.ts
+++ b/src/ui/modals/LintReportModal-class.ts
@@ -1,0 +1,164 @@
+// LintReportModal — displays a Markdown lint report with action buttons.
+//
+// The action buttons are organized into 4 layers:
+//   Layer 1: Pre-flight operations (alias completion, tag violation retag)
+//   Layer 1b: Polluted page fix (structural root cause)
+//   Layer 2: Causality-ordered fix buttons (duplicates → dead links → orphans → empty pages)
+//   Layer 3: Smart Fix All (batched all-in-one)
+//   Layer 4: Schema analysis (independent)
+//
+// Extracted from the original `src/ui/modals.ts` god file (PR split).
+// No behavior change — pure code movement.
+
+import { App, Modal, MarkdownRenderer, Component } from 'obsidian';
+import { TEXTS } from '../../texts';
+import type { LintFixCallbacks, LintCounts } from './types';
+
+export class LintReportModal extends Modal {
+  report: string;
+  fixCallbacks: LintFixCallbacks;
+  counts: LintCounts;
+  private language: string;
+  private renderComponent: Component | null = null;
+
+  constructor(app: App, report: string, fixCallbacks: LintFixCallbacks, counts: LintCounts, language: string = 'en') {
+    super(app);
+    this.report = report;
+    this.fixCallbacks = fixCallbacks;
+    this.counts = counts;
+    this.language = language;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    this.renderComponent = new Component();
+    this.renderComponent.load();
+
+    const t = TEXTS[this.language as keyof typeof TEXTS] || TEXTS.en;
+
+    const reportDiv = contentEl.createDiv({
+      attr: { style: 'max-height: 50vh; overflow-y: auto; padding: 8px 0;' }
+    });
+    void MarkdownRenderer.render(this.app, this.report, reportDiv, '', this.renderComponent);
+
+    // Reference to persisted log entry
+    if (t.lintLogReference) {
+      contentEl.createEl('p', {
+        text: `📋 ${t.lintLogReference}`,
+        attr: { style: 'font-size: 0.85em; color: var(--text-muted); margin: 4px 0 0 0;' }
+      });
+    }
+
+    // Action buttons — organized by operation logic
+    // Layer 1: Pre-flight operations (improve detection quality)
+    // Layer 2: Root cause fixes → downstream fixes (causality order)
+    // Layer 3: Smart all-in-one
+    // Layer 4: Analysis
+
+    const actionSection = contentEl.createDiv({
+      attr: { style: 'margin-top: 16px; border-top: 1px solid var(--background-modifier-border); padding-top: 12px;' }
+    });
+
+    actionSection.createEl('p', {
+      text: t.lintModalActionsTitle,
+      attr: { style: 'font-weight: bold; margin-bottom: 10px;' }
+    });
+
+    // === Layer 1: Alias completion (pre-flight, shown only when needed) ===
+    if (this.counts.pagesMissingAliases > 0 && this.fixCallbacks.onCompleteAliases) {
+      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
+      const btn = row.createEl('button', {
+        text: t.lintAliasesCompleteBtn.replace('{count}', String(this.counts.pagesMissingAliases)),
+        cls: 'mod-cta',
+        attr: { style: 'font-weight: bold;' }
+      });
+      btn.addEventListener('click', () => {
+        this.fixCallbacks.onCompleteAliases?.();
+        this.close();
+      });
+    }
+
+    // === Layer 1.5: Issue #85 v7 — Tag violation retag (LLM bulk) ===
+    if (this.counts.tagViolations > 0 && this.fixCallbacks.onRetagViolations) {
+      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
+      const btn = row.createEl('button', {
+        text: t.lintTagViolationRetagBtn.replace('{count}', String(this.counts.tagViolations)),
+        cls: 'mod-cta',
+        attr: { style: 'font-weight: bold;' }
+      });
+      btn.addEventListener('click', () => {
+        this.fixCallbacks.onRetagViolations?.();
+        this.close();
+      });
+    }
+
+    // === Layer 1b: Polluted page fix (structural root cause) ===
+    if (this.counts.pollutedPages > 0 && this.fixCallbacks.onFixPollutedPages) {
+      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
+      const btn = row.createEl('button', {
+        text: t.lintModalFixPolluted.replace('{count}', String(this.counts.pollutedPages)),
+        cls: 'mod-cta',
+        attr: { style: 'font-weight: bold;' }
+      });
+      btn.addEventListener('click', () => {
+        this.fixCallbacks.onFixPollutedPages?.();
+        this.close();
+      });
+    }
+
+    // === Layer 2: Causality-ordered fix buttons (duplicates → dead links → orphans → empty pages) ===
+    const fixableItems = [
+      { count: this.counts.duplicates, cb: this.fixCallbacks.onMergeDuplicates, text: t.lintModalMergeDuplicates },
+      { count: this.counts.deadLinks, cb: this.fixCallbacks.onFixDeadLinks, text: t.lintModalFixDeadLinks },
+      { count: this.counts.orphans, cb: this.fixCallbacks.onLinkOrphans, text: t.lintModalLinkOrphans },
+      { count: this.counts.emptyPages, cb: this.fixCallbacks.onFillEmptyPages, text: t.lintModalExpandEmpty },
+      { count: this.counts.emptyPages, cb: this.fixCallbacks.onDeleteEmptyStubs, text: t.lintModalDeleteEmpty },
+    ].filter(item => item.count > 0 && item.cb);
+
+    if (fixableItems.length > 0) {
+      const fixRow = actionSection.createDiv({
+        attr: { style: 'display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;' }
+      });
+      for (const item of fixableItems) {
+        const btn = fixRow.createEl('button', {
+          text: item.text.replace('{count}', String(item.count)),
+          cls: 'mod-cta'
+        });
+        btn.addEventListener('click', () => {
+          item.cb?.();
+          this.close();
+        });
+      }
+    }
+
+    // === Layer 3: Smart Fix All (batched all-in-one) ===
+    const totalFixable = this.counts.deadLinks + this.counts.emptyPages + this.counts.orphans + this.counts.duplicates + this.counts.pagesMissingAliases;
+    if (totalFixable > 0 && this.fixCallbacks.onFixAll) {
+      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
+      const btn = row.createEl('button', {
+        text: t.lintModalFixAll.replace('{count}', String(totalFixable)),
+        attr: { style: 'font-weight: bold;' }
+      });
+      btn.addEventListener('click', () => {
+        this.fixCallbacks.onFixAll?.();
+        this.close();
+      });
+    }
+
+    // === Layer 4: Schema analysis (independent) ===
+    if (this.fixCallbacks.onAnalyzeSchema) {
+      const row = actionSection.createDiv({ attr: { style: 'margin-top: 8px;' } });
+      row.createEl('button', {
+        text: t.lintModalAnalyzeSchema,
+      }).addEventListener('click', () => {
+        this.fixCallbacks.onAnalyzeSchema?.();
+        this.close();
+      });
+    }
+  }
+
+  onClose() {
+    this.renderComponent?.unload();
+    this.contentEl.empty();
+  }
+}

--- a/src/ui/modals/MultiFileSuggestModal-class.ts
+++ b/src/ui/modals/MultiFileSuggestModal-class.ts
@@ -1,489 +1,32 @@
-// Reusable UI modals for the LLM Wiki Plugin
+// MultiFileSuggestModal — v1.23.0 (#130)
+//
+// Two-pane file picker: left column lists all non-wiki markdown files
+// in the vault; right column shows the current selection queue. User
+// toggles files with a checkbox, then confirms with the "Start Ingest"
+// button at the bottom.
+//
+// Dedupe: adding the same file twice is a no-op (the second toggle
+// un-checks it).
+//
+// Clear: a "Clear Queue" button drops all pending entries.
+//
+// The selected files are NOT moved (the original #130 requirement —
+// in-place ingest avoids breaking the source-path provenance).
+//
+// Extracted from the original `src/ui/modals.ts` god file (PR split).
+// No behavior change — pure code movement.
+
+import { App, Modal } from 'obsidian';
+import type { TFile } from 'obsidian';
+import type { LLMWikiSettings } from '../../types';
+import { getText } from '../../core/i18n';
+import { buildFolderTree, type TreeNode } from '../../core/build-folder-tree';
+import type { IngestQueue } from '../../core/ingest-queue';
 
-import { App, TFile, TFolder, Modal, FuzzySuggestModal, MarkdownRenderer, Component } from 'obsidian';
-import { IngestReport, type LLMWikiSettings } from '../types';
-import { TEXTS } from '../texts';
-import { getText } from '../core/i18n';
-import { buildFolderTree } from '../core/build-folder-tree';
-import type { RejectionReason } from '../core/source-requirements';
-
-export class FileSuggestModal extends FuzzySuggestModal<TFile> {
-  onSelect: (file: TFile) => void;
-  private wikiFolder: string;
-
-  constructor(app: App, wikiFolder: string, onSelect: (file: TFile) => void) {
-    super(app);
-    this.wikiFolder = wikiFolder;
-    this.onSelect = onSelect;
-  }
-
-  getItems(): TFile[] {
-    return this.app.vault.getMarkdownFiles()
-      .filter(f => !f.path.startsWith(this.wikiFolder) && !f.path.startsWith(this.app.vault.configDir));
-  }
-
-  getItemText(file: TFile): string {
-    return file.path;
-  }
-
-  onChooseItem(file: TFile): void {
-    this.onSelect(file);
-  }
-}
-
-export class FolderSuggestModal extends FuzzySuggestModal<TFolder> {
-  onSelect: (folder: TFolder) => void;
-  private wikiFolder: string;
-
-  constructor(app: App, wikiFolder: string, onSelect: (folder: TFolder) => void) {
-    super(app);
-    this.wikiFolder = wikiFolder;
-    this.onSelect = onSelect;
-  }
-
-  getItems(): TFolder[] {
-    const folders: TFolder[] = [];
-    const root = this.app.vault.getRoot();
-
-    const collect = (folder: TFolder) => {
-      if (!folder.path.startsWith(this.app.vault.configDir) && !folder.path.startsWith(this.wikiFolder)) {
-        folders.push(folder);
-      }
-      for (const child of folder.children) {
-        if (child instanceof TFolder) {
-          collect(child);
-        }
-      }
-    };
-    collect(root);
-    return folders;
-  }
-
-  getItemText(folder: TFolder): string {
-    return folder.path;
-  }
-
-  onChooseItem(folder: TFolder): void {
-    this.onSelect(folder);
-  }
-}
-
-export interface LintFixCallbacks {
-  onCompleteAliases?: () => void;
-  onFixDeadLinks?: () => void;
-  onFillEmptyPages?: () => void;
-  onDeleteEmptyStubs?: () => void;
-  onLinkOrphans?: () => void;
-  onAnalyzeSchema?: () => void;
-  onMergeDuplicates?: () => void;
-  onFixAll?: () => void;
-  onFixPollutedPages?: () => void;
-  // Issue #85 v7: LLM-assisted retag of pages with out-of-vocabulary tags
-  onRetagViolations?: () => void;
-}
-
-export interface LintCounts {
-  deadLinks: number;
-  emptyPages: number;
-  orphans: number;
-  duplicates: number;
-  pagesMissingAliases: number;
-  pollutedPages: number;
-  // Issue #85 v7: out-of-vocabulary tag count
-  tagViolations: number;
-  // Issue #126: quotes not found in source files
-  ungroundedQuotes: number;
-}
-
-export class LintReportModal extends Modal {
-  report: string;
-  fixCallbacks: LintFixCallbacks;
-  counts: LintCounts;
-  private language: string;
-  private renderComponent: Component | null = null;
-
-  constructor(app: App, report: string, fixCallbacks: LintFixCallbacks, counts: LintCounts, language: string = 'en') {
-    super(app);
-    this.report = report;
-    this.fixCallbacks = fixCallbacks;
-    this.counts = counts;
-    this.language = language;
-  }
-
-  onOpen() {
-    const { contentEl } = this;
-    this.renderComponent = new Component();
-    this.renderComponent.load();
-
-    const t = TEXTS[this.language as keyof typeof TEXTS] || TEXTS.en;
-
-    const reportDiv = contentEl.createDiv({
-      attr: { style: 'max-height: 50vh; overflow-y: auto; padding: 8px 0;' }
-    });
-    void MarkdownRenderer.render(this.app, this.report, reportDiv, '', this.renderComponent);
-
-    // Reference to persisted log entry
-    if (t.lintLogReference) {
-      contentEl.createEl('p', {
-        text: `📋 ${t.lintLogReference}`,
-        attr: { style: 'font-size: 0.85em; color: var(--text-muted); margin: 4px 0 0 0;' }
-      });
-    }
-
-    // Action buttons — organized by operation logic
-    // Layer 1: Pre-flight operations (improve detection quality)
-    // Layer 2: Root cause fixes → downstream fixes (causality order)
-    // Layer 3: Smart all-in-one
-    // Layer 4: Analysis
-
-    const actionSection = contentEl.createDiv({
-      attr: { style: 'margin-top: 16px; border-top: 1px solid var(--background-modifier-border); padding-top: 12px;' }
-    });
-
-    actionSection.createEl('p', {
-      text: t.lintModalActionsTitle,
-      attr: { style: 'font-weight: bold; margin-bottom: 10px;' }
-    });
-
-    // === Layer 1: Alias completion (pre-flight, shown only when needed) ===
-    if (this.counts.pagesMissingAliases > 0 && this.fixCallbacks.onCompleteAliases) {
-      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
-      const btn = row.createEl('button', {
-        text: t.lintAliasesCompleteBtn.replace('{count}', String(this.counts.pagesMissingAliases)),
-        cls: 'mod-cta',
-        attr: { style: 'font-weight: bold;' }
-      });
-      btn.addEventListener('click', () => {
-        this.fixCallbacks.onCompleteAliases?.();
-        this.close();
-      });
-    }
-
-    // === Layer 1.5: Issue #85 v7 — Tag violation retag (LLM bulk) ===
-    if (this.counts.tagViolations > 0 && this.fixCallbacks.onRetagViolations) {
-      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
-      const btn = row.createEl('button', {
-        text: t.lintTagViolationRetagBtn.replace('{count}', String(this.counts.tagViolations)),
-        cls: 'mod-cta',
-        attr: { style: 'font-weight: bold;' }
-      });
-      btn.addEventListener('click', () => {
-        this.fixCallbacks.onRetagViolations?.();
-        this.close();
-      });
-    }
-
-    // === Layer 1b: Polluted page fix (structural root cause) ===
-    if (this.counts.pollutedPages > 0 && this.fixCallbacks.onFixPollutedPages) {
-      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
-      const btn = row.createEl('button', {
-        text: t.lintModalFixPolluted.replace('{count}', String(this.counts.pollutedPages)),
-        cls: 'mod-cta',
-        attr: { style: 'font-weight: bold;' }
-      });
-      btn.addEventListener('click', () => {
-        this.fixCallbacks.onFixPollutedPages?.();
-        this.close();
-      });
-    }
-
-    // === Layer 2: Causality-ordered fix buttons (duplicates → dead links → orphans → empty pages) ===
-    const fixableItems = [
-      { count: this.counts.duplicates, cb: this.fixCallbacks.onMergeDuplicates, text: t.lintModalMergeDuplicates },
-      { count: this.counts.deadLinks, cb: this.fixCallbacks.onFixDeadLinks, text: t.lintModalFixDeadLinks },
-      { count: this.counts.orphans, cb: this.fixCallbacks.onLinkOrphans, text: t.lintModalLinkOrphans },
-      { count: this.counts.emptyPages, cb: this.fixCallbacks.onFillEmptyPages, text: t.lintModalExpandEmpty },
-      { count: this.counts.emptyPages, cb: this.fixCallbacks.onDeleteEmptyStubs, text: t.lintModalDeleteEmpty },
-    ].filter(item => item.count > 0 && item.cb);
-
-    if (fixableItems.length > 0) {
-      const fixRow = actionSection.createDiv({
-        attr: { style: 'display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px;' }
-      });
-      for (const item of fixableItems) {
-        const btn = fixRow.createEl('button', {
-          text: item.text.replace('{count}', String(item.count)),
-          cls: 'mod-cta'
-        });
-        btn.addEventListener('click', () => {
-          item.cb?.();
-          this.close();
-        });
-      }
-    }
-
-    // === Layer 3: Smart Fix All (batched all-in-one) ===
-    const totalFixable = this.counts.deadLinks + this.counts.emptyPages + this.counts.orphans + this.counts.duplicates + this.counts.pagesMissingAliases;
-    if (totalFixable > 0 && this.fixCallbacks.onFixAll) {
-      const row = actionSection.createDiv({ attr: { style: 'margin-bottom: 10px;' } });
-      const btn = row.createEl('button', {
-        text: t.lintModalFixAll.replace('{count}', String(totalFixable)),
-        attr: { style: 'font-weight: bold;' }
-      });
-      btn.addEventListener('click', () => {
-        this.fixCallbacks.onFixAll?.();
-        this.close();
-      });
-    }
-
-    // === Layer 4: Schema analysis (independent) ===
-    if (this.fixCallbacks.onAnalyzeSchema) {
-      const row = actionSection.createDiv({ attr: { style: 'margin-top: 8px;' } });
-      row.createEl('button', {
-        text: t.lintModalAnalyzeSchema,
-      }).addEventListener('click', () => {
-        this.fixCallbacks.onAnalyzeSchema?.();
-        this.close();
-      });
-    }
-  }
-
-  onClose() {
-    this.renderComponent?.unload();
-    this.contentEl.empty();
-  }
-}
-
-export class IngestReportModal extends Modal {
-  private report: IngestReport;
-  private language: string;
-
-  constructor(app: App, report: IngestReport, language: string = 'en') {
-    super(app);
-    this.report = report;
-    this.language = language;
-  }
-
-  private t(key: string): string {
-    return getText(this.language, key as keyof typeof TEXTS.en) || key;
-  }
-
-  /** Map a gate rejection reason to its short localized label key. Mirrors WikiEngine.rejectionNoticeKey. */
-  private reasonLabelKey(reason: RejectionReason): string {
-    if (reason === 'incompatible-type') return 'rejectionReasonType';
-    if (reason === 'duplicate') return 'rejectionReasonDuplicate';
-    return 'rejectionReasonEmpty';
-  }
-
-  onOpen() {
-    const { sourceFile, createdPages, updatedPages, entitiesCreated, conceptsCreated, failedItems, contradictionsFound, success, errorMessage, collisions, elapsedSeconds, skippedFiles, totalFilesInFolder, rejectedFiles } = this.report;
-
-    const statusEmoji = success ? '✅' : '⚠️';
-    this.contentEl.createEl('h2', { text: `${statusEmoji} ${this.t('ingestReportTitle')}` });
-
-    // Source file
-    this.contentEl.createEl('p', { text: `${this.t('ingestReportSourceFile')}：${sourceFile}` });
-
-    // Skipped files (batch ingest only)
-    if (skippedFiles !== undefined && skippedFiles > 0) {
-      this.contentEl.createEl('p', {
-        text: `${this.t('ingestReportSkippedFiles')}: ${skippedFiles}/${totalFilesInFolder || skippedFiles}`,
-        attr: { style: 'color: var(--text-muted); font-size: 13px;' }
-      });
-    }
-
-    // Elapsed time
-    if (elapsedSeconds !== undefined) {
-      const minutes = Math.floor(elapsedSeconds / 60);
-      const seconds = elapsedSeconds % 60;
-      const timeStr = minutes > 0
-        ? `${minutes} ${this.t('timeMinutes')} ${seconds} ${this.t('timeSeconds')}`
-        : `${seconds} ${this.t('timeSeconds')}`;
-      this.contentEl.createEl('p', { text: `${this.t('ingestReportElapsedTime')}：${timeStr}` });
-    }
-
-    // Stats
-    const statsEl = this.contentEl.createDiv({ attr: { style: 'margin: 12px 0;' } });
-    const createdText = this.t('ingestReportCreatedPages').replace('{count}', String(createdPages.length));
-    const breakdown = entitiesCreated > 0 || conceptsCreated > 0
-      ? ` (${this.t('ingestReportEntitiesCount').replace('{count}', String(entitiesCreated))} + ${this.t('ingestReportConceptsCount').replace('{count}', String(conceptsCreated))})`
-      : '';
-    statsEl.createEl('p', { text: createdText + breakdown });
-    statsEl.createEl('p', { text: this.t('ingestReportUpdatedPages').replace('{count}', String(updatedPages.length)) });
-    if (contradictionsFound > 0) {
-      statsEl.createEl('p', { text: this.t('ingestReportContradictionsFound').replace('{count}', String(contradictionsFound)) });
-    }
-
-    // Collisions
-    if (collisions && collisions.length > 0) {
-      this.contentEl.createEl('h3', { text: '🔀 ' + this.t('ingestReportCollisions') + ` (${collisions.length})` });
-      const list = this.contentEl.createEl('ul');
-      for (const c of collisions) {
-        const sourceTypeLabel = c.sourceType === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
-        const targetTypeLabel = c.targetType === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
-        list.createEl('li', { text: `"${c.name}" (${sourceTypeLabel}) → ${targetTypeLabel}` });
-      }
-    }
-
-    // Created pages
-    if (createdPages.length > 0) {
-      this.contentEl.createEl('h3', { text: this.t('ingestReportCreated') });
-      const list = this.contentEl.createEl('ul');
-      for (const page of createdPages) {
-        list.createEl('li', { text: page });
-      }
-    }
-
-    // Updated pages
-    if (updatedPages.length > 0) {
-      this.contentEl.createEl('h3', { text: this.t('ingestReportUpdated') });
-      const list = this.contentEl.createEl('ul');
-      for (const page of updatedPages) {
-        list.createEl('li', { text: page });
-      }
-    }
-
-    // Failed items
-    if (failedItems.length > 0) {
-      this.contentEl.createEl('h3', { text: '⚠️ ' + this.t('ingestReportFailedTitle') });
-      const list = this.contentEl.createEl('ul');
-      for (const item of failedItems) {
-        const typeLabel = item.type === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
-        list.createEl('li', { text: `[${typeLabel}] ${item.name} — ${item.reason}` });
-      }
-      this.contentEl.createEl('p', {
-        text: this.t('ingestReportFailedGuidance'),
-        attr: { style: 'color: var(--text-muted); margin-top: 8px; font-size: 13px;' }
-      });
-    }
-
-    // Rejected / skipped files (requirements gate, #164)
-    if (rejectedFiles && rejectedFiles.length > 0) {
-      this.contentEl.createEl('h3', { text: '⏭️ ' + this.t('ingestReportRejectedFiles') + ` (${rejectedFiles.length})` });
-      const list = this.contentEl.createEl('ul');
-      for (const r of rejectedFiles) {
-        const name = r.path.split('/').pop() || r.path;
-        list.createEl('li', { text: `${name} — ${this.t(this.reasonLabelKey(r.reason))}` });
-      }
-    }
-
-    // Error
-    if (errorMessage) {
-      this.contentEl.createEl('p', {
-        text: `${this.t('ingestReportErrorDetail')}：${errorMessage}`,
-        attr: { style: 'color: var(--text-error); margin-top: 12px;' }
-      });
-    }
-
-    // Close button
-    const btnRow = this.contentEl.createDiv({ attr: { style: 'margin-top: 16px; text-align: right;' } });
-    btnRow.createEl('button', { text: this.t('ingestReportClose') }).addEventListener('click', () => this.close());
-  }
-
-  onClose() {
-    this.contentEl.empty();
-  }
-}
-
-/**
- * Small reusable yes/no confirmation modal (#164). `onChoice` fires exactly once:
- * true on confirm, false on cancel / Escape / dismiss.
- */
-export class ConfirmModal extends Modal {
-  private decided = false;
-
-  constructor(
-    app: App,
-    private opts: { title: string; body: string; confirmText: string; cancelText: string; onChoice: (confirmed: boolean) => void }
-  ) {
-    super(app);
-  }
-
-  onOpen() {
-    this.contentEl.createEl('h2', { text: this.opts.title });
-    this.contentEl.createEl('p', { text: this.opts.body });
-    const btnRow = this.contentEl.createDiv({ attr: { style: 'margin-top: 16px; text-align: right;' } });
-    btnRow.createEl('button', { text: this.opts.cancelText })
-      .addEventListener('click', () => this.decide(false));
-    btnRow.createEl('button', { text: this.opts.confirmText, cls: 'mod-cta', attr: { style: 'margin-left: 8px;' } })
-      .addEventListener('click', () => this.decide(true));
-  }
-
-  private decide(confirmed: boolean) {
-    this.decided = true;
-    this.opts.onChoice(confirmed);
-    this.close();
-  }
-
-  onClose() {
-    this.contentEl.empty();
-    // Escape / X / click-outside → treat as cancel, exactly once.
-    if (!this.decided) {
-      this.decided = true;
-      this.opts.onChoice(false);
-    }
-  }
-}
-
-export interface FixReportPhase {
-  label: string;
-  detail: string;
-}
-
-export class FixReportModal extends Modal {
-  private phases: FixReportPhase[];
-  private language: string;
-
-  constructor(app: App, phases: FixReportPhase[], language: string) {
-    super(app);
-    this.phases = phases;
-    this.language = language;
-  }
-
-  onOpen() {
-    const tk = (k: string) => getText(this.language, k as keyof typeof TEXTS.en) || k;
-    const titleText = tk('lintFixAllComplete');
-
-    this.contentEl.createEl('h2', { text: titleText });
-
-    const list = this.contentEl.createEl('ul', {
-      attr: { style: 'margin: 12px 0; line-height: 1.8;' }
-    });
-    for (const phase of this.phases) {
-      const itemText = phase.detail
-        ? `${phase.label}: ${phase.detail}`
-        : phase.label;
-      list.createEl('li', { text: itemText });
-    }
-
-    const indexNote = tk('lintFixIndexUpdated');
-    if (indexNote) {
-      this.contentEl.createEl('p', {
-        text: indexNote,
-        attr: { style: 'color: var(--text-muted); font-size: 13px; margin-top: 8px;' }
-      });
-    }
-
-    const btnRow = this.contentEl.createDiv({ attr: { style: 'margin-top: 16px; text-align: right;' } });
-    const closeText = tk('ingestReportClose');
-    btnRow.createEl('button', { text: closeText }).addEventListener('click', () => this.close());
-  }
-
-  onClose() {
-    this.contentEl.empty();
-  }
-}
-
-/**
- * MultiFileSuggestModal — v1.23.0 (#130)
- *
- * Two-pane file picker: left column lists all non-wiki markdown files
- * in the vault; right column shows the current selection queue. User
- * toggles files with a checkbox, then confirms with the "Start Ingest"
- * button at the bottom.
- *
- * Dedupe: adding the same file twice is a no-op (the second toggle
- * un-checks it).
- *
- * Clear: a "Clear Queue" button drops all pending entries.
- *
- * The selected files are NOT moved (the original #130 requirement —
- * in-place ingest avoids breaking the source-path provenance).
- */
 export class MultiFileSuggestModal extends Modal {
   /** The shared ingest queue. Modal reads + subscribes; never owns
    * the data. */
-  private ingestQueue: import('../core/ingest-queue').IngestQueue;
+  private ingestQueue: IngestQueue;
   /** Folder name used to filter wiki files out of the candidate set.
    * Comes from settings (the user-configurable wiki folder). */
   private wikiFolder: string;
@@ -520,12 +63,12 @@ export class MultiFileSuggestModal extends Modal {
    * `updateLeftPaneSelections` so user-collapsed folders stay
    * collapsed.
    */
-  private treeRoots: import('../core/build-folder-tree').TreeNode[] = [];
+  private treeRoots: TreeNode[] = [];
 
   constructor(
     app: App,
     settings: LLMWikiSettings,
-    ingestQueue: import('../core/ingest-queue').IngestQueue,
+    ingestQueue: IngestQueue,
     onStartIngest?: (ids: string[], files: TFile[]) => void,
   ) {
     super(app);
@@ -701,16 +244,9 @@ export class MultiFileSuggestModal extends Modal {
    * top-level entries. This avoids a "faux root" toggle that
    * confuses users (no Obsidian file explorer has a "vault root"
    * wrapper).
-   *
-   * @param node the TreeNode to render
-   * @param container the parent DOM element
-   * @param q current search query (lowercase); empty string = no filter
-   * @param depth 0 = top-level. Used for CSS indent and for the
-   *   "auto-expand on search" heuristic (only auto-expand at depth
-   *   ≤ 1, not 4+ levels deep — that would be visually overwhelming).
    */
   private renderTreeNode(
-    node: import('../core/build-folder-tree').TreeNode,
+    node: TreeNode,
     container: HTMLElement,
     q: string,
     depth: number,
@@ -873,7 +409,7 @@ export class MultiFileSuggestModal extends Modal {
    * is active.
    */
   private nodeOrDescendantMatches(
-    node: import('../core/build-folder-tree').TreeNode,
+    node: TreeNode,
     q: string,
   ): boolean {
     if (!q) return true;
@@ -995,7 +531,7 @@ export class MultiFileSuggestModal extends Modal {
   }
 
   private findFileInNode(
-    node: import('../core/build-folder-tree').TreeNode,
+    node: TreeNode,
     path: string,
   ): TFile | null {
     for (const f of node.files) if (f.path === path) return f;

--- a/src/ui/modals/index.ts
+++ b/src/ui/modals/index.ts
@@ -1,0 +1,17 @@
+// Public entry point for the modals/ directory (replaces the old
+// `src/ui/modals.ts` god file).
+//
+// Re-exports the 7 modal classes + 3 shared types originally declared
+// in the monolith. External callers (`main.ts`, `settings.ts`,
+// `lint/controller.ts`) keep importing from `./modals` / `../../ui/modals`
+// and TypeScript's directory import resolution automatically picks up
+// this `index.ts` — zero caller changes needed.
+
+export { FileSuggestModal, FolderSuggestModal } from './suggest-modals';
+export { ConfirmModal } from './ConfirmModal-class';
+export { LintReportModal } from './LintReportModal-class';
+export { IngestReportModal } from './IngestReportModal-class';
+export { FixReportModal } from './FixReportModal-class';
+export { MultiFileSuggestModal } from './MultiFileSuggestModal-class';
+
+export type { LintFixCallbacks, LintCounts, FixReportPhase } from './types';

--- a/src/ui/modals/suggest-modals.ts
+++ b/src/ui/modals/suggest-modals.ts
@@ -1,0 +1,68 @@
+// File & Folder suggest modals — small FuzzySuggestModal subclasses used
+// in settings.ts (folder picker) and settings tab flows (file picker).
+//
+// Extracted from the original `src/ui/modals.ts` god file (PR split).
+// No behavior change — pure code movement.
+
+import { App, TFile, TFolder, FuzzySuggestModal } from 'obsidian';
+
+export class FileSuggestModal extends FuzzySuggestModal<TFile> {
+  onSelect: (file: TFile) => void;
+  private wikiFolder: string;
+
+  constructor(app: App, wikiFolder: string, onSelect: (file: TFile) => void) {
+    super(app);
+    this.wikiFolder = wikiFolder;
+    this.onSelect = onSelect;
+  }
+
+  getItems(): TFile[] {
+    return this.app.vault.getMarkdownFiles()
+      .filter(f => !f.path.startsWith(this.wikiFolder) && !f.path.startsWith(this.app.vault.configDir));
+  }
+
+  getItemText(file: TFile): string {
+    return file.path;
+  }
+
+  onChooseItem(file: TFile): void {
+    this.onSelect(file);
+  }
+}
+
+export class FolderSuggestModal extends FuzzySuggestModal<TFolder> {
+  onSelect: (folder: TFolder) => void;
+  private wikiFolder: string;
+
+  constructor(app: App, wikiFolder: string, onSelect: (folder: TFolder) => void) {
+    super(app);
+    this.wikiFolder = wikiFolder;
+    this.onSelect = onSelect;
+  }
+
+  getItems(): TFolder[] {
+    const folders: TFolder[] = [];
+    const root = this.app.vault.getRoot();
+
+    const collect = (folder: TFolder) => {
+      if (!folder.path.startsWith(this.app.vault.configDir) && !folder.path.startsWith(this.wikiFolder)) {
+        folders.push(folder);
+      }
+      for (const child of folder.children) {
+        if (child instanceof TFolder) {
+          collect(child);
+        }
+      }
+    };
+    collect(root);
+    return folders;
+  }
+
+  getItemText(folder: TFolder): string {
+    return folder.path;
+  }
+
+  onChooseItem(folder: TFolder): void {
+    this.onSelect(folder);
+  }
+}

--- a/src/ui/modals/types.ts
+++ b/src/ui/modals/types.ts
@@ -1,0 +1,38 @@
+// Shared types for the modals/ directory.
+//
+// Pure type declarations extracted from the original `src/ui/modals.ts` so
+// that callers (lint controller, settings tab, main.ts) can keep importing
+// them from `./modals` (which resolves to `./modals/index.ts` after the
+// split) without an extra re-organization step.
+
+export interface LintFixCallbacks {
+  onCompleteAliases?: () => void;
+  onFixDeadLinks?: () => void;
+  onFillEmptyPages?: () => void;
+  onDeleteEmptyStubs?: () => void;
+  onLinkOrphans?: () => void;
+  onAnalyzeSchema?: () => void;
+  onMergeDuplicates?: () => void;
+  onFixAll?: () => void;
+  onFixPollutedPages?: () => void;
+  // Issue #85 v7: LLM-assisted retag of pages with out-of-vocabulary tags
+  onRetagViolations?: () => void;
+}
+
+export interface LintCounts {
+  deadLinks: number;
+  emptyPages: number;
+  orphans: number;
+  duplicates: number;
+  pagesMissingAliases: number;
+  pollutedPages: number;
+  // Issue #85 v7: out-of-vocabulary tag count
+  tagViolations: number;
+  // Issue #126: quotes not found in source files
+  ungroundedQuotes: number;
+}
+
+export interface FixReportPhase {
+  label: string;
+  detail: string;
+}

--- a/src/wiki/lint/controller.ts
+++ b/src/wiki/lint/controller.ts
@@ -36,6 +36,7 @@ import { runAnalysisPhase } from './llm-phases/analysis-phase';
 import { buildLintReport } from './report-builder';
 import { LintContext, LintPhaseContext, ProgrammaticFindings } from './types';
 import { NOTICE_NORMAL, NOTICE_ERROR } from '../../constants';
+import { SchemaTask } from '../../schema/schema-manager';
 
 // Re-export LintContext for back-compat — external callers (e.g. main.ts,
 // ui/modals/ indirect import) still reference `LintContext` from this file.
@@ -96,6 +97,10 @@ export async function runLintWiki(
       checkCancelled,
       stageNotice,
       totalPages: 0,
+      // v1.24.0: expose the shared system-prompt composer so LLM-assisted
+      // lint phases inject the same language directive + schema context +
+      // active tag vocabulary that the fix-runners receive.
+      buildSystemPrompt: (task: string) => ctx.wikiEngine.buildSystemPrompt(task as SchemaTask),
     };
 
     // ---- Phase 1: Preparation (read pages, fix links, normalize sources) ----

--- a/src/wiki/lint/controller.ts
+++ b/src/wiki/lint/controller.ts
@@ -38,7 +38,7 @@ import { LintContext, LintPhaseContext, ProgrammaticFindings } from './types';
 import { NOTICE_NORMAL, NOTICE_ERROR } from '../../constants';
 
 // Re-export LintContext for back-compat — external callers (e.g. main.ts,
-// modals.ts indirect import) still reference `LintContext` from this file.
+// ui/modals/ indirect import) still reference `LintContext` from this file.
 export type { LintContext } from './types';
 
 /**

--- a/src/wiki/lint/fix-runners.ts
+++ b/src/wiki/lint/fix-runners.ts
@@ -9,7 +9,7 @@ import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { detectRateLimitFailures, formatRateLimitNotice } from '../../core/rate-limit';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from '../../core/tag-vocab';
-import { enforceFrontmatterConstraints } from '../../core/frontmatter';
+import { mergeFrontmatterArrayField, replaceFrontmatterArrayField, parseFrontmatter } from '../../core/frontmatter';
 import { TOKENS_LINT_ALIAS_BATCH, NOTICE_ERROR, NOTICE_RATE_LIMIT } from '../../constants';
 import { buildWikiLanguageDirective, appendTagVocabularyToPrompt } from '../system-prompts';
 import { TagViolation } from './scanners';
@@ -92,24 +92,55 @@ export async function runAliasCompletion(
             response_format: { type: 'json_object' }
           });
 
+          // v1.24.0: Bug 3 — log provider + raw response shape BEFORE
+          // parseJsonResponse so an empty / unparseable result is
+          // attributable to either the provider (empty text) or our
+          // parser (rejected text). Without this, the user only sees
+          // "JSON parse completely failed (length 0)" with no context.
+          console.debug(
+            `[Alias] ${page.basename}: response type=${typeof response} ` +
+            `length=${typeof response === 'string' ? response.length : 'N/A'} | ` +
+            `provider=${client.constructor?.name ?? typeof client} | ` +
+            `first200=${JSON.stringify((typeof response === 'string' ? response : '').slice(0, 200))}`
+          );
+
           const parsed = await parseJsonResponse(response) as { aliases?: string[] } | null;
           if (parsed?.aliases?.length) {
             console.debug(`[Alias] ${page.basename}: generated ${parsed.aliases.length} aliases → [${parsed.aliases.join(', ')}]`);
 
-            const fmEnd = page.content.indexOf('\n---', 3);
-            if (fmEnd !== -1) {
-              const aliasesYaml = 'aliases:\n' + parsed.aliases.map(a => `  - "${a}"`).join('\n');
-              const updated = page.content.substring(0, fmEnd) + '\n' + aliasesYaml + page.content.substring(fmEnd);
-              await ctx.app.vault.adapter.write(page.path, updated);
-              results.push(`- [[${pageRel}]]: added ${parsed.aliases.length} aliases`);
-              return { success: true, name: page.basename, count: parsed.aliases.length };
-            } else {
-              console.warn(`[Alias] ${page.basename}: frontmatter closing marker not found`);
-            }
+            // v1.24.0: Bug 2 — use the shared merge helper so we never
+            // produce duplicate `aliases:` lines (the previous string-
+            // splice approach inserted a second `aliases:` even when
+            // the page already had `aliases: []`).
+            const fmBefore = parseFrontmatter(page.content);
+            const existingAliases = Array.isArray(fmBefore?.aliases) ? fmBefore.aliases : [];
+            const updated = mergeFrontmatterArrayField(page.content, 'aliases', parsed.aliases);
+            const fmAfter = parseFrontmatter(updated);
+            const mergedAliases = Array.isArray(fmAfter?.aliases) ? fmAfter.aliases : [];
+            const newAliases = mergedAliases.length - existingAliases.length;
+
+            await ctx.app.vault.adapter.write(page.path, updated);
+            results.push(`- [[${pageRel}]]: added ${newAliases} aliases (total ${mergedAliases.length})`);
+            return { success: true, name: page.basename, count: newAliases };
           }
-          return { success: false, name: page.basename, reason: 'No aliases generated' };
+          // v1.24.0 Bug 3: when parseJsonResponse fails to extract aliases,
+// surface the page basename + raw response shape via console.error
+// (not just console.debug). The user needs to see which page failed
+// without grepping through hundreds of LLM call logs.
+const respStr = typeof response === 'string' ? response : '';
+console.error(
+  `[Alias] ${page.basename}: no aliases extracted | ` +
+  `response length=${respStr.length} | ` +
+  `provider=${client.constructor?.name ?? typeof client} | ` +
+  `first100=${JSON.stringify(respStr.slice(0, 100))}`
+);
+return { success: false, name: page.basename, reason: 'No aliases generated' };
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);
+          // Note: `response` is in the outer try scope, so we can't
+          // reference it here. The pre-fix code already logged the
+          // page name in console.error. The richer diagnostic (provider
+          // name + raw response) is logged inside the try block above.
           console.error(`[Alias] ${page.basename}: generation failed — ${errMsg}`);
           new Notice(t.lintAliasesFillFailed.replace('{page}', page.basename).replace('{error}', errMsg), NOTICE_ERROR);
           return { success: false, name: page.basename, reason: errMsg };
@@ -457,23 +488,15 @@ Task: Return a JSON object with a single field "tags" that is an array of string
           continue;
         }
 
-        // Rebuild the frontmatter with the new tags. We reuse
-        // enforceFrontmatterConstraints so date / aliases / created /
-        // updated are preserved. The body is byte-identical to the
-        // input we read.
-        const updated = enforceFrontmatterConstraints(
-          content,  // original content; only the tags: line will change
-          v.pageType,
-          ctx.settings,
-        );
-        // enforceFrontmatterConstraints preserves all LLM-emitted tags
-        // (v6 preserve-LLM-intent), so we still need to REWRITE the
-        // tags: line explicitly with the LLM's new tags.
-        const rewritten = updated.replace(
-          /tags:\s*\[[^\]]*\]/,
-          `tags: [${safeNewTags.join(', ')}]`
-        );
-        await ctx.app.vault.adapter.write(v.path, rewritten);
+        // v1.24.0: use the shared REPLACE helper (full replacement
+        // semantic — retag rewrites the entire tags array, doesn't
+        // append). The previous regex `/tags:\s*\[[^\]]*\]/` only
+        // matched inline-style tags — block-style tags
+        // (`tags:\n  - x`) were silently not rewritten, leaving the
+        // LLM's retag un-applied. The replace helper also handles the
+        // block-style case correctly.
+        const updated = replaceFrontmatterArrayField(content, 'tags', safeNewTags);
+        await ctx.app.vault.adapter.write(v.path, updated);
         fixed++;
         results.push(`${v.path}: [${v.currentTags.join(', ')}] → [${safeNewTags.join(', ')}]`);
       } catch (e) {

--- a/src/wiki/lint/llm-phases/analysis-phase.ts
+++ b/src/wiki/lint/llm-phases/analysis-phase.ts
@@ -151,10 +151,16 @@ export async function runAnalysisPhase(
   if (!llm) {
     throw new Error('runAnalysisPhase: LLM client not available');
   }
+  // v1.24.0: compose the system prompt through the shared buildSystemPrompt
+  // composer (language directive + schema context + active tag vocabulary),
+  // matching the other lint LLM calls (fill-empty-page, fix-dead-link,
+  // link-orphan, merge-duplicates).
+  const systemPrompt = await ctx.buildSystemPrompt('lint');
   const response = await llm.createMessage({
     model: ctx.settings.model,
     max_tokens: TOKENS_LINT_DEDUP_LLM,
     messages: [{ role: 'user', content: prompt }],
+    ...(systemPrompt ? { system: systemPrompt } : {}),
     ...(ctx.settings.disableThinking ? { enableThinking: false } : {}),
   });
 

--- a/src/wiki/lint/llm-phases/dedup-phase.ts
+++ b/src/wiki/lint/llm-phases/dedup-phase.ts
@@ -182,6 +182,14 @@ export async function runDedupPhase(
     const concurrency = ctx.settings.pageGenerationConcurrency || 1;
     console.debug(`lintWiki: ${batches.length} batches, concurrency=${concurrency}`);
 
+    // v1.24.0: compose the system prompt once for the whole dedup run and
+    // reuse it across every batch worker (it is identical for all batches,
+    // and re-resolving it per batch would re-parse the schema on each worker).
+    // Uses the shared buildSystemPrompt composer so dedup receives the same
+    // language directive + schema context + active tag vocabulary as the
+    // fix-runners.
+    const systemPrompt = await ctx.buildSystemPrompt('lint');
+
     // Process batches in parallel with concurrency limit
     const allDuplicates: DuplicateResult[] = [];
     const dedupFailures: Array<{ name: string; reason: string }> = [];
@@ -220,6 +228,7 @@ export async function runDedupPhase(
             model: ctx.settings.model,
             max_tokens: TOKENS_LINT_DEDUP_LLM,
             messages: [{ role: 'user', content: dedupPrompt }],
+            ...(systemPrompt ? { system: systemPrompt } : {}),
             response_format: { type: 'json_object' },
             ...(ctx.settings.disableThinking ? { enableThinking: false } : {}),
           });

--- a/src/wiki/lint/scanners.ts
+++ b/src/wiki/lint/scanners.ts
@@ -45,13 +45,73 @@ export function detectAliasDeficiency(
       const info = pageMap.get(file.path);
       if (info) {
         const fmMatch = info.content.match(/^---\n([\s\S]*?)\n---/);
-        if (fmMatch && !fmMatch[1].includes('aliases:')) {
+        if (fmMatch && !hasNonEmptyAliases(fmMatch[1])) {
           result.push(info);
         }
       }
     }
   }
   return result;
+}
+
+/**
+ * v1.24.0: A page is "alias-deficient" when the frontmatter either
+ * lacks an `aliases:` line entirely, OR the aliases line is empty
+ * (`aliases: []` or `aliases:\n  - ""`). The previous `includes('aliases:')`
+ * check falsely treated empty arrays as "has aliases" — when a user
+ * deleted every alias entry in Obsidian, lint missed the deficiency.
+ *
+ * Inline-style and block-style empty arrays are both detected:
+ *   - `aliases: []`                 → empty inline
+ *   - `aliases:\n  - ""\n  - ""`    → block with only empty strings
+ *   - `aliases:\n` (no entries)     → block with zero entries
+ */
+function hasNonEmptyAliases(frontmatter: string): boolean {
+  // Match `aliases:` followed by everything up to end-of-line (no \n).
+  // Use [^\n]* for the trailing content to avoid consuming newlines
+  // that belong to subsequent block entries.
+  const aliasesLineMatch = frontmatter.match(/^aliases:[ \t]*(.*)$/m);
+  if (!aliasesLineMatch) return false;
+
+  const inlineContent = aliasesLineMatch[1].trim();
+
+  // Inline-style: `aliases: []` or `aliases: [a, b, ...]`.
+  if (inlineContent.startsWith('[')) {
+    const innerMatch = inlineContent.match(/^\[(.*)\]$/);
+    if (innerMatch) {
+      const items = innerMatch[1]
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+        .map(s => s.replace(/^['"](.*)['"]$/, '$1'));
+      return items.some(item => item.length > 0);
+    }
+  }
+
+  // Inline empty OR block-style: look for indented `-` entries
+  // on subsequent lines and check whether they have content.
+  const aliasesLineIdx = aliasesLineMatch.index ?? 0;
+  const afterAliases = frontmatter.substring(aliasesLineIdx + aliasesLineMatch[0].length);
+  const blockEntries = afterAliases.match(/^[ \t]+-[ \t]*(.*)$/gm) || [];
+
+  let blockHasContent = false;
+  for (const rawEntry of blockEntries) {
+    const m = rawEntry.match(/^[ \t]+-[ \t]*(.*?)[ \t]*$/);
+    if (!m) continue;
+    const entryValue = m[1].replace(/^['"](.*)['"]$/, '$1');
+    if (entryValue.length > 0) {
+      blockHasContent = true;
+      break;
+    }
+  }
+
+  // If `aliases: foo` had inline content but no brackets, treat it
+  // as a single-entry list with content.
+  if (!blockHasContent && inlineContent.length > 0) {
+    return true;
+  }
+
+  return blockHasContent;
 }
 
 // Scan wiki pages for dead links ([[wikilinks]] pointing to non-existent targets).

--- a/src/wiki/lint/types.ts
+++ b/src/wiki/lint/types.ts
@@ -69,6 +69,15 @@ export interface LintPhaseContext {
     setMessage: (message: string) => void;
   } | null;
   totalPages: number;
+  /**
+   * v1.24.0: compose the `system` prompt for LLM-assisted lint phases.
+   * Mirrors `EngineContext.buildSystemPrompt` — the shared composer that
+   * injects the language directive + schema context + active tag vocabulary.
+   * Phases call it (e.g. with 'lint') and use the result as the `system`
+   * field, matching fill-empty-page / fix-dead-link / link-orphan /
+   * merge-duplicates. Returns undefined when there is nothing to inject.
+   */
+  buildSystemPrompt: (task: string) => Promise<string | undefined>;
 }
 
 export interface ScannerPage {

--- a/src/wiki/prompts/seed-selection.ts
+++ b/src/wiki/prompts/seed-selection.ts
@@ -3,17 +3,22 @@
 // Used when the Tier 1 lex-based fast path returns no hits or weak
 // signals. The LLM picks the top 1-3 most semantically relevant pages
 // based on (path, summary) pairs. These become seeds for PPR.
+//
+// Split into system + user prompts (Bug B+ v1.24.0 P2): the role
+// instructions belong in `system` (most providers, including DeepSeek in
+// JSON mode, require a system message; without it, the LLM may return
+// an empty body even though status=200). User content is just the
+// question + the candidate page list.
 
-export const SEED_SELECTION_PROMPT = `You are selecting Wiki pages most semantically relevant to a user's question.
-
-User Question: "{{query}}"
-
-Available Pages:
-{{pages}}
+/**
+ * System prompt: role, task, output format. Sent as the `system` field
+ * to AI-SDK so providers can route it to the appropriate system channel.
+ */
+export const SEED_SELECTION_SYSTEM_PROMPT = `You are selecting Wiki pages most semantically relevant to a user's question.
 
 Task:
 1. Read the user question and infer the underlying intent (even if the wording is abstract or in a different language).
-2. From the page list, pick up to 3 pages whose summaries best match the question's intent.
+2. From the page list provided in the user message, pick up to 3 pages whose summaries best match the question's intent.
 3. Consider synonyms, translations, abbreviations, and conceptual matches — not just literal word overlap.
 4. If no pages seem relevant at all, output an empty list.
 
@@ -25,3 +30,14 @@ Output Format (strict JSON):
 Important:
 - Output ONLY the JSON object, no other text.
 - Page paths must exactly match the format shown in the page list.`;
+
+/**
+ * Build the user message: question + the candidate page list. The
+ * system prompt above provides the role and output-format instructions.
+ */
+export function buildSeedSelectionUserPrompt(query: string, pagesList: string): string {
+  return `User Question: "${query}"
+
+Available Pages:
+${pagesList}`;
+}

--- a/src/wiki/query-engine/QueryView-class.ts
+++ b/src/wiki/query-engine/QueryView-class.ts
@@ -21,7 +21,7 @@ import { TEXTS } from '../../texts';
 import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { buildTurnIndicator, observeVisibleTurn } from '../turn-indicator';
-import { TOKENS_QUERY_LLM_SELECT, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_NORMAL, NOTICE_ERROR } from '../../constants';
+import { TOKENS_QUERY_LLM_SELECT, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_SHORT, NOTICE_NORMAL, NOTICE_ERROR, CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS } from '../../constants';
 import { getSectionLabels } from '../system-prompts';
 
 import { extractThinkingPanel } from './renderers/thinking-extract';
@@ -45,6 +45,8 @@ import {
   emptyWikiHint,
   wikiContextErrorHint,
 } from './pipeline/assemble-context';
+import { appendCustomQueryInstructions, logCustomInstructionsInjectionContext } from './custom-instructions';
+import { renderCustomInstructionsPanel, type CustomInstructionsPanelHandle } from './renderers/custom-instructions-panel';
 import type { RetrievalLabelData } from './types';
 
 export const VIEW_TYPE_QUERY = 'llm-wiki-query-view';
@@ -72,6 +74,10 @@ export class QueryView extends ItemView {
   inputArea: HTMLTextAreaElement;
   sendBtn: HTMLButtonElement;
   historyCountDisplay: HTMLElement;
+  // v1.24.0 #251: collapsible Custom Query Instructions panel handle.
+  // The panel owns its own DOM + event listeners; the handle is disposed
+  // on view close to avoid leaks across open/close cycles.
+  private _customInstructionsPanel: CustomInstructionsPanelHandle | null = null;
   private pendingInput: string;
   private activeRenderComponent: Component | null;
   // v1.24.0 Bug A: the per-view PPR graph cache has been removed; the graph
@@ -249,6 +255,18 @@ export class QueryView extends ItemView {
       }
     });
 
+    // v1.24.0 UX: Sync the Send button's disabled state with the input.
+    // Empty / whitespace-only input visually disables Send (the click
+    // handler also early-returns, so this is defence in depth).
+    // The listener is registered BEFORE `sendBtn` exists so we can hook the
+    // input event early; the call into `updateSendDisabledState` short-
+    // circuits when `sendBtn` is still null (constructor placeholder).
+    const updateSendDisabledState = () => {
+      if (!this.sendBtn) return;
+      this.sendBtn.disabled = !this.isStreaming && this.inputArea.value.trim().length === 0;
+    };
+    this.inputArea.addEventListener('input', updateSendDisabledState);
+
     const buttonRow = inputContainer.createDiv({
       cls: 'llm-wiki-query-button-row'
     });
@@ -257,6 +275,8 @@ export class QueryView extends ItemView {
       text: `${texts.queryModalSendButton} (${modKey}+Enter)`,
       cls: 'llm-wiki-query-send-btn mod-cta'
     });
+    // Now that sendBtn exists, sync the initial disabled state.
+    updateSendDisabledState();
     this.sendBtn.addEventListener('click', () => {
       if (this.isStreaming) {
         this.stopGeneration();
@@ -279,6 +299,19 @@ export class QueryView extends ItemView {
       cls: 'llm-wiki-query-clear-btn'
     }).addEventListener('click', () => {
       void this.clearHistory();
+    });
+
+    // v1.24.0 #251: Custom Query Instructions collapsible panel.
+    // Lives between the button row and the history-count display so the
+    // input area stays compact (panel is collapsed by default). Mounted
+    // AFTER buttonRow so its DOM sits above historyCountDisplay but the
+    // panel is collapsed until the user explicitly expands it.
+    this._customInstructionsPanel = renderCustomInstructionsPanel(inputContainer, {
+      initialValue: this.plugin.settings.customQueryInstructions ?? '',
+      maxChars: CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS,
+      language: this.plugin.settings.language,
+      applyHandler: (value) => { void this.applyCustomInstructions(value); },
+      clearHandler: () => { void this.clearCustomInstructions(); },
     });
 
     this.historyCountDisplay = inputContainer.createDiv({
@@ -307,6 +340,12 @@ export class QueryView extends ItemView {
       window.cancelAnimationFrame(this._streamRafHandle);
       this._streamRafHandle = null;
     }
+
+    // v1.24.0 #251: dispose the Custom Query Instructions panel.
+    // Removes event listeners + clears internal refs so a subsequent
+    // open with a fresh panel doesn't see stale listeners.
+    this._customInstructionsPanel?.dispose();
+    this._customInstructionsPanel = null;
 
     // v1.23.0 P2: Skip persisting queryHistory on close if the user just
     // cleared it. clearHistory already awaits saveSettings; re-saving
@@ -463,11 +502,12 @@ export class QueryView extends ItemView {
     try {
       if (this.plugin.llmClient?.createMessageStream) {
         let fullResponse = '';
+        logCustomInstructionsInjectionContext('streaming', userMessage, this.plugin.settings.customQueryInstructions);
         try {
           fullResponse = await this.plugin.llmClient.createMessageStream({
             model: this.plugin.settings.model,
             max_tokens: TOKENS_QUERY_LLM_SELECT,
-            system: wikiContext,
+            system: appendCustomQueryInstructions(wikiContext, this.plugin.settings.customQueryInstructions),
             messages: conversationMessages,
             onChunk: (chunk) => {
               if (this.aborted) return;
@@ -495,11 +535,12 @@ export class QueryView extends ItemView {
             : texts.queryPhaseNonStreaming;
           // Fallback: try non-streaming if streaming fails
           if (this.plugin.llmClient?.createMessage) {
+            logCustomInstructionsInjectionContext('non-stream-fallback', userMessage, this.plugin.settings.customQueryInstructions);
             try {
               fullResponse = await this.plugin.llmClient.createMessage({
                 model: this.plugin.settings.model,
                 max_tokens: TOKENS_QUERY_LLM_SELECT,
-                system: wikiContext,
+                system: appendCustomQueryInstructions(wikiContext, this.plugin.settings.customQueryInstructions),
                 messages: conversationMessages,
                 ...(this.plugin.settings.disableThinking ? { enableThinking: false } : {}),
                 ...(this.plugin.settings.chatTemperature !== undefined ? { temperature: this.plugin.settings.chatTemperature } : {}),
@@ -581,10 +622,11 @@ export class QueryView extends ItemView {
         statusTemplate = foundPagesInfo
           ? `${foundPagesInfo}, ${texts.queryPhaseNonStreaming}`
           : texts.queryPhaseNonStreaming;
+        logCustomInstructionsInjectionContext('non-stream-main', userMessage, this.plugin.settings.customQueryInstructions);
         const response = await this.plugin.llmClient!.createMessage({
           model: this.plugin.settings.model,
           max_tokens: TOKENS_QUERY_LLM_SELECT,
-          system: wikiContext,
+          system: appendCustomQueryInstructions(wikiContext, this.plugin.settings.customQueryInstructions),
           messages: conversationMessages,
           ...(this.plugin.settings.disableThinking ? { enableThinking: false } : {}),
           ...(this.plugin.settings.chatTemperature !== undefined ? { temperature: this.plugin.settings.chatTemperature } : {}),
@@ -653,6 +695,9 @@ export class QueryView extends ItemView {
     this.currentResponseDiv = null;
     this.sendBtn.setText(`${texts.queryModalSendButton} (Ctrl+Enter)`);
     this.sendBtn.className = 'llm-wiki-query-send-btn mod-cta';
+    // After generation: input area may be empty (consumed by send) OR have
+    // pending input restored. Re-sync the disabled state in both cases.
+    this.sendBtn.disabled = this.inputArea.value.trim().length === 0;
 
     // Restore pending input if user stopped generation
     if (this.pendingInput) {
@@ -914,6 +959,31 @@ export class QueryView extends ItemView {
         .replace('{}', '0')
         .replace('{}', maxRounds.toString())
     );
+  }
+
+  // v1.24.0 #251: persist user-supplied custom instructions and notify.
+  // The cap is applied here too (defense in depth — the panel also caps
+  // at the input layer).
+  async applyCustomInstructions(value: string): Promise<void> {
+    const capped = value.length > CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS
+      ? value.slice(0, CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS)
+      : value;
+    this.plugin.settings.customQueryInstructions = capped;
+    await this.plugin.saveSettings();
+    console.debug(
+      `[QueryView.applyCustomInstructions] saved length=${capped.length} chars`,
+    );
+    const texts = TEXTS[this.plugin.settings.language];
+    new Notice(texts.instructionsApplied, NOTICE_SHORT);
+  }
+
+  // v1.24.0 #251: clear user-supplied custom instructions and notify.
+  async clearCustomInstructions(): Promise<void> {
+    this.plugin.settings.customQueryInstructions = '';
+    await this.plugin.saveSettings();
+    console.debug('[QueryView.clearCustomInstructions] cleared');
+    const texts = TEXTS[this.plugin.settings.language];
+    new Notice(texts.instructionsCleared, NOTICE_SHORT);
   }
 
   /**

--- a/src/wiki/query-engine/QueryView-class.ts
+++ b/src/wiki/query-engine/QueryView-class.ts
@@ -57,6 +57,12 @@ export class QueryView extends ItemView {
       role: 'user' | 'assistant';
       content: string;
       timestamp: number;
+      /** v1.24.0: retrieval metadata persisted per assistant message. */
+      retrieval?: {
+        arm: string;
+        count: number;
+        topPaths: string[];
+      };
     }>;
   };
   isStreaming: boolean;
@@ -197,6 +203,14 @@ export class QueryView extends ItemView {
     this.history.messages.forEach((msg, idx) => {
       const turnIdx = Math.floor(idx / 2);
       this.renderHistoryMessage(msg.role, msg.content, turnIdx);
+      // v1.24.0: re-hydrate retrieval labels from persisted history.
+      // Find the just-rendered message wrapper by its position.
+      if (msg.role === 'assistant' && msg.retrieval) {
+        const wrapper = this.historyContainer.lastElementChild as HTMLElement | null;
+        if (wrapper) {
+          this.addRetrievalLabel(wrapper, msg.retrieval);
+        }
+      }
     });
 
     // 自动滚动到最新的消息底部
@@ -547,7 +561,10 @@ export class QueryView extends ItemView {
           this.history.messages.push({
             role: 'assistant',
             content: fullResponse,
-            timestamp: Date.now()
+            timestamp: Date.now(),
+            // v1.24.0: persist retrieval metadata so the label
+            // survives view re-open.
+            retrieval: this._lastRetrieval ?? undefined,
           });
           // v1.23.0 P2: Persist queryHistory after each completed turn
           // so that an abrupt Obsidian close (which may not trigger
@@ -583,7 +600,8 @@ export class QueryView extends ItemView {
         this.history.messages.push({
           role: 'assistant',
           content: response,
-          timestamp: Date.now()
+          timestamp: Date.now(),
+          retrieval: this._lastRetrieval ?? undefined,
         });
         // v1.23.0 P2: Crash-safe persistence (see streaming branch above).
         this.plugin.settings.queryHistory = this.history.messages;
@@ -803,9 +821,12 @@ export class QueryView extends ItemView {
    * rendered chat) can see which retrieval method was used.
    * Skipped silently if no retrieval metadata was captured.
    */
-  private addRetrievalLabel(messageWrapper: HTMLElement): void {
-    if (!this._lastRetrieval) return;
-    renderRetrievalLabel(messageWrapper, this._lastRetrieval, this.plugin.settings.wikiFolder);
+  private addRetrievalLabel(
+    messageWrapper: HTMLElement,
+    retrieval: RetrievalLabelData | null = this._lastRetrieval,
+  ): void {
+    if (!retrieval) return;
+    renderRetrievalLabel(messageWrapper, retrieval, this.plugin.settings.wikiFolder);
   }
 
   limitHistory() {

--- a/src/wiki/query-engine/QueryView-class.ts
+++ b/src/wiki/query-engine/QueryView-class.ts
@@ -22,7 +22,6 @@ import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { buildTurnIndicator, observeVisibleTurn } from '../turn-indicator';
 import { TOKENS_QUERY_LLM_SELECT, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_NORMAL, NOTICE_ERROR } from '../../constants';
-import { buildGraphFromContent, type LoadedPage } from '../../core/build-graph';
 import { getSectionLabels } from '../system-prompts';
 
 import { extractThinkingPanel } from './renderers/thinking-extract';
@@ -75,8 +74,8 @@ export class QueryView extends ItemView {
   historyCountDisplay: HTMLElement;
   private pendingInput: string;
   private activeRenderComponent: Component | null;
-  /** Cached graph for PPR — built lazily from loaded page content. */
-  private _graph: ReturnType<typeof buildGraphFromContent> | null = null;
+  // v1.24.0 Bug A: the per-view PPR graph cache has been removed; the graph
+  // now lives in WikiEngine and is shared across all QueryView leaves.
   /** Cached section labels for Tier B extraction (settings don't change mid-query). */
   private _sectionLabels: ReturnType<typeof getSectionLabels> | null = null;
   /** Last PPR cascade result — for displaying retrieval source in the response UI. */
@@ -134,16 +133,16 @@ export class QueryView extends ItemView {
   }
 
   /**
-   * v1.23.2 (review-C P0): Invalidate the cached PPR graph + last
-   * retrieval result so the next sendMessage rebuilds against whatever
-   * wiki/ state is current. Called from main.ts onIngestDoneDispatch
-   * across every open QueryView. Idempotent.
+   * v1.24.0 Bug A: Invalidate the engine-level PPR graph cache + this view's
+   * last retrieval result so the next sendMessage rebuilds against whatever
+   * wiki/ state is current. Called from main.ts onIngestDoneDispatch across
+   * every open QueryView. Idempotent.
    */
   public invalidateGraph(): void {
+    this.plugin.wikiEngine.invalidateGraph();
     const self = this as unknown as InternalView;
-    self._graph = null;
     self._lastRetrieval = null;
-    console.debug('[QueryView] graph + last retrieval invalidated');
+    console.debug('[QueryView] engine graph + last retrieval invalidated');
   }
 
   async onOpen() {
@@ -927,8 +926,8 @@ export class QueryView extends ItemView {
    *   3. loadRelevantPagesForQuery (Phase 3 — Tier B summaries)
    *   4. assembleWikiContext (Phase 4 — system prompt assembly)
    *
-   * `_graph` and `_lastRetrieval` writes remain on the class — cache lives
-   * here, not in the pipeline.
+   * v1.24.0 Bug A: the PPR graph cache moved to WikiEngine; only
+   * `_lastRetrieval` writes remain on the class.
    */
   async buildWikiContext(userMessage: string, onProgress?: (phase: string) => void): Promise<string> {
     console.debug('=== buildWikiContext started ===');
@@ -948,12 +947,17 @@ export class QueryView extends ItemView {
         return emptyWikiHint(this.plugin.settings.wikiLanguage);
       }
 
+      // v1.24.0 Bug A: warmup the engine-level graph BEFORE the PPR cascade
+      // so the first query already has full graph state. The cache is shared
+      // across QueryView leaves and invalidated on vault writes.
+      const graph = await this.plugin.wikiEngine.getOrBuildGraph(indexResult.allPaths);
+
       // Phase 2: PPR cascade + optional LLM seed augmentation.
       // delegate returns { matches, armLabel, llmAugmented }
       const seedResult = await selectPprSeeds(
         userMessage,
         indexResult.pageRefs,
-        this._graph,
+        graph,
         this.plugin.llmClient as unknown as Parameters<typeof selectPprSeeds>[3],
         this.plugin.settings,
         texts as unknown as Record<string, string>,
@@ -971,7 +975,7 @@ export class QueryView extends ItemView {
       console.debug(`[Step 2] PPR cascade selected ${relevantPages.length} pages (arm: ${seedResult.armLabel || 'none'})`);
       console.debug(`[Step 2]   top-5 paths:`, seedResult.matches.slice(0, 5).map(m => `${m.page.path} (${m.arm}, score=${m.score.toFixed(3)})`));
       console.debug(`[Step 2]   query tokens:`, userMessage.toLowerCase().split(/\s+/).filter(k => k.length > 0));
-      console.debug(`[Step 2]   graph state: ${this._graph ? `${this._graph.nodes.length} nodes / ${this._graph.edges.size} edges` : 'none'}`);
+      console.debug(`[Step 2]   graph state: ${graph ? `${graph.nodes.length} nodes / ${graph.edges.size} edges` : 'none'}`);
       console.debug(`[Step 2]   LLM augmentation: ${seedResult.llmAugmented ? 'triggered' : 'skipped (fast path sufficient)'}`);
 
       // Phase 3: Loading pages
@@ -997,15 +1001,7 @@ export class QueryView extends ItemView {
       );
       console.debug('[Step 3] Pages loaded:', rawLoadedPages.length);
 
-      // Build the graph from loaded pages (first query only, then cached).
-      if (!this._graph) {
-        const loadedForGraph: LoadedPage[] = relevantPages.map((path, i) => ({
-          path,
-          content: rawLoadedPages[i] || '',
-        }));
-        this._graph = buildGraphFromContent(loadedForGraph, indexResult.allPaths, wikiFolder);
-        console.debug('[Step 3] Graph built:', this._graph.nodes.length, 'nodes,', this._graph.edges.size, 'edges');
-      }
+      console.debug('[Step 3] Graph shared from engine:', graph.nodes.length, 'nodes,', graph.edges.size, 'edges');
 
       // Phase: Context ready, about to generate
       onProgress?.(texts.queryPhaseContextReady);

--- a/src/wiki/query-engine/custom-instructions.ts
+++ b/src/wiki/query-engine/custom-instructions.ts
@@ -1,0 +1,82 @@
+// v1.24.0 #251: Custom Query Instructions — pure system-prompt injection helper.
+//
+// Issue #251 lets users append a persistent instructions block to the Query
+// Wiki system prompt. The helper is a pure function (no IO, no side effects)
+// so it can be unit-tested in isolation and called from any call site that
+// needs to inject the user's instructions.
+//
+// Strict scope: this helper is ONLY called from the 3 QueryView send sites
+// (streaming / non-stream fallback / non-stream main). Ingest / lint / page
+// generation / Save to Wiki / seed selection / duplicate merge are
+// intentionally NOT affected.
+
+import { CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS } from '../../constants';
+
+/** Marker header used to delimit the user instructions block in the system prompt. */
+export const CUSTOM_INSTRUCTIONS_HEADER = '# User Custom Query Instructions';
+
+/**
+ * Append user custom instructions to the Query Wiki system prompt.
+ *
+ * Pure function. Returns the input unchanged when:
+ * - `instructions` is `undefined` (pre-v1.24.0 data.json reads as undefined)
+ * - `instructions` is `''` or whitespace-only (feature off)
+ *
+ * Trims the instructions before appending so accidental whitespace from copy-
+ * paste doesn't bloat the prompt. The 5000-char cap is applied as defense in
+ * depth — the UI also caps at the input layer.
+ *
+ * Logs a single debug line when instructions are actually appended, so the
+ * developer-tools console shows whether the per-send injection happened (and
+ * how many chars were injected). Empty/whitespace paths stay silent to avoid
+ * noise on every query.
+ */
+export function appendCustomQueryInstructions(
+  systemPrompt: string,
+  instructions: string | undefined,
+): string {
+  if (!instructions || instructions.trim().length === 0) return systemPrompt;
+  const trimmed = instructions.trim();
+  const capped = trimmed.length > CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS
+    ? trimmed.slice(0, CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS)
+    : trimmed;
+  console.debug(
+    `[QueryWiki custom-instructions] injecting length=${capped.length} chars`,
+  );
+  return `${systemPrompt}\n\n${CUSTOM_INSTRUCTIONS_HEADER}\n${capped}`;
+}
+
+/**
+ * Trace the per-send injection context — called once per LLM request so the
+ * developer-tools console shows WHICH query was paired with custom
+ * instructions, and whether the instructions were applied / empty / capped.
+ *
+ * The helper itself logs the actual injection; this companion log adds the
+ * call-site context (query preview + send path name) so a user can correlate
+ * the line "[QueryWiki custom-instructions] ..." with the query they typed.
+ *
+ * Three send paths share this logger: `streaming` / `non-stream-fallback` /
+ * `non-stream-main`. The path label is printed so a user can tell which
+ * branch fired (e.g. after a streaming failure the fallback path is taken).
+ */
+export function logCustomInstructionsInjectionContext(
+  sendPath: 'streaming' | 'non-stream-fallback' | 'non-stream-main',
+  userMessage: string,
+  instructions: string | undefined,
+): void {
+  const queryPreview = userMessage.length > 60
+    ? userMessage.slice(0, 60) + '…'
+    : userMessage;
+  if (!instructions || instructions.trim().length === 0) {
+    console.debug(
+      `[QueryWiki custom-instructions] send=${sendPath} query="${queryPreview}" instructions=EMPTY`,
+    );
+    return;
+  }
+  const trimmed = instructions.trim();
+  const capped = trimmed.length > CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS;
+  console.debug(
+    `[QueryWiki custom-instructions] send=${sendPath} query="${queryPreview}" ` +
+      `instructions=${trimmed.length} chars${capped ? ' (capped to 5000)' : ''} → APPLIED`,
+  );
+}

--- a/src/wiki/query-engine/pipeline/assemble-context.ts
+++ b/src/wiki/query-engine/pipeline/assemble-context.ts
@@ -5,6 +5,7 @@
 // settings → returns the system prompt string sent to the LLM.
 
 import { WIKI_LANGUAGES } from '../../../types';
+import { WIKI_FOLDER_PLACEHOLDER } from '../../../core/prompt-builders';
 
 export interface AssembleContextInput {
   indexContent: string;
@@ -20,6 +21,18 @@ export interface AssembleContextInput {
 
 /**
  * Build the wiki-context system prompt for the query LLM.
+ *
+ * v1.24.0 (Bug C 3.0): the prompt uses the literal placeholder
+ * `__WIKI_FOLDER__` instead of `${input.wikiFolder}` for every wiki-link.
+ * Why: the LLM's responses persist to chat history, and history is replayed
+ * as few-shot context for every subsequent query. If the real wikiFolder
+ * were baked into the prompt, then into history, then into subsequent
+ * prompts, the LLM would follow that established folder even after the
+ * user changed the setting. The placeholder makes the LLM-folder
+ * relationship transparent; render-time substitution (in
+ * `thinking-extract.ts`) replaces the placeholder with the current
+ * `settings.wikiFolder` for the user-facing display only.
+ *
  * Identical wording to the original inline code (regression-tested by
  * existing manual e2e — prompts are not unit-tested to keep the
  * canonical template under one author's editorial control).
@@ -35,6 +48,9 @@ export function assembleWikiContext(input: AssembleContextInput): string {
     ? `(Pages selected via ${armInfo} retrieval.)`
     : '(No relevant pages found. The LLM should answer from general knowledge.)';
 
+  // Bug C 3.0: use the placeholder constant, never the real wikiFolder.
+  const wf = WIKI_FOLDER_PLACEHOLDER;
+
   const wikiContext = `${langDirective}
 
 You are a Wiki assistant with access to a structured knowledge base.
@@ -49,25 +65,25 @@ ${retrievalNote}
 
 Instructions:
 - Answer based on the Wiki pages above (not general knowledge)
-- Use ONLY Obsidian's wiki-link syntax: [[${input.wikiFolder}/entities/page-name]] (NOT HTML links)
-- Link format MUST include wiki folder: [[${input.wikiFolder}/entities/page-name]]
+- Use ONLY Obsidian's wiki-link syntax: [[${wf}/entities/page-name]] (NOT HTML links)
+- Link format MUST include wiki folder: [[${wf}/entities/page-name]]
 
 CRITICAL RULES:
-✅ CORRECT: [[${input.wikiFolder}/entities/example-page]], [[${input.wikiFolder}/concepts/example-concept]]
+✅ CORRECT: [[${wf}/entities/example-page]], [[${wf}/concepts/example-concept]]
 ❌ WRONG: <a href="...">, [link text](url), [[example-page]], [[entities/example-page]]
 - Obsidian wiki-links use DOUBLE brackets: [[path]]
 - NO HTML: Never use <a href="...">text</a>
 - NO Markdown external links: Never use [text](url)
-- Include ${input.wikiFolder}/ prefix: Links must start with [[${input.wikiFolder}/...
+- Include ${wf}/ prefix: Links must start with [[${wf}/...
 
 CITATION REQUIREMENTS:
 - When referencing specific information from a Wiki page, include an inline wiki-link
 - At the end of your answer, add a "## References" section (or "## 参考文献" for Chinese) listing all wiki pages you cited
-- Format each reference as: [[${input.wikiFolder}/path/page-name|Display Name]] — brief description
+- Format each reference as: [[${wf}/path/page-name|Display Name]] — brief description
 - Example:
   ## References
-  1. [[${input.wikiFolder}/concepts/example-concept|Example Concept]] — Core mechanism explanation
-  2. [[${input.wikiFolder}/entities/example-entity|Example Entity]] — Background and history
+  1. [[${wf}/concepts/example-concept|Example Concept]] — Core mechanism explanation
+  2. [[${wf}/entities/example-entity|Example Entity]] — Background and history
 
 If Wiki lacks relevant information:
 - Acknowledge it and suggest ingesting more sources

--- a/src/wiki/query-engine/pipeline/seed-selector.ts
+++ b/src/wiki/query-engine/pipeline/seed-selector.ts
@@ -7,19 +7,24 @@
 // primary semantic matcher here — handles synonyms, cross-language
 // aliases, and abstract queries that pure string matching can't reach.
 //
-// Graceful degradation: returns empty array on any failure (LLM
-// unavailable, parse error, network timeout). Caller falls back to
-// whatever the lex fast path returned.
+// On failure (LLM unavailable, parse error, network timeout, persistent
+// empty), returns [] and the caller falls back to whatever the lex
+// fast path returned. See transient-retry.ts for the Bug B retry policy.
 
 import { PageRef } from '../../../core/ppr-cascade';
 import { parseJsonResponse } from '../../../core/json';
-import { PROMPTS } from '../../../prompts';
+import { withTransientRetry } from '../../../core/transient-retry';
+import {
+  SEED_SELECTION_SYSTEM_PROMPT,
+  buildSeedSelectionUserPrompt,
+} from '../../prompts/seed-selection';
 
 /** Minimal LLMClient surface — only `createMessage` is required for seed selection. */
 export interface SeedLLMClient {
   createMessage(params: {
     model: string;
     max_tokens: number;
+    system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     response_format?: { type: 'json_object' | 'text' };
     enableThinking?: boolean;
@@ -54,25 +59,62 @@ export async function selectSeedsWithLLM(
     .map(p => `- ${p.path}: ${p.summary || '(no summary)'}`)
     .join('\n');
 
-  const prompt = PROMPTS.seedSelection
-    .replace('{{query}}', query)
-    .replace('{{pages}}', pagesList);
+  // Bug B+ fix: split into system + user. DeepSeek in JSON mode returns
+  // empty body if no system message is provided (status 200, body='').
+  // Keeping the role instructions in the system field forces a proper
+  // response from the LLM.
+  //
+  // Wrap the LLM call + JSON parse in withTransientRetry so a
+  // transient empty-string response or malformed JSON is retried.
+  // The `fn` performs both steps so parse failures naturally surface
+  // as thrown errors caught by the retry helper. We do NOT pass
+  // `isTransientEmpty` because an empty `seeds` array is a valid
+  // answer per the prompt's task 4 ("no relevant pages" → []).
+  const retryResult = await withTransientRetry({
+    fn: async () => {
+      const response = await client.createMessage({
+        model: settings.model,
+        max_tokens: 200,
+        system: SEED_SELECTION_SYSTEM_PROMPT,
+        messages: [{
+          role: 'user',
+          content: buildSeedSelectionUserPrompt(query, pagesList),
+        }],
+        response_format: { type: 'json_object' },
+        ...(settings.disableThinking ? { enableThinking: false } : {}),
+      });
+      // Debug log: response length + first 100 chars AFTER the call.
+      // Critical for diagnosing empty-body / truncated / unexpected-shape
+      // responses that previously caused silent seed-selector failures.
+      // JSON.stringify escapes control chars (matches fix-runners.ts style).
+      console.debug(
+        `[LLM response] Seed selection: length=${response.length}, ` +
+        `first100=${JSON.stringify(response.slice(0, 100))}`,
+      );
+      const parsed = await parseJsonResponse(response) as { seeds?: string[] } | null;
+      if (!parsed || !Array.isArray(parsed.seeds)) {
+        throw new Error('parseJsonResponse returned null or non-array seeds');
+      }
+      return parsed.seeds;
+    },
+    label: 'Seed selection',
+    isAuthError: (error) => {
+      const statusCode = (error as { statusCode?: number }).statusCode;
+      return statusCode === 401 || statusCode === 403;
+    },
+    isRateLimitError: (error) => {
+      const statusCode = (error as { statusCode?: number }).statusCode;
+      return statusCode === 429;
+    },
+  });
 
-  try {
-    const response = await client.createMessage({
-      model: settings.model,
-      max_tokens: 200,
-      messages: [{ role: 'user', content: prompt }],
-      response_format: { type: 'json_object' },
-      ...(settings.disableThinking ? { enableThinking: false } : {}),
-    });
-    const parsed = await parseJsonResponse(response) as { seeds?: string[] } | null;
-    const rawSeeds = parsed?.seeds || [];
-    // Validate against pageRefs — drop any paths that don't exist.
-    const validPaths = new Set(pageRefs.map(p => p.path));
-    return rawSeeds.filter(s => validPaths.has(s));
-  } catch (error) {
-    console.warn('[LLM seed selection failed]', error);
+  if (retryResult.error) {
     return [];
   }
+
+  const rawSeeds = retryResult.value ?? [];
+
+  // Validate against pageRefs — drop any paths that don't exist.
+  const validPaths = new Set(pageRefs.map(p => p.path));
+  return rawSeeds.filter(s => validPaths.has(s));
 }

--- a/src/wiki/query-engine/renderers/custom-instructions-panel.ts
+++ b/src/wiki/query-engine/renderers/custom-instructions-panel.ts
@@ -1,0 +1,157 @@
+// v1.24.0 #251: Custom Query Instructions — collapsible panel renderer.
+//
+// Renders a `<details>` block inside the Query Wiki input area with:
+//   - `<summary>` (collapsed by default)
+//   - User-facing description
+//   - `<textarea>` with placeholder + char counter
+//   - Apply + Clear buttons
+//   - DOM-level truncation past `maxChars` (input layer defense)
+//
+// Persistence is owned by QueryView (it calls saveSettings after Apply/Clear).
+// This module is DOM-only and event-handler-only — no IO, no state mutation
+// beyond the textarea value and the internal counter.
+//
+// Uses native DOM APIs (createElement/appendChild/setAttribute) instead of
+// Obsidian's `createEl`/`createDiv` prototype extensions — this keeps the
+// renderer portable, easier to unit-test in jsdom, and identical to the
+// pattern used by other renderers in this directory (see wiki-link-clicks.ts
+// and history-message.ts).
+
+import { TEXTS } from '../../../texts';
+import type { LLMWikiSettings } from '../../../types';
+
+export interface CustomInstructionsPanelOptions {
+  initialValue: string;
+  maxChars: number;
+  language: LLMWikiSettings['language'];
+  applyHandler: (value: string) => void | Promise<void>;
+  clearHandler: () => void | Promise<void>;
+}
+
+export interface CustomInstructionsPanelHandle {
+  /** Read current textarea value (post any truncation). */
+  getValue(): string;
+  /** Write a new value into the textarea + counter. Truncates to maxChars. */
+  setValue(value: string): void;
+  /** Clear the textarea (does NOT call the clearHandler). */
+  clear(): void;
+  /** Remove event listeners and clear internal refs. */
+  dispose(): void;
+}
+
+/** Helper: create an HTMLElement with class + optional text/attrs, appended to parent. */
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  parent: HTMLElement,
+  cls: string,
+  opts: { text?: string; attrs?: Record<string, string> } = {},
+): HTMLElementTagNameMap[K] {
+  const node = parent.ownerDocument.createElement(tag);
+  node.className = cls;
+  if (opts.attrs) for (const [k, v] of Object.entries(opts.attrs)) node.setAttribute(k, v);
+  if (opts.text !== undefined) node.textContent = opts.text;
+  parent.appendChild(node);
+  return node;
+}
+
+/**
+ * Render the collapsible Custom Query Instructions panel into `parent`.
+ * Returns a handle for programmatic value access + cleanup.
+ */
+export function renderCustomInstructionsPanel(
+  parent: HTMLElement,
+  options: CustomInstructionsPanelOptions,
+): CustomInstructionsPanelHandle {
+  const texts = TEXTS[options.language];
+
+  const details = el('details', parent, 'llm-wiki-query-instructions-block');
+  el('summary', details, '', { text: texts.customInstructionsTitle });
+
+  const body = el('div', details, 'llm-wiki-query-instructions-body');
+  el('div', body, 'llm-wiki-query-instructions-desc', { text: texts.customInstructionsDesc });
+
+  const textarea = el('textarea', body, 'llm-wiki-query-instructions-textarea', {
+    attrs: {
+      rows: '6',
+      placeholder: texts.customInstructionsPlaceholder,
+    },
+  });
+  // initialValue is truncated defensively (callers should also cap, but
+  // defense in depth: never expose a textarea pre-loaded past the cap).
+  const initialCapped = options.initialValue.length > options.maxChars
+    ? options.initialValue.slice(0, options.maxChars)
+    : options.initialValue;
+  textarea.value = initialCapped;
+
+  const counter = el('div', body, 'llm-wiki-query-instructions-counter');
+  const updateCounter = () => {
+    counter.textContent = texts.customInstructionsCharCount
+      .replace('{current}', String(textarea.value.length))
+      .replace('{max}', String(options.maxChars));
+  };
+  updateCounter();
+
+  const buttonRow = el('div', body, 'llm-wiki-query-instructions-button-row');
+  const applyBtn = el('button', buttonRow, 'llm-wiki-query-instructions-apply mod-cta', {
+    text: texts.customInstructionsApply,
+  });
+  // v1.24.0 #251 UX: Apply button is disabled when the textarea is empty
+  // (after trim). This prevents a stale-state Notice when the user clicks
+  // Apply on an empty box. Re-evaluated on every input event.
+  const updateApplyDisabledState = () => {
+    applyBtn.disabled = textarea.value.trim().length === 0;
+  };
+  updateApplyDisabledState();
+  const clearBtn = el('button', buttonRow, 'llm-wiki-query-instructions-clear', {
+    text: texts.customInstructionsClear,
+  });
+
+  let disposed = false;
+
+  const inputHandler = () => {
+    if (textarea.value.length > options.maxChars) {
+      textarea.value = textarea.value.slice(0, options.maxChars);
+    }
+    updateCounter();
+    updateApplyDisabledState();
+  };
+  const applyHandler = () => {
+    if (disposed) return;
+    // Defensive: ignore click if somehow still disabled (race with dispose
+    // during click — input event may not have fired yet).
+    if (textarea.value.trim().length === 0) return;
+    void options.applyHandler(textarea.value);
+  };
+  const clearHandler = () => {
+    if (disposed) return;
+    textarea.value = '';
+    updateCounter();
+    updateApplyDisabledState();
+    void options.clearHandler();
+  };
+
+  textarea.addEventListener('input', inputHandler);
+  applyBtn.addEventListener('click', applyHandler);
+  clearBtn.addEventListener('click', clearHandler);
+
+  return {
+    getValue: () => textarea.value,
+    setValue: (value: string) => {
+      if (disposed) return;
+      textarea.value = value.length > options.maxChars ? value.slice(0, options.maxChars) : value;
+      updateCounter();
+    },
+    clear: () => {
+      if (disposed) return;
+      textarea.value = '';
+      updateCounter();
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      textarea.removeEventListener('input', inputHandler);
+      applyBtn.removeEventListener('click', applyHandler);
+      clearBtn.removeEventListener('click', clearHandler);
+    },
+  };
+}

--- a/src/wiki/query-engine/renderers/retrieval-label.ts
+++ b/src/wiki/query-engine/renderers/retrieval-label.ts
@@ -18,12 +18,16 @@ import type { RetrievalLabelData } from '../types';
  *   fell back to keyword scoring), not a reference to the wiki index
  *   file. The new label 'Lexical' tells the user "this came from word
  *   matching, not from the link graph".
+ * - 'index' (the actual arm identifier emitted by select-seeds.ts when
+ *   no PPR signal exists) was previously hidden behind the generic
+ *   "🔎 index" fallback — which read as a debug message. We now map
+ *   it explicitly to "📋 Index" (visual cue: list-style icon).
  * - 'none' / empty arm was previously rendered as '—' (em-dash) — looks
  *   like an error. The new label 'No specific source' tells the user
  *   the LLM ran without a defined retrieval arm.
- * - Unknown arm values are no longer hidden behind '📇 index' — the raw
- *   identifier is shown with a 🔎 prefix so future arms surface
- *   visibly rather than masquerading as a default.
+ * - Unknown arm values are no longer hidden — the raw identifier is
+ *   shown with a 🔎 prefix so future arms surface visibly rather than
+ *   masquerading as a default.
  */
 function armDisplay(arm: string): string {
   if (arm === 'none' || arm === '') {
@@ -36,6 +40,7 @@ function armDisplay(arm: string): string {
       if (a === 'PPR') return '🔗 PPR';
       if (a === 'PPR+') return '🔗 PPR+';
       if (a === 'lex') return '📖 Lexical';
+      if (a === 'index') return '📋 Index';
       // Unknown arm: surface the raw identifier so it's never hidden
       // behind a misleading default.
       return `🔎 ${a}`;

--- a/src/wiki/query-engine/renderers/retrieval-label.ts
+++ b/src/wiki/query-engine/renderers/retrieval-label.ts
@@ -10,16 +10,35 @@
 
 import type { RetrievalLabelData } from '../types';
 
-/** Translate the internal arm identifier to a user-facing glyph + text segment. */
+/** Translate the internal arm identifier to a user-facing glyph + text segment.
+ *
+ * v1.24.0 (legibility pass):
+ * - 'lex' was previously rendered as '📇 index' — misleading, since 'lex'
+ *   is the **lexical fallback** (PPR cascade found no graph match and
+ *   fell back to keyword scoring), not a reference to the wiki index
+ *   file. The new label 'Lexical' tells the user "this came from word
+ *   matching, not from the link graph".
+ * - 'none' / empty arm was previously rendered as '—' (em-dash) — looks
+ *   like an error. The new label 'No specific source' tells the user
+ *   the LLM ran without a defined retrieval arm.
+ * - Unknown arm values are no longer hidden behind '📇 index' — the raw
+ *   identifier is shown with a 🔎 prefix so future arms surface
+ *   visibly rather than masquerading as a default.
+ */
 function armDisplay(arm: string): string {
-  if (arm === 'none') return '—';
+  if (arm === 'none' || arm === '') {
+    return '🚫 No specific source';
+  }
   return arm
     .split('/')
     .map(a => {
-      if (a === 'PPR+LLM') return '🔗 PPR+LLM';
+      if (a === 'PPR+LLM') return '🔗 PPR + LLM';
       if (a === 'PPR') return '🔗 PPR';
       if (a === 'PPR+') return '🔗 PPR+';
-      return '📇 index';
+      if (a === 'lex') return '📖 Lexical';
+      // Unknown arm: surface the raw identifier so it's never hidden
+      // behind a misleading default.
+      return `🔎 ${a}`;
     })
     .join(' · ');
 }
@@ -38,7 +57,10 @@ export function renderRetrievalLabel(
   const label = messageWrapper.createDiv({
     cls: 'llm-wiki-query-retrieval-label',
   });
-  label.setText(`🔍 ${r.count} page(s) · ${armDisplay(r.arm)}`);
+  // v1.24.0: pluralize correctly — "1 page" vs "3 pages" — instead of
+  // the previous "N page(s)" placeholder which read as jargon.
+  const pageWord = r.count === 1 ? 'page' : 'pages';
+  label.setText(`🔍 ${r.count} ${pageWord} · ${armDisplay(r.arm)}`);
 
   // v1.23.2: click to expand/collapse the list of retrieved pages inline
   // below the label (no Notice).

--- a/src/wiki/query-engine/renderers/retrieval-label.ts
+++ b/src/wiki/query-engine/renderers/retrieval-label.ts
@@ -73,6 +73,10 @@ export function renderRetrievalLabel(
     cls: 'llm-wiki-query-retrieval-detail',
   });
   r.topPaths.forEach(p => {
+    // topPaths are vault-real paths (e.g. "wiki/entities/foo.md") populated
+    // by selectPprSeeds from PPR matches — not LLM-generated strings. So no
+    // placeholder substitution is needed here; strip the user's current
+    // wikiFolder prefix + .md suffix to produce the relative form shown.
     const rel = p.replace(wikiFolder + '/', '').replace('.md', '');
     const pageDiv = detail.createDiv({ cls: 'llm-wiki-query-retrieval-page' });
     pageDiv.setText(`📄 [[${rel}]]`);

--- a/src/wiki/query-engine/renderers/thinking-extract.ts
+++ b/src/wiki/query-engine/renderers/thinking-extract.ts
@@ -6,13 +6,13 @@
 // own the Component lifecycle.
 
 import { renderThinkingBlocksUI } from './thinking-block';
-import { normalizeWikiLinkContent } from '../../../core/prompt-builders';
+import { normalizeWikiLinkContent, substituteWikiFolderPlaceholder } from '../../../core/prompt-builders';
 import { extractThinkingBlocks } from '../../../core/markdown';
 
 export interface ThinkingPanelResult {
   /** DOM element to prepend (a <details> collapsible panel) — null when no blocks. */
   thinkingEl: HTMLElement | null;
-  /** Content after thinking blocks removed + wiki-links normalized — what MarkdownRenderer sees. */
+  /** Content after thinking blocks removed + wiki-links normalized + placeholder substituted — what MarkdownRenderer sees. */
   normalized: string;
 }
 
@@ -21,9 +21,15 @@ export interface ThinkingPanelResult {
  * Fast guard: skip the regex pass when no delimiters are present (the common
  * case during streaming when no reasoning content has yet arrived).
  *
- * `wikiFolder` is required — without it, `normalizeWikiLinkContent` skips
- * the prefix substitution and falls back to the test default. Caller
- * (QueryView.renderMarkdownContent) supplies the user's wiki folder.
+ * v1.24.0 (Bug C 3.0): pipeline order is
+ *   1. `normalizeWikiLinkContent` — collapse the LLM's emitted folder prefix
+ *      (current wikiFolder or the literal default 'wiki') into the placeholder
+ *      `__WIKI_FOLDER__`. This makes the rendered-text history invariant across
+ *      wikiFolder changes.
+ *   2. `substituteWikiFolderPlaceholder` — replace `__WIKI_FOLDER__` with the
+ *      user's CURRENT `wikiFolder` so the user sees a clickable Obsidian link.
+ * `wikiFolder` is required — without it, both steps become no-ops and we
+ * fall through with whatever the LLM emitted (caller is `QueryView.renderMarkdownContent`).
  */
 export function extractThinkingPanel(
   content: string,
@@ -35,7 +41,11 @@ export function extractThinkingPanel(
   const { thinkingBlocks, visibleContent } = hasThinkTags
     ? extractThinkingBlocks(content)
     : { thinkingBlocks: [] as string[], visibleContent: content };
-  const normalized = normalizeWikiLinkContent(visibleContent, wikiFolder);
+  // Collapse the LLM's folder back to the placeholder, then substitute the
+  // real folder at the very end. Doing these in the wrong order would lose
+  // information (substitute first would lock the current folder into history).
+  const withPlaceholder = normalizeWikiLinkContent(visibleContent, wikiFolder);
+  const normalized = substituteWikiFolderPlaceholder(withPlaceholder, wikiFolder);
   return {
     thinkingEl: renderThinkingBlocksUI(thinkingBlocks, language),
     normalized,

--- a/src/wiki/query-engine/state.ts
+++ b/src/wiki/query-engine/state.ts
@@ -8,9 +8,10 @@
 /**
  * Subset of private QueryView state read/written by white-box tests.
  * Field names MUST match the QueryView implementation — keeping the cast
- * `(view as unknown as InternalView)._graph` working is the whole point.
+ * `(view as unknown as InternalView)._lastRetrieval` working is the whole
+ * point. v1.24.0 Bug A removed the per-view `_graph` cache; graph now lives
+ * in WikiEngine.
  */
 export interface InternalView {
-  _graph: unknown;
   _lastRetrieval: unknown;
 }

--- a/src/wiki/query-engine/types.ts
+++ b/src/wiki/query-engine/types.ts
@@ -17,6 +17,14 @@ export interface HistoryMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: number;
+  /**
+   * v1.24.0: Retrieval metadata for this assistant message.
+   * Set at generation time and persisted so the label survives
+   * view re-open / rehydration. Optional — older persisted
+   * history (from pre-v1.24.0) that lacks this field renders
+   * without a label (no crash).
+   */
+  retrieval?: RetrievalLabelData;
 }
 
 export interface QueryViewHistory {

--- a/src/wiki/query-engine/types.ts
+++ b/src/wiki/query-engine/types.ts
@@ -8,7 +8,6 @@
 // retrieval-label renderer).
 
 import type { Component } from 'obsidian';
-import type { buildGraphFromContent } from '../../core/build-graph';
 import type { getSectionLabels } from '../system-prompts';
 
 export type { QueryHistory } from './SuggestSaveModal-class';
@@ -45,6 +44,7 @@ export interface RetrievalLabelData {
  * Subset of QueryView instance fields exposed for type-safe reads/writes
  * outside the class (e.g., by the invalidateGraph public method, or by
  * test code via the white-box `as unknown as InternalView` cast).
+ * v1.24.0 Bug A: removed per-view `_graph`; graph now lives in WikiEngine.
  */
 export interface QueryViewStateFields {
   isStreaming: boolean;
@@ -57,7 +57,6 @@ export interface QueryViewStateFields {
   historyCountDisplay: HTMLElement;
   pendingInput: string;
   activeRenderComponent: Component | null;
-  _graph: ReturnType<typeof buildGraphFromContent> | null;
   _sectionLabels: ReturnType<typeof getSectionLabels> | null;
   _lastRetrieval: RetrievalLabelData | null;
   _turnIndicator: HTMLElement | null;

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -46,6 +46,8 @@ import { SourceAnalyzer } from './source-analyzer';
 import { TOKENS_PAGE_GENERATION, NOTICE_ABORT, NOTICE_RATE_LIMIT, NOTICE_NORMAL, PAGES_CACHE_TTL_MS, COMPATIBLE_SOURCE_EXTENSIONS } from '../constants';
 import { PageFactory } from './page-factory';
 import { ConversationIngestor, ConversationOrchestration, formatConversation, ConversationHistory } from './conversation-ingest';
+import { buildGraphFromContent } from '../core/build-graph';
+import type { Graph } from '../core/build-graph';
 
 /**
  * Issue #173 Symptom B: drop exact-string duplicates from a page-path list
@@ -63,6 +65,15 @@ export function dedupPages(paths: string[]): string[] {
     out.push(p);
   }
   return out;
+}
+
+/** True iff two sets contain exactly the same strings. */
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) {
+    if (!b.has(v)) return false;
+  }
+  return true;
 }
 
 export class WikiEngine {
@@ -100,6 +111,10 @@ export class WikiEngine {
   // pagesCache so back-to-back single-file ingests don't re-walk the vault.
   private ingestedHashesCache: Set<string> | null = null;
   private ingestedHashesCacheTime = 0;
+  // v1.24.0 Bug A: shared graph cache for PPR — built lazily from loaded page
+  // content, invalidated on every vault write via invalidatePageCaches.
+  private _cachedGraph: Graph | null = null;
+  private _cachedGraphAllPaths: Set<string> | null = null;
   private ctx: EngineContext;
 
   constructor(
@@ -351,6 +366,52 @@ export class WikiEngine {
   private invalidatePageCaches(): void {
     this.pagesCache = null;
     this.ingestedHashesCache = null;
+    this._cachedGraph = null;
+    this._cachedGraphAllPaths = null;
+  }
+
+  /**
+   * v1.24.0 Bug A: public graph invalidation. Idempotent; drops the engine-level
+   * PPR graph cache so the next query rebuilds it from current vault content.
+   * Called by main.ts onIngestDoneDispatch across every open QueryView leaf.
+   */
+  invalidateGraph(): void {
+    this._cachedGraph = null;
+    this._cachedGraphAllPaths = null;
+    console.debug('[WikiEngine] graph cache invalidated');
+  }
+
+  /**
+   * v1.24.0 Bug A: shared graph builder for PPR. Returns a cached Graph when
+   * the requested path set is unchanged, otherwise rebuilds by reading every
+   * path in `allPaths` from the vault.
+   *
+   * The cache is intentionally long-lived: it only invalidates when the vault
+   * is written to (via invalidatePageCaches) or when the caller explicitly
+   * calls invalidateGraph(). This makes the first query of a session as fast
+   * as subsequent ones because the graph is already available for the PPR
+   * cascade.
+   */
+  async getOrBuildGraph(allPaths: Set<string>): Promise<Graph> {
+    const pathsChanged = this._cachedGraphAllPaths === null || !setsEqual(this._cachedGraphAllPaths, allPaths);
+    if (this._cachedGraph !== null && !pathsChanged) {
+      console.debug('[WikiEngine] graph cache hit:', this._cachedGraph.nodes.length, 'nodes');
+      return this._cachedGraph;
+    }
+
+    console.debug('[WikiEngine] graph cache miss — building', allPaths.size, 'nodes');
+    // Read all pages in parallel; cap concurrency with allSettled so one
+    // unreadable file does not abort the whole graph build.
+    const readTasks = [...allPaths].map(async (path) => {
+      const content = await this.tryReadFile(path);
+      return { path, content: content ?? '' };
+    });
+    const loadedPages = await Promise.all(readTasks);
+
+    const graph = buildGraphFromContent(loadedPages, allPaths, this.settings.wikiFolder);
+    this._cachedGraph = graph;
+    this._cachedGraphAllPaths = new Set(allPaths);
+    return graph;
   }
 
   /**

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -296,9 +296,21 @@ export class WikiEngine {
     return applySectionLabels(prompt, this.settings);
   }
 
-  updateSettings(settings: LLMWikiSettings): void {
+  /**
+   * Apply new settings. Returns `true` iff `wikiFolder` changed (and the
+   * path-keyed caches were therefore dropped). The return value lets
+   * `main.saveSettings()` act on the same condition in one pass without
+   * exposing the cache-invalidation knob.
+   */
+  updateSettings(settings: LLMWikiSettings): boolean {
+    // Compare BEFORE assigning so a same-folder update doesn't drop the cache.
+    const wikiFolderChanged = settings.wikiFolder !== this.settings.wikiFolder;
     this.settings = settings;
     this.ctx.settings = settings;
+    if (wikiFolderChanged) {
+      this.invalidatePageCaches();
+    }
+    return wikiFolderChanged;
   }
 
   /**

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -303,10 +303,6 @@ export class WikiEngine {
     return c;
   }
 
-  private async buildSystemPrompt(task: SchemaTask): Promise<string | undefined> {
-    return buildSystemPrompt(this.settings, t => this.schemaManager.getSchemaContext(t as SchemaTask), task);
-  }
-
   private applySectionLabels(prompt: string): string {
     return applySectionLabels(prompt, this.settings);
   }
@@ -379,6 +375,16 @@ export class WikiEngine {
     this._cachedGraph = null;
     this._cachedGraphAllPaths = null;
     console.debug('[WikiEngine] graph cache invalidated');
+  }
+
+  /**
+   * v1.24.0: expose buildSystemPrompt so lint phases can compose their
+   * `system` prompt through the shared composer (language directive + schema
+   * context + active tag vocabulary) — exactly like EngineContext and the
+   * fix-runners. Lint phases call this instead of raw getSchemaContext.
+   */
+  async buildSystemPrompt(task: SchemaTask): Promise<string | undefined> {
+    return buildSystemPrompt(this.settings, t => this.schemaManager.getSchemaContext(t as SchemaTask), task);
   }
 
   /**

--- a/styles.css
+++ b/styles.css
@@ -132,6 +132,20 @@
   border: none;
   border-radius: 4px;
 }
+.llm-wiki-query-send-btn:hover:not(:disabled) {
+  background: var(--interactive-accent-hover);
+  filter: brightness(1.08);
+}
+.llm-wiki-query-send-btn:disabled {
+  background: var(--background-modifier-border);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+.llm-wiki-query-send-btn:disabled:hover {
+  background: var(--background-modifier-border);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
 
 .llm-wiki-query-stop-btn {
   flex: 2;
@@ -1084,4 +1098,97 @@
 }
 .llm-wiki-multi-file-actions button {
   padding: 6px 14px;
+}
+
+/* v1.24.0 #251: Custom Query Instructions collapsible panel.
+   Renders inside the Query Wiki input area; collapsed by default. */
+.llm-wiki-query-instructions-block {
+  margin: 12px 0 8px 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-secondary);
+}
+.llm-wiki-query-instructions-block > summary {
+  cursor: pointer;
+  padding: 6px 12px;
+  font-size: 0.85em;
+  color: var(--text-muted);
+  user-select: none;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.llm-wiki-query-instructions-block > summary::-webkit-details-marker {
+  display: none;
+}
+.llm-wiki-query-instructions-block > summary::before {
+  content: '▸';
+  display: inline-block;
+  transition: transform 0.15s ease;
+  font-size: 0.85em;
+  color: var(--text-faint);
+}
+.llm-wiki-query-instructions-block[open] > summary::before {
+  content: '▾';
+}
+.llm-wiki-query-instructions-body {
+  padding: 0 12px 12px 12px;
+}
+.llm-wiki-query-instructions-desc {
+  font-size: 0.8em;
+  color: var(--text-muted);
+  margin: 6px 0 8px 0;
+}
+.llm-wiki-query-instructions-textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--font-monospace);
+  font-size: 0.85em;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+}
+.llm-wiki-query-instructions-counter {
+  font-size: 0.75em;
+  color: var(--text-faint);
+  text-align: right;
+  margin: 2px 0 6px 0;
+}
+.llm-wiki-query-instructions-button-row {
+  display: flex;
+  gap: 8px;
+}
+.llm-wiki-query-instructions-apply {
+  flex: 1 1 0;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  padding: 6px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.llm-wiki-query-instructions-apply:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+.llm-wiki-query-instructions-apply:disabled {
+  background: var(--background-modifier-border);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+.llm-wiki-query-instructions-apply:disabled:hover {
+  background: var(--background-modifier-border);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+.llm-wiki-query-instructions-clear {
+  flex: 1 1 0;
+  background: var(--interactive-normal);
+  color: var(--text-muted);
+  padding: 6px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary

v1.24.0 MINOR batch (11 commits, 68 files, +4352/-756). Four independent work streams, kept as atomic commits for bisect/rollback clarity:

### 1. modals.ts split (`4b65450`)
1008-LOC `src/ui/modals.ts` → `src/ui/modals/` directory (8 modal classes, index/types/suggest-modals).

### 2. Query Wiki bug fixes (`6a15e4c`→`1d943ea`)
- `6a15e4c` detect `aliases:[]` as alias-deficient
- `70002cb` correct frontmatter writes (dedupe, block-style aware)
- `b46f7b1` / `81813ae` human-readable + persisted retrieval labels
- `8d5baf3` invalidate caches when `wikiFolder` changes
- `1d943ea` wikiFolder-transparent prompt + `withTransientRetry` LLM seed-selector + system-field fix (DeepSeek JSON mode)

### 3. First-query PPR graph warmup (`305f601`)
Engine-level `_cachedGraph`; `getOrBuildGraph(allPaths)` + `invalidateGraph()`. First query of a session now runs PPR instead of falling back to lex-only.

### 4. #251 Custom Query Instructions + Lint system injection (`d4a93c4` + `cb4bf73`)
- `d4a93c4` collapsible Custom Query Instructions panel in Query Wiki (persisted in data.json, 5000-char cap, 3 send-site injection). Closes #251.
- `cb4bf73` inject shared `buildSystemPrompt` (language directive + schema context + active tag vocabulary) into dedup/analysis LLM calls — previously these sent no `system` prompt (DeepSeek JSON mode missed schema rules).

## Test plan
- `pnpm lint && npx tsc --noEmit && pnpm test && pnpm build && pnpm css-lint` — all green
- 1744 tests passing (124 files)
- Manual e2e on Obsidian: Query Wiki custom instructions inject + persist; Lint dedup/analysis now carry system prompt

## Notes
- No version bump / tag in this PR — release (version bump + docs + tag) is a separate step via the release workflow.
- Lint cache commits (`8d5baf3` + `1d943ea` + `305f601`) share `wiki-engine.ts` cache machinery and should be reverted as a unit if needed.

Closes #251

Co-authored-by: green-dalii <654534332@qq.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>