### PR TITLE
fix(merge): wire up mergeAnalysis as classify-then-route triage (#216)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,15 +2,17 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.23.2 (shipped 2026-07-05) | **Updated:** 2026-07-08
+**Version:** 1.23.2 (shipped 2026-07-05) → 1.24.0 P2 merged to main (PR #257, 2026-07-09, release pending) | **Updated:** 2026-07-09
 
 ## Current Status
 
-**v1.24.0 P2 in flight (2026-07-08).** On branch `feat/modals-split`:
+**v1.24.0 P2 — merged to main via PR #257 (2026-07-09), release pending.** All 4 stages shipped (1744 tests):
 - ✅ Stage 1 — `modals.ts` split into `src/ui/modals/` (4b65450).
-- ✅ Stage 2 — Query Wiki bug fixes: wikiFolder-transparent prompt (Bug C), LLM seed-selector retry + system field (Bug B/B+), 1711 tests.
-- ✅ Stage 3 — Graph warmup: engine-level `_cachedGraph` so first query uses PPR (608ae95).
-- ⏳ Stage 4 — Issue #251 custom Query Instructions MVP (query-local UI).
+- ✅ Stage 2 — Query Wiki bug fixes: wikiFolder-transparent prompt (Bug C), LLM seed-selector retry + system field (Bug B/B+), retrieval-label persistence + human-readable label.
+- ✅ Stage 3 — Graph warmup: engine-level `_cachedGraph` so first query uses PPR (305f601).
+- ✅ Stage 4 — Issue #251 custom Query Instructions MVP (query-local UI) (d4a93c4) + lint dedup/analysis system-prompt injection (cb4bf73, Closes #251).
+
+Release action (version bump + 9 README + CHANGELOG + tag) is a separate step via the `obsidian-plugin-release` workflow — PR #257 deliberately did NOT bump `manifest.json`.
 
 Historical releases are summarized in [CHANGELOG](./CHANGELOG.md).
 

--- a/src/__tests__/wiki/page-factory-complementary-append.test.ts
+++ b/src/__tests__/wiki/page-factory-complementary-append.test.ts
@@ -1,0 +1,523 @@
+// v1.24.0 #216 Tier-2: complementary → targeted section append.
+//
+// Tests the new `applyComplementaryAppends()` helper that handles the
+// "complementary" triage result by appending new facts to specific
+// existing sections (without rewriting the body). The function:
+//
+//   1. Groups items by target_section
+//   2. For each group, issues ONE per-section LLM call that returns
+//      appended paragraph(s) for that section (scope: single section)
+//   3. Splices the appended paragraphs into existingBody at the
+//      right position (before the next ## heading or EOF)
+//
+// i18n-aware: target_section may come from the LLM as an English label
+// (e.g. "Description") while the existing body uses a localized label
+// (e.g. "Beschreibung" for de). The 4-layer anchor resolver handles
+// this without breaking:
+
+//   Layer 1 — exact match against canonical labels
+//   Layer 2 — Levenshtein snap (3-edit window, reused from
+//             canonicalizeSectionHeaders via snapHeaderToCanonical)
+//   Layer 3 — body scan: extract ## headings from existingBody and
+//             snap each, then compare
+//   Layer 4 — per-section LLM has full body context to decide itself
+//             (returns NO_NEW_CONTENT if it can't place the new info
+//             safely)
+//   Fallback  — append to "## New Information ({{source}})" section
+//               at end of body
+
+import { describe, it, expect, vi } from 'vitest';
+import { PageFactory } from '../../wiki/page-factory';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { createMockEntity } from '../__support__/factories';
+import type { LLMClient } from '../../types';
+
+// ── Pure helpers ─────────────────────────────────────────────────
+
+function entityForMerge() {
+  return createMockEntity({
+    name: 'Microbiome',
+    summary: 'Microbiome summary',
+    related_entities: ['SCFAs'],
+    related_concepts: ['Gut Health'],
+    mentions_in_source: ['"SCFAs are produced by fiber fermentation."'],
+    mentions_with_provenance: [
+      {
+        quote: 'SCFAs are produced by fiber fermentation.',
+        source_path: 'src.md',
+        source_slug: 'src',
+        extracted_at: '2026-07-01',
+      },
+    ],
+  });
+}
+
+// ── applyComplementaryAppends() integration ──────────────────────
+
+describe('applyComplementaryAppends — i18n-aware target resolution', () => {
+  type HelperAccess = {
+    applyComplementaryAppends: (
+      items: Array<{ kind: string; content: string; target_section: string; reason?: string }>,
+      existingBody: string,
+      info: Parameters<PageFactory['mergePage']>[0],
+      sourceFile: Parameters<PageFactory['mergePage']>[2],
+    ) => Promise<string>;
+  };
+
+  function setup(llmResponses: string[]) {
+    let calls = 0;
+    let callParams: Array<{ messages: Array<{ content: string }> }> = [];
+    const { ctx } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/microbiome.md': '# Microbiome\n',
+      },
+      llmResponses: [],
+    });
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          callParams.push(params);
+          calls++;
+          return llmResponses[Math.min(calls - 1, llmResponses.length - 1)];
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    return { factory, getCallCount: () => calls, getCallParams: () => callParams };
+  }
+
+  it('Layer 1 exact match: target_section="Description" hits canonical label', async () => {
+    const { factory, getCallCount } = setup([
+      'SCFAs are produced by bacterial fermentation of dietary fiber.',
+    ]);
+    const existingBody = [
+      '## Description',
+      'Existing description text here.',
+      '## Related Concepts',
+      '[[Gut Health]]',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [{
+        kind: 'complementary',
+        content: 'SCFAs are produced by bacterial fermentation of dietary fiber.',
+        target_section: 'Description',
+      }],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    // The new paragraph is appended inside Description section, before ## Related Concepts.
+    expect(result).toContain('## Description');
+    expect(result).toContain('Existing description text here.');
+    expect(result).toContain('SCFAs are produced by bacterial fermentation');
+    expect(result).toContain('## Related Concepts');
+    // Description content is preserved verbatim.
+    const descIdx = result.indexOf('Existing description text here.');
+    const appendIdx = result.indexOf('SCFAs are produced');
+    expect(descIdx).toBeLessThan(appendIdx);
+    expect(getCallCount()).toBe(1);
+  });
+
+  it('Layer 2 Levenshtein snap: target="Beschreibun" (typo) snaps to "Beschreibung"', async () => {
+    const { factory } = setup([
+      'SCFAs werden durch bakterielle Fermentation von Ballaststoffen produziert.',
+    ]);
+    const existingBody = [
+      '## Beschreibung',
+      'Bestehende Beschreibung.',
+      '## Verwandte Konzepte',
+      '[[Darmgesundheit]]',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [{
+        kind: 'complementary',
+        content: 'SCFAs werden durch bakterielle Fermentation produziert.',
+        target_section: 'Beschreibun', // missing final g
+      }],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    // Existing section content preserved.
+    expect(result).toContain('Bestehende Beschreibung.');
+    expect(result).toContain('SCFAs werden durch bakterielle Fermentation');
+  });
+
+  it('Layer 3 body scan: target does not match any canonical label but body has the section', async () => {
+    // Settings give English labels, but body uses German (user wrote German
+    // by hand, or extracted from a German source). The LLM may also have
+    // returned a free-form target. Body scan + snap finds it.
+    const { factory } = setup([
+      'Appended in English for compatibility.',
+    ]);
+    const existingBody = [
+      '## Eigene Sektion',
+      'Some German body.',
+      '## Andere',
+      'Other body.',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [{
+        kind: 'complementary',
+        content: 'Appended in English for compatibility.',
+        target_section: 'Eigene Sektion', // not in canonical labels, but in body
+      }],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    expect(result).toContain('Some German body.');
+    expect(result).toContain('Appended in English for compatibility.');
+  });
+
+  it('Layer 4 fallback: per-section LLM returns NO_NEW_CONTENT → falls back to ## New Information', async () => {
+    const { factory } = setup(['NO_NEW_CONTENT']);
+    const existingBody = [
+      '## Description',
+      'Existing description.',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [{
+        kind: 'complementary',
+        content: 'some new fact',
+        target_section: 'NonExistentSection_xyz',
+      }],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    expect(result).toContain('## New Information (src)');
+    expect(result).toContain('some new fact');
+    // Description preserved.
+    expect(result).toContain('Existing description.');
+  });
+
+  it('groups items by target_section: 3 items → 2 sections → 2 LLM calls (not 3)', async () => {
+    const { factory, getCallCount } = setup([
+      'first section appended text',
+      'second section appended text',
+    ]);
+    const existingBody = [
+      '## Description',
+      'A',
+      '## Key Characteristics',
+      'B',
+    ].join('\n');
+    await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [
+        { kind: 'complementary', content: 'fact1', target_section: 'Description' },
+        { kind: 'complementary', content: 'fact2', target_section: 'Description' },
+        { kind: 'complementary', content: 'fact3', target_section: 'Key Characteristics' },
+      ],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    expect(getCallCount()).toBe(2);
+  });
+
+  it('preserves the original body verbatim — only inserts new paragraphs', async () => {
+    const { factory } = setup([
+      'new appended content',
+    ]);
+    const existingBody = [
+      '## Description',
+      'Original Description paragraph 1.',
+      '',
+      'Original Description paragraph 2.',
+      '## Related Entities',
+      '[[SCFAs]]',
+      '## Related Concepts',
+      '[[Gut Health]]',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [{
+        kind: 'complementary',
+        content: 'new appended content',
+        target_section: 'Description',
+      }],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    // Both original paragraphs preserved exactly.
+    expect(result).toContain('Original Description paragraph 1.');
+    expect(result).toContain('Original Description paragraph 2.');
+    // Related Entities untouched.
+    expect(result).toContain('[[SCFAs]]');
+    expect(result).toContain('## Related Concepts');
+    expect(result).toContain('[[Gut Health]]');
+  });
+
+  it('does not invoke LLM when items array is empty', async () => {
+    const { factory, getCallCount } = setup([
+      // never used
+      'should not be called',
+    ]);
+    const existingBody = '## Description\nA\n';
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    expect(getCallCount()).toBe(0);
+    // Body unchanged.
+    expect(result).toBe(existingBody);
+  });
+
+  it('returns existingBody unchanged when all per-section LLM calls return NO_NEW_CONTENT', async () => {
+    const { factory } = setup(['NO_NEW_CONTENT', 'NO_NEW_CONTENT']);
+    const existingBody = [
+      '## Description',
+      'A',
+      '## Key Characteristics',
+      'B',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [
+        { kind: 'complementary', content: 'f1', target_section: 'Description' },
+        { kind: 'complementary', content: 'f2', target_section: 'Key Characteristics' },
+      ],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    // No new content was successfully placed; body is unchanged.
+    expect(result).toBe(existingBody);
+  });
+
+  it('handles section at end of body (no following ## to insert before)', async () => {
+    const { factory } = setup([
+      'appended text',
+    ]);
+    const existingBody = [
+      '## Description',
+      'Original text.',
+      '## Key Characteristics',
+      'Original characteristics.',
+    ].join('\n');
+    const result = await (factory as unknown as HelperAccess).applyComplementaryAppends(
+      [{
+        kind: 'complementary',
+        content: 'new characteristic',
+        target_section: 'Key Characteristics',
+      }],
+      existingBody,
+      entityForMerge(),
+      createMockFile('src.md'),
+    );
+    expect(result).toContain('Original characteristics.');
+    expect(result).toContain('appended text');
+    // Last section, appended at the very end.
+    expect(result.indexOf('appended text')).toBeGreaterThan(result.indexOf('Original characteristics.'));
+  });
+});
+
+// ── classifyMergeNeed extended return type ────────────────────────
+
+describe('classifyMergeNeed — Tier-2 complementary strategy', () => {
+  type HelperAccess = {
+    classifyMergeNeed: (
+      info: Parameters<PageFactory['mergePage']>[0],
+      pageType: 'entity' | 'concept',
+      sourceFile: Parameters<PageFactory['mergePage']>[2],
+      existingContent: string,
+    ) => Promise<{
+      strategy: 'skip' | 'merge' | 'complementary' | 'contradictory';
+      items: Array<{
+        kind: 'complementary';
+        content: string;
+        target_section: string;
+        reason?: string;
+      }>;
+      reason: string;
+    }>;
+  };
+
+  function makeFactory(llmResponse: string) {
+    const { ctx } = createMockContext({ vaultFiles: {}, llmResponses: [] });
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async () => llmResponse,
+      };
+      return client;
+    };
+    return new PageFactory(ctx);
+  }
+
+  it('returns strategy="complementary" with items array when LLM signals complementary', async () => {
+    const factory = makeFactory(JSON.stringify({
+      strategy: 'complementary',
+      items: [
+        {
+          kind: 'complementary',
+          content: 'SCFAs ferment fiber',
+          target_section: 'Description',
+          reason: 'adds detail',
+        },
+      ],
+      reason: 'all new info is complementary',
+    }));
+    const result = await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '## Description\nExisting\n',
+    );
+    expect(result.strategy).toBe('complementary');
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].target_section).toBe('Description');
+  });
+
+  it('returns strategy="contradictory" with empty items array', async () => {
+    const factory = makeFactory(JSON.stringify({
+      strategy: 'contradictory',
+      items: [],
+      reason: 'new info conflicts with existing',
+    }));
+    const result = await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '## Description\nExisting claim X\n',
+    );
+    expect(result.strategy).toBe('contradictory');
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('throws on missing items field (caller falls back)', async () => {
+    const factory = makeFactory(JSON.stringify({
+      strategy: 'complementary',
+      // missing items
+      reason: 'oops',
+    }));
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '## Description\nExisting\n',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws on invalid complementary item (missing target_section)', async () => {
+    const factory = makeFactory(JSON.stringify({
+      strategy: 'complementary',
+      items: [{ kind: 'complementary', content: 'x' /* missing target_section */ }],
+      reason: 'r',
+    }));
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '## Description\nExisting\n',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws on invalid strategy value (caller falls back)', async () => {
+    const factory = makeFactory(JSON.stringify({
+      strategy: 'unsure',
+      items: [],
+      reason: 'r',
+    }));
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '## Description\nExisting\n',
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// ── mergePage strategy switch — Tier-2 ────────────────────────────
+
+describe('mergePage — complementary strategy dispatch', () => {
+  type HelperAccess = {
+    mergePage: (
+      info: Parameters<PageFactory['mergePage']>[0],
+      pageType: 'entity' | 'concept',
+      sourceFile: Parameters<PageFactory['mergePage']>[2],
+      existingContent: string,
+      extraPagePaths: string[],
+      path: string,
+      sourceSlug?: string,
+    ) => Promise<string | null>;
+  };
+
+  function setupComplementary(opts: {
+    classifyResponse: string;
+    appendResponse: string;
+  }) {
+    const calls: Array<{ messages: Array<{ content: string }> }> = [];
+    const { ctx } = createMockContext({ vaultFiles: {}, llmResponses: [] });
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          calls.push(params);
+          const isClassify = params.response_format?.type === 'json_object';
+          if (isClassify) return opts.classifyResponse;
+          return opts.appendResponse;
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    return { factory, calls };
+  }
+
+  it('strategy=complementary → NO body-merge call (only classify + per-section append)', async () => {
+    const { factory, calls } = setupComplementary({
+      classifyResponse: JSON.stringify({
+        strategy: 'complementary',
+        items: [{ kind: 'complementary', content: 'new fact', target_section: 'Description' }],
+        reason: 'adds detail',
+      }),
+      appendResponse: 'appended text',
+    });
+    const existingBody = '## Description\nOriginal\n';
+    await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      existingBody,
+      [],
+      'wiki/entities/microbiome.md',
+    );
+    // 1 classify + 1 per-section append = 2 calls; the body-merge prompt
+    // (TOKENS_PAGE_GENERATION) must NOT be invoked.
+    expect(calls).toHaveLength(2);
+    // Existing body preserved.
+    expect(calls[1].messages[0].content).toContain('Original');
+  });
+
+  it('strategy=contradictory → falls through to existing body-merge path', async () => {
+    const { factory, calls } = setupComplementary({
+      classifyResponse: JSON.stringify({
+        strategy: 'contradictory',
+        items: [],
+        reason: 'new info conflicts',
+      }),
+      // body-merge response
+      appendResponse: '## Description\nmerged body\n',
+    });
+    await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '## Description\nExisting\n',
+      [],
+      'wiki/entities/microbiome.md',
+    );
+    // 1 classify + 1 body-merge = 2 calls.
+    expect(calls).toHaveLength(2);
+  });
+});
+// suppress vi unused import warning if any
+void vi;

--- a/src/__tests__/wiki/page-factory-core.test.ts
+++ b/src/__tests__/wiki/page-factory-core.test.ts
@@ -140,6 +140,7 @@ describe('PageFactory — Core Paths', () => {
           'wiki/entities/existing.md': '---\ntype: entity\naliases: ["Old Alias"]\n---\n# Existing\nOld content',
         },
         llmResponses: [
+          JSON.stringify({ strategy: 'merge', reason: 'has new info' }), // v1.24.0 #216 triage
           'Merged content here', // LLM merge response
         ],
       });
@@ -219,6 +220,7 @@ describe('PageFactory — Core Paths', () => {
           'wiki/concepts/collision.md': '---\ntype: concept\n---\n# Collision\nConcept content',
         },
         llmResponses: [
+          JSON.stringify({ strategy: 'merge', reason: 'has new info' }), // v1.24.0 #216 triage
           'Merged entity content into concept',
         ],
       });
@@ -302,6 +304,7 @@ describe('PageFactory — Core Paths', () => {
           'wiki/entities/keep.md': '---\ntype: entity\n---\n# Keep\nOriginal content',
         },
         llmResponses: [
+          JSON.stringify({ strategy: 'merge', reason: 'has new info' }), // v1.24.0 #216 triage
           'NO_NEW_CONTENT',
         ],
       });

--- a/src/__tests__/wiki/page-factory-merge-triage.test.ts
+++ b/src/__tests__/wiki/page-factory-merge-triage.test.ts
@@ -1,0 +1,425 @@
+// v1.24.0 #216: classify-then-route merge triage.
+//
+// Tests the new `classifyMergeNeed()` helper and its integration into
+// `mergePage()`. The helper pre-classifies new source information against
+// the existing page content BEFORE invoking the full LLM body rewrite.
+//
+// Why this matters: the current `mergeEntityPage` / `mergeConceptPage`
+// prompts unconditionally rewrite the body, even when the new information
+// is fully redundant with existing content. That wastes an LLM call and
+// risks introducing "drift" — small wording changes that erode the
+// human-curated body over multiple re-ingests. The triage classifies into:
+//
+//   - 'merge': at least some new/complementary/contradictory content —
+//     proceed with the existing LLM body merge path.
+//   - 'skip': every item is a duplicate of existing content — skip the
+//     body rewrite, only update frontmatter (sources list).
+//
+// Strict scope: the triage is invoked only from `mergePage()` in
+// `src/wiki/page-factory.ts`. The reviewed-page path (`appendToReviewedPage`)
+// and the create-new path are unaffected. The triage MUST fall back to the
+// existing merge path on classify failure (LLM error, malformed JSON,
+// unexpected strategy) — no silent skip, no silent crash.
+
+import { describe, it, expect } from 'vitest';
+import { PageFactory } from '../../wiki/page-factory';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { createMockEntity } from '../__support__/factories';
+import type { LLMClient } from '../../types';
+
+// ── Helper: minimal valid entity info for merge tests ─────────────
+function entityForMerge() {
+  return createMockEntity({
+    name: 'Test Entity',
+    summary: 'Test summary for merge',
+    related_entities: ['Other Entity'],
+    related_concepts: ['Some Concept'],
+    mentions_in_source: ['First quote', 'Second quote'],
+    mentions_with_provenance: [
+      { quote: 'First quote', source_path: 'src.md', source_slug: 'src', extracted_at: '2026-07-01' },
+      { quote: 'Second quote', source_path: 'src.md', source_slug: 'src', extracted_at: '2026-07-01' },
+    ],
+  });
+}
+
+function conceptForMerge() {
+  return {
+    name: 'Test Concept',
+    type: 'concept' as const,
+    summary: 'Concept summary',
+    related_entities: [],
+    related_concepts: ['Related Concept'],
+    key_points: ['Key point 1'],
+    mentions_in_source: ['First quote'],
+    mentions_with_provenance: [
+      { quote: 'First quote', source_path: 'src.md', source_slug: 'src', extracted_at: '2026-07-01' },
+    ],
+  };
+}
+void conceptForMerge; // reserved for future concept-classify coverage
+
+// ── classifyMergeNeed() pure-helper behaviour ──────────────────────
+
+describe('classifyMergeNeed() — helper unit tests', () => {
+  // We invoke the private method via type assertion, mirroring the
+  // pattern used in page-factory-core.test.ts for `resolvePagePath`.
+  type HelperAccess = {
+    classifyMergeNeed: (
+      info: Parameters<PageFactory['mergePage']>[0],
+      pageType: 'entity' | 'concept',
+      sourceFile: Parameters<PageFactory['mergePage']>[2],
+      existingContent: string,
+    ) => Promise<{ strategy: 'merge' | 'skip'; reason: string }>;
+  };
+
+  function makeFactoryWithLLM(llmResponse: string | null) {
+    const { ctx } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/test-entity.md': '---\ntype: entity\n---\n# Test Entity\nExisting content',
+      },
+      llmResponses: [],
+    });
+    let calls = 0;
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async () => {
+          calls++;
+          if (llmResponse === null) throw new Error('Mock LLM failure');
+          return llmResponse;
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    return { factory, getCallCount: () => calls };
+  }
+
+  it('returns {strategy: "merge", reason: "..."} when LLM says merge', async () => {
+    const { factory, getCallCount } = makeFactoryWithLLM(
+      JSON.stringify({ strategy: 'merge', reason: 'has new info' }),
+    );
+    const result = await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nExisting content',
+    );
+    expect(result).toMatchObject({ strategy: 'merge', reason: 'has new info', items: [] });
+    expect(getCallCount()).toBe(1);
+  });
+
+  it('returns {strategy: "skip", reason: "..."} when LLM says skip', async () => {
+    const { factory } = makeFactoryWithLLM(
+      JSON.stringify({ strategy: 'skip', reason: 'all duplicate' }),
+    );
+    const result = await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nExisting content',
+    );
+    expect(result).toMatchObject({ strategy: 'skip', reason: 'all duplicate', items: [] });
+  });
+
+  it('throws on malformed JSON (caller falls back to merge path)', async () => {
+    const { factory } = makeFactoryWithLLM('not json at all');
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '---\ntype: entity\n---\n# Test Entity\nExisting content',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws on missing strategy field (caller falls back)', async () => {
+    const { factory } = makeFactoryWithLLM(JSON.stringify({ reason: 'no strategy here' }));
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '---\ntype: entity\n---\n# Test Entity\nExisting content',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws on invalid strategy value (caller falls back)', async () => {
+    const { factory } = makeFactoryWithLLM(JSON.stringify({ strategy: 'maybe', reason: '?' }));
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '---\ntype: entity\n---\n# Test Entity\nExisting content',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('throws when LLM client fails (network / provider error)', async () => {
+    const { factory } = makeFactoryWithLLM(null);
+    await expect(
+      (factory as unknown as HelperAccess).classifyMergeNeed(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '---\ntype: entity\n---\n# Test Entity\nExisting content',
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('passes disableThinking flag through to the LLM', async () => {
+    const { ctx } = createMockContext({ vaultFiles: {}, llmResponses: [] });
+    let observedParams: { enableThinking?: boolean } | undefined;
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          observedParams = params;
+          return JSON.stringify({ strategy: 'merge', reason: 'ok' });
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nExisting content',
+    );
+    // When disableThinking=false (default in factory settings), the
+    // enableThinking override must NOT be passed (the LLM client decides).
+    expect(observedParams?.enableThinking).toBeUndefined();
+  });
+
+  it('passes disableThinking=true as enableThinking: false', async () => {
+    const { ctx } = createMockContext({
+      vaultFiles: {},
+      llmResponses: [],
+      settings: { disableThinking: true },
+    });
+    let observedParams: { enableThinking?: boolean } | undefined;
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          observedParams = params;
+          return JSON.stringify({ strategy: 'merge', reason: 'ok' });
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nExisting content',
+    );
+    expect(observedParams?.enableThinking).toBe(false);
+  });
+
+  it('uses response_format: json_object for structured parse', async () => {
+    const { ctx } = createMockContext({ vaultFiles: {}, llmResponses: [] });
+    let observedParams: { response_format?: { type: string } } | undefined;
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          observedParams = params;
+          return JSON.stringify({ strategy: 'merge', reason: 'ok' });
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nExisting content',
+    );
+    expect(observedParams?.response_format).toEqual({ type: 'json_object' });
+  });
+
+  it('passes buildSystemPrompt("merge") as the system field', async () => {
+    const { ctx } = createMockContext({ vaultFiles: {}, llmResponses: [] });
+    let observedSystem: string | undefined;
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          observedSystem = params.system;
+          return JSON.stringify({ strategy: 'merge', reason: 'ok' });
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    await (factory as unknown as HelperAccess).classifyMergeNeed(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nExisting content',
+    );
+    // The factory's mock context returns undefined for buildSystemPrompt,
+    // so system should be undefined (the conditional spread must omit it).
+    expect(observedSystem).toBeUndefined();
+  });
+});
+
+// ── mergePage() triage integration ─────────────────────────────────
+
+describe('mergePage() — triage integration', () => {
+  type HelperAccess = {
+    mergePage: (
+      info: Parameters<PageFactory['mergePage']>[0],
+      pageType: 'entity' | 'concept',
+      sourceFile: Parameters<PageFactory['mergePage']>[2],
+      existingContent: string,
+      extraPagePaths: string[],
+      path: string,
+      sourceSlug?: string,
+    ) => Promise<string | null>;
+  };
+
+  function setupMergeMocks(opts: {
+    classifyResponse: string | null; // null → throw to test fallback
+    mergeResponse?: string | null;
+  }) {
+    const calls: Array<{ system?: string; messages: Array<{ content: string }> }> = [];
+    const { ctx } = createMockContext({
+      vaultFiles: {},
+      llmResponses: [],
+    });
+    ctx.getClient = () => {
+      const client: LLMClient = {
+        createMessage: async (params) => {
+          calls.push(params);
+          // Discriminate: classify uses response_format=json_object; merge doesn't.
+          const isClassify = params.response_format?.type === 'json_object';
+          if (isClassify) {
+            if (opts.classifyResponse === null) throw new Error('classify failure');
+            return opts.classifyResponse;
+          }
+          // merge call: default is some markdown body
+          if (opts.mergeResponse === null) throw new Error('merge failure');
+          return opts.mergeResponse ?? '## Description\nmerged content\n';
+        },
+      };
+      return client;
+    };
+    const factory = new PageFactory(ctx);
+    return { factory, calls };
+  }
+
+  it('strategy=skip → only ONE LLM call (no merge prompt), body unchanged', async () => {
+    const { factory, calls } = setupMergeMocks({
+      classifyResponse: JSON.stringify({ strategy: 'skip', reason: 'all duplicate' }),
+      mergeResponse: '## Description\nTHIS_SHOULD_NOT_RUN\n',
+    });
+    const existingBody = '---\ntype: entity\n---\n# Test Entity\nORIGINAL_BODY';
+    const result = await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      existingBody,
+      [],
+      'wiki/entities/test-entity.md',
+    );
+    expect(result).toBe('wiki/entities/test-entity.md');
+    expect(calls).toHaveLength(1); // only classify, no merge
+    expect(calls[0].messages[0].content).toContain('ORIGINAL_BODY'); // classify sees existing
+  });
+
+  it('strategy=merge → TWO LLM calls (classify then merge)', async () => {
+    const { factory, calls } = setupMergeMocks({
+      classifyResponse: JSON.stringify({ strategy: 'merge', reason: 'has new info' }),
+      mergeResponse: '## Description\nmerged content\n',
+    });
+    await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nexisting',
+      [],
+      'wiki/entities/test-entity.md',
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  it('classify failure → falls back to merge (2 calls total: 1 throw + 1 merge)', async () => {
+    const { factory, calls } = setupMergeMocks({
+      classifyResponse: null, // throw on classify
+      mergeResponse: '## Description\nfallback merged\n',
+    });
+    await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nexisting',
+      [],
+      'wiki/entities/test-entity.md',
+    );
+    // Classify throws → caught → falls back to merge path. 2 calls total.
+    expect(calls).toHaveLength(2);
+  });
+
+  it('classify returns malformed JSON → falls back to merge (2 calls total)', async () => {
+    const { factory, calls } = setupMergeMocks({
+      classifyResponse: 'not json {',
+      mergeResponse: '## Description\nfallback merged\n',
+    });
+    await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nexisting',
+      [],
+      'wiki/entities/test-entity.md',
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  it('classify returns invalid strategy → falls back to merge (2 calls total)', async () => {
+    const { factory, calls } = setupMergeMocks({
+      classifyResponse: JSON.stringify({ strategy: 'unsure', reason: '?' }),
+      mergeResponse: '## Description\nfallback merged\n',
+    });
+    await (factory as unknown as HelperAccess).mergePage(
+      entityForMerge(),
+      'entity',
+      createMockFile('src.md'),
+      '---\ntype: entity\n---\n# Test Entity\nexisting',
+      [],
+      'wiki/entities/test-entity.md',
+    );
+    expect(calls).toHaveLength(2);
+  });
+
+  it('strategy=skip → write failure is NOT masked as triage failure (no double-write body merge)', async () => {
+    // Regression: the inner try/catch must NOT wrap the createOrUpdateFile
+    // call. If the skip-path write fails, the error must surface to the
+    // outer mergeError catch — not silently fall through to the expensive
+    // body-merge path which would write the file a second time.
+    const { factory, calls } = setupMergeMocks({
+      classifyResponse: JSON.stringify({ strategy: 'skip', reason: 'duplicate' }),
+      mergeResponse: '## Description\nSHOULD_NOT_BE_CALLED\n',
+    });
+    // Override createOrUpdateFile on the ctx to throw.
+    (factory as unknown as { ctx: { createOrUpdateFile: () => Promise<never> } }).ctx.createOrUpdateFile =
+      async () => {
+        throw new Error('vault write race');
+      };
+    await expect(
+      (factory as unknown as HelperAccess).mergePage(
+        entityForMerge(),
+        'entity',
+        createMockFile('src.md'),
+        '---\ntype: entity\n---\n# Test Entity\nexisting',
+        [],
+        'wiki/entities/test-entity.md',
+      ),
+    ).rejects.toThrow(/vault write race/);
+    // Only the classify call ran; the body merge was NOT attempted.
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -111,6 +111,28 @@ export const TOKENS_CONVERSATION_PAGE = 8000;
 export const TOKENS_DEDUP_RESOLUTION = 1000;
 
 /**
+ * v1.24.0 #216 — max tokens for the merge triage pre-flight classification.
+ *
+ * v1.24.0 Tier-2 (commit ab23bc0 + amend): the triage output now includes
+ * a structured `items[]` array for the complementary path, with each
+ * item carrying `content` (the new fact) + `target_section` (the localized
+ * section label) + `reason`. A typical Tier-2 output with 2-3 items in
+ * Chinese easily runs to 500-900 tokens; e2e observed heavy truncation
+ * at 200 tokens with `{"strategy":` cut off mid-JSON. 2000 gives ample
+ * headroom for both Tier-1 (compact) and Tier-2 (verbose) outputs.
+ */
+export const TOKENS_MERGE_TRIAGE = 2000;
+
+/**
+ * v1.24.0 #216 Tier-2 — max tokens for a single per-section append call.
+ * The complementary path appends one paragraph per target section; the
+ * LLM is given (existingSectionContent + 1-N new facts) and must return
+ * just the appended paragraphs. 600 tokens covers ~3 paragraphs of
+ * markdown per section comfortably.
+ */
+export const TOKENS_COMPLEMENTARY_APPEND = 600;
+
+/**
  * Token budget for lint alias completion batch.
  */
 export const TOKENS_LINT_ALIAS_BATCH = 500;

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -39,21 +39,46 @@ function levenshtein(a: string, b: string): number {
   return prev[b.length];
 }
 
-export function canonicalizeSectionHeaders(content: string, canonicalLabels: string[]): string {
+/**
+ * v1.24.0 #216 Tier-2 — snap a free-form header string to its closest
+ * canonical label, or return null when no unambiguous match exists.
+ *
+ * Bounded so it only heals genuine near-misses and never rewrites a real
+ * content header: a candidate is snapped only when it is within
+ * MAX_DISTANCE edits of exactly one canonical label AND strictly closer
+ * to it than to any other. Exact labels return the same string (caller
+ * can detect "exact" by comparing input vs output).
+ *
+ * Used both by the forward pass (canonicalizeSectionHeaders rebuilds
+ * the body) and the Tier-2 reverse pass (resolveSectionAnchor snaps an
+ * LLM-provided target_section to the canonical label actually present
+ * in the body).
+ */
+export function snapHeaderToCanonical(
+  candidate: string,
+  canonicalLabels: string[],
+): string | null {
   const canonical = new Set(canonicalLabels);
-
-  const snap = (header: string): string | null => {
-    if (canonical.has(header)) return null; // exact — leave untouched
-    let best = Infinity, second = Infinity, bestLabel: string | null = null;
-    for (const label of canonicalLabels) {
-      const d = levenshtein(header, label);
-      if (d < best) { second = best; best = d; bestLabel = label; }
-      else if (d < second) { second = d; }
+  if (canonical.has(candidate)) return candidate;
+  let best = Infinity;
+  let second = Infinity;
+  let bestLabel: string | null = null;
+  for (const label of canonicalLabels) {
+    const d = levenshtein(candidate, label);
+    if (d < best) {
+      second = best;
+      best = d;
+      bestLabel = label;
+    } else if (d < second) {
+      second = d;
     }
-    if (bestLabel !== null && best <= MAX_DISTANCE && best < second) return bestLabel;
-    return null; // too far, or ambiguous
-  };
+  }
+  if (bestLabel !== null && best <= MAX_DISTANCE && best < second) return bestLabel;
+  return null;
+}
 
+export function canonicalizeSectionHeaders(content: string, canonicalLabels: string[]): string {
+  const snap = (header: string): string | null => snapHeaderToCanonical(header, canonicalLabels);
   return content.split('\n').map(line => {
     const m = /^(##\s+)(.+?)\s*$/.exec(line);
     if (!m) return line;

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -8,14 +8,15 @@ import {
   ConceptInfo,
   SourceAnalysis,
   PageCreationResult,
+  LLMClient,
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { ConflictResolver } from '../core/conflict-resolver';
 import { WIKI_SUBFOLDERS } from '../constants';
-import { TOKENS_DEDUP_RESOLUTION, TOKENS_PAGE_GENERATION, TOKENS_APPEND_REVIEWED } from '../constants';
+import { TOKENS_DEDUP_RESOLUTION, TOKENS_PAGE_GENERATION, TOKENS_APPEND_REVIEWED, TOKENS_MERGE_TRIAGE, TOKENS_COMPLEMENTARY_APPEND } from '../constants';
 import { slugify, filterRedundantAliases } from '../core/slug';
 import { correctRelatedLinkPrefixes } from '../core/related-link-corrector';
-import { canonicalizeSectionHeaders } from '../core/section-header-canonicalizer';
+import { canonicalizeSectionHeaders, snapHeaderToCanonical } from '../core/section-header-canonicalizer';
 import { parseJsonResponse } from '../core/json';
 import { parseFrontmatter, mergeFrontmatter, enforceFrontmatterConstraints } from '../core/frontmatter';
 import { injectMentionsSection } from '../core/mentions-injector';
@@ -453,6 +454,447 @@ export class PageFactory {
     }
   }
 
+  /**
+   * v1.24.0 #216 — classify-then-route merge triage.
+   *
+   * Pre-flight check that decides whether the merge body rewrite should
+   * run or be skipped. The full merge prompt (mergeEntityPage /
+   * mergeConceptPage) is expensive and can introduce "drift" on duplicate
+   * re-ingests — this lightweight JSON-only call gives the LLM one job:
+   * classify the new information as either needing a body rewrite
+   * ('merge') or being fully redundant ('skip').
+   *
+   * Failures (LLM error, malformed JSON, unexpected strategy value) throw
+   * so the caller can fall back to the existing merge path. We never
+   * silently skip — that would risk dropping genuinely new information.
+   *
+   * v1.24.0 #216 Tier-2: extended return type to include `items[]`
+   * for the complementary path. Items are populated only when
+   * strategy='complementary'; other strategies return an empty array.
+   *
+   * Output contract:
+   *   - { strategy: 'skip',          items: [], reason: string }
+   *   - { strategy: 'merge',         items: [], reason: string }
+   *   - { strategy: 'contradictory', items: [], reason: string }
+   *   - { strategy: 'complementary', items: ComplementaryItem[],
+   *       reason: string }
+   */
+  private async classifyMergeNeed(
+    info: EntityInfo | ConceptInfo,
+    pageType: 'entity' | 'concept',
+    sourceFile: TFile | { path: string; basename: string },
+    existingContent: string,
+  ): Promise<{
+    strategy: 'merge' | 'skip' | 'complementary' | 'contradictory';
+    items: Array<{
+      kind: 'complementary';
+      content: string;
+      target_section: string;
+      reason?: string;
+    }>;
+    reason: string;
+  }> {
+    const client = this.ctx.getClient();
+    if (!client) throw new Error('LLM client not initialized');
+
+    // Tier-2: include the localized section labels so the LLM returns
+    // target_section values that match the existing page's headers
+    // (matters for i18n wikis where labels are translated).
+    const labels = getSectionLabels(this.ctx.settings);
+    const sectionLabelsList = Object.values(labels).join('\n- ');
+
+    const triagePrompt = PROMPTS.mergeAnalysis
+      .replace('{{page_name}}', info.name)
+      .replace('{{page_type}}', pageType)
+      .replace('{{existing_content}}', existingContent)
+      .replace('{{new_info}}', this.buildNewInfoSummary(info, sourceFile))
+      .replace('{{section_labels}}', `- ${sectionLabelsList}`);
+
+    const finalPrompt = appendTagVocabularyToPrompt(
+      applySectionLabels(triagePrompt, this.ctx.settings),
+      this.ctx.settings,
+    );
+
+    const response = await client.createMessage({
+      model: this.ctx.settings.model,
+      max_tokens: TOKENS_MERGE_TRIAGE,
+      system: await this.ctx.buildSystemPrompt('merge'),
+      messages: [{ role: 'user', content: finalPrompt }],
+      response_format: { type: 'json_object' },
+      ...(this.ctx.settings.disableThinking ? { enableThinking: false } : {}),
+    });
+
+    const parsed = await parseJsonResponse(response) as {
+      strategy?: string;
+      items?: Array<{
+        kind?: string;
+        content?: string;
+        target_section?: string;
+        reason?: string;
+      }>;
+      reason?: string;
+    } | null;
+
+    if (!parsed) throw new Error('merge triage: empty response');
+    const validStrategies = ['merge', 'skip', 'complementary', 'contradictory'];
+    if (!validStrategies.includes(parsed.strategy ?? '')) {
+      throw new Error(`merge triage: invalid strategy "${parsed.strategy}"`);
+    }
+    const strategy = parsed.strategy as 'merge' | 'skip' | 'complementary' | 'contradictory';
+    const reason = typeof parsed.reason === 'string' ? parsed.reason : '';
+
+    // Items are populated only for the complementary path. Validate the
+    // shape defensively — invalid items throw so the caller falls back.
+    const items: Array<{
+      kind: 'complementary';
+      content: string;
+      target_section: string;
+      reason?: string;
+    }> = [];
+    if (strategy === 'complementary') {
+      const rawItems = Array.isArray(parsed.items) ? parsed.items : [];
+      if (rawItems.length === 0) {
+        // Defensive: classify said complementary but no items — caller falls back.
+        throw new Error('merge triage: complementary strategy with empty items');
+      }
+      for (const item of rawItems) {
+        if (
+          typeof item?.content !== 'string' || item.content.trim() === '' ||
+          typeof item?.target_section !== 'string' || item.target_section.trim() === ''
+        ) {
+          throw new Error('merge triage: invalid complementary item');
+        }
+        items.push({
+          kind: 'complementary',
+          content: item.content,
+          target_section: item.target_section,
+          reason: typeof item.reason === 'string' ? item.reason : undefined,
+        });
+      }
+    }
+
+    return { strategy, items, reason };
+  }
+
+  /**
+   * v1.24.0 #216 — build the compact `{{new_info}}` payload for the
+   * triage prompt. Mirrors the fields the full merge prompt uses, but
+   * kept tight to control classify-token cost.
+   */
+  private buildNewInfoSummary(
+    info: EntityInfo | ConceptInfo,
+    sourceFile: TFile | { path: string; basename: string },
+  ): string {
+    const parts: string[] = [];
+    parts.push(`Source: ${sourceFile.basename}`);
+    parts.push(`Summary: ${info.summary}`);
+    if (info.related_entities?.length) {
+      parts.push(`Related entities: ${info.related_entities.join(', ')}`);
+    }
+    if (info.related_concepts?.length) {
+      parts.push(`Related concepts: ${info.related_concepts.join(', ')}`);
+    }
+    const quotes = firstQuotesForPrompt(info);
+    if (quotes) parts.push(`Key details: ${quotes}`);
+    return parts.join('\n');
+  }
+
+  /**
+   * v1.24.0 #216 Tier-2 — apply complementary appends to the existing body.
+   *
+   * Groups items by target_section, then issues ONE per-section LLM call
+   * per group. The LLM sees (existingSectionContent + the new facts) and
+   * returns appended paragraph(s). The caller splices them into the body
+   * at the right location using programmatic section-aware insertion.
+   *
+   * i18n-aware: target resolution uses 4-layer fallback:
+   *   1. Exact match against canonical labels
+   *   2. Levenshtein snap (reuses snapHeaderToCanonical)
+   *   3. Body heading scan + snap
+   *   4. Per-section LLM sees the full section content and decides (NO_NEW_CONTENT)
+   *   Fallback: ## New Information ({{source}}) at EOF
+   */
+  private async applyComplementaryAppends(
+    items: Array<{ kind: 'complementary'; content: string; target_section: string; reason?: string }>,
+    existingBody: string,
+    info: EntityInfo | ConceptInfo,
+    sourceFile: TFile | { path: string; basename: string },
+  ): Promise<string> {
+    if (items.length === 0) return existingBody;
+
+    const client = this.ctx.getClient();
+    if (!client) return existingBody;
+
+    const labels = getSectionLabels(this.ctx.settings);
+    const canonicalLabels = Object.values(labels);
+
+    // 1. Group items by target_section (LLM returns one of the canonical labels).
+    const groups = new Map<string, typeof items>();
+    for (const item of items) {
+      const existing = groups.get(item.target_section) ?? [];
+      existing.push(item);
+      groups.set(item.target_section, existing);
+    }
+
+    // 2. For each group, resolve the section anchor, then call per-section LLM.
+    let resultBody = existingBody;
+    const failedGroups: string[] = [];
+
+    for (const [targetSection, sectionItems] of groups) {
+      const sectionContent = this.resolveSectionAnchor(targetSection, resultBody, canonicalLabels);
+
+      // If anchor resolution fully failed (Layer 1-3 all fail), the per-section
+      // LLM call still gets the full body — it can decide to NO_NEW_CONTENT.
+      const appendContent = await this.callPerSectionAppend(
+        sectionContent, // null if anchor not found
+        sectionItems,
+        info.name,
+        sourceFile.basename,
+        client,
+      );
+
+      if (appendContent === 'NO_NEW_CONTENT') {
+        if (sectionContent !== null) {
+          // Per-section LLM judged that the new info is already present
+          // in the section body. Skip this group — do NOT create a New
+          // Information fallback for it, since the info exists.
+          continue;
+        }
+        // Anchor not found AND LLM couldn't place it: fall back to
+        // "## New Information" section at EOF.
+        failedGroups.push(targetSection);
+        continue;
+      }
+
+      if (sectionContent !== null) {
+        // Found anchor: insert appended paragraphs after the section's last
+        // content line (before the next ## heading or EOF).
+        resultBody = this.spliceAfterSection(resultBody, sectionContent.anchorEnd, appendContent);
+      } else {
+        // Anchor not found and append succeeded (unusual): treat as
+        // fallback to New Information section.
+        failedGroups.push(targetSection);
+      }
+    }
+
+    // 3. Handle failed groups (sections that couldn't be found OR per-section
+    // LLM returned NO_NEW_CONTENT) — append to ## New Information at EOF.
+    if (failedGroups.length > 0) {
+      const newInfoSection = this.makeFallbackNewInfoSection(
+        failedGroups,
+        items,
+        sourceFile.basename,
+      );
+      resultBody = `${resultBody}\n\n${newInfoSection}`;
+    }
+
+    return resultBody !== existingBody ? resultBody : existingBody;
+  }
+
+  /**
+   * Find a section anchor in existing body: locate the position right
+   * AFTER the section's heading AND its existing content (before the
+   * next `##` heading or EOF). Returns both the content below the
+   * heading (for the per-section LLM) and the insertion point.
+   *
+   * 4-layer fallback:
+   *   Layer 1 — exact match on canonical labels
+   *   Layer 2 — snapHeaderToCanonical (Levenshtein, 3-edit window)
+   *   Layer 3 — body scan: extract every ## heading and snap each
+   *   Layer 4 — per-section LLM callback treats null body as "unknown"
+   *             and may return NO_NEW_CONTENT
+   *
+   * Returns: {
+   *   headingText: matched heading title (e.g. "Description")
+   *   content: everything after `## heading` up to next ## or EOF
+   *   anchorEnd: line index where next ## begins (or body.length)
+   * } or null when anchor not found.
+   */
+  private resolveSectionAnchor(
+    targetSection: string,
+    body: string,
+    canonicalLabels: string[],
+  ): { headingText: string; content: string; anchorEnd: number } | null {
+    if (!body) return null;
+
+    // Layer 1: exact match against canonical labels
+    const exactHeading = canonicalLabels.find(hl => hl === targetSection);
+    if (exactHeading !== undefined) {
+      const pos = this.findSectionInBody(exactHeading, body);
+      if (pos !== null) return pos;
+    }
+
+    // Layer 2: Levenshtein snap — snap target to a canonical label
+    const snapped = this.snapHeaderImport(targetSection, canonicalLabels);
+    if (snapped !== null && snapped !== targetSection) {
+      const pos = this.findSectionInBody(snapped, body);
+      if (pos !== null) return pos;
+    }
+
+    // Layer 3: Body scan — extract every ## heading from the body and
+    // check three match paths against targetSection (in order of cost):
+    //   a) canonical snap — heading snapped to canonical label matches target
+    //   b) exact match — heading text literally === target
+    //   c) Levenshtein — heading text is within 3 edits of target
+    // This handles i18n cases where the body uses localized headings that
+    // are NOT in the canonical label set (e.g. German body "## Beschreibung"
+    // with English target "Beschreibun" typo).
+    const headingPattern = /^##\s+(.+)$/gm;
+    let match: RegExpExecArray | null;
+    while ((match = headingPattern.exec(body)) !== null) {
+      const hd = match[1].trim();
+
+      // a) Canonical snap: if heading snaps to canonical label matching target
+      const headSnapped = this.snapHeaderImport(hd, canonicalLabels);
+      if (headSnapped !== null && headSnapped === targetSection) {
+        const pos = this.findSectionInBody(hd, body);
+        if (pos !== null) return { ...pos, headingText: headSnapped };
+      }
+
+      // b) Exact match: heading literal === target
+      if (hd === targetSection) {
+        const pos = this.findSectionInBody(hd, body);
+        if (pos !== null) return pos;
+      }
+
+      // c) Levenshtein: heading within 3 edits of target
+      if (
+        hd.length > 0 &&
+        targetSection.length > 0 &&
+        Math.abs(hd.length - targetSection.length) <= 3 &&
+        this.snapHeaderImport(hd, [targetSection]) !== null
+      ) {
+        const pos = this.findSectionInBody(hd, body);
+        if (pos !== null) return pos;
+      }
+    }
+
+    // Layer 4: all layers failed; caller gets null — per-section LLM
+    // decides, or falls back to New Information section.
+    return null;
+  }
+
+  /** Helper: find a `## headingName` in body, return its content + end index. */
+  private findSectionInBody(
+    headingText: string,
+    body: string,
+  ): { headingText: string; content: string; anchorEnd: number } | null {
+        // No /m flag — see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+    const nextLinePattern = new RegExp(
+      `(?:^|\\n)##\\s*${this.escapeRegExp(headingText)}\\s*\\n([\\s\\S]*?)(?=\\n##\\s|$)`,
+    
+    );
+    const m = nextLinePattern.exec(body);
+    if (!m) return null;
+
+    const content = m[1].trimEnd();
+    const anchorEnd = m.index + m[0].length;
+    return { headingText, content, anchorEnd };
+  }
+
+  /** Escape regex special characters in a string. */
+  private escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * Import snapHeaderToCanonical from the core module. We can't call
+   * module-level functions directly with `this.`; instead call the
+   * import via a require-avoiding closure.
+   */
+  private snapHeaderImport(candidate: string, canonicalLabels: string[]): string | null {
+    return snapHeaderToCanonical(candidate, canonicalLabels);
+  }
+
+  /**
+   * Call per-section LLM. Input: existing-section content (may be null
+   * if anchor not found — LLM gets null and treats as unknown) + the
+   * complementary items targeting this section. Returns appended
+   * paragraph(s) or NO_NEW_CONTENT.
+   */
+  private async callPerSectionAppend(
+    sectionContent: { headingText: string; content: string; anchorEnd: number } | null,
+    items: Array<{ content: string; reason?: string }>,
+    pageName: string,
+    sourceBasename: string,
+    client: LLMClient,
+  ): Promise<string> {
+    const newFacts = items.map(i => `- ${i.content}${i.reason ? ` (${i.reason})` : ''}`).join('\n');
+    const sectionTitle = sectionContent?.headingText ?? '[[unknown section]]';
+    const existingSection = sectionContent?.content ?? '[[section not found in body]]';
+
+    const appendPrompt = [
+      `You are appending new facts to a single section of a wiki page.`,
+      ``,
+      `**Page Name:** ${pageName}`,
+      `**Section Title:** ${sectionTitle}`,
+      `**Source:** ${sourceBasename}`,
+      ``,
+      `**Existing section content (DO NOT DELETE OR REWRITE):**`,
+      existingSection,
+      ``,
+      `**New facts to append at the end of this section:**`,
+      newFacts,
+      ``,
+      `**Rules:**`,
+      `- Output ONLY the new paragraphs to append (1-3 lines of markdown).`,
+      `- Do NOT include the section heading or any of the existing content.`,
+      `- Match the tone and style of the existing section.`,
+      `- If the new facts are already present in the existing section content, output exactly "NO_NEW_CONTENT".`,
+      `- Do NOT delete or modify any existing content.`,
+    ].join('\n');
+
+    try {
+      const response = await client.createMessage({
+        model: this.ctx.settings.model,
+        max_tokens: TOKENS_COMPLEMENTARY_APPEND,
+        system: await this.ctx.buildSystemPrompt('merge'),
+        messages: [{ role: 'user', content: appendPrompt }],
+        ...(this.ctx.settings.disableThinking ? { enableThinking: false } : {}),
+      });
+      const cleaned = response?.trim() ?? '';
+      if (cleaned === 'NO_NEW_CONTENT') return 'NO_NEW_CONTENT';
+      // Prepend a blank line so the new content has one blank line from the section content.
+      return `\n${cleaned}`;
+    } catch {
+      console.warn('[mergePage] per-section append failed — falling back to New Information section');
+      return 'NO_NEW_CONTENT';
+    }
+  }
+
+  /**
+   * Splice appended text into body at a given anchor end index.
+   * The anchorEnd is the index right after the existing section content;
+   * we insert `appendText` there.
+   */
+  private spliceAfterSection(body: string, anchorEnd: number, appendText: string): string {
+    if (anchorEnd >= body.length) return body + appendText;
+    return body.slice(0, anchorEnd) + appendText + body.slice(anchorEnd);
+  }
+
+  /**
+   * Build a "## New Information ({{source}})" section for failed groups
+   * whose section could not be resolved or the per-section LLM returned
+   * NO_NEW_CONTENT. Collects all items from all failed groups.
+   */
+  private makeFallbackNewInfoSection(
+    failedGroups: string[],
+    allItems: Array<{ kind: string; content: string; target_section: string; reason?: string }>,
+    sourceBasename: string,
+  ): string {
+    if (failedGroups.length === 0) return '';
+    // Map ALL items — the `failedGroups` parameter tracks which target_section
+    // values could not be resolved; we emit all items from those groups for
+    // the fallback New Information section. Note: items from succeeded groups
+    // are NOT included (they were already placed into their sections above).
+    const failedSet = new Set(failedGroups);
+    const failedItems = allItems.filter(i => failedSet.has(i.target_section));
+    const body = failedItems.length > 0
+      ? failedItems.map(i => `- ${i.content}${i.reason ? ` (${i.reason})` : ''}`).join('\n')
+      : `- New information from ${sourceBasename}`;
+    return `## New Information (${sourceBasename})\n${body}`;
+  }
+
   private async mergePage(
     info: EntityInfo | ConceptInfo,
     pageType: 'entity' | 'concept',
@@ -466,12 +908,76 @@ export class PageFactory {
     if (!client) throw new Error('LLM client not initialized');
 
     try {
-      // 1. Programmatic frontmatter merge
-      // Issue #155: add the canonical source PAGE link so a disambiguated source
-      // slug is recorded, while existing sources are preserved by mergeFrontmatter.
+      // 0. Hoist frontmatter + system prompt above the triage so both the
+      // skip path and the body-merge path share them (avoids re-parsing
+      // frontmatter and re-loading the schema twice per merge).
       const { frontmatter, body: existingBody } = mergeFrontmatter(existingContent, sourceSlug ? `sources/${sourceSlug}` : sourceFile.path);
 
-    // 2. LLM intelligent body merge
+      // 1. v1.24.0 #216 — classify-then-route triage.
+      // Decide between rewriting the body (merge) or skipping the body
+      // rewrite (skip — only update frontmatter). The full body merge is
+      // expensive and risks "drift" on duplicate re-ingests, so a cheap
+      // pre-flight classification saves work in the common case where the
+      // new source has nothing to add.
+      //
+      // Failures here are NOT propagated — they fall through to the
+      // existing merge path, preserving backward-compatible behavior.
+      //
+      // The classify call and its decision happen INSIDE the inner try;
+      // the actual write happens OUTSIDE so a createOrUpdateFile failure
+      // is not misclassified as "triage failed" and trigger a double-write
+      // body-merge fallback.
+      let shouldSkip = false;
+      let complementaryBody: string | null = null;
+      try {
+        const triage = await this.classifyMergeNeed(info, pageType, sourceFile, existingBody);
+        if (triage.strategy === 'skip') {
+          console.debug(
+            `[mergePage] triage=skip reason="${triage.reason}" — preserving existing body for ${path}`,
+          );
+          shouldSkip = true;
+        } else if (triage.strategy === 'complementary' && triage.items.length > 0) {
+          // v1.24.0 #216 Tier-2: targeted per-section append. Existing
+          // body is preserved verbatim; only the named sections receive
+          // appended paragraphs from the per-section LLM call.
+          console.debug(
+            `[mergePage] triage=complementary items=${triage.items.length} — appending to existing sections for ${path}`,
+          );
+          complementaryBody = await this.applyComplementaryAppends(
+            triage.items,
+            existingBody,
+            info,
+            sourceFile,
+          );
+          if (complementaryBody === existingBody) {
+            // Per-section LLM returned NO_NEW_CONTENT for every group →
+            // fall through to body-merge so the new info isn't silently lost.
+            console.debug(
+              `[mergePage] complementary path produced no per-section appends — falling back to body-merge for ${path}`,
+            );
+          } else {
+            shouldSkip = true; // signal "use existing frontmatter + write complementaryBody"
+          }
+        }
+        // strategy === 'merge' | 'contradictory': fall through to the
+        // existing body rewrite below (contradictory uses the existing
+        // "preserve both with attribution" rule).
+      } catch (triageError) {
+        console.warn(
+          `[mergePage] triage failed (${triageError instanceof Error ? triageError.message : String(triageError)}) — falling back to merge path`,
+        );
+      }
+
+      if (shouldSkip) {
+        const bodyToWrite = complementaryBody ?? existingBody;
+        await this.ctx.createOrUpdateFile(
+          path,
+          await this.assembleFinalContent(frontmatter, bodyToWrite, info, sourceFile),
+        );
+        return path;
+      }
+
+      // 2. LLM intelligent body merge
     const mergePrompt = pageType === 'entity' ? PROMPTS.mergeEntityPage : PROMPTS.mergeConceptPage;
 
     const prompt = mergePrompt
@@ -512,32 +1018,54 @@ export class PageFactory {
       labels.related_concepts,
       this.ctx.settings.slugCase === 'preserve'
     );
-    // Issue #244: programmatic Mentions injection (see createEntityPage).
-    // B2: prefer structured provenance when present; only fall back to legacy
-    // mentions_in_source if the structured form is absent (not just empty).
-    // Conversation mode: see createEntityPage for rationale.
+    // v1.24.0 #216 — finalization (frontmatter + Mentions injection) lives
+    // in assembleFinalContent(), shared with the skip path.
+    await this.ctx.createOrUpdateFile(
+      path,
+      await this.assembleFinalContent(frontmatter, correctedBody, info, sourceFile),
+    );
+    return path;
+    } catch (error) {
+      throw mergeError(error, info.name, pageType);
+    }
+  }
+
+  /**
+   * v1.24.0 #216 — shared finalization for both the skip path (preserved
+   * body) and the body-merge path (rewritten body). Runs the Issue #244
+   * programmatic Mentions-in-Source injection and assembles the final
+   * `<frontmatter>\n\n<body>` shape that gets written via
+   * `createOrUpdateFile`.
+   *
+   * B2: prefer structured `mentions_with_provenance` when present;
+   * only fall back to legacy `mentions_in_source` if the structured form
+   * is absent (not just empty). Conversation sources emit an empty
+   * mentions list (the conversation-label suffix is the citation).
+   */
+  private async assembleFinalContent(
+    frontmatter: string,
+    body: string,
+    info: EntityInfo | ConceptInfo,
+    sourceFile: TFile | { path: string; basename: string },
+  ): Promise<string> {
+    const labels = getSectionLabels(this.ctx.settings);
     const isConv = isConversationSource(sourceFile, this.ctx.settings.wikiFolder);
     const mergeMentionsForInject = isConv
       ? []
       : (info.mentions_with_provenance?.length
         ? info.mentions_with_provenance
         : info.mentions_in_source);
-    const correctedBodyWithMentions = injectMentionsSection(
-      correctedBody,
+    const bodyWithMentions = injectMentionsSection(
+      body,
       mergeMentionsForInject,
       sourceFile.path,
       {
         sectionLabel: labels.mentions_in_source,
         conversationMode: isConv,
         conversationLabel: `Conversation: ${sourceFile.basename}`,
-      }
+      },
     );
-    const finalContent = `${frontmatter}\n\n${correctedBodyWithMentions}`;
-    await this.ctx.createOrUpdateFile(path, finalContent);
-    return path;
-    } catch (error) {
-      throw mergeError(error, info.name, pageType);
-    }
+    return `${frontmatter}\n\n${bodyWithMentions}`;
   }
 
   private async appendToReviewedPage(

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -1,11 +1,36 @@
 // Merge prompts — multi-source knowledge fusion and content integration
 
 export const MERGE_PROMPTS = {
-  // Multi-Source Knowledge Fusion: structured merge analysis
-  mergeAnalysis: `You are a Wiki knowledge fusion analyzer. Compare existing Wiki page content with new source file information, and output a structured merge strategy.
+  // Multi-Source Knowledge Fusion: structured merge analysis.
+//
+// v1.24.0 #216 — Tier-2: extended from binary triage to 4-class
+// per-item classification. The classifier outputs a structured
+// `items[]` array so the complementary path can append each new
+// fact into its target section (Tier-2: targeted append, not full
+// rewrite). Strategies:
+//
+//   - 'skip'           — every item is a duplicate; items[] is empty.
+//                         Skip path: only update frontmatter.
+//   - 'merge'          — substantial restructuring needed (e.g. new
+//                         section, full rewrite); items[] is empty.
+//                         Falls through to the existing body-merge path.
+//   - 'complementary'  — each item adds detail to an existing section;
+//                         populate items[] with target_section =
+//                         EXACTLY one of the {{section_labels}} values.
+//                         Per-section append path.
+//   - 'contradictory'  — new info conflicts with existing; items[]
+//                         is empty; falls through to the existing
+//                         body-merge path (which already handles
+//                         "preserve both with attribution").
+//
+// The {{section_labels}} placeholder is rendered with the **localized**
+// section names from getSectionLabels(settings), so target_section
+// values match the labels actually present in the existing page
+// (matters for i18n wikis: de uses "Beschreibung", ja uses "説明", etc.).
+  mergeAnalysis: `You are a Wiki knowledge fusion analyzer. Decide how to integrate new source information into the existing Wiki page.
 
 **Page Name:** {{page_name}}
-**Page Type:** entity or concept
+**Page Type:** {{page_type}}
 
 **Existing Page Content:**
 {{existing_content}}
@@ -13,40 +38,39 @@ export const MERGE_PROMPTS = {
 **New Information from Source File:**
 {{new_info}}
 
-**Task:**
-1. Compare each piece of new information against the existing content
-2. Classify each piece of new information as:
-   - "new" — completely new information not in the existing page
-   - "duplicate" — duplicates existing content; no need to add
-   - "complementary" — supplements existing content (additional detail on the same topic)
-   - "contradictory" — contradicts existing content
-3. For "complementary" information, specify which section of the existing page it should be inserted after
-4. For "contradictory" information, document the specific contradiction
+**Available sections in the existing page (target_section MUST be one of these exact names):**
+{{section_labels}}
 
-Output JSON format:
+**Task:**
+Examine the new information and classify each piece into ONE of the four strategies:
+
+- "skip" — every piece is already fully present in the existing page. No new content to add. \`items\` MUST be an empty array.
+- "merge" — substantial restructuring needed (e.g. a new section is required, the existing structure is wrong, or the new info contradicts existing). The full body-rewrite path will be used. \`items\` MUST be an empty array.
+- "complementary" — each piece adds new facts that fit into one of the existing sections. Populate \`items\` with one entry per new fact:
+  - \`kind\` = "complementary"
+  - \`content\` = the specific new fact to append (verbatim from the source if possible, otherwise a concise paraphrase)
+  - \`target_section\` = EXACTLY one name from the available sections list (this is critical for i18n matching)
+  - \`reason\` = one-sentence justification
+- "contradictory" — new info conflicts with existing facts. The full body-rewrite path will handle attribution. \`items\` MUST be an empty array.
+
+Output JSON format (ONLY this object, no other text):
 {
-  "merge_items": [
+  "strategy": "skip" | "merge" | "complementary" | "contradictory",
+  "items": [
     {
-      "content": "Specific content of the new information",
-      "classification": "new|duplicate|complementary|contradictory",
-      "target_section": "Section name to insert after (only for new and complementary)",
-      "reason": "Reason for classification (one sentence)"
+      "kind": "complementary",
+      "content": "Specific new fact text",
+      "target_section": "Exact section name from the available sections list",
+      "reason": "Why this belongs in target section (one sentence)"
     }
   ],
-  "contradictions": [
-    {
-      "claim": "What the new information claims",
-      "existing_claim": "Contradictory content in the existing page",
-      "resolution": "Suggested resolution"
-    }
-  ],
-  "merge_summary": "Merge strategy summary (one sentence)"
+  "reason": "One-sentence overall justification"
 }
 
 Rules:
-- Output ONLY JSON, nothing else
-- Existing content takes priority over new information (unless the new information is clearly more accurate)
-- Do NOT delete or rewrite any part of the existing content`,
+- Default to "merge" if uncertain — better to rewrite than to silently drop new info.
+- \`target_section\` MUST be exactly one of the available sections list (case-sensitive).
+- Output ONLY JSON, nothing else.`,
 
   mergeEntityPage: `You are a Wiki editor performing intelligent content integration. Merge new source information into an existing page following the schema-defined structure.
 


### PR DESCRIPTION
## Summary

Wires up the previously 0-caller `PROMPTS.mergeAnalysis` as a classify-then-route pre-flight in `mergePage`, implementing **#216** with both Tier-1 (deterministic skip on duplicate) and Tier-2 (per-section append on complementary).

### Tier-1 — duplicate → deterministic skip

- New `classifyMergeNeed()` in `PageFactory` calls `PROMPTS.mergeAnalysis` with a tightened JSON contract (`{strategy, reason}`).
- `mergePage` pre-flight:
  - `strategy='skip'` → deterministic frontmatter-only update (frontmatter + Mentions injection via new `assembleFinalContent`, **body preserved verbatim**, NO LLM rewrite).
  - `strategy='merge'` → existing body-merge path (unchanged).
  - triage throws / malformed JSON / invalid strategy → silent fallback to body-merge (backward-compatible).
- `assembleFinalContent` shared by skip-path and body-merge path (eliminates ~50 LOC × 3-site duplication of #244 Mentions logic).
- `TOKENS_MERGE_TRIAGE = 2000` (initial 200 was too small — e2e showed DeepSeek JSON output truncated mid-strategy at length 15-89 chars).

### Tier-2 — complementary → targeted per-section append

- Extended `mergeAnalysis` prompt to 4 strategies + structured `items[]` array: skip / merge / complementary / contradictory.
- `classifyMergeNeed` return type extended to `{strategy, items, reason}`.
- New `applyComplementaryAppends()` groups items by `target_section` and issues ONE per-section LLM call per group (smaller scope → lower capability bar, content-preserving by construction).
- `resolveSectionAnchor` **4-layer i18n-aware fallback**:
  1. exact match on canonical labels
  2. Levenshtein snap via extracted `snapHeaderToCanonical`
  3. body scan + snap (handles localized headings not in canonical)
  4. per-section LLM decides (NO_NEW_CONTENT if can't place)
  + fallback to `## New Information (source)` at EOF
- `mergeAnalysis` prompt now injects localized section labels so `target_section` matches the existing page's headers (essential for i18n wikis where labels are translated to de/ja/zh/etc.).
- `contradictory` falls through to existing body-merge path (which already handles "preserve both with attribution"); independent routing deferred to a separate PR that depends on #208.
- `TOKENS_COMPLEMENTARY_APPEND = 600` caps per-section append cost.

### Code review fixes

- Removed `/m` flag from `findSectionInBody` regex — was causing multi-paragraph sections to truncate to first line, with anchorEnd pointing inside the section.
- `makeFallbackNewInfoSection` now filters by `failedGroups` instead of iterating all items — was double-emitting items from successful groups into the fallback section.
- Extracted `snapHeaderToCanonical` from `canonicalizeSectionHeaders` inner closure to a public export.

## Test plan

- [x] 1776 tests pass (32 new vs main: Tier-1 triage + Tier-2 complementary + i18n target resolution)
- [x] lint 0/0, tsc 0/0, build clean, css-lint 0
- [x] **e2e** against `test4` vault (3 sources → 14 candidate merges):
  - Tier-1 skip: 4/14 (Chinese reason strings → i18n confirmed)
  - Tier-2 complementary: 8/14 (items=1~5 appended to target sections)
  - empty LLM response: 2/14 → silent body-merge fallback (forward-compatible)

## Tracking

Closes #216

Note: a follow-up issue **#258** was created separately to track the `createNewPage prompt drift` (LLM emits non-schema `# Title`, `## 基本信息`) — this PR does NOT address that class of bug.