### PR TITLE
fix(merge): normalize blank-line separator for Tier-2 per-section append

### DIFF
--- a/src/__tests__/wiki/page-factory-list-section-no-blank.test.ts
+++ b/src/__tests__/wiki/page-factory-list-section-no-blank.test.ts
@@ -1,0 +1,263 @@
+// v1.24.0 #185 follow-up: Tier-2 per-section append trailing-blank-line bug.
+//
+// Symptom (observed during the #185 e2e on `## 相关概念` / `## 相关实体`):
+// when complementary items are appended to a list-typed section, an extra
+// blank line appeared between the existing bullets and the new bullet:
+//
+//   ## 相关概念
+//   - [[concepts/tool-calling|tool-calling]]
+//   - [[concepts/prompt-caching|prompt caching]]
+//                                              ← extra blank line (bug)
+//   - [[concepts/exekutive-funktionen|Exekutive Funktionen]]
+//
+// Root cause: vault bodies always end with `\n` after the last bullet, and
+// the splice site concatenated a separator onto that trailing newline with
+// no normalization → even a single-`\n` separator became `\n\n` (visible
+// blank line) at runtime, regardless of intent.
+//
+// Fix (page-factory.ts):
+//   1. `callPerSectionAppend` returns the cleaned LLM text verbatim (no
+//      hard `\n` prepend). Empty responses short-circuit to NO_NEW_CONTENT.
+//   2. `spliceAfterSection` strips trailing whitespace from the prefix
+//      before applying the separator, so the separator shape alone
+//      controls the resulting blank-line behavior.
+//   3. `isListSection` autodetects list-typed sections by scanning for
+//      any markdown list marker (`-`, `*`, `+`, numbered); the caller
+//      passes this boolean into spliceAfterSection:
+//        list section      → single `\n` (no blank)
+//        paragraph section → `\n\n` (blank line)
+//
+// These tests pin all four scenarios through the real `applyComplementaryAppends`
+// code path (no harness LLM-queue guessing), following the pattern in
+// page-factory-complementary-append.test.ts: construct PageFactory directly,
+// override `getClient` with a single canned response, and assert on the
+// spliced result.
+
+import { describe, it, expect } from 'vitest';
+import { PageFactory } from '../../wiki/page-factory';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { createMockEntity } from '../__support__/factories';
+import type { LLMClient } from '../../types';
+
+type HelperAccess = {
+  applyComplementaryAppends: (
+    items: Array<{ kind: 'complementary'; content: string; target_section: string; reason?: string }>,
+    existingBody: string,
+    info: Parameters<PageFactory['mergePage']>[0],
+    sourceFile: Parameters<PageFactory['mergePage']>[2],
+  ) => Promise<string>;
+};
+
+function makeFactory(perSectionResponse: string) {
+  const { ctx } = createMockContext({ vaultFiles: {}, llmResponses: [] });
+  ctx.getClient = () => {
+    const client: LLMClient = {
+      createMessage: async () => perSectionResponse,
+    };
+    return client;
+  };
+  return new PageFactory(ctx);
+}
+
+function runAppend(
+  factory: PageFactory,
+  existingBody: string,
+  targetSection: string,
+  appended: string,
+) {
+  return (factory as unknown as HelperAccess).applyComplementaryAppends(
+    [{ kind: 'complementary', content: 'stub', target_section: targetSection, reason: 'stub' }],
+    existingBody,
+    createMockEntity({ name: 'Target Page', summary: 'stub', related_concepts: [] }),
+    createMockFile('src.md'),
+  );
+}
+
+describe('mergePage Tier-2 trailing-blank-line normalization (#185 follow-up)', () => {
+  it('list section: NO blank line between existing bullets and appended bullet', async () => {
+    const factory = makeFactory('- [[concepts/exekutive-funktionen|Exekutive Funktionen]]');
+    // Real vault bodies always end with a trailing \n after the last bullet —
+    // this is exactly the condition that triggers the blank-line bug if
+    // spliceAfterSection does not normalize trailing whitespace on the prefix.
+    const existingBody = [
+      '---',
+      'type: concept',
+      '---',
+      '',
+      '# Target Page',
+      '',
+      '## 相关概念',
+      '- [[concepts/tool-calling|tool-calling]]',
+      '- [[concepts/prompt-caching|prompt caching]]',
+      '',  // trailing newline — the bug trigger
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, '相关概念', 'stub');
+
+    const idx = result.indexOf('## 相关概念');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const after = result.slice(idx);
+
+    // Single \n separator between existing and new bullet — the visual list
+    // stays contiguous (no blank line splitting it).
+    expect(after).toContain(
+      '- [[concepts/prompt-caching|prompt caching]]\n- [[concepts/exekutive-funktionen|Exekutive Funktionen]]',
+    );
+    expect(after).not.toMatch(/prompt caching\]\]\n\n-/);
+  });
+
+  it('paragraph section (`## 定义`): KEEPS a blank line before appended paragraph', async () => {
+    const factory = makeFactory('A new paragraph appended by the LLM.');
+    // Same trailing-newline reality for paragraph sections.
+    const existingBody = [
+      '---',
+      'type: concept',
+      '---',
+      '',
+      '# Target Page',
+      '',
+      '## 定义',
+      'Some prior definition text that ends the paragraph.',
+      '',  // trailing newline
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, '定义', 'stub');
+
+    const idx = result.indexOf('## 定义');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const after = result.slice(idx);
+
+    // Blank line between the old paragraph and the new one — correct for
+    // paragraph-typed sections (the fix must NOT collapse this to a single \n).
+    expect(after).toMatch(/ends the paragraph\.\n\nA new paragraph/);
+    // No accidental triple-newline.
+    expect(after).not.toMatch(/paragraph\.\n\n\nA new paragraph/);
+  });
+
+  // ── isListSection edge cases (code-review findings #1 + #5) ─────────
+
+  it('list section ending with a closing paragraph still classifies as list (mixed content)', async () => {
+    // Hand-edited blocks often end with a one-line summary AFTER the bullets.
+    // The detector must scan all lines, not only the last, so the appended
+    // bullet stays visually contiguous with the existing list.
+    const factory = makeFactory('- [[concepts/exekutive-funktionen|Exekutive Funktionen]]');
+    const existingBody = [
+      '# Target Page',
+      '',
+      '## 相关概念',
+      '- [[concepts/tool-calling|tool-calling]]',
+      '- [[concepts/prompt-caching|prompt caching]]',
+      'Both are foundational building blocks.',
+      '',  // trailing newline
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, '相关概念', 'stub');
+    const after = result.slice(result.indexOf('## 相关概念'));
+
+    // Single \n separator (list mode), even though the section ends on a paragraph.
+    expect(after).toContain(
+      'Both are foundational building blocks.\n- [[concepts/exekutive-funktionen|Exekutive Funktionen]]',
+    );
+    expect(after).not.toMatch(/building blocks\.\n\n-/);
+  });
+
+  it('numbered-list section (`1. foo`) classifies as list (regex branch pin)', async () => {
+    const factory = makeFactory('3. Third');
+    const existingBody = [
+      '# Target Page',
+      '',
+      '## Steps',
+      '1. First',
+      '2. Second',
+      '',  // trailing newline
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, 'Steps', 'stub');
+    const after = result.slice(result.indexOf('## Steps'));
+
+    expect(after).toContain('2. Second\n3. Third');
+    expect(after).not.toMatch(/2\. Second\n\n3/);
+  });
+
+  // ── spliceAfterSection edge cases (code-review findings #4 + #7) ─────
+
+  it('list section followed by another `##` heading: suffix gets normalized separator too', async () => {
+    // The new `\n` separator must not collide with the existing `\n` before
+    // the next `##` heading — we want one newline between the new bullet and
+    // the next heading's blank line (which is two \n in well-formed markdown).
+    const factory = makeFactory('- [[concepts/exekutive-funktionen|Exekutive Funktionen]]');
+    const existingBody = [
+      '# Target Page',
+      '',
+      '## Related Concepts',
+      '- a',
+      '- b',
+      '',  // empty line before next heading
+      '## Description',
+      'Some description.',
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, 'Related Concepts', 'stub');
+    const after = result.slice(result.indexOf('## Related Concepts'));
+
+    // Single \n between existing last bullet and new bullet.
+    expect(after).toContain('- b\n- [[concepts/exekutive-funktionen|Exekutive Funktionen]]');
+    // No blank line between the new bullet and the ## Description heading —
+    // that's correct: bullet directly before heading is fine markdown.
+    expect(after).not.toMatch(/Exekutive Funktionen\]\]\n\n-/);
+    // ## Description preserved.
+    expect(after).toContain('## Description');
+    expect(after).toContain('Some description.');
+  });
+
+  it('body without trailing newline: separator is still applied once', async () => {
+    // anchorEnd === body.length path: prefix trimEnd makes the result
+    // independent of whether the body ends with `\n` or not.
+    const factory = makeFactory('- new');
+    const existingBody = [
+      '# Target Page',
+      '',
+      '## List',
+      '- a',
+      '- b',  // NO trailing \n
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, 'List', 'stub');
+    const after = result.slice(result.indexOf('## List'));
+
+    expect(after).toContain('- b\n- new');
+    expect(after).not.toMatch(/- b\n\n- new/);
+  });
+
+  // ── empty LLM response handling (code-review finding #3) ────────────
+
+  it('empty LLM response short-circuits to NO_NEW_CONTENT — no stray blank line', async () => {
+    // The fix: `cleaned === ''` (weak model returns nothing) now also
+    // short-circuits to NO_NEW_CONTENT, so the existing
+    // sectionContent !== null → skip branch handles it. No stray
+    // separator is injected into the body.
+    const factory = makeFactory('');
+    const existingBody = [
+      '# Target Page',
+      '',
+      '## 相关概念',
+      '- a',
+      '- b',
+      '',  // trailing newline
+    ].join('\n');
+
+    const result = await runAppend(factory, existingBody, '相关概念', 'stub');
+    const after = result.slice(result.indexOf('## 相关概念'));
+
+    // Body is unchanged — no appended bullet, no stray blank line.
+    // Trailing `\n` preserved (vault bodies always end with one).
+    expect(after).toBe(
+      [
+        '## 相关概念',
+        '- a',
+        '- b',
+        '',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/wiki/page-factory.ts
+++ b/src/wiki/page-factory.ts
@@ -38,6 +38,30 @@ function mergeError(error: unknown, name: string, pageType: string): Error {
 }
 
 /**
+ * Autodetect whether a section body is list-typed. A section is list-typed
+ * if **any** non-blank line begins with a markdown list marker (`-`, `*`,
+ * `+`, or a digit followed by `.`). The section may end with a closing
+ * paragraph — a hand-edited `## 相关概念` block ending with a summary line
+ * after its bullets still classifies as list-typed so the appended bullet
+ * stays visually contiguous with the existing list.
+ *
+ * Returns `false` (paragraph mode) only when the section has NO list
+ * markers anywhere — typical `## 描述` / `## 定义` blocks. Appended
+ * content uses a SINGLE `\n` separator for list-typed sections (no blank
+ * line) and a `\n\n` separator (blank line) for paragraph sections.
+ */
+function isListSection(body: string): boolean {
+  if (!body) return false;
+  const lines = body.split('\n');
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    if (/^[-*+] |^\d+\. /.test(trimmed)) return true;
+  }
+  return false;
+}
+
+/**
  * Issue #244 + W5: Pick the first 2 quote strings for the merge/append
  * `{{key_details}}` prompt injection. Prefers the new structured
  * `mentions_with_provenance` over legacy `mentions_in_source` so an LLM
@@ -669,7 +693,18 @@ export class PageFactory {
       if (sectionContent !== null) {
         // Found anchor: insert appended paragraphs after the section's last
         // content line (before the next ## heading or EOF).
-        resultBody = this.spliceAfterSection(resultBody, sectionContent.anchorEnd, appendContent);
+        // The separator shape (single \n vs blank line) is decided from
+        // the section's own content: list-typed sections want a single \n
+        // (no blank line splitting the visual list); paragraph-typed
+        // sections want a blank line so the appended text reads as a
+        // distinct paragraph. See `spliceAfterSection` for the contract.
+        const sectionIsList = isListSection(sectionContent.content);
+        resultBody = this.spliceAfterSection(
+          resultBody,
+          sectionContent.anchorEnd,
+          appendContent,
+          sectionIsList,
+        );
       } else {
         // Anchor not found and append succeeded (unusual): treat as
         // fallback to New Information section.
@@ -853,23 +888,30 @@ export class PageFactory {
         ...(this.ctx.settings.disableThinking ? { enableThinking: false } : {}),
       });
       const cleaned = response?.trim() ?? '';
-      if (cleaned === 'NO_NEW_CONTENT') return 'NO_NEW_CONTENT';
-      // Prepend a blank line so the new content has one blank line from the section content.
-      return `\n${cleaned}`;
+      // Empty response (weak model or no new info to add) is equivalent to
+      // NO_NEW_CONTENT — falling through here would let spliceAfterSection
+      // inject a stray blank line with no content. Short-circuit so the
+      // caller's existing NO_NEW_CONTENT branch handles it.
+      if (cleaned === '' || cleaned === 'NO_NEW_CONTENT') return 'NO_NEW_CONTENT';
+      // Verbatim: the splice site picks the section-break separator (single \n
+      // for lists, blank line for paragraphs).
+      return cleaned;
     } catch {
       console.warn('[mergePage] per-section append failed — falling back to New Information section');
       return 'NO_NEW_CONTENT';
     }
   }
 
-  /**
-   * Splice appended text into body at a given anchor end index.
-   * The anchorEnd is the index right after the existing section content;
-   * we insert `appendText` there.
-   */
-  private spliceAfterSection(body: string, anchorEnd: number, appendText: string): string {
-    if (anchorEnd >= body.length) return body + appendText;
-    return body.slice(0, anchorEnd) + appendText + body.slice(anchorEnd);
+  private spliceAfterSection(
+    body: string,
+    anchorEnd: number,
+    appendText: string,
+    sectionIsList: boolean,
+  ): string {
+    const separator = sectionIsList ? '\n' : '\n\n';
+    const prefix = body.slice(0, anchorEnd).trimEnd();
+    const suffix = body.slice(anchorEnd);
+    return prefix + separator + appendText + suffix;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fix the trailing-blank-line bug discovered during the #185 e2e verification on `## 相关概念` / `## 相关实体` list-typed sections.

## Symptom

Appending bullets to list-typed sections produced a visible blank line between existing bullets and the new bullet on re-ingest:

```
## 相关概念
- [[concepts/tool-calling|tool-calling]]
- [[concepts/prompt-caching|prompt caching]]
                                              ← extra blank line (bug)
- [[concepts/exekutive-funktionen|Exekutive Funktionen]]
```

## Root cause

Vault bodies always end with `\n` after the last bullet. `spliceAfterSection` concatenated a separator onto that trailing newline with no normalization — even a single-`\n` separator became `\n\n` at runtime, regardless of intent.

## Fix (page-factory.ts)

- **`spliceAfterSection`** strips trailing whitespace from the prefix via `trimEnd()` before applying the separator. The separator shape alone now controls the resulting blank-line behavior — independent of body's trailing whitespace.
- **`isListSection`** now scans ALL lines (not just the last), so hand-edited sections ending with a closing paragraph after bullets still classify as list-typed.
- Caller passes the autodetected boolean to spliceAfterSection: single `\n` for lists, `\n\n` for paragraphs.
- **`callPerSectionAppend`** returns the cleaned LLM text verbatim (no hard `\n` prepend) and treats empty responses as NO_NEW_CONTENT, preventing stray-blank-line injection from weak models.

## Tests

7 new tests pin both branches and 5 edge cases (mixed list+paragraph, numbered list, next-heading suffix, no trailing newline, empty LLM response). RED check against pre-fix baseline: 5/7 fail — verifies the test is not a shell test.

## Compatibility

- Source-level: additive (new helper + new param + new empty-response branch).
- Settings schema: unchanged.
- File format: unchanged.
- Default behavior: **changed for the bug scenario only** — list sections no longer get the extra blank line. Paragraph sections retain their blank-line behavior. Verified by reading existing `page-factory-complementary-append.test.ts` tests; all still pass.
- Command/Setting IDs: unchanged.
- Obsidian API: unchanged.

## Why this PR first

The fix is a prerequisite for the upcoming #185 PR (aliases propagation): the #185 e2e verification surfaced this bug, and shipping #185 together with this fix avoids re-introducing the bug on first #185 deployment.

Closes: discovered during #185 e2e verification (no separate Issue tracker).

Co-authored-by: green-dalii <654534332@qq.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>