### PR TITLE
feat(ingest): propagate source-note frontmatter aliases to sources/<slug> (#185)

### DIFF
--- a/src/__tests__/__support__/engine-context.ts
+++ b/src/__tests__/__support__/engine-context.ts
@@ -19,6 +19,7 @@
 
 import { TFile } from 'obsidian'; // mocked in setup.ts
 import { EngineContext, LLMClient, LLMWikiSettings } from '../../types';
+import { parseFrontmatter } from '../../core/frontmatter';
 
 // ── Mock File ────────────────────────────────────────────────────
 
@@ -143,6 +144,19 @@ export function createMockContext(opts: MockContextOptions = {}): { ctx: EngineC
             basename: path.split('/').pop()?.replace('.md', '') || '',
             extension: 'md',
           });
+        },
+      },
+      // Issue #185: mock metadataCache so SourceAnalyzer can read the
+      // source note's frontmatter `aliases:` for propagation to the
+      // generated sources/<slug> page. Delegates to the production
+      // `parseFrontmatter` so the mock handles every YAML shape the
+      // production path does (inline `[a, b]`, block `- a\n- b`,
+      // quoted strings, empty `[]`).
+      metadataCache: {
+        getFileCache: (file: { path: string }) => {
+          const content = vault.read(file.path);
+          const fm = content == null ? null : parseFrontmatter(content);
+          return fm ? { frontmatter: fm } : null;
         },
       },
     } as unknown as EngineContext['app'],

--- a/src/__tests__/wiki/source-analyzer-extract-aliases.test.ts
+++ b/src/__tests__/wiki/source-analyzer-extract-aliases.test.ts
@@ -1,0 +1,176 @@
+// Issue #185: propagate source-note frontmatter `aliases:` to the
+// generated sources/<slug> page. Step 1 — extract.
+//
+// Reading source frontmatter is the responsibility of SourceAnalyzer
+// (it owns the vault read + parse logic). Step 1 verifies that the
+// analyzer pulls `aliases:` out of the source note's frontmatter and
+// exposes it on the returned SourceAnalysis as `source_note_aliases`.
+//
+// Scope guard: Step 1 ONLY adds extraction. Propagation into the
+// `sources/<slug>` page frontmatter is Step 2.
+
+import { describe, it, expect } from 'vitest';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { SourceAnalyzer } from '../../wiki/source-analyzer';
+import { TFile } from 'obsidian';
+
+const NOTE_WITH_ALIASES_YAML = 'sources/exekutive-funktionen.md';
+const NOTE_WITHOUT_FRONTMATTER = 'sources/plain.md';
+const NOTE_WITH_EMPTY_ALIASES = 'sources/empty-aliases.md';
+const NOTE_BLANK = 'sources/blank.md';
+
+function makeAnalyzer(
+  vaultFiles: Record<string, string>,
+  llmResponses: string[]
+): SourceAnalyzer {
+  const { ctx } = createMockContext({ vaultFiles, llmResponses });
+  return new SourceAnalyzer(ctx);
+}
+
+// The SourceAnalyzer only reads file.path and file.basename from the TFile.
+// Our mock provides both fields, so the cast is safe for testing.
+async function runAnalyzer(analyzer: SourceAnalyzer, path: string) {
+  // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+  return analyzer.analyzeSource(createMockFile(path) as unknown as TFile);
+}
+
+describe('SourceAnalyzer — Issue #185 source-note aliases extraction', () => {
+  it('extracts a 5-item YAML aliases array from the source note frontmatter (#185)', async () => {
+    const a = makeAnalyzer(
+      {
+        // The repro from the issue: German inflectional variants curated
+        // by the note author. After ingest, the generated sources/<slug>
+        // page currently misses all of these — this test only verifies
+        // extraction; propagation is Step 2.
+        [NOTE_WITH_ALIASES_YAML]: `---
+aliases: [Exekutive Funktionen, Executive Function, Exekutiv Funktionen, Exekutiven Funktionen, exekutive Funktionen]
+tags: [concept]
+---
+
+# Exekutive Funktionen
+
+Some body content.
+`,
+      },
+      [JSON.stringify({
+        source_title: 'Exekutive Funktionen',
+        summary: 'Cognitive control processes.',
+        entities: [{ name: 'Prefrontal Cortex', type: 'place', summary: 'brain region', mentions_in_source: [] }],
+        concepts: [],
+      })]
+    );
+    const result = await runAnalyzer(a, NOTE_WITH_ALIASES_YAML);
+    expect(result).not.toBeNull();
+    expect(result!.source_note_aliases).toEqual([
+      'Exekutive Funktionen',
+      'Executive Function',
+      'Exekutiv Funktionen',
+      'Exekutiven Funktionen',
+      'exekutive Funktionen',
+    ]);
+  });
+
+  it('returns an empty array when the source has no frontmatter block', async () => {
+    const a = makeAnalyzer(
+      { [NOTE_WITHOUT_FRONTMATTER]: '# Plain Note\nJust text, no frontmatter.' },
+      [JSON.stringify({
+        source_title: 'Plain Note',
+        summary: 'No FM.',
+        entities: [{ name: 'X', type: 'other', summary: 'x', mentions_in_source: [] }],
+      })]
+    );
+    const result = await runAnalyzer(a, NOTE_WITHOUT_FRONTMATTER);
+    expect(result).not.toBeNull();
+    expect(result!.source_note_aliases).toEqual([]);
+  });
+
+  it('returns an empty array when the frontmatter has no aliases key', async () => {
+    const a = makeAnalyzer(
+      {
+        // tags only — the analyzer must not synthesize aliases from other fields
+        [NOTE_WITHOUT_FRONTMATTER]: `---
+tags: [concept]
+---
+
+# Tag-only Note
+
+Body.
+`,
+      },
+      [JSON.stringify({
+        source_title: 'Tag-only Note',
+        summary: 'No aliases.',
+        entities: [{ name: 'X', type: 'other', summary: 'x', mentions_in_source: [] }],
+      })]
+    );
+    const result = await runAnalyzer(a, NOTE_WITHOUT_FRONTMATTER);
+    expect(result).not.toBeNull();
+    expect(result!.source_note_aliases).toEqual([]);
+  });
+
+  it('returns an empty array when aliases: is present but empty', async () => {
+    const a = makeAnalyzer(
+      { [NOTE_WITH_EMPTY_ALIASES]: `---
+aliases: []
+---
+
+# Empty Aliases
+
+Body.
+` },
+      [JSON.stringify({
+        source_title: 'Empty Aliases',
+        summary: 'Empty alias list.',
+        entities: [{ name: 'X', type: 'other', summary: 'x', mentions_in_source: [] }],
+      })]
+    );
+    const result = await runAnalyzer(a, NOTE_WITH_EMPTY_ALIASES);
+    expect(result).not.toBeNull();
+    expect(result!.source_note_aliases).toEqual([]);
+  });
+
+  it('returns null for blank sources without ever extracting aliases (#164 + #185)', async () => {
+    // #164 guards blank inputs; #185 extraction must run inside the
+    // post-FM-guard window — never trigger parsing on blank content.
+    const a = makeAnalyzer(
+      { [NOTE_BLANK]: '' },
+      // No LLM call should happen — the analyzer must short-circuit.
+      ['__unused__']
+    );
+    const result = await runAnalyzer(a, NOTE_BLANK);
+    expect(result).toBeNull();
+  });
+
+  it('extracts a block-style `aliases:` array (the most common Obsidian format) (#185)', async () => {
+    // Obsidian's frontmatter UI defaults to block-style
+    // `aliases:\n  - a\n  - b` rather than inline `[a, b]`. The mock's
+    // delegated parseFrontmatter must surface both shapes as a string array,
+    // matching Obsidian's real metadataCache.getFileCache behavior.
+    const a = makeAnalyzer(
+      {
+        ['sources/block-style-aliases.md']: `---
+aliases:
+  - "Exekutive Funktionen"
+  - "Executive Function"
+  - "Exekutiv Funktionen"
+tags: [concept]
+---
+
+Body.
+`,
+      },
+      [JSON.stringify({
+        source_title: 'Block Aliases',
+        summary: 'Block-style check.',
+        entities: [{ name: 'X', type: 'other', summary: 'x', mentions_in_source: [] }],
+      })]
+    );
+    const result = await runAnalyzer(a, 'sources/block-style-aliases.md');
+    expect(result).not.toBeNull();
+    expect(result!.source_note_aliases).toEqual([
+      'Exekutive Funktionen',
+      'Executive Function',
+      'Exekutiv Funktionen',
+    ]);
+  });
+});

--- a/src/__tests__/wiki/wiki-engine-summary-aliases.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-aliases.test.ts
@@ -1,0 +1,165 @@
+// Issue #185: propagate source-note aliases to wiki/sources/<slug>. Step 2 — inject.
+//
+// Goal: when `WikiEngine.createSummaryPage` writes a fresh sources/<slug>
+// page, the source note's curated frontmatter `aliases:` (already extracted
+// in Step 1 by SourceAnalyzer.analyzeSource) must be appended to the
+// generated page's frontmatter. Downstream fix-dead-link uses this alias
+// pool (slugify-normalized) to retarget dead links written with inflection
+// variants.
+//
+// Implementation choice: a minimal private helper on WikiEngine that does
+// read-frontmatter → merge-dedup → replace-or-inject. Reuses the same
+// pattern as PageFactory.appendAliases (no cross-module dependency).
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+import { parseFrontmatter } from '../../core/frontmatter';
+
+const SOURCE_NOTE_PATH = 'sources/exekutive-funktionen.md';
+
+const SAMPLE_BODY = `# Exekutive Funktionen
+
+Ein Konzept der kognitiven Kontrolle, das Planung, Inhibition und kognitive Flexibilität umfasst. Im Kontext der LLM-Provider-Routen sind diese Funktionen relevant für Anbieter wie OpenRouter, die konfigurierbare Reasoning-Stufen unterstützen.
+`;
+
+function sourceFile(): TFile {
+  return Object.assign(new TFile(), {
+    path: SOURCE_NOTE_PATH,
+    basename: 'exekutive-funktionen',
+    extension: 'md',
+  });
+}
+
+// Shared LLM stubs — the engine consumes two responses per ingest:
+// (1) SourceAnalyzer extraction, (2) createSummaryPage summary generation.
+// Centralized so each `it()` test only specifies what differs.
+const EXTRACTION_RESPONSE = JSON.stringify({
+  source_title: 'Exekutive Funktionen',
+  summary: 'Cognitive control processes.',
+  entities: [{ name: 'Prefrontal Cortex', type: 'place', summary: 'brain region', mentions_in_source: [] }],
+  concepts: [],
+});
+const SUMMARY_RESPONSE = JSON.stringify({
+  frontmatter: { type: 'source', sources: ['[[sources/self-stub]]'], tags: ['concept'] },
+  body: '## Zusammenfassung\n\nKognitive Kontrolle.',
+});
+
+/**
+ * Build a minimal SourceAnalysis as it would arrive from SourceAnalyzer
+ * after a successful extraction. We only care about source_note_aliases
+ * here — the rest is a stub sufficient to run createSummaryPage through
+ * to its write step.
+ */
+function makeAnalysis(aliases: string[] | undefined): import('../../types').SourceAnalysis {
+  return {
+    source_file: SOURCE_NOTE_PATH,
+    source_title: 'Exekutive Funktionen',
+    summary: 'Cognitive control processes.',
+    entities: [{ name: 'Prefrontal Cortex', type: 'place', summary: 'brain region', mentions_in_source: [] }],
+    concepts: [],
+    contradictions: [],
+    related_pages: [],
+    key_points: [],
+    created_pages: [],
+    updated_pages: [],
+    source_note_aliases: aliases,
+  };
+}
+
+function harnessFor(extraFiles: Record<string, string> = {}) {
+  return createWikiEngineHarness({
+    files: { [SOURCE_NOTE_PATH]: SAMPLE_BODY, ...extraFiles },
+    llmResponses: [EXTRACTION_RESPONSE, SUMMARY_RESPONSE],
+  });
+}
+
+describe('WikiEngine.createSummaryPage — Issue #185 aliases propagation', () => {
+  it('appends source-note aliases to the generated sources/<slug> page frontmatter', async () => {
+    const curatedAliases = [
+      'Exekutive Funktionen',
+      'Executive Function',
+      'Exekutiv Funktionen',
+      'Exekutiven Funktionen',
+      'exekutive Funktionen',
+    ];
+    const h = harnessFor();
+
+    // Run only createSummaryPage so the test does not depend on the full
+    // ingest pipeline (entity extraction / matchExtractedToExisting / etc.).
+    // SourceAnalyzer is bypassed here — we pass the analysis directly,
+    // simulating the post-Step-1 contract.
+    const writtenPath: string = await h.engine.createSummaryPage(
+      sourceFile(),
+      makeAnalysis(curatedAliases),
+      [],
+    );
+
+    // Read the written page back from the harness's in-memory vault.
+    const written = h.files.get(writtenPath);
+    expect(written, `expected ${writtenPath} to be written by createSummaryPage`).toBeDefined();
+
+    const fm = parseFrontmatter(written!) ?? {};
+    expect(Array.isArray(fm.aliases), 'expected aliases to be an array on the source page').toBe(true);
+    for (const a of curatedAliases) {
+      expect((fm.aliases as string[])).toContain(a);
+    }
+  });
+
+  it('skips injection when the source note has no frontmatter aliases (no regression)', async () => {
+    const h = harnessFor();
+
+    const writtenPath: string = await h.engine.createSummaryPage(
+      sourceFile(),
+      makeAnalysis(undefined),
+      [],
+    );
+
+    const written = h.files.get(writtenPath);
+    expect(written).toBeDefined();
+    const fm = parseFrontmatter(written!) ?? {};
+    // No injection — existing aliases (if any LLM-emitted) remain untouched.
+    // The LLM stub doesn't emit aliases, so the array is either absent or empty.
+    expect(fm.aliases ?? []).toEqual([]);
+  });
+
+  it('does not duplicate aliases when an existing sources/<slug> page already carries them (re-ingest dedup)', async () => {
+    const h = harnessFor({
+      // Pre-existing source page (re-ingest scenario). It already carries
+      // 2 of the 5 curated aliases — the injection must NOT duplicate.
+      ['wiki/sources/exekutive-funktionen.md']: `---
+type: source
+tags: [concept]
+aliases:
+  - "Executive Function"
+  - "Exekutiv Funktionen"
+---
+
+Existing summary.
+`,
+    });
+
+    const writtenPath: string = await h.engine.createSummaryPage(
+      sourceFile(),
+      makeAnalysis([
+        'Executive Function',           // already present
+        'Exekutiv Funktionen',          // already present
+        'Exekutive Funktionen',         // NEW
+        'Exekutiven Funktionen',        // NEW
+      ]),
+      [],
+    );
+
+    const written = h.files.get(writtenPath)!;
+    const fm = parseFrontmatter(written) ?? {};
+    const aliases = fm.aliases as string[];
+    expect(aliases).toEqual([
+      'Executive Function',
+      'Exekutiv Funktionen',
+      'Exekutive Funktionen',
+      'Exekutiven Funktionen',
+    ]);
+    // No duplicates
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+});

--- a/src/core/batch-merger.ts
+++ b/src/core/batch-merger.ts
@@ -224,7 +224,12 @@ export function buildSourceAnalysis(
     contradictions?: ContradictionInfo[];
     relatedPages?: string[];
     keyPoints?: string[];
-  }
+  },
+  // Issue #185: curated `aliases:` authored on the source note
+  // frontmatter. Forwarded as-is into SourceAnalysis.source_note_aliases
+  // so the downstream WikiEngine.createSummaryPage can inject them into
+  // the generated `sources/<slug>` frontmatter.
+  sourceNoteAliases?: string[]
 ): SourceAnalysis {
   return {
     source_file: filePath,
@@ -236,7 +241,8 @@ export function buildSourceAnalysis(
     related_pages: accumulation.relatedPages,
     key_points: accumulation.keyPoints,
     created_pages: [],
-    updated_pages: []
+    updated_pages: [],
+    source_note_aliases: sourceNoteAliases
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,21 @@ export interface SourceAnalysis {
   key_points: string[];
   created_pages: string[];
   updated_pages: string[];
+  /**
+   * Issue #185 — curated `aliases:` authored on the source note
+   * frontmatter. Read by `SourceAnalyzer.analyzeSource` from
+   * `app.metadataCache.getFileCache(file)?.frontmatter?.aliases`.
+   * Always a string array (or undefined when the source has no
+   * frontmatter at all). NOT normalized — values come through
+   * verbatim so downstream propagation can deduplicate against the
+   * generated `sources/<slug>` page's existing aliases.
+   *
+   * Strict scope: extracted by the analyzer; consumed by
+   * `WikiEngine.createSummaryPage` to inject into the
+   * `sources/<slug>` page (Step 2). NOT used for entity/concept
+   * pages — those follow the existing `info.aliases` path.
+   */
+  source_note_aliases?: string[];
 }
 
 export interface EntityInfo {

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -168,6 +168,16 @@ export class SourceAnalyzer {
       return null;
     }
 
+    // Issue #185: source note's frontmatter `aliases:` are appended to
+    // the generated `sources/<slug>` page (consumed there by
+    // `fix-dead-link`'s slugify-normalized cross-page alias match).
+    const noteFm = this.ctx.app.metadataCache
+      .getFileCache(file)?.frontmatter as { aliases?: unknown } | undefined;
+    const rawNoteAliases = noteFm?.aliases;
+    const sourceNoteAliases: string[] = Array.isArray(rawNoteAliases)
+      ? rawNoteAliases.filter((a): a is string => typeof a === 'string')
+      : [];
+
     console.debug('Existing Wiki pages count: — delayed until post-extraction matching');
 
     // Calculate batch limits using pure functions (Phase 1)
@@ -496,7 +506,10 @@ export class SourceAnalyzer {
       firstBatchData ? {
         sourceTitle: firstBatchData.sourceTitle,
         summary: firstBatchData.summary
-      } : undefined
+      } : undefined,
+      // Issue #185: forward curated source-note aliases so the
+      // generated sources/<slug> page can carry them.
+      sourceNoteAliases
     );
 
     console.debug('=== Iterative extraction complete ===');

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -18,7 +18,7 @@ import { TEXTS } from '../texts';
 import { getText } from '../core/i18n';
 import { slugify } from '../core/slug';
 import { resolveSourceSlug } from '../core/source-slug';
-import { parseFrontmatter, upsertFrontmatterField, extractBody } from '../core/frontmatter';
+import { parseFrontmatter, upsertFrontmatterField, mergeFrontmatterArrayField, extractBody } from '../core/frontmatter';
 import { setGenerationComplete } from '../core/incomplete-page-cleaner';
 import { hashBody, checkContentRequirements } from '../core/source-requirements';
 import type { SourceRejection } from '../core/source-requirements';
@@ -996,8 +996,31 @@ export class WikiEngine {
     const cleanedContent = cleanMarkdownResponse(pageContent);
     // #164: stamp a content fingerprint so future ingests can detect duplicates.
     // Injected programmatically — the LLM can't be trusted to emit it.
-    const stampedContent = upsertFrontmatterField(cleanedContent, 'contentHash', hashBody(extractBody(content)));
-    await this.createOrUpdateFile(path, stampedContent);
+    let finalContent = upsertFrontmatterField(cleanedContent, 'contentHash', hashBody(extractBody(content)));
+
+    // Issue #185: append the source note's curated frontmatter `aliases:`
+    // to the generated `sources/<slug>` page. Merged inline (BEFORE the
+    // write) so the page lands complete on disk in one `createOrUpdateFile`
+    // call — no partial-write window. Downstream `fix-dead-link`
+    // (slugify-normalized cross-page alias match at lint/scanners.ts:150 +
+    // fix-dead-link.ts:237) consumes this pool to retarget dead links
+    // written with inflection variants — a German "Exekutiven Funktionen"
+    // link in body text resolves to the canonical page via this alias.
+    //
+    // `mergeFrontmatterArrayField` short-circuits when the additions are
+    // already present (frontmatter.ts:211), so the `!==` check below is
+    // purely an observability gate.
+    if (analysis.source_note_aliases?.length) {
+      const withAliases = mergeFrontmatterArrayField(finalContent, 'aliases', analysis.source_note_aliases);
+      if (withAliases !== finalContent) {
+        console.debug(
+          `[Issue #185] Propagated ${analysis.source_note_aliases.length} alias(es) to ${path}`
+        );
+        finalContent = withAliases;
+      }
+    }
+
+    await this.createOrUpdateFile(path, finalContent);
     return path;
   }
 


### PR DESCRIPTION
## Summary

Propagate the source note's curated `aliases:` frontmatter to the generated `sources/<slug>` page, closing the Round-trip aliases gap reported in #185.

## Problem

Authors curate inflectional and language-variant aliases on source notes (e.g. `Exekutive Funktionen`, `Executive Function`, `Exekutiv Funktionen`, `Exekutiven Funktionen`, `exekutive Funktionen`). After ingest, the generated `sources/<slug>.md` page did NOT carry any of these aliases. As a result:

- The `sources/<slug>` page is orphaned in the wiki's alias graph until the next re-ingest.
- `fix-dead-link` (which depends on alias matching) cannot resolve incoming links pointing to these variants.
- Round-trip symmetry is broken: source ↔ wiki aliases diverge after a single ingest.

## Solution

Two-step propagation, fully frontmatter-only (no LLM calls, zero token cost).

### Step 1 — SourceAnalyzer extracts aliases

`source-analyzer.ts` reads the source note's frontmatter via `metadataCache.getFileCache(file).frontmatter.aliases`, filters for string entries, and exposes them on `SourceAnalysis.source_note_aliases`.

- Default-on (no settings flag). Implicit per user evaluation: surface only, fall back silently.
- Sources-only scope (not entity/concept pages — those have their own alias bookkeeping).

### Step 2 — WikiEngine injects aliases on first write

`wiki-engine.ts createSummaryPage()` invokes `mergeFrontmatterArrayField` (v1.24.0 frontmatter helper) to inline-merge `aliases:` BEFORE the first createOrUpdateFile. This avoids read-modify-write waste and preserves existing aliases if the file was edited externally.

## Compatibility

- **Settings schema:** additive only — `SourceAnalysis.source_note_aliases` is optional.
- **File format:** no change. Generated `sources/<slug>` pages follow the existing frontmatter format.
- **Default behavior:** additive — sources without curated aliases see no change. Sources WITH curated aliases get those aliases propagated (which is the desired behavior).
- **Command/Setting IDs:** unchanged.
- **Obsidian API:** uses `metadataCache.getFileCache` (already in use elsewhere).
- **Token cost:** zero (deterministic frontmatter parse).

## Why this PR second

The empty-line bug fix (PR #260, already merged) is a hard prerequisite. The #185 e2e verification surfaced that bug — without it, the first run on a list-typed `sources/<slug>` page would re-introduce the bug. Shipping #185 on top of the bug fix is the natural order.

## E2E verified

```
[Issue #185] Propagated 5 alias(es) to test4/sources/exekutive-funktionen_c45412.md
```

Confirmed 5 aliases present on the generated source page after a real ingest.

## Tests

9 new tests (128 → 137 = +9 source-analyzer-extract-aliases + wiki-engine-summary-aliases tests). All 1785 tests pass on this branch.

Closes #185

Co-authored-by: green-dalii <654534332@qq.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>