### PR TITLE
fix: allow LM Studio ingest without API key

### DIFF
--- a/src/__tests__/core/initialize-llm-client-gate.test.ts
+++ b/src/__tests__/core/initialize-llm-client-gate.test.ts
@@ -1,0 +1,101 @@
+// initializeLLMClient must allow lmstudio (and ollama) with an empty
+// apiKey — same gate as testLLMConnection (#223). Without this, ingest
+// commands see llmClient === null and show errorNoApiKey.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LLMWikiPlugin from '../../main';
+
+vi.mock('../../llm-sdk/create-llm-client', () => ({
+  createLLMClientFromSettingsSync: vi.fn(() => ({
+    createMessage: vi.fn().mockResolvedValue('ok'),
+    createMessageStream: vi.fn(),
+    listModels: vi.fn().mockResolvedValue([]),
+  })),
+  preloadLLMClientModules: vi.fn().mockResolvedValue(undefined),
+  _resetPreloadedModulesForTests: vi.fn(),
+}));
+
+describe('initializeLLMClient — local provider API key gate', () => {
+  const mockApp = {
+    vault: {
+      getAbstractFileByPath: vi.fn().mockReturnValue(null),
+      getMarkdownFiles: vi.fn().mockReturnValue([]),
+      read: vi.fn().mockResolvedValue(''),
+    },
+  };
+  const mockManifest = {
+    id: 'test-plugin',
+    name: 'Test',
+    version: '1.0.0',
+    minAppVersion: '0.15.0',
+  };
+  let plugin: LLMWikiPlugin;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = new LLMWikiPlugin(mockApp as never, mockManifest as never);
+    (plugin as unknown as Record<string, unknown>).settings = {
+      provider: 'openai',
+      apiKey: '',
+      baseUrl: 'http://localhost:1234/v1',
+      model: 'qwen2.5-7b',
+      language: 'en',
+      wikiFolder: 'wiki',
+      llmReady: true,
+      maxTokensPerCall: 0,
+      autoIngestNotificationLevel: 'notice',
+      autoWatchSources: false,
+      startupCheck: false,
+      slugCase: 'preserve',
+    };
+  });
+
+  it('initializes llmClient for lmstudio with empty apiKey (ingest gate)', () => {
+    (plugin as unknown as Record<string, unknown>).settings = {
+      ...(plugin as unknown as Record<string, unknown>).settings as Record<string, unknown>,
+      provider: 'lmstudio',
+      apiKey: '',
+    };
+
+    plugin.initializeLLMClient();
+
+    expect(plugin.llmClient).not.toBeNull();
+  });
+
+  it('initializes llmClient for ollama with empty apiKey (existing behavior)', () => {
+    (plugin as unknown as Record<string, unknown>).settings = {
+      ...(plugin as unknown as Record<string, unknown>).settings as Record<string, unknown>,
+      provider: 'ollama',
+      apiKey: '',
+      baseUrl: 'http://localhost:11434/v1',
+    };
+
+    plugin.initializeLLMClient();
+
+    expect(plugin.llmClient).not.toBeNull();
+  });
+
+  it('leaves llmClient null for openai with empty apiKey', () => {
+    (plugin as unknown as Record<string, unknown>).settings = {
+      ...(plugin as unknown as Record<string, unknown>).settings as Record<string, unknown>,
+      provider: 'openai',
+      apiKey: '',
+    };
+
+    plugin.initializeLLMClient();
+
+    expect(plugin.llmClient).toBeNull();
+  });
+
+  it('initializes llmClient for lmstudio when apiKey is whitespace-only', () => {
+    (plugin as unknown as Record<string, unknown>).settings = {
+      ...(plugin as unknown as Record<string, unknown>).settings as Record<string, unknown>,
+      provider: 'lmstudio',
+      apiKey: '   ',
+    };
+
+    plugin.initializeLLMClient();
+
+    expect(plugin.llmClient).not.toBeNull();
+  });
+});

--- a/src/__tests__/core/local-no-key-provider.test.ts
+++ b/src/__tests__/core/local-no-key-provider.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOCAL_NO_KEY_PROVIDERS,
+  isLocalNoKeyProvider,
+  allowsEmptyApiKey,
+} from '../../core/local-no-key-provider';
+
+describe('local-no-key-provider', () => {
+  it('lists ollama and lmstudio as the only no-key local providers', () => {
+    expect([...LOCAL_NO_KEY_PROVIDERS]).toEqual(['ollama', 'lmstudio']);
+  });
+
+  it('isLocalNoKeyProvider identifies ollama and lmstudio', () => {
+    expect(isLocalNoKeyProvider('ollama')).toBe(true);
+    expect(isLocalNoKeyProvider('lmstudio')).toBe(true);
+    expect(isLocalNoKeyProvider('openai')).toBe(false);
+    expect(isLocalNoKeyProvider('custom')).toBe(false);
+  });
+
+  it('allowsEmptyApiKey: lmstudio with empty key is allowed', () => {
+    expect(allowsEmptyApiKey('lmstudio', '')).toBe(true);
+    expect(allowsEmptyApiKey('lmstudio', '   ')).toBe(true);
+    expect(allowsEmptyApiKey('lmstudio', null)).toBe(true);
+    expect(allowsEmptyApiKey('lmstudio', undefined)).toBe(true);
+  });
+
+  it('allowsEmptyApiKey: ollama with empty key is allowed', () => {
+    expect(allowsEmptyApiKey('ollama', '')).toBe(true);
+  });
+
+  it('allowsEmptyApiKey: cloud providers still require a key', () => {
+    expect(allowsEmptyApiKey('openai', '')).toBe(false);
+    expect(allowsEmptyApiKey('openai', '   ')).toBe(false);
+    expect(allowsEmptyApiKey('anthropic', undefined)).toBe(false);
+    expect(allowsEmptyApiKey('openai', 'sk-test')).toBe(true);
+  });
+});

--- a/src/core/local-no-key-provider.ts
+++ b/src/core/local-no-key-provider.ts
@@ -1,0 +1,21 @@
+/**
+ * Local OpenAI-compatible providers that accept an empty/missing API key.
+ * Kept in one place so Test Connection, client init, and ingest gates
+ * cannot drift (regression class: #223 / LM Studio ingest still blocked).
+ */
+export const LOCAL_NO_KEY_PROVIDERS = ['ollama', 'lmstudio'] as const;
+
+export type LocalNoKeyProvider = (typeof LOCAL_NO_KEY_PROVIDERS)[number];
+
+export function isLocalNoKeyProvider(provider: string): boolean {
+  return (LOCAL_NO_KEY_PROVIDERS as readonly string[]).includes(provider);
+}
+
+/**
+ * True when the provider may initialize / run without a configured API key.
+ * Cloud providers still require a non-empty trimmed key.
+ */
+export function allowsEmptyApiKey(provider: string, apiKey: string | undefined | null): boolean {
+  if (isLocalNoKeyProvider(provider)) return true;
+  return Boolean(apiKey?.trim());
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { TOKENS_QUERY_MODEL_DETECT, NOTICE_NORMAL, NOTICE_ERROR, NOTICE_ABORT, N
 import { wrapWithAdvancedSettings } from './llm-client-wrapper';
 import { createLLMClientFromSettingsSync, preloadLLMClientModules } from './llm-sdk/create-llm-client';
 import { runSchemaAnalyze } from './schema/analyze';
+import { allowsEmptyApiKey } from './core/local-no-key-provider';
 
 // v1.23.0 P1-7: AI-SDK migration. Eagerly preload SDK modules on plugin
 // load so sync `createLLMClient` works without blocking. Failure is
@@ -413,7 +414,9 @@ export default class LLMWikiPlugin extends Plugin {
 
     // Migrate existing users: if they already have a working config, trust it
     if (savedData && !('llmReady' in savedData)) {
-      const hasConfig = savedData.provider && (savedData.apiKey?.trim() || savedData.provider === 'ollama') && savedData.model;
+      const hasConfig = savedData.provider
+        && allowsEmptyApiKey(savedData.provider, savedData.apiKey)
+        && savedData.model;
       this.settings.llmReady = !!hasConfig;
       if (hasConfig) {
         console.debug('loadSettings: existing user with config detected, llmReady = true');
@@ -475,7 +478,11 @@ export default class LLMWikiPlugin extends Plugin {
   }
 
   initializeLLMClient() {
-    if (!this.settings.apiKey?.trim() && this.settings.provider !== 'ollama') {
+    // Local providers (ollama, lmstudio) do not require an API key —
+    // same gate as testLLMConnection (#223). Leaving llmClient null here
+    // is what made ingest show errorNoApiKey after a successful LM Studio
+    // connection test.
+    if (!allowsEmptyApiKey(this.settings.provider, this.settings.apiKey)) {
       this.llmClient = null;
       return;
     }
@@ -1050,9 +1057,7 @@ export default class LLMWikiPlugin extends Plugin {
   async testLLMConnection(): Promise<{ success: boolean; message: string }> {
     const t = TEXTS[this.settings.language] || TEXTS.en;
 
-    const localNoKeyProviders = ['ollama', 'lmstudio'];
-    const isLocalNoKeyProvider = localNoKeyProviders.includes(this.settings.provider);
-    if (!isLocalNoKeyProvider && (!this.settings.apiKey || this.settings.apiKey.trim() === '')) {
+    if (!allowsEmptyApiKey(this.settings.provider, this.settings.apiKey)) {
       return { success: false, message: t.errorNoApiKey || 'API Key is not configured' };
     }
 

--- a/src/schema/auto-maintain.ts
+++ b/src/schema/auto-maintain.ts
@@ -11,6 +11,7 @@ import { needsLogHeaderMigration, migrateLogHeader } from '../core/log-header';
 import { ensureWelcomeNote, type EnsureResult, type VaultAdapter } from '../core/ensure-welcome-note';
 import { getWelcomeFileName } from '../core/i18n';
 import { resolveModelForTask } from '../core/model-resolver';
+import { isLocalNoKeyProvider } from '../core/local-no-key-provider';
 import type { LLMClient } from '../types';
 
 export class AutoMaintainManager {
@@ -733,7 +734,8 @@ export class AutoMaintainManager {
     if (!llmClient) {
       return { ok: false, error: 'LLM client not configured. Open Settings → LLM Provider.' };
     }
-    if (!this.settings.apiKey) {
+    // ollama / lmstudio accept empty API key (same gate as initializeLLMClient)
+    if (!this.settings.apiKey && !isLocalNoKeyProvider(this.settings.provider)) {
       return { ok: false, error: 'API key not configured.' };
     }
     if (!this.settings.model) {


### PR DESCRIPTION
## Summary
- LM Studio users could pass Test Connection with an empty API key, but Ingest still showed `errorNoApiKey` because `initializeLLMClient()` only exempted `ollama`.
- Centralize the empty-key policy in `allowsEmptyApiKey` (`ollama` / `lmstudio`) and apply it to client init, `llmReady` migration, Test Connection, and `probeLlm`.
- Adds regression tests so ingest-gate and Test Connection cannot drift again.

## Test plan
- [ ] Settings → Provider = LM Studio (Local), leave API Key empty, set model, Save
- [ ] Test Connection succeeds
- [ ] Cmd+P → Ingest current/selected file — no "Please configure API Key first"
- [ ] Same flow with Ollama (empty key) still works
- [ ] OpenAI / Anthropic with empty key still blocked
- [ ] `pnpm lint && npx tsc --noEmit && pnpm test && pnpm build && pnpm css-lint`


Made with [Cursor](https://cursor.com)