### PR TITLE
feat(llm-sdk): Bedrock Stage 1 via bedrock-mantle endpoint

### DIFF
--- a/src/__tests__/llm-sdk/bedrock-factory.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-factory.test.ts
@@ -1,0 +1,106 @@
+// v1.24.1 PATCH — Bedrock Stage 1 factory tests.
+//
+// Verifies that the two new `bedrock-*` provider ids in
+// PREDEFINED_PROVIDERS dispatch to the correct underlying client
+// (AnthropicSdkClient for Messages, OpenAICompatSdkClient for Chat
+// Completions) and that the resolved baseURL points at the region-scoped
+// bedrock-mantle endpoint.
+//
+// Strategy: exercise the async factory end-to-end (it dynamically imports
+// the SDK modules just like production). The factory is the only place
+// `bedrockRegion` is consumed, so the baseURL assertion has to live here.
+// We reach the private `baseURL` field via a structural `unknown` cast —
+// AnthropicSdkClient and OpenAICompatSdkClient both store it as a
+// `private readonly` field, so a structural cast is the natural fit.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { AnthropicSdkClient } from '../../llm-sdk/anthropic-sdk-client';
+import { OpenAICompatSdkClient } from '../../llm-sdk/openai-compat-sdk-client';
+import {
+  createLLMClientFromSettings,
+  createLLMClientFromSettingsSync,
+  preloadLLMClientModules,
+} from '../../llm-sdk/create-llm-client';
+
+function privateBaseURL(client: unknown): string | undefined {
+  // Both client classes store baseURL as `private readonly baseURL`.
+  // Standard TS idiom for reaching private fields in tests: structural
+  // cast through `unknown`. Branch on typeof to keep the result
+  // accurate when the optional field is absent.
+  const c = client as { baseURL?: unknown };
+  return typeof c.baseURL === 'string' ? c.baseURL : undefined;
+}
+
+describe('Bedrock Stage 1 factory (v1.24.1 PATCH)', () => {
+  beforeAll(async () => {
+    await preloadLLMClientModules();
+  });
+
+  describe('async factory', () => {
+    it('bedrock-anthropic dispatches to AnthropicSdkClient with region-scoped baseURL', async () => {
+      const client = await createLLMClientFromSettings({
+        provider: 'bedrock-anthropic',
+        apiKey: 'ABSK-test',
+        bedrockRegion: 'us-east-1',
+      });
+      expect(client).toBeInstanceOf(AnthropicSdkClient);
+      expect(privateBaseURL(client)).toBe('https://bedrock-mantle.us-east-1.api.aws');
+    });
+
+    it('bedrock-openai dispatches to OpenAICompatSdkClient with /v1 region-scoped baseURL', async () => {
+      const client = await createLLMClientFromSettings({
+        provider: 'bedrock-openai',
+        apiKey: 'ABSK-test',
+        bedrockRegion: 'eu-central-1',
+      });
+      expect(client).toBeInstanceOf(OpenAICompatSdkClient);
+      expect(privateBaseURL(client)).toBe('https://bedrock-mantle.eu-central-1.api.aws/v1');
+    });
+  });
+
+  describe('sync factory (after preload)', () => {
+    it('bedrock-anthropic dispatches to AnthropicSdkClient with default region when unspecified', () => {
+      const client = createLLMClientFromSettingsSync({
+        provider: 'bedrock-anthropic',
+        apiKey: 'ABSK-test',
+      });
+      expect(client).toBeInstanceOf(AnthropicSdkClient);
+      // Default region is us-east-1 (broadest Bedrock model coverage).
+      expect(privateBaseURL(client)).toBe('https://bedrock-mantle.us-east-1.api.aws');
+    });
+
+    it('bedrock-openai dispatches to OpenAICompatSdkClient honoring custom region', () => {
+      const client = createLLMClientFromSettingsSync({
+        provider: 'bedrock-openai',
+        apiKey: 'ABSK-test',
+        bedrockRegion: 'ap-northeast-2',
+      });
+      expect(client).toBeInstanceOf(OpenAICompatSdkClient);
+      expect(privateBaseURL(client)).toBe('https://bedrock-mantle.ap-northeast-2.api.aws/v1');
+    });
+  });
+
+  describe('regression — non-Bedrock providers still dispatch correctly', () => {
+    it('anthropic still routes to AnthropicSdkClient with empty baseURL', async () => {
+      const client = await createLLMClientFromSettings({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+      });
+      expect(client).toBeInstanceOf(AnthropicSdkClient);
+      // Official endpoint: no baseURL override needed — should be undefined.
+      expect(privateBaseURL(client)).toBeUndefined();
+    });
+
+    it('openai still routes to OpenAISdkClient', async () => {
+      const client = await createLLMClientFromSettings({
+        provider: 'openai',
+        apiKey: 'sk-test',
+      });
+      // provider === 'openai' routes to OpenAISdkClient (official); the
+      // bedrock-* branches must NOT be reached. bedrock-openai is
+      // OpenAICompatSdkClient — confirm OpenAISdkClient is selected here.
+      const { OpenAISdkClient } = await import('../../llm-sdk/openai-sdk-client');
+      expect(client).toBeInstanceOf(OpenAISdkClient);
+    });
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -273,6 +273,61 @@ export const LINT_YIELD_EVERY_COMPARISON = 500;
 /** Batch size for vault reads during lint preparation. */
 export const LINT_PREP_BATCH_READ = 200;
 
+// ============================================================================
+// Amazon Bedrock Stage 1 (v1.24.1 PATCH) — bedrock-mantle endpoint
+// ============================================================================
+
+/**
+ * AWS regions where Amazon Bedrock is currently available.
+ * Source: https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html
+ * Stage 1 supports 18 regions via the unified bedrock-mantle endpoint (no
+ * regional variant suffix needed for Messages / Chat Completions endpoints).
+ */
+export const BEDROCK_REGIONS = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'eu-central-1',
+  'eu-central-2',
+  'eu-north-1',
+  'eu-south-1',
+  'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ap-south-1',
+  'ca-central-1',
+  'sa-east-1',
+] as const;
+
+export type BedrockRegion = typeof BEDROCK_REGIONS[number];
+
+/** Default region if user has not selected one. us-east-1 has the broadest model coverage. */
+export const BEDROCK_DEFAULT_REGION: BedrockRegion = 'us-east-1';
+
+/**
+ * Returns the bedrock-mantle Anthropic Messages baseURL for the given region.
+ * Per https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
+ * the endpoint is region-scoped; bearer auth only; body schema is identical
+ * to api.anthropic.com.
+ */
+export function bedrockMantleMessagesUrl(region: BedrockRegion): string {
+  return `https://bedrock-mantle.${region}.api.aws`;
+}
+
+/**
+ * Returns the bedrock-mantle OpenAI Chat Completions baseURL for the given
+ * region. Same host as Messages, but the chat completions protocol lives
+ * at the `/v1` prefix.
+ */
+export function bedrockMantleChatCompletionsUrl(region: BedrockRegion): string {
+  return `https://bedrock-mantle.${region}.api.aws/v1`;
+}
+
 /**
  * Per-candidate token estimate for duplicate-detection prompt budget.
  * Each candidate ≈ 120 chars ≈ 30 tokens.

--- a/src/llm-sdk/create-llm-client.ts
+++ b/src/llm-sdk/create-llm-client.ts
@@ -19,12 +19,69 @@
 // (they all expect a sync `LLMClient` instance).
 
 import { LLMClient } from '../types';
+import {
+  bedrockMantleChatCompletionsUrl,
+  bedrockMantleMessagesUrl,
+  BEDROCK_DEFAULT_REGION,
+  type BedrockRegion,
+} from '../constants';
 
 export interface ProviderSettings {
   provider: string;
   apiKey: string;
   baseUrl?: string;
+  /**
+   * v1.24.1 PATCH Bedrock Stage 1 — AWS region used by the two
+   * `bedrock-*` provider ids. Ignored when provider is anything else.
+   * Falls back to BEDROCK_DEFAULT_REGION (us-east-1) when unset.
+   */
+  bedrockRegion?: string;
   useOfficialOpenAI?: boolean;
+}
+
+/**
+ * v1.24.1 PATCH Bedrock Stage 1 — resolve the AWS region from settings,
+ * narrowing `string | undefined` to the typed `BedrockRegion` union.
+ * Settings UI dropdown only emits `BEDROCK_REGIONS` values, so runtime
+ * is sound; the cast is here for TS-only safety.
+ */
+function resolveBedrockRegion(settings: ProviderSettings): BedrockRegion {
+  return (settings.bedrockRegion as BedrockRegion | undefined) || BEDROCK_DEFAULT_REGION;
+}
+
+/**
+ * v1.24.1 PATCH Bedrock Stage 1 — construct a Bedrock-backed LLM client
+ * for either the Anthropic Messages protocol or the OpenAI Chat
+ * Completions protocol. Both reuse existing SDK clients via the
+ * region-scoped bedrock-mantle baseURL; bearer auth is wired by the
+ * underlying SDK.
+ *
+ * The class constructors are injected (rather than dynamic-imported)
+ * so the same helper works for both the async factory (which does
+ * dynamic imports inside) and the sync factory (which reads from
+ * preloadedModules). Either way, the resolved client is identical.
+ */
+function createBedrockClient(
+  providers: {
+    AnthropicSdkClient: typeof import('./anthropic-sdk-client').AnthropicSdkClient;
+    OpenAICompatSdkClient: typeof import('./openai-compat-sdk-client').OpenAICompatSdkClient;
+  },
+  settings: ProviderSettings,
+  apiKey: string,
+  protocol: 'anthropic' | 'openai',
+): LLMClient {
+  const region = resolveBedrockRegion(settings);
+  if (protocol === 'anthropic') {
+    return new providers.AnthropicSdkClient({
+      apiKey,
+      baseURL: bedrockMantleMessagesUrl(region),
+    });
+  }
+  return new providers.OpenAICompatSdkClient({
+    apiKey,
+    baseURL: bedrockMantleChatCompletionsUrl(region),
+    provider: settings.provider,
+  });
 }
 
 /**
@@ -39,6 +96,26 @@ export async function createLLMClientFromSettings(settings: ProviderSettings): P
   const provider = settings.provider;
   const apiKey = settings.apiKey.trim();
   const baseUrl = settings.baseUrl?.trim() || undefined;
+
+  // v1.24.1 PATCH Bedrock Stage 1 — region-scoped bedrock-mantle endpoint,
+  // reusing existing SDK clients via custom baseURL.
+  if (provider === 'bedrock-anthropic') {
+    return createBedrockClient(
+      { AnthropicSdkClient, OpenAICompatSdkClient },
+      settings,
+      apiKey,
+      'anthropic',
+    );
+  }
+
+  if (provider === 'bedrock-openai') {
+    return createBedrockClient(
+      { AnthropicSdkClient, OpenAICompatSdkClient },
+      settings,
+      apiKey,
+      'openai',
+    );
+  }
 
   if (provider === 'anthropic') {
     return new AnthropicSdkClient({ apiKey });
@@ -116,6 +193,26 @@ export function createLLMClientFromSettingsSync(settings: ProviderSettings): LLM
   const provider = settings.provider;
   const apiKey = settings.apiKey.trim();
   const baseUrl = settings.baseUrl?.trim() || undefined;
+
+  // v1.24.1 PATCH Bedrock Stage 1 — region-scoped bedrock-mantle endpoint,
+  // reusing existing SDK clients via custom baseURL.
+  if (provider === 'bedrock-anthropic') {
+    return createBedrockClient(
+      { AnthropicSdkClient, OpenAICompatSdkClient },
+      settings,
+      apiKey,
+      'anthropic',
+    );
+  }
+
+  if (provider === 'bedrock-openai') {
+    return createBedrockClient(
+      { AnthropicSdkClient, OpenAICompatSdkClient },
+      settings,
+      apiKey,
+      'openai',
+    );
+  }
 
   if (provider === 'anthropic') {
     return new AnthropicSdkClient({ apiKey });

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -245,6 +245,11 @@ export const DE_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'AWS-Region',
+    bedrockRegionDesc: 'Amazon-Bedrock-Region für dieses Konto. Bestimmt die bedrock-mantle-Endpunkt-URL; kann nicht über baseURL überschrieben werden.',
+    bedrockRegionHint: 'bedrock-mantle ist in 18 Regionen verfügbar; die Modellabdeckung variiert je nach Region.',
+
     // Other
     availableModelsLoading: 'Verfügbare Modelle werden geladen...',
     noModelsAvailable: 'Keine Modelle verfügbar',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -263,6 +263,11 @@ export const EN_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'AWS Region',
+    bedrockRegionDesc: 'Amazon Bedrock region for this account. Drives the bedrock-mantle endpoint URL; cannot be overridden via baseURL.',
+    bedrockRegionHint: 'bedrock-mantle is available in 18 regions; model coverage varies by region.',
+
     // Other
     availableModelsLoading: 'Loading available models...',
     noModelsAvailable: 'No models available',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -245,6 +245,11 @@ export const ES_TEXTS = {
     anthropicSDK: 'SDK de Anthropic',
     openaiSDK: 'SDK de OpenAI',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'Región de AWS',
+    bedrockRegionDesc: 'Región de Amazon Bedrock para esta cuenta. Determina la URL del endpoint bedrock-mantle; no se puede sobrescribir mediante baseURL.',
+    bedrockRegionHint: 'bedrock-mantle está disponible en 18 regiones; la cobertura de modelos varía según la región.',
+
     // Other
     availableModelsLoading: 'Cargando modelos disponibles...',
     noModelsAvailable: 'No hay modelos disponibles',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -245,6 +245,11 @@ export const FR_TEXTS = {
     anthropicSDK: 'SDK Anthropic',
     openaiSDK: 'SDK OpenAI',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'Région AWS',
+    bedrockRegionDesc: 'Région Amazon Bedrock pour ce compte. Détermine l\'URL du point de terminaison bedrock-mantle ; ne peut pas être remplacée via baseURL.',
+    bedrockRegionHint: 'bedrock-mantle est disponible dans 18 régions ; la couverture des modèles varie selon la région.',
+
     // Other
     availableModelsLoading: 'Chargement des modèles disponibles...',
     noModelsAvailable: 'Aucun modèle disponible',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -258,6 +258,11 @@ export const IT_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'Regione AWS',
+    bedrockRegionDesc: 'Regione Amazon Bedrock per questo account. Determina l\'URL dell\'endpoint bedrock-mantle; non può essere sovrascritta tramite baseURL.',
+    bedrockRegionHint: 'bedrock-mantle è disponibile in 18 regioni; la copertura dei modelli varia in base alla regione.',
+
     // Altro
     availableModelsLoading: 'Caricamento dei modelli disponibili...',
     noModelsAvailable: 'Nessun modello disponibile',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -243,6 +243,11 @@ export const JA_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'AWS リージョン',
+    bedrockRegionDesc: 'このアカウントの Amazon Bedrock リージョン。bedrock-mantle エンドポイントの URL を決定し、baseURL で上書きできません。',
+    bedrockRegionHint: 'bedrock-mantle は 18 リージョンで利用可能。モデル対応はリージョンごとに異なります。',
+
     // Other
     availableModelsLoading: '利用可能なモデルを読み込み中...',
     noModelsAvailable: '利用可能なモデルがありません',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -244,6 +244,11 @@ export const KO_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'AWS 리전',
+    bedrockRegionDesc: '이 계정의 Amazon Bedrock 리전. bedrock-mantle 엔드포인트 URL을 결정하며 baseURL로 재정의할 수 없습니다.',
+    bedrockRegionHint: 'bedrock-mantle은 18개 리전에서 사용 가능; 리전별로 모델 지원 범위가 다릅니다.',
+
     // Other
     availableModelsLoading: '사용 가능한 모델 로딩 중...',
     noModelsAvailable: '사용 가능한 모델 없음',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -245,6 +245,11 @@ export const PT_TEXTS = {
     anthropicSDK: 'SDK da Anthropic',
     openaiSDK: 'SDK da OpenAI',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'Região AWS',
+    bedrockRegionDesc: 'Região do Amazon Bedrock para esta conta. Determina a URL do endpoint bedrock-mantle; não pode ser substituída via baseURL.',
+    bedrockRegionHint: 'bedrock-mantle está disponível em 18 regiões; a cobertura de modelos varia conforme a região.',
+
     // Other
     availableModelsLoading: 'Carregando modelos disponíveis...',
     noModelsAvailable: 'Nenhum modelo disponível',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -242,6 +242,11 @@ export const ZH_HANT_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'AWS 區域',
+    bedrockRegionDesc: '本帳號所在的 Amazon Bedrock 區域。驅動 bedrock-mantle 端點 URL；不能透過 baseURL 覆寫。',
+    bedrockRegionHint: 'bedrock-mantle 在 18 個區域可用；各區域模型覆蓋範圍不同。',
+
     // 其他
     availableModelsLoading: '載入可用模型...',
     noModelsAvailable: '無可用模型',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -244,6 +244,11 @@ export const ZH_TEXTS = {
     anthropicSDK: 'Anthropic SDK',
     openaiSDK: 'OpenAI SDK',
 
+    // v1.24.1 PATCH Bedrock Stage 1
+    bedrockRegionName: 'AWS 区域',
+    bedrockRegionDesc: '本账户所在的 Amazon Bedrock 区域。驱动 bedrock-mantle 端点 URL；不能通过 baseURL 覆盖。',
+    bedrockRegionHint: 'bedrock-mantle 在 18 个区域可用；各区域模型覆盖范围不同。',
+
     // 其他
     availableModelsLoading: '加载可用模型...',
     noModelsAvailable: '无可用模型',

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,13 @@ export interface LLMWikiSettings {
   wikiFolder: string;
   language: 'en' | 'zh' | 'zh-Hant' | 'ja' | 'ko' | 'de' | 'fr' | 'es' | 'pt' | 'it';
   wikiLanguage: string;
+  /**
+   * v1.24.1 PATCH Stage 1 — AWS region used by both Bedrock providers. Only
+   * applied when provider is `bedrock-anthropic` or `bedrock-openai`. Falls
+   * back to `us-east-1` (broadest model coverage) when unset. Always a
+   * region string (e.g. "us-east-1"), not a URL component.
+   */
+  bedrockRegion?: string;
   useCustomWikiLanguage?: boolean;
   availableModels?: string[];
   useCustomModel?: boolean;
@@ -612,6 +619,34 @@ export const PREDEFINED_PROVIDERS: Record<string, ProviderConfig> = {
     apiKeyPlaceholderZh: '...',
     requiresBaseUrl: false
   },
+  // v1.24.1 PATCH Bedrock Stage 1 — reuses AnthropicSdkClient via the
+  // bedrock-mantle endpoint (Bearer auth, no AWS SDK). baseUrl is filled
+  // dynamically by createLLMClientFromSettings based on `bedrockRegion`.
+  'bedrock-anthropic': {
+    id: 'bedrock-anthropic',
+    name: 'Amazon Bedrock (Anthropic via mantle)',
+    nameEn: 'Amazon Bedrock (Anthropic via mantle)',
+    nameZh: 'Amazon Bedrock（Anthropic via mantle）',
+    baseUrl: '',  // Resolved at runtime from bedrockRegion (see constants.ts)
+    apiKeyPlaceholder: 'ABSK... (Bedrock bearer key)',
+    apiKeyPlaceholderEn: 'ABSK... (Bedrock bearer key)',
+    apiKeyPlaceholderZh: 'ABSK...（Bedrock bearer key）',
+    requiresBaseUrl: false
+  },
+  // v1.24.1 PATCH Bedrock Stage 1 — reuses OpenAICompatSdkClient via
+  // bedrock-mantle /v1 chat-completions. Same bearer auth as Bedrock-
+  // Anthropic; region is resolved at runtime from `bedrockRegion`.
+  'bedrock-openai': {
+    id: 'bedrock-openai',
+    name: 'Amazon Bedrock (OpenAI via mantle)',
+    nameEn: 'Amazon Bedrock (OpenAI via mantle)',
+    nameZh: 'Amazon Bedrock（OpenAI via mantle）',
+    baseUrl: '',  // Resolved at runtime from bedrockRegion
+    apiKeyPlaceholder: 'ABSK... (Bedrock bearer key)',
+    apiKeyPlaceholderEn: 'ABSK... (Bedrock bearer key)',
+    apiKeyPlaceholderZh: 'ABSK...（Bedrock bearer key）',
+    requiresBaseUrl: false
+  },
   ollama: {
     id: 'ollama',
     name: 'Ollama (Local)',
@@ -728,4 +763,9 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   // compatible). Stored in data.json alongside queryHistory. Scoped
   // strictly to Query Wiki chat; no other workflow is affected.
   customQueryInstructions: '',
+
+  // v1.24.1 PATCH Bedrock Stage 1 — default region is the broadest-coverage
+  // region (us-east-1). Only consulted when provider is one of the two
+  // bedrock-* provider ids. Has no effect on other providers.
+  bedrockRegion: 'us-east-1',
 };

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -5,6 +5,7 @@ import { App, PluginSettingTab, Setting, Notice, TFile, requestUrl, BaseComponen
 import LLMWikiPlugin from '../main';
 import { PREDEFINED_PROVIDERS, LLMWikiSettings, WIKI_LANGUAGES, VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS } from '../types';
 import { TEXTS } from '../texts';
+import { BEDROCK_REGIONS, BEDROCK_DEFAULT_REGION } from '../constants';
 import { FolderSuggestModal } from './modals';
 import { HistoryModal } from './history-modal';
 import { classifyFetchError } from './settings-helpers';
@@ -311,6 +312,8 @@ export class LLMWikiSettingTab extends PluginSettingTab {
     const providerConfig = PREDEFINED_PROVIDERS[this.tempSettings.provider];
     const isOllama = this.tempSettings.provider === 'ollama';
     const isLmStudio = this.tempSettings.provider === 'lmstudio';
+    const isBedrock = this.tempSettings.provider === 'bedrock-anthropic'
+      || this.tempSettings.provider === 'bedrock-openai';
 
     // Provider Dropdown
     new Setting(containerEl)
@@ -371,6 +374,32 @@ export class LLMWikiSettingTab extends PluginSettingTab {
           .setPlaceholder(providerConfig?.baseUrl || 'https://api.example.com/v1')
           .setValue(this.tempSettings.baseUrl)
           .onChange((value) => { this.tempSettings.baseUrl = value; this.tempSettings.llmReady = false; }));
+    }
+
+    // v1.24.1 PATCH Bedrock Stage 1 — region selector (only when provider
+    // is one of the two bedrock-* ids). Region drives the baseURL the
+    // factory resolves; the user does NOT edit baseURL for Bedrock.
+    if (isBedrock) {
+      const currentRegion = this.tempSettings.bedrockRegion || BEDROCK_DEFAULT_REGION;
+      new Setting(containerEl)
+        .setName(this.getText('bedrockRegionName'))
+        .setDesc(`${this.getText('bedrockRegionDesc')} ${this.getText('bedrockRegionHint')}`)
+        .addDropdown(dropdown => {
+          BEDROCK_REGIONS.forEach(region => {
+            dropdown.addOption(region, region);
+          });
+          dropdown.setValue(currentRegion);
+          dropdown.onChange((value) => {
+            // Region change alters the resolved baseURL → models fetched
+            // for the previous region are now stale (mirror the provider
+            // dropdown's reset).
+            this.tempSettings.bedrockRegion = value;
+            this.tempSettings.llmReady = false;
+            this.tempSettings.availableModels = [];
+            this.tempSettings.useCustomModel = false;
+            this.tempSettings.model = '';
+          });
+        });
     }
 
     // LLM execution controls (concurrency + batch delay) — Issue #81 layout refactor


### PR DESCRIPTION
## Summary

v1.24.1 PATCH — Phase 3 of 5. Adds Amazon Bedrock access for 12+ models (Claude 5+, GPT-5.4/5.5, DeepSeek V3.x, Mistral, Kimi K2, Qwen3, GLM 4.7, Grok 4.3, Gemma 3, Nemotron 3, MiniMax M2 series) via the **bedrock-mantle** endpoint. Zero new npm dependencies; bundle delta ~+3 KB.

Replaces the rejected draft of dmsessions' PR #263 (which bundled SSO + bearer + every model into a +1.2 MB package). Stage 1 of a 3-stage split:

| Stage | Status | Trigger |
|---|---|---|
| Stage 1 (this PR) | ship now | Always — base feature, marginal cost |
| Stage 2 (@ai-sdk/amazon-bedrock v5) | Deferred | 3+ user issues requesting Sonnet 4.x + Llama 4 |
| Stage 3 (SSO + AWS Profile) | Indefinite | 5+ enterprise requests; bundle delta +1.2 MB |

Full design rationale + bundle math: see `project_v1.24.1_bedrock_stage1.md` in project memory.

## Coverage (no extra deps)

- **Messages API** (via `AnthropicSdkClient`): Claude Sonnet 5+, Fable 5, Haiku 4.5, Opus 4.7-4.8
- **Chat Completions API** (via `OpenAICompatSdkClient`): GPT-5.4/5.5, GPT OSS 20B/120B, DeepSeek V3.1/3.2, Mistral Large 3, Kimi K2, Qwen3, GLM 4.7/5, Grok 4.3, Gemma 3, Nemotron 3, MiniMax M2/M2.1/M2.5

**Known gap** (Stage 1 doesn't cover): Claude Sonnet 4.x / Opus 4.1-4.6, Llama 3/4, Jamba, Cohere — these need bedrock-runtime Converse protocol. Stage 2 will close this gap when 3+ users ask.

## What's in this PR

- `src/constants.ts`: `BEDROCK_REGIONS` (18-element union), `BEDROCK_DEFAULT_REGION`, two URL builders (`bedrockMantleMessagesUrl` / `bedrockMantleChatCompletionsUrl`)
- `src/types.ts`: two new `PREDEFINED_PROVIDERS` entries (`bedrock-anthropic`, `bedrock-openai`) — display name "Amazon Bedrock (... via mantle)", placed between GLM and the local providers; new `bedrockRegion?: string` on `LLMWikiSettings` with default `'us-east-1'`
- `src/llm-sdk/create-llm-client.ts`: extends `ProviderSettings` + adds `resolveBedrockRegion()` / `createBedrockClient()` helpers that consolidate 4× duplicated branch logic; new bedrock branches in both async + sync factories
- `src/ui/settings.ts`: `isBedrock` flag + 18-option region dropdown conditional on Bedrock providers; region onChange resets `availableModels` / `useCustomModel` / `model` (mirrors provider dropdown reset, prevents stale model inventory after region switch)
- `src/texts/*.ts` ×10: `bedrockRegionName`, `bedrockRegionDesc`, `bedrockRegionHint`
- `src/__tests__/llm-sdk/bedrock-factory.test.ts` (NEW): 6 tests — async × 2 + sync × 2 + 2 regression tests

## Test Results

```
pnpm lint:        0/0
npx tsc --noEmit: 0 errors
pnpm test:        1953 passing (144 files)
pnpm build:       clean
pnpm css-lint:    0 violations
```

Bundle delta: ~+3 KB (new i18n keys ×10 + factory helpers + 18 region labels + provider display strings).

## Gate 4 Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | Bedrock factory is cold-path. No new hot loops. |
| Memory | ✅ | `BEDROCK_REGIONS` is module-cached (18 strings). |
| IO | ✅ | Zero new vault operations. Zero new npm deps. |
| Network | ✅ | Same wire as existing baseURL-resolved providers. |
| Token | ✅ | No LLM call sites changed. |

## Maintainer Requesting @dmsessions for End-to-End Test

PR author/maintainer `@green-dalii` does **not** have AWS Bedrock credentials. **`@dmsessions`**, since you authored the original PR #263 and have AWS access, could you please verify this on your end?

Test plan (manual):
1. Settings → LLM Provider → "Amazon Bedrock (Anthropic via mantle)" → enter ABSK key + select a region
2. **Test Connection** — should hit `https://bedrock-mantle.${region}.api.aws` and succeed
3. Repeat for "Amazon Bedrock (OpenAI via mantle)" at the `/v1` endpoint
4. Verify region dropdown appears only for the two Bedrock providers
5. Run a small Ingest on each to confirm a real model round-trip

If you cannot test today, the unit tests + bundle math are sufficient gate to ship — please ack and we can revisit if your tests fail later.

## Closes

- Closes/Supersedes **PR #263** (dmsessions: original Bedrock bearer + SSO). The all-at-once design would have shipped +1.2 MB unjustified. Stage 1 takes the 3 KB subset that all users need; Stages 2/3 land only on demand.
