### PR TITLE
docs: align CLAUDE.md + ROADMAP.md current phase + v1.24.1 PATCH Phases 1-4 status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,22 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-07-12
+**Last Updated:** 2026-07-13
 
 ---
 
-## Current Phase: v1.24.0 RELEASED (2026-07-10) → v1.24.1 PATCH Phases 1-4 merged (2026-07-12), Phases 5-7 in flight
+## Current Phase: v1.24.0 RELEASED (2026-07-10) → v1.24.1 PATCH Phase 5 merged (PR #281, 2026-07-13); #275 + Phase 6 #258 + Phase 7 release remaining
 
-**v1.24.1 PATCH status (5 PRs merged on main between 2026-07-11 and 2026-07-12):**
+**v1.24.1 PATCH status (PRs merged on main 2026-07-11 to 2026-07-13):**
 - ✅ Phase 1 (#271): Fix #1 #268 Tier C forceRecreate bypass
 - ✅ Phase 2 (#276): page-factory.ts 1297-LOC god-class split (10 modules + 99 tests)
-- ✅ Phase 3 (#277): Bedrock Stage 1 via bedrock-mantle (~+3 KB, zero new npm deps)
+- ✅ Phase 3 (#277/280): Bedrock Stage 1 via bedrock-mantle (~+3 KB, zero new npm deps)
 - ✅ Phase 4 (#269): #272 LM Studio no-key ingest fix
-- 🟡 Phase 5 (in progress): parseJsonResponse quiet path + max_tokens 1000 raise (3 sites)
-- 🟡 Phase 6 (planned): #258 entities-page duplicate-info section suppressor
-- ⏳ Phase 7 (release): version bump + 10 READMEs + CHANGELOG + tag
+- ✅ Phase 5 (#281, merged 2026-07-13): 5-stage seed-selection pipeline (lex → LLM keywords → local scan → LLM KB fallback → PPR) + post-e2e noise/correctness fixes (Settings unified↔per-task cascade, wiki-engine graph path normalization, load-pages `.md` suffix defense, llm-sdk streaming-chunk console-debug removal, dead `indexContent` field removal). 1825 → 2060 tests.
+- 🟡 Phase 5.5 (Route 1): salvage `0a3bf3e` from `fix/json-empty-response-quiet-path` to close **#255**, **#274**, **#275** (parseJsonResponse quiet path + 3 max_tokens raised to 1000). Note: this is a DIFFERENT commit from #281 — the original "Phase 5" plan described `0a3bf3e`; #281 was a separately grown branch that landed first.
+- 🟡 Phase 6 (planned): #258 entities-page duplicate-info section suppressor (first-principles analysis pending).
+- ⏳ Phase 7 (release): version bump + 10 READMEs + CHANGELOG + tag. Re-scoped after #281 — see ROADMAP "Re-scoped v1.24.1 PATCH" section.
+
+**Open issues still pending after #281**: #255, #258, #274, #275 (the first three close with the Phase 5.5 salvage; #258 needs separate first-principles investigation).
 
 Full composition + execution plan: [ROADMAP.md](./ROADMAP.md#v1241-composition)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.24.0 (shipped 2026-07-10) → v1.24.1 PATCH Phases 1-4 merged 2026-07-12 (Phases 5-7 in flight) | **Updated:** 2026-07-12
+**Version:** 1.24.0 (shipped 2026-07-10) → v1.24.1 PATCH Phase 5 (PR #281) merged 2026-07-13. #275 + #258 + Phase 7 release remaining. | **Updated:** 2026-07-13
 
 ## Current Status
 
@@ -16,15 +16,24 @@
 - ✅ **PR #276 (Phase 2)** — page-factory.ts 1297-LOC god-class → 10 module files + facade + 99 unit tests (`green-dalii`).
 - ✅ **PR #277/280 (Phase 3)** — Bedrock Stage 1 via bedrock-mantle. New providers `bedrock-anthropic` + `bedrock-openai`. 18-region dropdown. ~+3 KB bundle. Zero new npm deps (`green-dalii`, design based on dmsessions PR #263).
 - ✅ **PR #269/272 (Phase 4)** — LM Studio no-key ingest fix (`rkuzmin`).
-- 🟡 **PR #281 (Phase 5, in progress)** — parseJsonResponse quiet path + max_tokens 1000 raise (3 sites: seed-selector + fix-runners alias + fix-runners tags) — NO `disableThinking` injection (user decision 2026-07-12).
-- 🟡 **PR #282 (Phase 6, planned)** — #258 entities-page duplicate-info section suppressor (`green-dalii`).
-- ⏳ **Phase 7** — v1.24.1 release workflow: version bump, CHANGELOG, README ×10, ROADMAP sync, pre-release-gate, tag.
+- ✅ **PR #281 (Phase 5, merged 2026-07-13)** — 5-stage seed-selection pipeline (lex → LLM keywords → local scan → LLM KB fallback → PPR) + post-e2e noise/correctness fixes (Settings unified↔per-task cascade, wiki-engine graph path normalization, load-pages `.md` suffix defense, llm-sdk streaming-chunk console debug removal, dead `indexContent` field removal). 1825 → 2060 tests. **Note**: PR #281 is NOT the same as the original Phase 5 plan (`parseJsonResponse quiet path + max_tokens 1000`, the `0a3bf3e` commit on `fix/json-empty-response-quiet-path`). That earlier Phase 5 plan is **unmerged** and is being re-scoped to v1.24.2 (see Fix #0 below).
+- 🟡 **PR #282 (Phase 6, planned)** — #258 entities-page duplicate-info section suppressor (`green-dalii`). First-principles analysis pending (prompt-cause vs schema-cause vs stochastic) before implementation.
+- ⏳ **Phase 7** — v1.24.1 release workflow: version bump, CHANGELOG, README ×10, ROADMAP sync, pre-release-gate, tag. (Re-scoped — see "Re-scoped v1.24.1 PATCH" below.)
 
 ### Deferred from v1.24.1 PATCH
 
-- **#275 (deepseek seed-selector empty body)** — root cause addressed in Phase 5 (max_tokens 200→1000). Streaming-mode port deferred to v1.24.2 Fix #0.
+- **#275 (deepseek seed-selector empty body)** — **STILL OPEN as of 2026-07-13**. PR #281 did NOT close it. The `0a3bf3e` commit on `fix/json-empty-response-quiet-path` (parseJsonResponse quiet path + 3 max_tokens raised to 1000) is the actual root-cause fix but **is unmerged** (WIP on that branch also includes an unfinished Phase 5.4 prompt-context overflow fallback). Salvage plan: peel `0a3bf3e` off the WIP, resolve the 3-file conflict with #281, land as a new PATCH. Streaming-mode port for `selectSeedsWithLLM` remains deferred to v1.24.2 Fix #0.
+- **#255 (Lint console errors)** and **#274 (Ollama Qwen3.5:9b no-key)** — root cause also addressed in the same `0a3bf3e` commit; will close together with #275.
 - **Windows `Headers` TypeError** — withdrawn 2026-07-10 (user input error: non-ASCII in API key; not a plugin bug).
 - **PR #263 Bedrock Stage 2/3** — SSO/profile-mode + Converse protocol. Stage 2 triggers at 3+ user requests; Stage 3 at 5+ enterprise requests.
+
+### Re-scoped v1.24.1 PATCH (post-#281)
+
+The original Phase 5/6/7 plan in this document was written before #281 was created. With #281 now in main, the remaining work is narrower:
+
+1. **Salvage 0a3bf3e** to close #275/#274/#255. (Tracked separately — see Route 1 notes in project memory.)
+2. **Phase 6 = #258** (one PR, first-principles analysis + small fix). Independent of #275.
+3. **Phase 7 = v1.24.1 PATCH release** — when (1) and (2) are merged, do version bump + 9 READMEs + CHANGELOG + ROADMAP + memory + pre-release-gate + tag. If (1) and (2) defer beyond a comfortable window, can ship v1.24.1 with just #281 and open v1.24.2 immediately.
 
 **v1.24.0 release composition:**
 - ✅ PR #248 — `controller.ts` `runLintWiki` god function → 3 LLM phase modules.


### PR DESCRIPTION
## Summary

Sync `CLAUDE.md` + `ROADMAP.md` to reflect the actual current state of v1.24.1 PATCH after **PR #281 (Phase 5) merged 2026-07-13**. The original PR body (opened 2026-07-12) targeted 'Phases 1-4 merged, Phases 5-7 in flight'; that framing is now stale.

## What's in this PR

The original commit (`b2881c9`) and a follow-up commit (`fbf9970`) together bring CLAUDE.md + ROADMAP.md in sync with main HEAD = `98fea01` (post-#281).

**Original `b2881c9` (Phase 1-4 sync)**:
- `CLAUDE.md`: `Last Updated: 2026-07-10` → `2026-07-12`. `Current Phase` rewritten to enumerate Phases 1-4 ✅ + Phases 5-7 🟡/⏳.
- `ROADMAP.md`: Header version/updated dates.

**Follow-up `fbf9970` (post-#281 correction)**:
- `CLAUDE.md`: `Last Updated: 2026-07-13`. `Current Phase` line rewritten again — Phase 5 now ✅ (PR #281 merged). Phase 5 description corrected to the actual 5-stage pipeline + noise/correctness fixes (was 'parseJsonResponse quiet path', which is the **unmerged** `0a3bf3e` on a different branch — see Route 1 note).
- `ROADMAP.md`: Header Version/Updated → 2026-07-13. Phase 5 line marked ✅. Phase 6/7 still planned. Deferred #275 description corrected (still OPEN, NOT closed by #281). New 'Re-scoped v1.24.1 PATCH' section tells the reader the remaining work is (1) salvage 0a3bf3e to close #255/#274/#275, (2) Phase 6 #258, (3) release.

## Important context: two different 'Phase 5' plans

There are now **two distinct 'Phase 5' efforts** in the v1.24.1 PATCH timeline. They fix different defect classes and must NOT be conflated:

| Plan | What it fixes | Status |
|---|---|---|
| **Original Phase 5** (`0a3bf3e` on `fix/json-empty-response-quiet-path`) | parseJsonResponse quiet path + 3 max_tokens raised to 1000 — closes #255/#274/#275 (empty-body noise on thinking models) | **Unmerged**. WIP on that branch also includes an unfinished Phase 5.4 prompt-context overflow fallback. Salvage plan: peel `0a3bf3e` off the WIP, resolve 3-file conflict with #281 (constants.ts / constants.test.ts / seed-selector.ts), land as new PATCH. |
| **PR #281 (5-stage pipeline)** | lex → LLM keywords → local scan → LLM KB fallback → PPR + post-e2e noise/correctness fixes (Settings unified↔per-task cascade, wiki-engine graph path normalization, load-pages `.md` suffix defense, llm-sdk streaming-chunk console-debug removal) | **Merged 2026-07-13**. Test count 1825 → 2060. Does NOT close #255/#274/#275. |

The follow-up commit `fbf9970` reflects this distinction in the docs so future readers don't merge the two concepts.

## Backward-compat

- Docs only. No code, no behavior change.
- No settings schema change. No file format change. No command/setting ID change.

## Out of scope

- **#275** root-cause fix (the salvage above) — tracked under 'Phase 5.5 / Route 1' in both files. New PR will be opened for that.
- **#258** (Phase 6) — first-principles analysis still pending; new PR after analysis.
- **Phase 7 (v1.24.1 release)** — version bump + 10 READMEs + CHANGELOG + tag. Triggered after #275 salvage + #258 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)