### PR TITLE
fix(prompt): drop redundant Basic Information section from entity pages (#258)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.24.0 (shipped 2026-07-10) → v1.24.1 PATCH Phase 5 (PR #281) merged 2026-07-13. #275 + #258 + Phase 7 release remaining. | **Updated:** 2026-07-13
+**Version:** 1.24.0 (shipped 2026-07-10) → v1.24.1 PATCH Phases 1-5 merged (PR #281 + #282 on 2026-07-13/14). #275 + #258 + Phase 7 release remaining. | **Updated:** 2026-07-14
 
 ## Current Status
 
@@ -16,24 +16,26 @@
 - ✅ **PR #276 (Phase 2)** — page-factory.ts 1297-LOC god-class → 10 module files + facade + 99 unit tests (`green-dalii`).
 - ✅ **PR #277/280 (Phase 3)** — Bedrock Stage 1 via bedrock-mantle. New providers `bedrock-anthropic` + `bedrock-openai`. 18-region dropdown. ~+3 KB bundle. Zero new npm deps (`green-dalii`, design based on dmsessions PR #263).
 - ✅ **PR #269/272 (Phase 4)** — LM Studio no-key ingest fix (`rkuzmin`).
-- ✅ **PR #281 (Phase 5, merged 2026-07-13)** — 5-stage seed-selection pipeline (lex → LLM keywords → local scan → LLM KB fallback → PPR) + post-e2e noise/correctness fixes (Settings unified↔per-task cascade, wiki-engine graph path normalization, load-pages `.md` suffix defense, llm-sdk streaming-chunk console debug removal, dead `indexContent` field removal). 1825 → 2060 tests. **Note**: PR #281 is NOT the same as the original Phase 5 plan (`parseJsonResponse quiet path + max_tokens 1000`, the `0a3bf3e` commit on `fix/json-empty-response-quiet-path`). That earlier Phase 5 plan is **unmerged** and is being re-scoped to v1.24.2 (see Fix #0 below).
-- 🟡 **PR #282 (Phase 6, planned)** — #258 entities-page duplicate-info section suppressor (`green-dalii`). First-principles analysis pending (prompt-cause vs schema-cause vs stochastic) before implementation.
-- ⏳ **Phase 7** — v1.24.1 release workflow: version bump, CHANGELOG, README ×10, ROADMAP sync, pre-release-gate, tag. (Re-scoped — see "Re-scoped v1.24.1 PATCH" below.)
+- ✅ **PR #281 (Phase 5, merged 2026-07-13)** — 5-stage seed-selection pipeline (lex → LLM keywords → local scan → LLM KB fallback → PPR) + post-e2e noise/correctness fixes (Settings unified↔per-task cascade, wiki-engine graph path normalization, load-pages `.md` suffix defense, llm-sdk streaming-chunk console debug removal, dead `indexContent` field removal). 1825 → 2060 tests. **Note**: PR #281 is NOT the same as the original Phase 5 plan (`parseJsonResponse quiet path + max_tokens 1000`, the `0a3bf3e` commit on `fix/json-empty-response-quiet-path`). That earlier Phase 5 plan is **unmerged** — but a quiet-path-only salvage landed as PR #282 (see below).
+- ✅ **PR #282 (Phase 5.5, merged 2026-07-14)** — parseJsonResponse empty-body quiet path salvaged from `0a3bf3e` (NO max_tokens raise — that part discarded per "改大不改小" + main already has `TOKENS_QUERY_SEED_SELECT=2000`). Closes #255 + #274. `throwOnEmpty: true` is defense-in-depth for #275. 2060 → 2073 tests (+13).
+- 🟡 **Phase 6** — #258 entities-page duplicate-info section suppressor. First-principles analysis pending (prompt-cause vs schema-cause vs stochastic) before implementation.
+- ⏳ **Phase 7** — v1.24.1 release workflow: version bump, CHANGELOG, README ×10, ROADMAP sync, pre-release-gate, tag.
 
 ### Deferred from v1.24.1 PATCH
 
-- **#275 (deepseek seed-selector empty body)** — **STILL OPEN as of 2026-07-13**. PR #281 did NOT close it. The `0a3bf3e` commit on `fix/json-empty-response-quiet-path` (parseJsonResponse quiet path + 3 max_tokens raised to 1000) is the actual root-cause fix but **is unmerged** (WIP on that branch also includes an unfinished Phase 5.4 prompt-context overflow fallback). Salvage plan: peel `0a3bf3e` off the WIP, resolve the 3-file conflict with #281, land as a new PATCH. Streaming-mode port for `selectSeedsWithLLM` remains deferred to v1.24.2 Fix #0.
-- **#255 (Lint console errors)** and **#274 (Ollama Qwen3.5:9b no-key)** — root cause also addressed in the same `0a3bf3e` commit; will close together with #275.
+- **#275 (deepseek seed-selector empty body)** — **STILL OPEN as of 2026-07-14** (user chose Option A: keep OPEN until explicit deepseek-v4-pro + thinking + json_object e2e confirms non-empty body). PR #281 + #282 did NOT close it. Indirect mitigation: `TOKENS_QUERY_SEED_SELECT=2000` (raised from 200 out-of-band during the #281 cycle) gives 10× budget; user's #281 e2e did not observe #275 reproduce. **No targeted code fix**: max_tokens raise is budget-only, not root-cause. `throwOnEmpty: true` in seed-selector (added in #282) lets `withTransientRetry` retry 3 times, but retries with same `max_tokens` won't help if the model keeps emitting thinking. **To close properly**: needs an explicit e2e that runs `selectSeedsWithLLM` with deepseek-v4-pro + thinking + json_object and confirms non-empty body. Streaming-mode port for `selectSeedsWithLLM` remains the proper fix in v1.24.2 Fix #0.
+- **#255 (Lint console errors)** — **CLOSED by PR #282 (2026-07-14)**. silentOnEmpty across 3 Lint callers + 1 ingest caller.
+- **#274 (Ollama Qwen3.5:9b no-key)** — **CLOSED by PR #282 (2026-07-14)**. Same quiet path.
 - **Windows `Headers` TypeError** — withdrawn 2026-07-10 (user input error: non-ASCII in API key; not a plugin bug).
 - **PR #263 Bedrock Stage 2/3** — SSO/profile-mode + Converse protocol. Stage 2 triggers at 3+ user requests; Stage 3 at 5+ enterprise requests.
 
-### Re-scoped v1.24.1 PATCH (post-#281)
+### Re-scoped v1.24.1 PATCH (post-#281 / post-#282)
 
-The original Phase 5/6/7 plan in this document was written before #281 was created. With #281 now in main, the remaining work is narrower:
+The original Phase 5/6/7 plan in this document was written before #281 was created. With #281 + #282 now in main, the remaining work is narrower:
 
-1. **Salvage 0a3bf3e** to close #275/#274/#255. (Tracked separately — see Route 1 notes in project memory.)
+1. **#275 e2e verification** — explicit e2e that runs `selectSeedsWithLLM` with deepseek-v4-pro + thinking + json_object. If passes → close #275 (maintainer comment + state COMPLETED). If fails → open a v1.24.2 PATCH for proper root-cause fix (streaming mode per #275 workaround).
 2. **Phase 6 = #258** (one PR, first-principles analysis + small fix). Independent of #275.
-3. **Phase 7 = v1.24.1 PATCH release** — when (1) and (2) are merged, do version bump + 9 READMEs + CHANGELOG + ROADMAP + memory + pre-release-gate + tag. If (1) and (2) defer beyond a comfortable window, can ship v1.24.1 with just #281 and open v1.24.2 immediately.
+3. **Phase 7 = v1.24.1 PATCH release** — when (1) and (2) are done, do version bump + 9 READMEs + CHANGELOG + ROADMAP + memory + pre-release-gate + tag. If (1) and (2) defer beyond a comfortable window, can ship v1.24.1 with just #281 + #282 and open v1.24.2 immediately.
 
 **v1.24.0 release composition:**
 - ✅ PR #248 — `controller.ts` `runLintWiki` god function → 3 LLM phase modules.

--- a/src/__tests__/__support__/engine-context.ts
+++ b/src/__tests__/__support__/engine-context.ts
@@ -171,7 +171,6 @@ export function createMockContext(opts: MockContextOptions = {}): { ctx: EngineC
     deleteFile: async () => {},
     buildSystemPrompt: async () => undefined,
     getSectionLabels: () => ({
-      section_basic_information: 'Basic Information',
       section_description: 'Description',
       section_related_entities: 'Related Entities',
       section_related_concepts: 'Related Concepts',

--- a/src/__tests__/schema/default-schema.test.ts
+++ b/src/__tests__/schema/default-schema.test.ts
@@ -52,6 +52,21 @@ describe('buildDefaultSchemaBody', () => {
     expect(body).toContain('## Maintenance Policies');
   });
 
+  // #258: removed "Basic Information" section so system-prompt context the LLM reads agrees with the user-prompt output format.
+  it('Entity Page Template does NOT include a Basic Information section (#258)', () => {
+    const entityMatch = body.match(/## Entity Page Template[\s\S]*?(?=\n## |\s*$)/);
+    expect(entityMatch).not.toBeNull();
+    expect(entityMatch![0]).not.toMatch(/\*\*Basic Information\*\*/);
+    expect(entityMatch![0]).toContain('**Description**');
+  });
+
+  it('Concept Page Template has never included a Basic Information section (#258)', () => {
+    // Sentinel against future schema edits that introduce the block.
+    const conceptMatch = body.match(/## Concept Page Template[\s\S]*?(?=\n## |\s*$)/);
+    expect(conceptMatch).not.toBeNull();
+    expect(conceptMatch![0]).not.toMatch(/\*\*Basic Information\*\*/);
+  });
+
   it('preserves entity and concept subtype valid lists', () => {
     // Entity: person, organization, project, product, event, place, other
     expect(body).toMatch(/person[\s\S]*?organization[\s\S]*?project[\s\S]*?product[\s\S]*?event[\s\S]*?place[\s\S]*?other/);

--- a/src/__tests__/schema/schema-section-template.test.ts
+++ b/src/__tests__/schema/schema-section-template.test.ts
@@ -8,8 +8,12 @@ describe('buildSchemaSectionTemplate', () => {
     it('returns canonical entity sections when schema is default', () => {
       const ctx = parseSchemaContext(buildDefaultSchemaBody(), 'entity');
       const tpl = buildSchemaSectionTemplate(ctx, 'entity');
-      // Default behavior: canonical entity sections (no change from v1.20.0)
-      expect(tpl).toContain('## Basic Information');
+      // Default behavior: canonical entity sections (v1.24.1 PATCH — Basic
+      // Information removed from the prompt path and the default schema; the
+      // canonical fallback in schema-context.ts must agree or the
+      // system-prompt context will still tell the LLM to render the
+      // redundant block. See Issue #258.
+      expect(tpl).not.toContain('## Basic Information');
       expect(tpl).toContain('## Description');
       expect(tpl).toContain('## Related Entities');
       expect(tpl).toContain('## Related Concepts');
@@ -71,8 +75,11 @@ User added a new top-level section.
       const body = '## Concept Page Template\n**Sections:**\n1. **Definition**: x';
       const ctx = parseSchemaContext(body, 'entity');
       const tpl = buildSchemaSectionTemplate(ctx, 'entity');
-      // No Entity Page Template in body — fall back to canonical entity sections
-      expect(tpl).toContain('## Basic Information');
+      // No Entity Page Template in body — fall back to canonical entity
+      // sections. As of v1.24.1 PATCH (Issue #258), the canonical entity
+      // list starts at Description, not Basic Information.
+      expect(tpl).not.toContain('## Basic Information');
+      expect(tpl).toContain('## Description');
     });
   });
 });

--- a/src/__tests__/wiki/lint/section-labels-hint.test.ts
+++ b/src/__tests__/wiki/lint/section-labels-hint.test.ts
@@ -1,0 +1,50 @@
+// Issue #258: buildSectionLabelsHint (used by lint/fill-empty-page.ts and
+// any other LLM-driven empty-page regenerator) used to list "Basic
+// Information" as the first entity-page section. That label conflicted
+// with the prompt + default-schema fix that removed the block — the lint
+// regen path would re-introduce the same `## 基本信息\n- Type: ...\n- Source:`
+// drift the original fix eliminated. The fix at lint/utils.ts:10 removes
+// the redundant `basic_information` line and renumbers the entity list to
+// start at Description.
+import { describe, it, expect } from 'vitest';
+import { buildSectionLabelsHint } from '../../../wiki/lint/utils';
+import { LLMWikiSettings } from '../../../types';
+
+function mkSettings(overrides: Partial<LLMWikiSettings> = {}): LLMWikiSettings {
+  return {
+    wikiLanguage: 'zh',
+    ...overrides,
+  } as LLMWikiSettings;
+}
+
+describe('buildSectionLabelsHint (#258 lint regen parity)', () => {
+  it('entity labels start at Description and skip Basic Information', () => {
+    const hint = buildSectionLabelsHint(mkSettings());
+    // The redundant entity label MUST NOT appear — the prompt + schema +
+    // user-customized schema agree it is gone.
+    expect(hint).not.toContain('基本信息');
+    expect(hint).not.toContain('Basic Information');
+    // Description is the new first entity section.
+    const entitySection = hint.split('Concept pages use:')[0];
+    expect(entitySection).toContain('描述');
+    // The remaining canonical entity sections are still listed.
+    expect(entitySection).toContain('相关实体');
+    expect(entitySection).toContain('相关概念');
+    expect(entitySection).toContain('来源提及');
+  });
+
+  it('concept labels have never included Basic Information', () => {
+    // Sentinel: concept pages never had the Basic Information block in any
+    // version. Confirm the lint hint honours that contract.
+    const hint = buildSectionLabelsHint(mkSettings());
+    const conceptSection = hint.split('Concept pages use:')[1]?.split('Source pages use:')[0] ?? '';
+    expect(conceptSection).not.toContain('基本信息');
+    expect(conceptSection).not.toContain('Basic Information');
+  });
+
+  it('English wikiLanguage also drops Basic Information from entity labels', () => {
+    const hint = buildSectionLabelsHint(mkSettings({ wikiLanguage: 'en' }));
+    expect(hint).not.toContain('Basic Information');
+    expect(hint).toContain('Description');
+  });
+});

--- a/src/__tests__/wiki/prompts/prompt-hardcode.test.ts
+++ b/src/__tests__/wiki/prompts/prompt-hardcode.test.ts
@@ -3,6 +3,7 @@ import { INGESTION_PROMPTS } from '../../../wiki/prompts/ingestion';
 import { LINT_PROMPTS } from '../../../wiki/prompts/lint';
 import { FIX_PROMPTS } from '../../../wiki/prompts/fixes';
 import { MERGE_PROMPTS } from '../../../wiki/prompts/merge';
+import { GENERATION_PROMPTS } from '../../../wiki/prompts/generation';
 
 describe('Prompt templates — no hardcoded wiki/ paths', () => {
   it('resolveEntityDedup uses {{wikiFolder}} placeholder for example path', () => {
@@ -35,25 +36,51 @@ describe('Prompt templates — no hardcoded wiki/ paths', () => {
 
 // #188: merge.ts must use {{section_*}} placeholders, not hardcoded English headers
 describe('Prompt templates — merge.ts section headers (#188)', () => {
-  it('mergeEntityPage uses {{section_*}} placeholders for Related sections', () => {
+  it('mergeEntityPage uses placeholders only for sections the entity page actually carries', () => {
     const tpl = MERGE_PROMPTS.mergeEntityPage;
-    // Must use placeholders, not hardcoded English
     expect(tpl).toContain('{{section_related_entities}}');
     expect(tpl).toContain('{{section_related_concepts}}');
-    expect(tpl).toContain('{{section_basic_information}}');
     expect(tpl).toContain('{{section_description}}');
-    // Issue #244: Mentions in Source section is now written programmatically
-    // by the page-factory post-processing. No longer part of LLM prompt.
+    // #258: Basic Information body block was removed — the merge prompt must not ask the LLM to render or update it.
+    expect(tpl).not.toContain('{{section_basic_information}}');
+    // #244: Mentions in Source is now written programmatically.
     expect(tpl).not.toContain('{{section_mentions_in_source}}');
   });
 
-  it('mergeConceptPage uses {{section_*}} placeholders for Related sections', () => {
+  it('mergeConceptPage uses placeholders only for sections the concept page actually carries', () => {
     const tpl = MERGE_PROMPTS.mergeConceptPage;
     expect(tpl).toContain('{{section_related_entities}}');
     expect(tpl).toContain('{{section_related_concepts}}');
-    expect(tpl).toContain('{{section_basic_information}}');
     expect(tpl).toContain('{{section_description}}');
-    // Issue #244: Mentions in Source section is now written programmatically.
+    // #258: Concept pages never had a Basic Information block — keep it that way.
+    expect(tpl).not.toContain('{{section_basic_information}}');
+    // #244: Mentions in Source is now written programmatically.
     expect(tpl).not.toContain('{{section_mentions_in_source}}');
+  });
+});
+
+// #258: entity page-creation prompts must not embed a "Basic Information"
+// body block — that block duplicates frontmatter fields (type / sources /
+// tags) and the LLM occasionally copied it verbatim. Fix is at the prompt
+// layer (root cause), not via a sanitizer.
+describe('Prompt templates — entity pages drop redundant Basic Information (#258)', () => {
+  it('generateEntityPage does not embed a Basic Information body block', () => {
+    const tpl = GENERATION_PROMPTS.generateEntityPage;
+    expect(tpl).not.toContain('{{section_basic_information}}');
+    // After the H1, the body must not re-state frontmatter `tags: [...]`
+    // and `sources: [...]` fields via `- Type:` / `- Source: [[...]]`.
+    // (The leading `**Entity Information:**` block above the H1 contains a
+    // legitimate `- Type: {{entity_type}}` input spec — that is required.)
+    const h1Idx = tpl.indexOf('# {{entity_name}}');
+    expect(h1Idx).toBeGreaterThan(-1);
+    const body = tpl.slice(h1Idx);
+    expect(body).not.toMatch(/^-\s*Type:\s*\{\{/m);
+    expect(body).not.toMatch(/^-\s*Source:\s*\[\[\s*\{\{/m);
+  });
+
+  it('generateConceptPage does not embed a Basic Information body block', () => {
+    // Concept pages never had this block; this is a sentinel against future copy-paste.
+    const tpl = GENERATION_PROMPTS.generateConceptPage;
+    expect(tpl).not.toContain('{{section_basic_information}}');
   });
 });

--- a/src/schema/schema-context.ts
+++ b/src/schema/schema-context.ts
@@ -117,7 +117,6 @@ export { buildDefaultSchemaBody };
  *  explicit section list. */
 const CANONICAL_SECTIONS: Record<string, string[]> = {
   entity: [
-    'Basic Information',
     'Description',
     'Related Entities',
     'Related Concepts',
@@ -154,7 +153,7 @@ const TEMPLATE_HEADINGS: Record<string, string[]> = {
  * 4. If no explicit list found, fall back to canonical defaults
  *
  * Returns a markdown string with each section as a `## Heading` placeholder.
- * For example: `## Basic Information\n[content]\n\n## Description\n[content]`
+ * For example: `## Description\n[content]\n\n## Related Entities\n[content]`
  */
 export function buildSchemaSectionTemplate(ctx: SchemaContext, pageType: string): string {
   const fallbackSections = CANONICAL_SECTIONS[pageType] ?? [];

--- a/src/schema/schema-manager.ts
+++ b/src/schema/schema-manager.ts
@@ -65,11 +65,10 @@ Pages in \`entities/\` MUST follow this structure:
 - \`reviewed:\` (optional) — if true, page is human-verified and protected
 
 **Sections:**
-1. **Basic Information**: Type, source file link
-2. **Description**: 3-6 sentences with concrete facts, bidirectional links
-3. **Related Entities**: Links to related entities using [[entities/...]]
-4. **Related Concepts**: Links to related concepts using [[concepts/...]]
-5. **Mentions in Source**: Verbatim quotes with source attribution — see [Mentions Format](#mentions-format) below
+1. **Description**: 3-6 sentences with concrete facts, bidirectional links
+2. **Related Entities**: Links to related entities using [[entities/...]]
+3. **Related Concepts**: Links to related concepts using [[concepts/...]]
+4. **Mentions in Source**: Verbatim quotes with source attribution — see [Mentions Format](#mentions-format) below
 
 ## Concept Page Template
 Pages in \`concepts/\` MUST follow this structure:

--- a/src/wiki/lint/utils.ts
+++ b/src/wiki/lint/utils.ts
@@ -8,7 +8,6 @@ export function escapeRegex(s: string): string {
 export function buildSectionLabelsHint(settings: LLMWikiSettings): string {
   const labels = getSectionLabels(settings);
   const entityLabels = [
-    `- ${labels.basic_information}`,
     `- ${labels.description}`,
     `- ${labels.related_entities}`,
     `- ${labels.related_concepts}`,

--- a/src/wiki/prompts/generation.ts
+++ b/src/wiki/prompts/generation.ts
@@ -52,10 +52,6 @@ aliases: ["Alternative name or translation"]  # REQUIRED: at least 1 alias, must
 
 # {{entity_name}}
 
-## {{section_basic_information}}
-- Type: {{entity_type}}
-- Source: [[{{source_file}}]]
-
 ## {{section_description}}
 [Detailed description of the entity with bidirectional links]
 

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -75,7 +75,6 @@ Rules:
   mergeEntityPage: `You are a Wiki editor performing intelligent content integration. Merge new source information into an existing page following the schema-defined structure.
 
 **Schema Rules (MUST follow this structure):**
-- ## {{section_basic_information}}: Type, sources, key attributes
 - ## {{section_description}}: Core definition and significance (3-6 sentences)
 - ## {{section_related_entities}}: Links to related entities
 - ## {{section_related_concepts}}: Links to related concepts
@@ -104,9 +103,6 @@ Rules:
 **Output Format:**
 Output ONLY the body content (no frontmatter):
 
-## {{section_basic_information}}
-[Type, sources, key attributes — updated]
-
 ## {{section_description}}
 [Integrated description — merge existing + new, no duplication]
 
@@ -119,7 +115,6 @@ Output ONLY the body content (no frontmatter):
   mergeConceptPage: `You are a Wiki editor performing intelligent content integration. Merge new source information into an existing concept page following the schema-defined structure.
 
 **Schema Rules (MUST follow this structure):**
-- ## {{section_basic_information}}: Type, sources, definition
 - ## {{section_description}}: Detailed explanation with examples (3-6 sentences)
 - ## {{section_related_concepts}}: Connected concepts using [[concepts/...]]
 - ## {{section_related_entities}}: Connected entities using [[entities/...]]
@@ -148,9 +143,6 @@ Output ONLY the body content (no frontmatter):
 
 **Output Format:**
 Output ONLY the body content (no frontmatter):
-
-## {{section_basic_information}}
-[Type, sources, definition — updated]
 
 ## {{section_description}}
 [Integrated description — merge existing + new]


### PR DESCRIPTION
# Drop redundant Basic Information section from entity pages (#258)

`createNewPage()` (and the lint `fill empty page` regen path) sometimes emitted a redundant `## 基本信息` body block on entity pages, with `- Type: ...\n- Source: [[...]]` bullets that duplicate the frontmatter fields. Probabilistic, not 100% — root cause is prompt-level.

## Root cause

Five independent code paths declared "Basic Information" as the first entity section:
1. `prompts/generation.ts` `generateEntityPage` output block — LLM could copy the template verbatim
2. `prompts/merge.ts` `mergeEntityPage` + `mergeConceptPage` placeholders — reformat path
3. `schema/schema-manager.ts` entity Sections list — system-prompt context
4. `schema/schema-context.ts` `CANONICAL_SECTIONS.entity` — fallback for default-schema users
5. `wiki/lint/utils.ts` `buildSectionLabelsHint` entityLabels — lint fill-empty-page regeneration

LLM saw consistent instruction across system-prompt + user-prompt + lint hint and merged its output, occasionally producing the redundant block.

## Fix

Per user decision in #258 replies: **fix at the prompt/source layer, no sanitizer, no migration of legacy content.**

5 production files updated (-22 lines net):
- `src/wiki/prompts/generation.ts` — entity prompt output block removed
- `src/wiki/prompts/merge.ts` — 4 placeholder blocks removed (entity + concept schema rules and output formats)
- `src/schema/schema-manager.ts` — entity Sections renumbered 5→4
- `src/schema/schema-context.ts` — `CANONICAL_SECTIONS.entity` + JSDoc example updated
- `src/wiki/lint/utils.ts` — `entityLabels[0]` removed

## Tests

- `src/__tests__/wiki/lint/section-labels-hint.test.ts` (NEW, 3 tests)
- 4 existing test files updated with new assertions / flipped inverted assertions
- 1 mock dead-key removed (`src/__tests__/__support__/engine-context.ts`)
- 2073 → 2080 tests (+7 net)

## Quality closure

- **Gate 1** (lint/tsc/test/build/css-lint): all green (lint 0/0, tsc 0, test 2080/2080, build clean, css-lint 0)
- **Gate 2** (no side effects): call-site audit done — `fill-empty-page.ts:50` consumes `buildSectionLabelsHint` shorter string, downstream `buildEmptyPagePrompt`/`applySectionLabels` unchanged
- **Gate 3** (no breaking changes): public API untouched, prompt-string content reduced (additive for users — entities now have one fewer section to populate)
- **Gate 4** (no perf regression): pure string deletions in prompts; `buildSectionLabelsHint` still iterates `SECTION_LABELS` (150 entries = 15 × 10 locales) once per call — unchanged before/after; `applySectionLabels` `basic_information` no-op regex remains sub-microsecond
- **Gate 5** (docs): ROADMAP `### v1.24.1 composition` will receive `#284 ✅` in Phase 7 (v1.24.1 release workflow)
- **Gate 6** (release clean): TBD in Phase 7

Review via simplify (4 cleanup agents, 6 actionable cleanups applied) + code-review at high effort (8 angles, 2 stale-doc/dead-mock-key findings fixed).

## i18n

`SECTION_LABELS[locale].basic_information` entries retained across all 10 locales for backward compatibility with user-customized `schema/config.md` that may still mention the section. Labels are dead-weights (no prompt template references the placeholder anymore) but kept for backward compat.

## User constraint compliance

- ✅ 无破坏性 — public API/signatures/types/settings all unchanged
- ✅ 无副作用 — call-sites unchanged; `applySectionLabels` no longer substitutes a placeholder that no longer exists (no-op)
- ✅ 无性能回归 — pure string deletions
- ✅ 第一性原理 — root cause was prompt-level (5 paths agreed on "Basic Information" = first section), not schema-forced
- ✅ 不私自注入 disableThinking — N/A, no LLM settings touched

Closes #258

Co-authored-by: green-dalii <654534332@qq.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
