### PR TITLE
fix(related-page): stop persisting raw LLM output on the related path

### DIFF
--- a/src/__tests__/wiki/page-factory/related-page.test.ts
+++ b/src/__tests__/wiki/page-factory/related-page.test.ts
@@ -190,3 +190,123 @@ describe('updateRelatedPage — normal path rewrites via LLM', () => {
     ).rejects.toThrow(/LLM client not initialized/);
   });
 });
+
+// Issue #267 established a non-lossy re-ingest on the merge path. This path
+// never had it: the Mentions section lives in the body handed to the LLM, and
+// the reply was persisted verbatim, so a rewrite that dropped the section
+// destroyed every accumulated quote. Observed in the wild with a local model:
+// a 2-source hub lost 4 quotes, a 3-source hub lost 1.
+describe('updateRelatedPage — Mentions are never LLM-owned (#267 parity)', () => {
+  const PAGE_WITH_MENTIONS = [
+    '---',
+    'created: 2026-07-10',
+    'updated: 2026-07-10',
+    'sources:',
+    '  - "[[sources/old]]"',
+    'tags: []',
+    '---',
+    '',
+    '## Description',
+    'Old body.',
+    '',
+    '## Mentions in Source',
+    '',
+    '- "a curated quote from an earlier source" — [[sources/old|old]]',
+  ].join('\n');
+
+  function analysisWithMentions(): SourceAnalysis {
+    return {
+      ...makeAnalysis(PAGE_TITLE),
+      entities: [{
+        name: PAGE_TITLE,
+        type: 'other' as const,
+        summary: 's',
+        mentions_in_source: ['a fresh quote from the new source'],
+        related_entities: [],
+        related_concepts: [],
+      }],
+    };
+  }
+
+  it('preserves accumulated quotes when the LLM rewrite omits the Mentions section', async () => {
+    const ctx = makeCtx({
+      pageContent: PAGE_WITH_MENTIONS,
+      llmResponse: '## Description\nA rewritten body with no mentions section at all.',
+    });
+
+    const result = await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      analysisWithMentions(),
+      { path: 'sources/new.md', basename: 'new' },
+    );
+
+    expect(result).toBe(true);
+    const written = ctx.written.get(PAGE_PATH)!;
+    expect(written).toContain('a curated quote from an earlier source');
+    expect(written).toContain('[[sources/old|old]]');
+    // The LLM's new prose is still adopted.
+    expect(written).toContain('A rewritten body with no mentions section at all.');
+  });
+
+  it('unions the new source\'s mentions with the accumulated ones', async () => {
+    const ctx = makeCtx({
+      pageContent: PAGE_WITH_MENTIONS,
+      llmResponse: '## Description\nRewritten.',
+    });
+
+    await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      analysisWithMentions(),
+      { path: 'sources/new.md', basename: 'new' },
+    );
+
+    const written = ctx.written.get(PAGE_PATH)!;
+    expect(written).toContain('a curated quote from an earlier source');
+    expect(written).toContain('a fresh quote from the new source');
+  });
+
+  it('canonicalizes a garbled section label in the LLM rewrite (#241 parity)', async () => {
+    const ctx = makeCtx({
+      pageContent: PAGE_WITH_MENTIONS,
+      // One edit away from the canonical label. Uncanonicalized, the injector
+      // would not recognize it, append a second section, and leave this one
+      // behind as an orphan that label-exact retrieval can no longer see.
+      llmResponse: '## Description\nRewritten.\n\n## Mentions in Sourse\n\n- stale',
+    });
+
+    await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      analysisWithMentions(),
+      { path: 'sources/new.md', basename: 'new' },
+    );
+
+    const written = ctx.written.get(PAGE_PATH)!;
+    expect(written).not.toContain('Mentions in Sourse');
+    expect(written.match(/^## Mentions in Source$/gm)).toHaveLength(1);
+  });
+
+  it('does not feed the Mentions section into the rewrite prompt', async () => {
+    let seenPrompt = '';
+    const ctx = makeCtx({ pageContent: PAGE_WITH_MENTIONS });
+    ctx.getClient = () => ({
+      createMessage: async (req: { messages: Array<{ content: string }> }) => {
+        seenPrompt = req.messages[0].content;
+        return '## Description\nRewritten.';
+      },
+    }) as ReturnType<RelatedPageContext['getClient']>;
+
+    await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      analysisWithMentions(),
+      { path: 'sources/new.md', basename: 'new' },
+    );
+
+    // The model never sees the citations, so it cannot drift their format.
+    expect(seenPrompt).not.toContain('a curated quote from an earlier source');
+    expect(seenPrompt).toContain('Old body.');
+  });
+});

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -20,9 +20,14 @@ import { TOKENS_PAGE_GENERATION } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
+import { stripMentionsSection } from '../../core/mentions-parser';
+import { canonicalizeSectionHeaders } from '../../core/section-header-canonicalizer';
+import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
+import { getSectionLabels } from '../system-prompts';
 import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { UNIVERSAL_LINK_CONSTRAINTS } from '../prompts/constraints';
 import { appendToReviewedPage, type MergeContext } from './merge-page';
+import { assembleFinalContent } from './mentions-integration';
 
 /**
  * Minimal context contract required by `updateRelatedPage`. Mirrors the real
@@ -97,9 +102,16 @@ export async function updateRelatedPage(
     return true;
   }
 
+  const labels = getSectionLabels(ctx.settings);
+
+  // The Mentions section is programmatic since #244 and must never be
+  // LLM-rewritten. Strip it from the prompt body so the model cannot drift its
+  // format; it is re-attached deterministically by assembleFinalContent below.
+  const promptBody = stripMentionsSection(existingBody, labels.mentions_in_source);
+
   const prompt = PROMPTS.updateRelatedPage
     .replace('{{page_name}}', pageName)
-    .replace('{{existing_body}}', existingBody)
+    .replace('{{existing_body}}', promptBody)
     .replace('{{source_basename}}', sourceFile.basename)
     .replace('{{new_info}}', JSON.stringify(newInfo))
     .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
@@ -117,8 +129,32 @@ export async function updateRelatedPage(
 
   const cleanedBody = cleanMarkdownResponse(updatedBody);
 
-  // 2. Assemble: programmatic frontmatter + LLM body.
-  const finalContent = `${frontmatter}\n\n${cleanedBody}`;
-  await ctx.createOrUpdateFile(page.path, finalContent);
+  // Parity with createNewPage / mergePage: this path used to persist the model's
+  // reply verbatim, so it ran neither the header canonicalizer (#241) nor the
+  // related-link prefix corrector (#187). A garbled section label therefore
+  // stayed garbled — and Tier-B retrieval matches labels exactly — while a
+  // `sources/`-mis-prefixed link in a Related section was never re-typed.
+  const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
+  const correctedBody = correctRelatedLinkPrefixes(
+    canonicalizedBody,
+    newInfo.related_entities,
+    newInfo.related_concepts,
+    labels.related_entities,
+    labels.related_concepts,
+    ctx.settings.slugCase === 'preserve',
+  );
+
+  // 2. Assemble: programmatic frontmatter + LLM body + Mentions section.
+  // Issue #267 established a non-lossy re-ingest on the merge path, but this
+  // path never had it: the Mentions section lives in the body handed to the LLM,
+  // so a rewrite that failed to reproduce it destroyed every accumulated quote.
+  // Route through assembleFinalContent exactly as mergePage does — it unions the
+  // page's mentions with this source's, and falls back to preserving an
+  // unparseable section verbatim. `existingBody` (not promptBody) is passed so
+  // the accumulated mentions are recovered from the unstripped page.
+  await ctx.createOrUpdateFile(
+    page.path,
+    await assembleFinalContent(ctx, frontmatter, correctedBody, newInfo, sourceFile, existingBody),
+  );
   return true;
 }


### PR DESCRIPTION
Fixes #287.

`updateRelatedPage` wrote the model's reply straight to disk, running none of the deterministic post-processing the other write paths run. Because the Mentions section lives in that body, a rewrite that failed to reproduce it destroyed every accumulated quote on the page.

## Changes

- Route the body through `assembleFinalContent`, exactly as `mergePage` does — unions accumulated + new mentions, and preserves an unparseable section verbatim via the #267 fail-safe.
- Run `canonicalizeSectionHeaders` (#241) and `correctRelatedLinkPrefixes` (#187), so all three write paths line up.
- Strip the Mentions section from the rewrite prompt — the model cannot drift a format it never sees.

## Tests

Four regression tests, each verified red against the current implementation. Full suite green (2084 tests, `tsc --noEmit` clean).

---

I opened this without waiting for a go-ahead because the failure mode is silent data loss. If you would rather fix it your own way, close this — no hard feelings, the issue stands on its own.
