### PR TITLE
fix(ingest): preserve schema sections the LLM drops in body rewrites (#292)

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { canonicalizeSectionHeaders } from '../../core/section-header-canonicalizer';
+import {
+  canonicalizeSectionHeaders,
+  classifyHeader,
+  preserveExistingSections,
+} from '../../core/section-header-canonicalizer';
 
 describe('canonicalizeSectionHeaders (deterministic repair of LLM-garbled section headers)', () => {
   // The de labels the model is handed and expected to copy verbatim.
@@ -61,5 +65,111 @@ describe('canonicalizeSectionHeaders (deterministic repair of LLM-garbled sectio
     expect(r).toContain('## Erwähnungen in der Quelle');
     expect(r).not.toContain('Erwägungen');
     expect(r).toContain('- [[entities/Caspase|Caspase]]');
+  });
+});
+
+describe('classifyHeader (canonical-or-foreign, tolerant of a parenthetical suffix)', () => {
+  const DE = [
+    'Beschreibung', 'Verwandte Konzepte', 'Verwandte Entitäten',
+    'Erwähnungen in der Quelle', 'Neue Informationen',
+  ];
+
+  it('classifies a plain canonical header with no suffix', () => {
+    expect(classifyHeader('Beschreibung', DE)).toEqual({ label: 'Beschreibung', suffix: null });
+  });
+
+  it('[the field case] classifies a suffixed New Information header and reports the suffix', () => {
+    // The suffix is emitted by the code, not the model: the generation prompt
+    // uses {{date}}, the complementary-append fallback the source basename.
+    expect(classifyHeader('Neue Informationen (Silent Inflammation)', DE))
+      .toEqual({ label: 'Neue Informationen', suffix: 'Silent Inflammation' });
+  });
+
+  it('heals a garbled base label under a suffix', () => {
+    expect(classifyHeader('Neue Informatonen (SIBO)', DE))
+      .toEqual({ label: 'Neue Informationen', suffix: 'SIBO' });
+  });
+
+  it('leaves a genuinely foreign header foreign, with or without a suffix', () => {
+    expect(classifyHeader('Active Tag Vocabulary', DE)).toBeNull();
+    expect(classifyHeader('Active Tag Vocabulary (2026-07-19)', DE)).toBeNull();
+  });
+
+  it('does not treat nested parentheses as a suffix', () => {
+    expect(classifyHeader('Beschreibung (a (b))', DE)).toBeNull();
+  });
+});
+
+describe('preserveExistingSections (re-assert schema sections the LLM dropped)', () => {
+  const DE = [
+    'Beschreibung', 'Verwandte Konzepte', 'Verwandte Entitäten',
+    'Erwähnungen in der Quelle', 'Neue Informationen',
+  ];
+
+  it('restores a canonical section the rewrite dropped entirely', () => {
+    const oldBody = '## Beschreibung\nalter Text\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
+    const newBody = '## Verwandte Konzepte\n- [[concepts/X|X]]';
+    const out = preserveExistingSections(oldBody, newBody, DE);
+    expect(out).toContain('## Beschreibung');
+    expect(out).toContain('alter Text');
+  });
+
+  it('leaves a section the model rewrote untouched — content is the model\'s call', () => {
+    const oldBody = '## Beschreibung\nalter Text';
+    const newBody = '## Beschreibung\nneuer, besserer Text';
+    const out = preserveExistingSections(oldBody, newBody, DE);
+    expect(out).toBe(newBody);
+    expect(out).not.toContain('alter Text');
+  });
+
+  it('[regression: suffix collision] a different New Information block does not count as keeping the old one', () => {
+    // The field failure this guard was blind to: New Information is the one
+    // schema section that legitimately repeats, one block per contributing
+    // source. Keyed by base label alone, emitting (Quercetin) made the guard
+    // consider (Silent Inflammation) preserved — and it was lost for good.
+    // Measured across a full-corpus rebuild: 26 sections on 11 pages, every
+    // single loss of this shape.
+    const oldBody = [
+      '## Beschreibung', 'Text',
+      '', '## Neue Informationen (Silent Inflammation)', '- alter Befund',
+    ].join('\n');
+    const newBody = [
+      '## Beschreibung', 'Text',
+      '', '## Neue Informationen (Quercetin)', '- neuer Befund',
+    ].join('\n');
+    const out = preserveExistingSections(oldBody, newBody, DE);
+    expect(out).toContain('## Neue Informationen (Quercetin)');
+    expect(out).toContain('## Neue Informationen (Silent Inflammation)');
+    expect(out).toContain('- alter Befund');
+  });
+
+  it('keeps an identical suffixed section exactly once', () => {
+    const body = '## Neue Informationen (SIBO)\n- Befund';
+    expect(preserveExistingSections(body, body, DE)).toBe(body);
+  });
+
+  it('does not restore a section that carried no content', () => {
+    const oldBody = '## Beschreibung\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
+    const newBody = '## Verwandte Konzepte\n- [[concepts/X|X]]';
+    expect(preserveExistingSections(oldBody, newBody, DE)).toBe(newBody);
+  });
+
+  it('never restores a foreign section — only the schema is re-asserted', () => {
+    const oldBody = '## Active Tag Vocabulary\n- leak\n\n## Beschreibung\nText';
+    const newBody = '## Beschreibung\nText';
+    const out = preserveExistingSections(oldBody, newBody, DE);
+    expect(out).toBe(newBody);
+    expect(out).not.toContain('Active Tag Vocabulary');
+  });
+
+  it('ignores the lead paragraph and H1 — only `##` sections are candidates', () => {
+    const oldBody = '# Titel\n\nEinleitung\n\n## Beschreibung\nText';
+    const newBody = '## Beschreibung\nText';
+    expect(preserveExistingSections(oldBody, newBody, DE)).toBe(newBody);
+  });
+
+  it('is a no-op when the rewrite kept everything', () => {
+    const body = '## Beschreibung\nText\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
+    expect(preserveExistingSections(body, body, DE)).toBe(body);
   });
 });

--- a/src/__tests__/wiki/page-factory/complementary-appends.test.ts
+++ b/src/__tests__/wiki/page-factory/complementary-appends.test.ts
@@ -121,7 +121,7 @@ describe('spliceAfterSection — separator choice (#185 follow-up)', () => {
 
 describe('makeFallbackNewInfoSection', () => {
   it('returns empty string when no failed groups', () => {
-    expect(makeFallbackNewInfoSection([], [], 'article')).toBe('');
+    expect(makeFallbackNewInfoSection([], [], 'article', 'New Information')).toBe('');
   });
 
   it('emits a New Information section with only the failed items', () => {
@@ -130,7 +130,7 @@ describe('makeFallbackNewInfoSection', () => {
       { kind: 'complementary', content: 'b', target_section: 'B' },
       { kind: 'complementary', content: 'c', target_section: 'C' },
     ];
-    const out = makeFallbackNewInfoSection(['A', 'C'], items, 'article');
+    const out = makeFallbackNewInfoSection(['A', 'C'], items, 'article', 'New Information');
     expect(out).toContain('## New Information (article)');
     expect(out).toContain('- a');
     expect(out).toContain('- c');
@@ -138,7 +138,7 @@ describe('makeFallbackNewInfoSection', () => {
   });
 
   it('uses a placeholder body when allItems has no matching items', () => {
-    const out = makeFallbackNewInfoSection(['X'], [], 'article');
+    const out = makeFallbackNewInfoSection(['X'], [], 'article', 'New Information');
     expect(out).toContain('- New information from article');
   });
 });

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -77,6 +77,50 @@ export function snapHeaderToCanonical(
   return null;
 }
 
+/** A schema section's identity: its canonical label plus any parenthetical suffix. */
+export interface SectionIdentity {
+  label: string;
+  /** The text inside a trailing ` (...)`, or null when the header carries none. */
+  suffix: string | null;
+}
+
+/**
+ * Classify a header as canonical-or-not, tolerant of a trailing parenthetical
+ * suffix, and report that suffix as part of the section's identity.
+ *
+ * The New Information section carries such a suffix by design: the generation
+ * prompt emits `## {{section_new_information}} ({{date}})` and the
+ * complementary-append fallback emits `## {{section_new_information}} ({{source}})`.
+ * The bare snapper rejects those — the suffix pushes the header well past
+ * MAX_DISTANCE — so a legitimate, content-bearing accumulation section would be
+ * classified as foreign. Match the base header (before a final ` (...)`) too,
+ * while a genuinely foreign header still snaps to nothing whether or not it has
+ * a suffix.
+ *
+ * The suffix is returned rather than discarded because it is load-bearing: New
+ * Information is the one schema section that legitimately occurs MULTIPLE times
+ * on a page, one block per contributing source, distinguished only by that
+ * suffix. Callers that decide keep-vs-drop per section must therefore compare
+ * full identities, not base labels. Used for those decisions only — NOT by
+ * canonicalizeSectionHeaders, which must leave a suffixed header's text intact.
+ */
+export function classifyHeader(
+  header: string,
+  canonicalLabels: string[],
+): SectionIdentity | null {
+  const direct = snapHeaderToCanonical(header, canonicalLabels);
+  if (direct !== null) return { label: direct, suffix: null };
+  const m = /^(.*?)\s*\(([^()]*)\)\s*$/.exec(header);
+  if (!m) return null;
+  const base = snapHeaderToCanonical(m[1].trim(), canonicalLabels);
+  return base === null ? null : { label: base, suffix: m[2] };
+}
+
+/** Stable key for a section identity — canonical label plus suffix. */
+export function sectionIdentityKey(id: SectionIdentity): string {
+  return id.suffix === null ? id.label : `${id.label} (${id.suffix})`;
+}
+
 export function canonicalizeSectionHeaders(content: string, canonicalLabels: string[]): string {
   const snap = (header: string): string | null => snapHeaderToCanonical(header, canonicalLabels);
   return content.split('\n').map(line => {
@@ -85,4 +129,88 @@ export function canonicalizeSectionHeaders(content: string, canonicalLabels: str
     const target = snap(m[2]);
     return target ? `${m[1]}${target}` : line;
   }).join('\n');
+}
+
+/**
+ * Split a body into its canonical schema sections, keyed by full identity
+ * (label + suffix). Non-schema regions — frontmatter, H1, the lead paragraph
+ * before the first `##`, and any foreign section — are ignored. Each value is
+ * the whole block: header line plus its content lines up to the next `##`.
+ *
+ * Keyed by identity rather than by label because New Information repeats per
+ * source; keying by label alone would collapse those blocks onto one another.
+ * First occurrence of an identity wins, so an exactly-duplicated header cannot
+ * make the map grow.
+ */
+function canonicalSectionBlocks(
+  body: string,
+  canonicalLabels: string[],
+): Map<string, string[]> {
+  const blocks = new Map<string, string[]>();
+  let key: string | null = null;
+  let lines: string[] = [];
+  const flush = () => {
+    if (key !== null && !blocks.has(key)) blocks.set(key, lines);
+  };
+  for (const line of body.split('\n')) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      flush();
+      const id = classifyHeader(m[1], canonicalLabels);
+      key = id ? sectionIdentityKey(id) : null;
+      lines = key ? [line] : [];
+      continue;
+    }
+    if (key !== null) lines.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+/**
+ * Re-assert schema sections the LLM dropped during a body rewrite.
+ *
+ * updateRelatedPage and the mergePage full-rewrite path hand the model the
+ * existing body and adopt its rewrite as the new body. Mentions (#267), headers
+ * (#241) and link prefixes (#187) are all re-asserted deterministically
+ * afterwards — but the COMPLETENESS of the schema body was still the model's to
+ * decide: a rewrite that silently omits `## Description` dropped that section
+ * for good.
+ *
+ * The schema, not the model, decides which sections must exist, so restore any
+ * canonical section that carried content in `oldBody` and is wholly absent from
+ * `newBody`. Conservative by construction: it only ever APPENDS a dropped
+ * section back (at the end, in first-seen order) — it never edits or removes
+ * what the model produced, so a section the model legitimately rewrote (its
+ * identity still present, however much its content changed) is left untouched.
+ * The same non-lossy guarantee #267 gives the Mentions section, generalized to
+ * the rest of the schema body.
+ *
+ * Presence is decided per full identity (label + suffix), which matters for the
+ * one section that repeats: emitting `## New Information (Source B)` must not
+ * count as keeping `## New Information (Source A)`.
+ *
+ * `oldBody` must be mentions-stripped so the Mentions label is never a candidate
+ * here — that section is re-attached separately by assembleFinalContent. Pure,
+ * O(lines × labels).
+ */
+export function preserveExistingSections(
+  oldBody: string,
+  newBody: string,
+  canonicalLabels: string[],
+): string {
+  const oldBlocks = canonicalSectionBlocks(oldBody, canonicalLabels);
+  const newBlocks = canonicalSectionBlocks(newBody, canonicalLabels);
+
+  const restored: string[] = [];
+  for (const [key, block] of oldBlocks) {
+    if (newBlocks.has(key)) continue; // model kept the section — its call
+    // Only restore sections that actually carried content; an empty scaffold the
+    // model correctly omitted stays omitted.
+    if (block.slice(1).some(l => l.trim() !== '')) {
+      restored.push(block.join('\n').replace(/\s+$/, ''));
+    }
+  }
+  if (restored.length === 0) return newBody;
+  return `${newBody.replace(/\s+$/, '')}\n\n${restored.join('\n\n')}\n`;
 }

--- a/src/wiki/page-factory/complementary-appends.ts
+++ b/src/wiki/page-factory/complementary-appends.ts
@@ -179,6 +179,7 @@ export function makeFallbackNewInfoSection(
   failedGroups: string[],
   allItems: ComplementaryItem[],
   sourceBasename: string,
+  newInformationLabel: string,
 ): string {
   if (failedGroups.length === 0) return '';
   // Map ALL items — the `failedGroups` parameter tracks which target_section
@@ -189,7 +190,7 @@ export function makeFallbackNewInfoSection(
   const body = failedItems.length > 0
     ? failedItems.map(i => `- ${i.content}${i.reason ? ` (${i.reason})` : ''}`).join('\n')
     : `- New information from ${sourceBasename}`;
-  return `## New Information (${sourceBasename})\n${body}`;
+  return `## ${newInformationLabel} (${sourceBasename})\n${body}`;
 }
 
 /**
@@ -340,6 +341,7 @@ export async function applyComplementaryAppends(
       failedGroups,
       items,
       sourceFile.basename,
+      labels.new_information,
     );
     resultBody = `${resultBody}\n\n${newInfoSection}`;
   }

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -35,7 +35,11 @@ import {
 import { PROMPTS } from '../../prompts';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
-import { canonicalizeSectionHeaders } from '../../core/section-header-canonicalizer';
+import {
+  canonicalizeSectionHeaders,
+  preserveExistingSections,
+} from '../../core/section-header-canonicalizer';
+import { stripMentionsSection } from '../../core/mentions-parser';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
@@ -175,9 +179,18 @@ export async function mergePage(
       labels.related_concepts,
       ctx.settings.slugCase === 'preserve',
     );
+    // Completeness is the schema's call, not the model's: restore any canonical
+    // section that carried content before the rewrite and is wholly absent from
+    // it. The old body is mentions-stripped first so that section is never a
+    // candidate here — assembleFinalContent re-attaches it below.
+    const guardedBody = preserveExistingSections(
+      stripMentionsSection(existingBody, labels.mentions_in_source),
+      correctedBody,
+      Object.values(labels),
+    );
     await ctx.createOrUpdateFile(
       path,
-      await assembleFinalContent(ctx, frontmatter, correctedBody, info, sourceFile, existingBody),
+      await assembleFinalContent(ctx, frontmatter, guardedBody, info, sourceFile, existingBody),
     );
     return path;
   } catch (error) {

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -21,7 +21,10 @@ import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
 import { stripMentionsSection } from '../../core/mentions-parser';
-import { canonicalizeSectionHeaders } from '../../core/section-header-canonicalizer';
+import {
+  canonicalizeSectionHeaders,
+  preserveExistingSections,
+} from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { getSectionLabels } from '../system-prompts';
 import { getExistingWikiPages } from '../lint/get-existing-pages';
@@ -144,6 +147,17 @@ export async function updateRelatedPage(
     ctx.settings.slugCase === 'preserve',
   );
 
+  // Completeness is the schema's call, not the model's: restore any canonical
+  // section that carried content before the rewrite and is wholly absent from
+  // it. `promptBody` is the mentions-stripped body the model actually saw, so
+  // the Mentions section is never a candidate here — assembleFinalContent
+  // re-attaches it below.
+  const guardedBody = preserveExistingSections(
+    promptBody,
+    correctedBody,
+    Object.values(labels),
+  );
+
   // 2. Assemble: programmatic frontmatter + LLM body + Mentions section.
   // Issue #267 established a non-lossy re-ingest on the merge path, but this
   // path never had it: the Mentions section lives in the body handed to the LLM,
@@ -154,7 +168,7 @@ export async function updateRelatedPage(
   // the accumulated mentions are recovered from the unstripped page.
   await ctx.createOrUpdateFile(
     page.path,
-    await assembleFinalContent(ctx, frontmatter, correctedBody, newInfo, sourceFile, existingBody),
+    await assembleFinalContent(ctx, frontmatter, guardedBody, newInfo, sourceFile, existingBody),
   );
   return true;
 }


### PR DESCRIPTION
Closes #292.

`updateRelatedPage` and the `mergePage` full-rewrite path hand the model the existing body and adopt its rewrite. Mentions (#267), headers (#241) and link prefixes (#187) are re-asserted deterministically afterwards, but the completeness of the schema body was still the model's to decide.

This adds a pure `preserveExistingSections`, run on both rewrite paths, which restores any canonical section that carried content before the rewrite and is wholly absent from it. It only appends a dropped section back. It never edits or removes model output, so a section the model legitimately rewrote is left untouched.

**One design point is load-bearing.** Presence is decided per full section identity, meaning canonical label plus parenthetical suffix, not per label. `New Information` is the one schema section that legitimately repeats, one block per contributing source, distinguished only by that suffix. A label-keyed check treats emitting `## New Information (Source B)` as keeping `## New Information (Source A)`. `classifyHeader` therefore snaps the base label before a trailing ` (...)` and reports the suffix as part of the identity. A genuinely foreign header still snaps to nothing, with or without a suffix. It is not used by `canonicalizeSectionHeaders`, which must leave a suffixed header's text intact.

The PR also localizes `makeFallbackNewInfoSection`, which hardcoded the English `## New Information` header and so produced a section that was non-canonical from birth on a localized vault. The label now comes from the locale files for all 10 languages.

**Final field numbers, and a correction to my earlier comment.** The full-corpus rebuild finished: 9272 writes across 2781 pages, every suspected-loss pre-image parked. Comparing those pre-images against the post-run state gives 26 lost sections across 11 pages. All 22 New Information loss events were of the collision shape above: in every case another New Information block was present in the rewrite, and there was no case where the section disappeared completely.

Two numbers in my earlier comment were wrong and I want to correct them rather than leave them standing. I wrote "39 of 39", which counted write events, not distinct sections; the correct figure is 26 distinct sections. I also wrote that plain canonical sections showed zero losses. That is not accurate. One page, `concepts/REM-Schlaf`, lost `## Related Entities` permanently, and the suffix mechanism does not explain it. Two further cases I had counted as losses turned out to be an artifact of my analysis: the header was still present but empty. So the honest statement is 26 New Information sections explained by the collision, plus one plain-section loss I cannot yet account for, out of 2781 pages. A further 36 parked pre-images were not evaluable because those pages were renamed later in the run.

The guard as written would not have prevented that one case, and I did not want to widen the PR on a single unexplained event. If it reproduces, it is a separate report with its own evidence.

**Gate 2 (side effects):** `preserveExistingSections` is pure — no IO, no state, no new error paths. Two call sites, both immediately before `assembleFinalContent`, which consumes the guarded body instead of the corrected one; no other consumer of that value exists on either path. `makeFallbackNewInfoSection` has exactly one production caller, updated in place.

**Gate 3 (breaking changes):** File format, settings, command IDs and Obsidian API surface unchanged. Default behavior changes only in the direction of retaining content that was previously dropped. One internal exported signature changes: `makeFallbackNewInfoSection` takes the localized label as a fourth argument. No public API.

**Gate 4 (performance):** Two additional linear body scans per rewrite, O(lines × labels), pure string work, immediately after an LLM call that dominates by orders of magnitude. No CPU, memory, IO, network or token impact worth measuring.

**Gate 1 on current `main` (5e13ac5):** `pnpm lint` 0/0, `npx tsc --noEmit` 0, `pnpm test` 2203 → 2216, `pnpm build` clean, `pnpm css-lint` 0 violations. The identity-keying regression test is red when the key is reverted to the base label.

Suggested label `enhancement`, milestone `v1.25.1 PATCH`, per your note on #292.
