### PR TITLE
fix(mentions): parse the pre-#244 grouped Mentions shape so legacy pages can heal (#289)

### DIFF
--- a/src/__tests__/core/mentions-formatter-roundtrip.test.ts
+++ b/src/__tests__/core/mentions-formatter-roundtrip.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { formatMentionsSection } from '../../core/mentions-formatter';
-import { parseMentionsSection, stripMentionsSection } from '../../core/mentions-parser';
+import { parseMentionsSection, stripMentionsSection, computeReingestMentions } from '../../core/mentions-parser';
 import { injectMentionsSection } from '../../core/mentions-injector';
 import { dedupMentionsByProvenanceKey } from '../../core/batch-merger';
 import type { MentionWithProvenance } from '../../types';
@@ -184,5 +184,120 @@ describe('#267 — non-lossy re-ingest (parse ∪ new → inject)', () => {
     const parsed = parseMentionsSection(existingBody, LABEL);
     const unioned = dedupMentionsByProvenanceKey(parsed.mentions, sameAgain)!;
     expect(unioned).toHaveLength(1);
+  });
+});
+
+// ─── #289: pre-#244 legacy blockquote shape ──────────────────────────────
+//
+// Before #244 the Mentions section was written by the model, grouped by source
+// under a blockquote header. The flat-only parser could not structure it, so
+// `computeReingestMentions` returned `preserveRaw`, the #267 fail-safe fired,
+// and the page never accumulated another quote — silently, and on every
+// subsequent ingest. Parsing the shape is the migration path: the section is
+// re-emitted flat the first time the page merges again.
+
+describe('#289 — legacy grouped-blockquote Mentions sections', () => {
+  const legacy = [
+    `## ${LABEL}`,
+    '',
+    '> **Source: [[sources/Nephrologie|Nephrologie]]**',
+    '> - "Das Nephron ist die kleinste funktionelle Einheit."',
+    '> - "Der Glomerulus filtert das Blut." (The glomerulus filters the blood.)',
+    '> **Source: [[sources/Physiologie|Physiologie]]**',
+    '> - "Die Filtrationsrate ist altersabhängig."',
+  ].join('\n');
+
+  it('parses a legacy block fully, so the fail-safe does not fire', () => {
+    const r = parseMentionsSection(legacy, LABEL);
+    expect(r.found).toBe(true);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions).toHaveLength(3);
+  });
+
+  it('attributes each quote to the group it sits under', () => {
+    const r = parseMentionsSection(legacy, LABEL);
+    expect(r.mentions[0].source_path).toBe('sources/Nephrologie');
+    expect(r.mentions[1].source_path).toBe('sources/Nephrologie');
+    expect(r.mentions[2].source_path).toBe('sources/Physiologie');
+  });
+
+  it('recovers a parenthetical translation', () => {
+    const r = parseMentionsSection(legacy, LABEL);
+    expect(r.mentions[1].translation).toBe('The glomerulus filters the blood.');
+  });
+
+  it('accepts a group header without a display alias', () => {
+    const body = [`## ${LABEL}`, '', '> **Source: [[sources/X]]**', '> - "q"'].join('\n');
+    const r = parseMentionsSection(body, LABEL);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions[0].source_path).toBe('sources/X');
+  });
+
+  it('accepts a localized group header — the shape is matched, not the English literal', () => {
+    const body = [`## ${LABEL}`, '', '> **Quelle: [[sources/X|X]]**', '> - "q"'].join('\n');
+    const r = parseMentionsSection(body, LABEL);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions[0].source_path).toBe('sources/X');
+  });
+
+  it('parses a block that mixes the legacy and flat shapes', () => {
+    const body = [
+      `## ${LABEL}`,
+      '',
+      '> **Source: [[sources/Alt|Alt]]**',
+      '> - "alter Beleg"',
+      '- "neuer Beleg" — [[sources/Neu|Neu]]',
+    ].join('\n');
+    const r = parseMentionsSection(body, LABEL);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions.map(m => m.source_path)).toEqual(['sources/Alt', 'sources/Neu']);
+  });
+
+  it('still fails safe on a quote that has no group to inherit attribution from', () => {
+    const body = [`## ${LABEL}`, '', '> - "orphan quote"'].join('\n');
+    const r = parseMentionsSection(body, LABEL);
+    expect(r.fullyParsed).toBe(false);
+    expect(r.mentions).toHaveLength(0);
+  });
+
+  it('still fails safe on genuinely hand-edited prose', () => {
+    const body = [`## ${LABEL}`, '', 'Some note the user typed by hand.'].join('\n');
+    expect(parseMentionsSection(body, LABEL).fullyParsed).toBe(false);
+  });
+
+  // ─── invariance gate: legacy → flat re-emit loses nothing ───────────────
+
+  it('[invariance] re-emits every legacy quote in the flat shape, losing none', () => {
+    const parsed = parseMentionsSection(legacy, LABEL);
+    const reemitted = formatMentionsSection(parsed.mentions, '', LABEL);
+
+    // Every quote survives, in order.
+    const quotes = parsed.mentions.map(m => m.quote);
+    expect(quotes).toHaveLength(3);
+    for (const q of quotes) expect(reemitted).toContain(q);
+
+    // And the result is now in the shape the parser accepts natively — the
+    // page is upgraded, so the next ingest parses it without the legacy path.
+    const reparsed = parseMentionsSection(reemitted, LABEL);
+    expect(reparsed.fullyParsed).toBe(true);
+    expect(reparsed.mentions.map(m => m.quote)).toEqual(quotes);
+    expect(reparsed.mentions.map(m => m.source_path))
+      .toEqual(['sources/Nephrologie', 'sources/Nephrologie', 'sources/Physiologie']);
+    expect(reemitted).not.toContain('>');
+  });
+
+  it('[invariance] a legacy page merging a new source keeps its old quotes', () => {
+    const result = computeReingestMentions(
+      legacy,
+      [mention({ quote: 'brandneuer Beleg', source_path: 'sources/Neu' })],
+      LABEL,
+    );
+    expect(result.preserveRaw).toBeNull(); // fail-safe no longer fires
+    expect(result.mentions.map(m => m.quote)).toEqual([
+      'Das Nephron ist die kleinste funktionelle Einheit.',
+      'Der Glomerulus filtert das Blut.',
+      'Die Filtrationsrate ist altersabhängig.',
+      'brandneuer Beleg',
+    ]);
   });
 });

--- a/src/core/mentions-parser.ts
+++ b/src/core/mentions-parser.ts
@@ -96,6 +96,26 @@ function findSection(
 // match is treated as a hand-edit and flips `fullyParsed` to false.
 const BULLET_RE = /^-\s+"([\s\S]+)"(?:\s+\(([^)]*)\))?\s+—\s+\[\[([^\]|]+)\|[^\]]*\]\]\s*$/;
 
+// Issue #289 — the pre-#244 shape, grouped by source under a blockquote header:
+//   > **Source: [[sources/X|X]]**
+//   > - "quote"
+//   > - "quote" (translation)
+//
+// That block was written by the MODEL, not by the formatter (the prompt showed it
+// the shape and asked it to copy it), so it varies in ways a programmatic block
+// never would: the bold run may or may not wrap the link, the link may or may not
+// carry a display alias, and the "Source:" prefix came from an English prompt
+// literal regardless of vault language. The group header is therefore matched
+// structurally — a blockquote line carrying a wikilink and no quote — rather than
+// by that literal, so a localized or lightly hand-edited header still parses.
+const LEGACY_GROUP_RE = /^>\s*\**\s*[^"[]*\[\[([^\]]+)\]\]\s*\**\s*$/;
+const LEGACY_QUOTE_RE = /^>\s*-\s+"([\s\S]+)"(?:\s+\(([^)]*)\))?\s*$/;
+
+/** Recover the link target from a wikilink body, dropping any `|display` alias. */
+function linkTarget(inner: string): string {
+  return inner.split('|')[0].trim();
+}
+
 export interface ParsedMentionsSection {
   /** Whether a `## <sectionLabel>` block existed at all. */
   found: boolean;
@@ -114,6 +134,12 @@ export interface ParsedMentionsSection {
 /**
  * Parse an existing `## <sectionLabel>` block back into structured mentions.
  * Returns `found:false` (an empty, fully-parsed result) when no block exists.
+ *
+ * Accepts both the flat formatter-produced shape and the pre-#244 grouped
+ * blockquote shape (#289), in either order and mixed within one block. Parsing
+ * the legacy shape is what gives it a migration path: the caller unions the
+ * result and the formatter re-emits the whole section flat, so the page is
+ * upgraded the first time it merges again, with no user action.
  */
 export function parseMentionsSection(body: string, sectionLabel: string): ParsedMentionsSection {
   if (!sectionLabel || !sectionLabel.trim()) {
@@ -127,22 +153,51 @@ export function parseMentionsSection(body: string, sectionLabel: string): Parsed
 
   const mentions: MentionWithProvenance[] = [];
   let fullyParsed = true;
-  for (const rawLine of content.split('\n')) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    const m = BULLET_RE.exec(line);
-    if (!m) {
-      fullyParsed = false;
-      continue;
-    }
-    const [, quote, translation, leftPath] = m;
+  // The source most recently named by a legacy group header. Quotes in the
+  // legacy shape carry no attribution of their own — they inherit it from the
+  // group they sit under.
+  let legacyGroupPath: string | null = null;
+
+  const push = (quote: string, translation: string | undefined, sourcePath: string) => {
     mentions.push({
       quote,
       ...(translation && translation.trim() ? { translation: translation.trim() } : {}),
-      source_path: leftPath,
+      source_path: sourcePath,
       source_slug: '',
       extracted_at: '',
     });
+  };
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const flat = BULLET_RE.exec(line);
+    if (flat) {
+      const [, quote, translation, leftPath] = flat;
+      push(quote, translation, leftPath);
+      continue;
+    }
+
+    // Issue #289 — legacy blockquote shape. Recognized so the block can be
+    // parsed and re-emitted flat by the formatter, which upgrades the page the
+    // first time it is merged again. Without this the block is unparseable, the
+    // #267 fail-safe fires, and the page never accumulates another quote.
+    const group = LEGACY_GROUP_RE.exec(line);
+    if (group) {
+      legacyGroupPath = linkTarget(group[1]).replace(/\.md$/, '');
+      continue;
+    }
+    const legacyQuote = LEGACY_QUOTE_RE.exec(line);
+    if (legacyQuote && legacyGroupPath) {
+      const [, quote, translation] = legacyQuote;
+      push(quote, translation, legacyGroupPath);
+      continue;
+    }
+
+    // A quote outside any group has no recoverable attribution, so it falls
+    // through to the fail-safe with everything else we cannot structure.
+    fullyParsed = false;
   }
   return { found: true, fullyParsed, mentions, raw };
 }


### PR DESCRIPTION
Closes #289. Implements option (a), as you preferred.

The parser now reads the legacy grouped-blockquote shape in addition to the flat one. The caller unions as usual and the formatter re-emits the section flat, so a page is upgraded the first time it merges again — no user action, nothing for the user to know about.

**On matching the legacy shape.** That block was written by the model copying a prompt example, not by the formatter, so it varies in ways a programmatic block never would: the bold run may or may not wrap the link, the link may or may not carry a display alias, and the `Source:` prefix came from an English prompt literal regardless of vault language. The group header is therefore matched structurally — a blockquote line carrying a wikilink and no quote — rather than by that literal. A localized or lightly hand-edited header still parses.

**The fail-safe is unchanged.** A quote with no group above it has no recoverable attribution and still falls through to `preserveRaw`, as does genuine hand-edited prose. Both cases have tests, and both stay green when the new parsing is disabled — the extension only ever converts "unparseable" into "parsed", never the reverse.

**On evidence, one caveat.** The 45-of-324 figure in the issue came from my vault before I rebuilt it. That rebuild regenerated every page in the flat shape, so my vault now contains zero legacy sections and I cannot offer a fresh field measurement for this fix the way I could for #288 and #292. The correctness argument here rests on the tests, not on a run. The legacy shape itself is taken from the prompt that produced it (`merge.ts` at `1c1db3a^`), not from memory.

Ten tests, two of them invariance gates: every legacy quote survives the re-emit and the result re-parses natively as flat, and a legacy page merging a new source keeps all its prior quotes. Eight are red without the parser extension.

**Gate 2 (side effects):** `parseMentionsSection` stays pure. One added branch and one module-level helper; no new error paths, no IO, no state. `computeReingestMentions` is unchanged — it simply sees `fullyParsed: true` where it previously saw `false`.

**Gate 3 (breaking changes):** No signature, format, settings or API change. Behavior changes in exactly one direction: sections that previously triggered the fail-safe now parse. Pages already in the flat shape are untouched.

**Gate 4 (performance):** Two additional regex attempts per line, only on lines the flat pattern already rejected. Parsing runs once per merge, next to an LLM call.

**Gate 1 on current `main` (5e13ac5):** `pnpm lint` 0/0, `npx tsc --noEmit` 0, `pnpm test` 2203 → 2213, `pnpm build` clean, `pnpm css-lint` 0 violations.

Diff is 181 insertions across 2 files, within the budget you sketched.
