### PR TITLE
refactor(settings): extract 8 section renderers (Phase C-PR2)

### DIFF
--- a/src/ui/settings-helpers.ts
+++ b/src/ui/settings-helpers.ts
@@ -25,9 +25,90 @@ export function classifyFetchError(msg: string): FetchErrorCategory {
 
   // Server: any 5xx status code, or server error keywords.
   if (/\b5\d\d\b/.test(msg)
-      || /\bserver[_\s-]?error\b|\bbad[_\s-]?gateway\b|\bservice[_\s-]?unavailable\b|\brate[_\s-]?limit/i.test(msg)) {
+      || /\bserver[_\s-]?error\b|\bbad[_\s-]?gateway\b|\bservice[_\s-]?unavailable\b|\b\d*rate[_\s-]?limit/i.test(msg)) {
     return 'Server';
   }
 
   return 'Network';
+}
+
+// ============================================================================
+// v1.25.1 Phase C-PR2 simplify pass — shared Settings UI helpers extracted from
+// the 8 section renderers. Two patterns were triplicated across sections:
+//   1. Range slider with dynamic tooltip + dynamic desc rewriteback
+//      (used in provider-section: pageGenerationConcurrency, batchDelayMs)
+//   2. Setting visibility toggling based on a mode value
+//      (used in wiki-config: extractionGranularity + tagVocabularyMode)
+//
+// Numeric-input clamp + chip-tag builders were considered but kept inline
+// in their respective sections — the per-site config (placeholder text,
+// field-key path, onSetting capture) diverges enough that extracting them
+// would force the helpers to grow callback parameters that defeat the
+// purpose. Documented in the simplify log so future maintainers don't
+// re-attempt the extraction.
+// ============================================================================
+
+import { Setting } from 'obsidian';
+
+export interface RangeSliderOptions {
+  /** Pre-resolved localized name for the Setting row. */
+  name: string;
+  /** Pre-resolved localized desc; the live value is appended via formatDesc. */
+  desc: string;
+  /** Initial numeric value. */
+  initialValue: number;
+  min: number;
+  max: number;
+  step: number;
+  /** Formats the live value text appended after `desc`. */
+  formatDesc: (value: number) => string;
+  /** Called when the user moves the slider. */
+  onChange: (value: number) => void;
+}
+
+/**
+ * Render a range slider with dynamic tooltip + dynamic desc rewriteback.
+ * Used by provider-section for pageGenerationConcurrency + batchDelayMs.
+ *
+ * Why extracted: the two slider sites were byte-identical except for
+ * limits, default, and desc-format logic. Centralizing the
+ * `setDynamicTooltip` UX + desc rewriteback via the captured Setting
+ * reference (via `Setting.then(s => ...)`) eliminates 30 LOC of
+ * copy-paste and prevents future drift.
+ */
+export function renderRangeSlider(
+  containerEl: HTMLElement,
+  opts: RangeSliderOptions,
+): void {
+  let captured: Setting;
+  new Setting(containerEl)
+    .setName(opts.name)
+    .setDesc(opts.desc + ' ' + opts.formatDesc(opts.initialValue))
+    .addSlider(slider => slider
+      .setLimits(opts.min, opts.max, opts.step)
+      .setValue(opts.initialValue)
+      .setDynamicTooltip()
+      .onChange((value) => {
+        opts.onChange(value);
+        captured.setDesc(opts.desc + ' ' + opts.formatDesc(value));
+      }))
+    .then(s => { captured = s; });
+}
+
+/**
+ * Toggle the `settingEl.style.display` of every Setting in the list. Pass
+ * `visible=true` to show (`'flex'`) and `false` to hide (`'none'`).
+ *
+ * Each Setting may be `null` if it hasn't been constructed yet — common
+ * when called from the dropdown's onChange before the gated Settings are
+ * created (e.g. granularity dropdown before customEntityLimit Setting).
+ */
+export function setSettingsVisible(
+  settings: Array<Setting | null>,
+  visible: boolean,
+): void {
+  const display = visible ? 'flex' : 'none';
+  for (const s of settings) {
+    if (s) s.settingEl.style.display = display;
+  }
 }

--- a/src/ui/settings-sections/advanced-section.ts
+++ b/src/ui/settings-sections/advanced-section.ts
@@ -1,0 +1,125 @@
+/**
+ * v1.25.1 Phase C-PR2: Advanced section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the Advanced
+ * Settings block:
+ *
+ *   - Advanced Settings Mode dropdown (default / custom)
+ *   - Disable Thinking toggle (only in custom mode)
+ *   - Three temperature / repetition penalty number inputs
+ *   - Force PDF Support toggle (v1.25.0 PR3 universal escape hatch)
+ *
+ * Why extracted:
+ *   - The block has nested conditional rendering (custom mode gates
+ *     4 sub-controls) and one cross-section invariant (forcePdfSupport
+ *     resets to false when Advanced mode flips back to default).
+ *     Isolating it makes both invariants easier to audit.
+ *
+ * Invariants preserved:
+ *   - Switching Advanced to default mode resets disableThinking +
+ *     all 3 temperature/penalty fields + forcePdfSupport to defaults.
+ *   - Switching Advanced to default does NOT touch writePdfMarkdownToVault
+ *     (that field lives in Wiki Configuration, v1.25.0 PR3).
+ *   - forcePdfSupport toggle renders ONLY for non-native providers
+ *     (anthropic/openai/bedrock-* already handle PDF natively, so the
+ *     escape hatch is meaningless and would mislead users).
+ *   - forcePdfSupport is reset to false when provider switches to a
+ *     native one (handled in provider-section.ts, not here).
+ */
+
+import { Setting } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { NATIVE_PDF_PROVIDER_IDS } from '../../constants';
+
+export function renderAdvancedSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+
+  // Advanced Settings Mode dropdown
+  new Setting(containerEl)
+    .setName(tab.getText('advancedSettingsModeName'))
+    .setDesc(tab.getText('advancedSettingsModeDesc'))
+    .addDropdown(dropdown => {
+      dropdown
+        .addOption('default', tab.getText('advancedSettingsDefault'))
+        .addOption('custom', tab.getText('advancedSettingsCustom'))
+        .setValue(tempSettings.advancedSettingsMode || 'default')
+        .onChange((value: string) => {
+          tempSettings.advancedSettingsMode = value as 'default' | 'custom';
+          if (value === 'default') {
+            tempSettings.disableThinking = false;
+            tempSettings.extractionTemperature = undefined;
+            tempSettings.chatTemperature = undefined;
+            tempSettings.repetitionPenalty = undefined;
+            // v1.25.0 PR3: reset forcePdfSupport - it's rendered only inside
+            // the Advanced block, so hiding the block without resetting
+            // the value would leave users with a no-UI-affordance setting.
+            tempSettings.forcePdfSupport = false;
+            // writePdfMarkdownToVault lives in Wiki Configuration (always
+            // visible) and is NOT reset here.
+          }
+          tab.display();
+        });
+    });
+
+  if (tempSettings.advancedSettingsMode !== 'custom') return;
+
+  // Disable Thinking
+  new Setting(containerEl)
+    .setName(tab.getText('disableThinkingName'))
+    .setDesc(tab.getText('disableThinkingDesc'))
+    .addToggle(toggle => toggle
+      .setValue(tempSettings.disableThinking === true)
+      .onChange((value) => {
+        tempSettings.disableThinking = value;
+      }));
+
+  // Three temperature / repetition penalty inputs. The local helper takes
+  // string keys and routes them through getTextDynamic (v1.25.1 Phase
+  // C-PR2 simplify pass — keep type-safe getText for literal keys, only
+  // widen for the parametric ones).
+  const renderNumericInput = (
+    nameKey: string,
+    descKey: string,
+    fieldKey: 'extractionTemperature' | 'chatTemperature' | 'repetitionPenalty',
+  ): void => {
+    new Setting(containerEl)
+      .setName(tab.getTextDynamic(nameKey))
+      .setDesc(tab.getTextDynamic(descKey))
+      .addText(text => {
+        text
+          .setPlaceholder(tab.getText('temperaturePlaceholder'))
+          .setValue(tempSettings[fieldKey]?.toString() ?? '')
+          .onChange((value) => {
+            const trimmed = value.trim();
+            if (trimmed === '') {
+              tempSettings[fieldKey] = undefined;
+            } else {
+              const parsed = parseFloat(trimmed);
+              if (!isNaN(parsed)) {
+                tempSettings[fieldKey] = parsed;
+              }
+            }
+          });
+        text.inputEl.type = 'number';
+        text.inputEl.min = '0';
+        text.inputEl.max = '2';
+        text.inputEl.step = '0.05';
+        text.inputEl.classList.add('llm-wiki-number-input');
+      });
+  };
+
+  renderNumericInput('extractionTemperatureName', 'extractionTemperatureDesc', 'extractionTemperature');
+  renderNumericInput('chatTemperatureName', 'chatTemperatureDesc', 'chatTemperature');
+  renderNumericInput('repetitionPenaltyName', 'repetitionPenaltyDesc', 'repetitionPenalty');
+
+  // v1.25.0 PR3: PDF force-support toggle (universal escape hatch).
+  // Renders for ANY non-native provider.
+  if (!(NATIVE_PDF_PROVIDER_IDS as readonly string[]).includes(tempSettings.provider)) {
+    new Setting(containerEl)
+      .setName(tab.getText('forcePdfSupportName'))
+      .setDesc(tab.getText('forcePdfSupportDesc'))
+      .addToggle(toggle => toggle
+        .setValue(tempSettings.forcePdfSupport === true)
+        .onChange((value) => { tempSettings.forcePdfSupport = value; }));
+  }
+}

--- a/src/ui/settings-sections/auto-maintain-section.ts
+++ b/src/ui/settings-sections/auto-maintain-section.ts
@@ -1,0 +1,200 @@
+/**
+ * v1.25.1 Phase C-PR2: Auto Maintenance section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the Auto
+ * Maintenance block:
+ *
+ *   - "Auto Maintenance" H2 heading
+ *   - Startup Check Notice Level dropdown (visible / silent)
+ *   - Beta + cost-warning infobox divs
+ *   - Auto-Watch Sources toggle
+ *   - Watched Folders list (rendered only when autoWatchSources is true)
+ *   - Web Clipper Preset toggle (Clippings/)
+ *   - Auto-Watch Mode dropdown (notify / auto)
+ *   - Auto-Ingest Notification Level dropdown (only in auto mode)
+ *   - Auto-Watch Debounce number input
+ *   - Periodic Lint dropdown (off / daily / weekly / monthly)
+ *   - Auto Smart Fix toggle
+ *   - Welcome Note toggle (v1.23.0 Phase 5.1.5)
+ *
+ * Why extracted:
+ *   - 160 LOC of auto-behavior configuration. The block has the deepest
+ *     conditional rendering in the file (autoWatchSources / autoWatchMode
+ *     both gate sub-blocks). Isolating it makes the conditional chain
+ *     inspectable.
+ *
+ * Invariants preserved:
+ *   - startupCheckNoticeLevel (v1.23.0 replacement for the removed
+ *     startupCheck toggle) controls only the Notice visibility, not
+ *     whether the pipeline runs.
+ *   - Watched Folders list is rendered dynamically from
+ *     tempSettings.watchedFolders[] (mutated via splice on Remove).
+ *   - Web Clipper Preset adds 'Clippings/' to watchedFolders.
+ *   - Auto-Watch Debounce is in seconds (UI) but stored as ms.
+ *   - Welcome Note toggle is named createWelcomeNote in settings.
+ */
+
+import { Setting, Notice } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { NOTICE_SHORT } from '../../constants';
+import { FolderSuggestModal } from '../modals';
+
+export function renderAutoMaintainSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+
+  // Auto Maintenance heading
+  new Setting(containerEl).setName(tab.getText('autoMaintainSection')).setHeading();
+
+  // Startup Check Notice Level (v1.23.0 replaces removed startupCheck toggle)
+  new Setting(containerEl)
+    .setName(tab.getText('startupCheckNoticeLevelName'))
+    .setDesc(tab.getText('startupCheckNoticeLevelDesc'))
+    .addDropdown(dropdown => dropdown
+      .addOption('visible', tab.getText('startupCheckNoticeVisible'))
+      .addOption('silent', tab.getText('startupCheckNoticeSilent'))
+      .setValue(tempSettings.startupCheckNoticeLevel)
+      .onChange((value: 'visible' | 'silent') => { tempSettings.startupCheckNoticeLevel = value; }));
+
+  // Beta + cost warning infoboxes
+  const betaDiv = containerEl.createDiv({ cls: 'llm-wiki-blue-infobox' });
+  betaDiv.setText('🧪 ' + tab.getText('autoMaintainBetaBadge'));
+
+  const warningDiv = containerEl.createDiv({ cls: 'llm-wiki-yellow-infobox' });
+  warningDiv.setText(tab.getText('autoMaintainCostWarning'));
+
+  // Auto-Watch Sources toggle
+  new Setting(containerEl)
+    .setName(tab.getText('autoWatchName'))
+    .setDesc(tab.getText('autoWatchDesc'))
+    .addToggle(toggle => toggle
+      .setValue(tempSettings.autoWatchSources)
+      .onChange((value) => { tempSettings.autoWatchSources = value; tab.display(); }));
+
+  if (tempSettings.autoWatchSources) {
+    if (!tempSettings.watchedFolders) tempSettings.watchedFolders = [];
+
+    new Setting(containerEl)
+      .setName(tab.getText('watchedFoldersName'))
+      .setDesc(tab.getText('watchedFoldersDesc'))
+      .addButton(button => button
+        .setButtonText(tab.getText('addWatchedFolderButton'))
+        .setCta()
+        .onClick(() => {
+          new FolderSuggestModal(tab.app, tempSettings.wikiFolder, (folder) => {
+            const folderPath = folder.path.endsWith('/') ? folder.path : `${folder.path}/`;
+            if (!tempSettings.watchedFolders.includes(folderPath)) {
+              tempSettings.watchedFolders.push(folderPath);
+              tab.display();
+            }
+          }).open();
+        }));
+
+    if (tempSettings.watchedFolders.length === 0) {
+      containerEl.createEl('p', {
+        text: tab.getText('noWatchedFoldersHint'),
+        cls: 'llm-wiki-section-hint'
+      });
+    }
+
+    for (let i = 0; i < tempSettings.watchedFolders.length; i++) {
+      const idx = i;
+      new Setting(containerEl)
+        .setName(tempSettings.watchedFolders[i])
+        .addButton(button => button
+          .setButtonText(tab.getText('removeWatchedFolderButton'))
+          .onClick(() => { tempSettings.watchedFolders.splice(idx, 1); tab.display(); }));
+    }
+
+    const hasClippings = tempSettings.watchedFolders.includes('Clippings/');
+    new Setting(containerEl)
+      .setName(tab.getText('webClipperPresetName'))
+      .setDesc(tab.getText('webClipperPresetDesc'))
+      .addToggle(toggle => toggle
+        .setValue(hasClippings)
+        .onChange((value) => {
+          if (value && !tempSettings.watchedFolders.includes('Clippings/')) tempSettings.watchedFolders.push('Clippings/');
+          else if (!value) {
+            const ci = tempSettings.watchedFolders.indexOf('Clippings/');
+            if (ci >= 0) tempSettings.watchedFolders.splice(ci, 1);
+          }
+          tab.display();
+        }));
+
+    new Setting(containerEl)
+      .setName(tab.getText('autoWatchModeName'))
+      .setDesc(tab.getText('autoWatchModeDesc'))
+      .addDropdown(dropdown => {
+        dropdown.addOption('notify', tab.getText('watchModeNotify'));
+        dropdown.addOption('auto', tab.getText('watchModeAuto'));
+        dropdown.setValue(tempSettings.autoWatchMode);
+        dropdown.onChange((value: 'notify' | 'auto') => { tempSettings.autoWatchMode = value; tab.display(); });
+      });
+
+    if (tempSettings.autoWatchMode === 'auto') {
+      new Setting(containerEl)
+        .setName(tab.getText('autoIngestLevelName'))
+        .setDesc(tab.getText('autoIngestLevelDesc'))
+        .addDropdown(dropdown => {
+          dropdown.addOption('notice', tab.getText('autoIngestLevelNotice'));
+          dropdown.addOption('modal', tab.getText('autoIngestLevelModal'));
+          dropdown.setValue(tempSettings.autoIngestNotificationLevel);
+          dropdown.onChange((value: 'notice' | 'modal') => { tempSettings.autoIngestNotificationLevel = value; });
+        });
+    }
+
+    new Setting(containerEl)
+      .setName(tab.getText('autoWatchDebounceName'))
+      .setDesc(tab.getText('autoWatchDebounceDesc'))
+      .addText(text => {
+        text
+          .setValue(String(Math.round(tempSettings.autoWatchDebounceMs / 1000)))
+          .onChange((value) => {
+            const parsed = parseInt(value);
+            if (parsed > 60) {
+              tempSettings.autoWatchDebounceMs = 60000;
+              text.setValue('60');
+              new Notice(tab.getText('numberRangeClamped').replace('{}', '60'), NOTICE_SHORT);
+            } else if (parsed < 1) {
+              tempSettings.autoWatchDebounceMs = 1000;
+              text.setValue('1');
+              new Notice(tab.getText('numberRangeClamped').replace('{}', '1'), NOTICE_SHORT);
+            } else if (!isNaN(parsed)) {
+              tempSettings.autoWatchDebounceMs = parsed * 1000;
+            }
+          });
+        text.inputEl.type = 'number';
+        text.inputEl.min = '1';
+        text.inputEl.max = '60';
+        text.inputEl.classList.add('llm-wiki-number-input');
+      });
+  }
+
+  // Periodic Lint
+  new Setting(containerEl)
+    .setName(tab.getText('periodicLintName'))
+    .setDesc(tab.getText('periodicLintDesc'))
+    .addDropdown(dropdown => {
+      dropdown.addOption('off', tab.getText('periodicLintOff'));
+      dropdown.addOption('daily', tab.getText('periodicLintDaily'));
+      dropdown.addOption('weekly', tab.getText('periodicLintWeekly'));
+      dropdown.addOption('monthly', tab.getText('periodicLintMonthly'));
+      dropdown.setValue(tempSettings.periodicLint);
+      dropdown.onChange((value: 'off' | 'daily' | 'weekly' | 'monthly') => { tempSettings.periodicLint = value; });
+    });
+
+  // Auto Smart Fix
+  new Setting(containerEl)
+    .setName(tab.getText('autoSmartFixName'))
+    .setDesc(tab.getText('autoSmartFixDesc'))
+    .addToggle(toggle => toggle
+      .setValue(tempSettings.autoSmartFix)
+      .onChange((value) => { tempSettings.autoSmartFix = value; }));
+
+  // v1.23.0 Phase 5.1.5: first-run Welcome note toggle.
+  new Setting(containerEl)
+    .setName(tab.getText('welcomeNoteSettingsToggle'))
+    .setDesc(tab.getText('welcomeNoteSettingsToggleDesc'))
+    .addToggle(toggle => toggle
+      .setValue(tempSettings.createWelcomeNote)
+      .onChange((value) => { tempSettings.createWelcomeNote = value; }));
+}

--- a/src/ui/settings-sections/language-section.ts
+++ b/src/ui/settings-sections/language-section.ts
@@ -1,0 +1,104 @@
+/**
+ * v1.25.1 Phase C-PR2: Language section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()` in settings.ts. Renders
+ * two H2 sub-sections:
+ *
+ *   1. "Language Settings" - UI language dropdown + Save button
+ *   2. "Wiki Output Language" - wiki language dropdown + custom mode
+ *      text input (rendered only when useCustomWikiLanguage is true)
+ *
+ * Why extracted:
+ *   - The original block ran ~80 LOC of side-effecting Setting builders
+ *     with no shared mutable state with WikiEngine. Extracting it makes
+ *     the boundaries of each H2 sub-section visible at a glance and
+ *     reduces settings.ts by ~80 LOC toward the ~190 LOC orchestrator
+ *     target.
+ *
+ * Invariants preserved:
+ *   - WIKI_LANGUAGES is the single source of truth for both dropdowns
+ *     (v1.22.0 #185 forward-compat - adding a locale updates both).
+ *   - Custom Wiki Language: priority is `useCustomWikiLanguage` -
+ *     dropdown always shows '__custom__' when true, regardless of the
+ *     underlying `wikiLanguage` value (preserves typed-name in text
+ *     input below).
+ *   - Switching to a standard language clears `useCustomWikiLanguage`.
+ *   - Switching to __custom__ keeps the typed name in `wikiLanguage`
+ *     for round-trip display, but clears it if it was a standard
+ *     language (avoids showing e.g. 'en' in the custom input by accident).
+ */
+
+import { Setting, Notice } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { WIKI_LANGUAGES } from '../../types';
+import { NOTICE_SHORT } from '../../constants';
+
+export function renderLanguageSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+
+  // 1. Language Settings: dropdown + Save button.
+  new Setting(containerEl)
+    .setName(tab.getText('languageTitle'))
+    .setDesc(tab.getText('languageDesc'))
+    .addDropdown(dropdown => {
+      for (const [key, label] of Object.entries(WIKI_LANGUAGES)) {
+        dropdown.addOption(key, label);
+      }
+      dropdown.setValue(tempSettings.language);
+      dropdown.onChange((value: 'en' | 'zh' | 'zh-Hant' | 'ja' | 'ko' | 'de' | 'fr' | 'es' | 'pt' | 'it') => {
+        tempSettings.language = value;
+        tab.display();
+      });
+    })
+    .addButton(button => button
+      .setButtonText(tab.getText('saveButton'))
+      .setCta()
+      .onClick(() => {
+        void (async () => {
+          tab.commitTempSettings();
+          await tab.plugin.saveSettings();
+          new Notice(tab.getText('savedNotice'), NOTICE_SHORT);
+        })();
+      }));
+
+  // 2. Wiki Output Language: heading + dropdown + optional custom input.
+  new Setting(containerEl).setName(tab.getText('wikiLanguageName')).setHeading();
+
+  new Setting(containerEl)
+    .setName(tab.getText('wikiLanguageName'))
+    .setDesc(tab.getText('wikiLanguageDesc'))
+    .addDropdown(dropdown => {
+      for (const [key, label] of Object.entries(WIKI_LANGUAGES)) dropdown.addOption(key, label);
+      dropdown.addOption('__custom__', tab.getText('customWikiLanguageOption'));
+      if (tempSettings.useCustomWikiLanguage) {
+        dropdown.setValue('__custom__');
+      } else {
+        const currentLang = tempSettings.wikiLanguage;
+        if (currentLang && WIKI_LANGUAGES[currentLang]) dropdown.setValue(currentLang);
+        else if (currentLang) dropdown.setValue('__custom__');
+        else dropdown.setValue('en');
+      }
+      dropdown.onChange((value: string) => {
+        if (value === '__custom__') {
+          tempSettings.useCustomWikiLanguage = true;
+          if (WIKI_LANGUAGES[tempSettings.wikiLanguage || '']) {
+            tempSettings.wikiLanguage = '';
+          }
+        } else {
+          tempSettings.wikiLanguage = value;
+          tempSettings.useCustomWikiLanguage = false;
+        }
+        tab.display();
+      });
+    });
+
+  if (tempSettings.useCustomWikiLanguage) {
+    new Setting(containerEl)
+      .setName(tab.getText('wikiLanguageName') + ' (Custom)')
+      .setDesc(tab.getText('customWikiLanguageHint'))
+      .addText(text => text
+        .setPlaceholder(tab.getText('customWikiLanguagePlaceholder'))
+        .setValue(tempSettings.wikiLanguage && !WIKI_LANGUAGES[tempSettings.wikiLanguage] ? tempSettings.wikiLanguage : '')
+        .onChange((value) => { tempSettings.wikiLanguage = value.trim(); }));
+  }
+}

--- a/src/ui/settings-sections/model-section.ts
+++ b/src/ui/settings-sections/model-section.ts
@@ -1,0 +1,211 @@
+/**
+ * v1.25.1 Phase C-PR2: Model section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the Model
+ * selection block:
+ *
+ *   - "Model" H2 heading
+ *   - Fetch Models button (with fallback URL resolution)
+ *   - Model Scope dropdown (unified vs per-task)
+ *   - Unified model picker (rendered via tab.renderModelField)
+ *   - Lint + Query model pickers (only in per-task mode)
+ *   - Max Tokens Per Call dropdown (only for local-like providers)
+ *
+ * Why extracted:
+ *   - 230 LOC of model-picker side effects with the most subtle
+ *     UX invariants in the codebase (v1.24.1 PATCH Phase 5.5.0
+ *     bidirectional cascade, v1.24.0 #208 sentinel-option UX).
+ *     Extracting gives them their own file for focused review.
+ *
+ * Invariants preserved:
+ *   - Switch unified -> per-task: prefill 3 per-task fields with
+ *     settings.model (consistent starting state).
+ *   - Switch per-task -> unified: cascade-clear 3 per-task overrides.
+ *   - Any model-field / provider change: set llmReady=false to force
+ *     user re-test (prevents stale-client bugs).
+ *   - Fetch Models: uses fetchModelsWithFallback for all providers
+ *     (Kimi Anthropic /v1 suffix case); only auto-picks the first
+ *     model via setFieldValue (which triggers the cascade).
+ *   - MaxTokens dropdown renders only for ollama/lmstudio/custom/
+ *     anthropic-compatible (preserves native provider defaults).
+ */
+
+import { Setting, Notice, requestUrl } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { PREDEFINED_PROVIDERS } from '../../types';
+import { resolveModelTaskUiMode } from '../settings-per-task-helpers';
+import { fetchModelsWithFallback } from '../../core/url-fallback';
+import { classifyFetchError } from '../settings-helpers';
+import { NOTICE_NORMAL, NOTICE_ERROR } from '../../constants';
+
+export function renderModelSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+  const providerConfig = PREDEFINED_PROVIDERS[tempSettings.provider];
+  const isOllama = tempSettings.provider === 'ollama';
+
+  // Model section heading
+  new Setting(containerEl).setName(tab.getText('modelSection')).setHeading();
+
+  // Fetch Models button
+  new Setting(containerEl)
+    .setName(tab.getText('fetchModelsName'))
+    .setDesc(tab.getText('fetchModelsDesc'))
+    .addButton(button => button
+      .setButtonText(tab.getText('fetchModelsButton'))
+      .onClick(async () => {
+        button.setButtonText(tab.getText('fetchingModels'));
+        button.setDisabled(true);
+        try {
+          const apiKey = isOllama ? 'ollama' : tempSettings.apiKey.trim();
+          const baseUrl = tempSettings.baseUrl?.trim() || providerConfig?.baseUrl || undefined;
+
+          // Smart filter based on provider: OpenRouter allows '/', Ollama allows ':'
+          const getModelFilter = (provider: string) => {
+            if (provider === 'openrouter') return (id: string) => !id.includes(':');
+            else if (provider === 'ollama') return (id: string) => !id.includes('/');
+            else return (id: string) => !id.includes(':') && !id.includes('/');
+          };
+          const modelFilter = getModelFilter(tempSettings.provider);
+
+          // v1.23.0 P1.5: use fetchModelsWithFallback for all providers.
+          // Unified fallback handles missing /v1 suffix (Kimi Anthropic
+          // case) - Test Connection and Fetch Models share the same
+          // module-level cache.
+          const providerForFallback =
+            tempSettings.provider === 'openai' ? 'openai' :
+            tempSettings.provider === 'anthropic' ? 'anthropic' :
+            tempSettings.provider as 'openai-compatible' | 'anthropic-compatible';
+
+          const fetchOneUrl = async (modelsUrl: string): Promise<string[]> => {
+            try {
+              const response = await requestUrl({
+                url: modelsUrl,
+                method: 'GET',
+                headers: tempSettings.provider === 'anthropic' || tempSettings.provider === 'anthropic-compatible'
+                  ? { 'x-api-key': apiKey, 'Anthropic-Version': '2023-06-01' }
+                  : { 'Authorization': `Bearer ${apiKey}` },
+                throw: false,
+              });
+              if (response.status >= 200 && response.status < 300) {
+                const data = response.json as { data?: Array<{ id: string }> };
+                if (data.data?.length) {
+                  return data.data.map((m: { id: string }) => m.id);
+                }
+              }
+              return [];
+            } catch {
+              return [];
+            }
+          };
+
+          const effectiveBaseUrl = baseUrl ?? (
+            tempSettings.provider === 'anthropic' ? 'https://api.anthropic.com/v1' :
+            tempSettings.provider === 'openai' ? 'https://api.openai.com/v1' :
+            ''
+          );
+
+          let models: string[];
+          try {
+            models = await fetchModelsWithFallback({
+              baseUrl: effectiveBaseUrl,
+              provider: providerForFallback,
+              fetchFn: fetchOneUrl,
+            });
+            if (models.length === 0) throw new Error('empty model list');
+          } catch {
+            throw new Error('All URL candidates failed');
+          }
+
+          tempSettings.availableModels = models.filter(modelFilter).sort();
+          if (tempSettings.availableModels.length > 0) {
+            new Notice(tab.getText('fetchSuccess').replace('{}', tempSettings.availableModels.length.toString()), NOTICE_NORMAL);
+            if (!tempSettings.model || !tempSettings.availableModels.includes(tempSettings.model)) {
+              tab.setFieldValue('model', tempSettings.availableModels[0]);
+            }
+            tempSettings.useCustomModel = false;
+          } else {
+            new Notice(tab.getText('fetchFailed'), NOTICE_NORMAL);
+            tempSettings.useCustomModel = true;
+          }
+          tab.display();
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          const category = classifyFetchError(errorMsg);
+          new Notice(tab.getTextDynamic(`fetchError${category}`), NOTICE_ERROR);
+          tempSettings.useCustomModel = true;
+          tempSettings.availableModels = [];
+          tab.display();
+        }
+        button.setButtonText(tab.getText('fetchModelsButton'));
+        button.setDisabled(false);
+      }));
+
+  // Model Scope dropdown (unified vs per-task)
+  new Setting(containerEl)
+    .setName(tab.getText('modelTaskModeName'))
+    .setDesc(tab.getText('modelTaskModeDesc'))
+    .addDropdown(dropdown => {
+      dropdown.addOption('unified', tab.getText('modelTaskModeUnified'));
+      dropdown.addOption('per-task', tab.getText('modelTaskModePerTask'));
+      dropdown.setValue(resolveModelTaskUiMode(tempSettings));
+      dropdown.onChange((value) => {
+        const nextMode: 'unified' | 'per-task' = value === 'per-task' ? 'per-task' : 'unified';
+        tempSettings.usePerTaskModels = nextMode === 'per-task';
+        if (nextMode === 'unified') {
+          tab.cascadeUnifiedModelChange();
+        } else {
+          tab.prefillPerTaskFromUnified();
+        }
+        tab.markLLMConfigStale();
+        tab.display();
+      });
+    });
+
+  // Unified model picker
+  tab.renderModelField(containerEl, 'model', {
+    name: resolveModelTaskUiMode(tempSettings) === 'per-task'
+      ? tab.getText('perTaskIngestModelName')
+      : tab.getText('selectModelName'),
+    desc: resolveModelTaskUiMode(tempSettings) === 'per-task'
+      ? tab.getText('perTaskIngestModelDesc')
+      : tab.getText('selectModelDesc').replace('{}', String(tempSettings.availableModels?.length ?? 0)),
+    dropdownSentinel: '__custom__',
+    dropdownSentinelLabel: tab.getText('customInputOption'),
+  });
+
+  // Lint + Query pickers (per-task only)
+  if (resolveModelTaskUiMode(tempSettings) === 'per-task') {
+    tab.renderModelField(containerEl, 'lintModel', {
+      name: tab.getText('perTaskLintModelName'),
+      desc: tab.getText('perTaskLintModelDesc'),
+      dropdownSentinel: '__custom__',
+      dropdownSentinelLabel: tab.getText('customInputOption'),
+    });
+    tab.renderModelField(containerEl, 'queryModel', {
+      name: tab.getText('perTaskQueryModelName'),
+      desc: tab.getText('perTaskQueryModelDesc'),
+      dropdownSentinel: '__custom__',
+      dropdownSentinelLabel: tab.getText('customInputOption'),
+    });
+  }
+
+  // Max Tokens Per Call (local-like providers only)
+  const localLikeProviders = ['ollama', 'lmstudio', 'custom', 'anthropic-compatible'];
+  if (localLikeProviders.includes(tempSettings.provider)) {
+    const tokenOptions = [0, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576];
+    const tokenLabels = ['0 (No limit)', '4K', '8K', '16K', '32K', '64K', '128K', '256K', '512K', '1M'];
+    const currentVal = tempSettings.maxTokensPerCall ?? 0;
+    new Setting(containerEl)
+      .setName(tab.getText('maxTokensPerCallName'))
+      .setDesc(tab.getText('maxTokensPerCallDesc'))
+      .addDropdown(dropdown => {
+        tokenOptions.forEach((val, idx) => {
+          dropdown.addOption(String(val), tokenLabels[idx]);
+        });
+        dropdown.setValue(String(currentVal));
+        dropdown.onChange((value) => {
+          tempSettings.maxTokensPerCall = parseInt(value);
+        });
+      });
+  }
+}

--- a/src/ui/settings-sections/provider-section.ts
+++ b/src/ui/settings-sections/provider-section.ts
@@ -1,0 +1,164 @@
+/**
+ * v1.25.1 Phase C-PR2: Provider section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the LLM
+ * Provider configuration block:
+ *
+ *   - Provider dropdown
+ *   - API key input (hidden for ollama/lmstudio; lmstudio shows hint)
+ *   - Base URL input (always shown for custom/anthropic-compatible;
+ *     otherwise only when override differs from default)
+ *   - Bedrock region dropdown (only when provider is bedrock-*)
+ *   - Page Generation Concurrency slider
+ *   - Batch Delay slider
+ *
+ * Why extracted:
+ *   - 130 LOC of provider-config side effects. Splitting into its own
+ *     module makes the provider-specific rendering path inspectable
+ *     without scrolling through unrelated Model / Advanced / Wiki code.
+ *
+ * Invariants preserved:
+ *   - Switching provider resets llmReady + availableModels + model +
+ *     useCustomModel (clears stale-client state).
+ *   - Switching to a native-PDF provider (anthropic / openai /
+ *     bedrock-*) auto-resets forcePdfSupport to false (v1.25.0 PR3
+ *     universal escape hatch UX invariant).
+ *   - baseUrl is set to PREDEFINED_PROVIDERS.baseUrl when switching to
+ *     a known provider; user can override afterwards.
+ *   - API key input is hidden for ollama / lmstudio (no key needed).
+ *   - Concurrency description swaps between singular/plural based on
+ *     the live value (UX nicety preserved).
+ */
+
+import { Setting } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { PREDEFINED_PROVIDERS } from '../../types';
+import { BEDROCK_REGIONS, BEDROCK_DEFAULT_REGION, NATIVE_PDF_PROVIDER_IDS } from '../../constants';
+import { renderRangeSlider } from '../settings-helpers';
+
+export function renderProviderSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+  const providerConfig = PREDEFINED_PROVIDERS[tempSettings.provider];
+  const isOllama = tempSettings.provider === 'ollama';
+  const isLmStudio = tempSettings.provider === 'lmstudio';
+  const isBedrock = tempSettings.provider === 'bedrock-anthropic'
+    || tempSettings.provider === 'bedrock-openai';
+
+  // LLM Provider (highest priority - must configure first).
+  // v1.25.1 Phase C-PR2 fix: this heading was previously emitted from
+  // LLMWikiSettingTab.display() and lost when the section was extracted.
+  // Restoring it preserves the pre-PR2 Settings tab layout users have
+  // muscle memory for.
+  new Setting(containerEl).setName(tab.getText('providerSection')).setHeading();
+
+  // Provider dropdown
+  new Setting(containerEl)
+    .setName(tab.getText('providerName'))
+    .setDesc(tab.getText('providerDesc'))
+    .addDropdown(dropdown => {
+      Object.values(PREDEFINED_PROVIDERS).forEach(config => {
+        const lang = tempSettings.language;
+        const displayName = lang === 'zh' ? config.nameZh : config.nameEn;
+        dropdown.addOption(config.id, displayName);
+      });
+      dropdown.setValue(tempSettings.provider);
+      dropdown.onChange((value) => {
+        tempSettings.provider = value;
+        tempSettings.llmReady = false;
+        tempSettings.availableModels = [];
+        tempSettings.useCustomModel = false;
+        tempSettings.model = '';
+        const config = PREDEFINED_PROVIDERS[value];
+        if (config && value !== 'custom') tempSettings.baseUrl = config.baseUrl;
+        // v1.25.0 PR3: if the user just switched to a native-PDF provider
+        // (anthropic / openai / bedrock-*), reset forcePdfSupport so they
+        // don't carry a stale escape-hatch value that no longer applies.
+        if ((NATIVE_PDF_PROVIDER_IDS as readonly string[]).includes(value)) {
+          tempSettings.forcePdfSupport = false;
+        }
+        tab.display();
+      });
+    });
+
+  // API Key (or hint for ollama/lmstudio)
+  if (!isOllama && !isLmStudio) {
+    new Setting(containerEl)
+      .setName(tab.getText('apiKeyName'))
+      .setDesc(tab.getText('apiKeyDesc'))
+      .addText(text => {
+        text.setPlaceholder(tab.getText('apiKeyPlaceholder'))
+          .setValue(tempSettings.apiKey)
+          .onChange((value) => { tempSettings.apiKey = value; tempSettings.llmReady = false; });
+        text.inputEl.type = 'password';
+      });
+  } else if (isLmStudio) {
+    containerEl.createEl('p', {
+      text: tab.getText('lmstudioHint'),
+      cls: 'llm-wiki-ollama-hint'
+    });
+  } else {
+    containerEl.createEl('p', {
+      text: tab.getText('ollamaHint'),
+      cls: 'llm-wiki-ollama-hint'
+    });
+  }
+
+  // Base URL
+  if (tempSettings.provider === 'custom' || tempSettings.provider === 'anthropic-compatible' || (providerConfig && tempSettings.baseUrl !== providerConfig.baseUrl)) {
+    new Setting(containerEl)
+      .setName(tab.getText('baseUrlName'))
+      .setDesc(tempSettings.provider === 'custom' || tempSettings.provider === 'anthropic-compatible'
+        ? tab.getText('baseUrlDescCustom') : tab.getText('baseUrlDescOverride'))
+      .addText(text => text
+        .setPlaceholder(providerConfig?.baseUrl || 'https://api.example.com/v1')
+        .setValue(tempSettings.baseUrl)
+        .onChange((value) => { tempSettings.baseUrl = value; tempSettings.llmReady = false; }));
+  }
+
+  // v1.24.1 PATCH Bedrock Stage 1 - region selector (only when provider
+  // is one of the two bedrock-* ids). Region drives the baseURL the
+  // factory resolves; the user does NOT edit baseURL for Bedrock.
+  if (isBedrock) {
+    const currentRegion = tempSettings.bedrockRegion || BEDROCK_DEFAULT_REGION;
+    new Setting(containerEl)
+      .setName(tab.getText('bedrockRegionName'))
+      .setDesc(`${tab.getText('bedrockRegionDesc')} ${tab.getText('bedrockRegionHint')}`)
+      .addDropdown(dropdown => {
+        BEDROCK_REGIONS.forEach(region => {
+          dropdown.addOption(region, region);
+        });
+        dropdown.setValue(currentRegion);
+        dropdown.onChange((value) => {
+          tempSettings.bedrockRegion = value;
+          tempSettings.llmReady = false;
+          tempSettings.availableModels = [];
+          tempSettings.useCustomModel = false;
+          tempSettings.model = '';
+        });
+      });
+  }
+
+  // Page Generation Concurrency + Batch Delay — both rendered via the
+  // shared renderRangeSlider helper (v1.25.1 Phase C-PR2 simplify pass).
+  renderRangeSlider(containerEl, {
+    name: tab.getText('pageGenerationConcurrencyName'),
+    desc: tab.getText('pageGenerationConcurrencyDesc'),
+    initialValue: tempSettings.pageGenerationConcurrency ?? 3,
+    min: 1,
+    max: 5,
+    step: 1,
+    formatDesc: (v) => tab.getText(v === 1 ? 'concurrencyValueSingular' : 'concurrencyValuePlural').replace('{}', String(v)),
+    onChange: (v) => { tempSettings.pageGenerationConcurrency = v; },
+  });
+
+  renderRangeSlider(containerEl, {
+    name: tab.getText('batchDelayName'),
+    desc: tab.getText('batchDelayDesc'),
+    initialValue: tempSettings.batchDelayMs ?? 300,
+    min: 100,
+    max: 2000,
+    step: 50,
+    formatDesc: (v) => tab.getText('batchDelayDesc').replace('{}', String(v)),
+    onChange: (v) => { tempSettings.batchDelayMs = v; },
+  });
+}

--- a/src/ui/settings-sections/status-section.ts
+++ b/src/ui/settings-sections/status-section.ts
@@ -1,0 +1,35 @@
+/**
+ * v1.25.1 Phase C-PR2: Status section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the inline
+ * "LLM-Wiki Status" indicator row (Section 2.5 in the original file),
+ * showing ready/client/wikiInit status to the user without any
+ * interactive controls.
+ *
+ * Why extracted:
+ *   - It's a single Setting row with a composite desc string. Trivially
+ *     small but conceptually distinct from the configuration sections
+ *     (it READS plugin state, doesn't WRITE it). Putting it in its own
+ *     module makes the read-only nature obvious.
+ *   - Reads `tab.isWikiInitialized()` (helper on the tab) to compute
+ *     the wikiInitStatus string.
+ */
+
+import { Setting } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+
+export function renderStatusSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+  const readyStatus = tempSettings.llmReady
+    ? '✅ ' + (tab.getText('statusReady') || 'Ready')
+    : '⚠️ ' + (tab.getText('statusNotReady') || 'Not configured - please complete setup below');
+  const clientStatus = tab.plugin.llmClient ? tab.getText('statusInitialized') : tab.getText('statusNotInitialized');
+  const wikiInitCheck = tab.isWikiInitialized();
+  const wikiInitStatus = wikiInitCheck
+    ? '✅ ' + (tab.getText('wikiInitStatusReady') || 'Wiki initialized')
+    : '⚠️ ' + (tab.getText('wikiInitStatusNotReady') || 'Wiki not initialized - will auto-create on first ingestion');
+
+  new Setting(containerEl)
+    .setName(tab.getText('llmWikiStatusSection'))
+    .setDesc(`${readyStatus} | ${clientStatus}  •  ${wikiInitStatus}`);
+}

--- a/src/ui/settings-sections/test-connection-section.ts
+++ b/src/ui/settings-sections/test-connection-section.ts
@@ -1,0 +1,65 @@
+/**
+ * v1.25.1 Phase C-PR2: Test Connection section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the Test
+ * Connection button that probes the live LLM endpoint and on success
+ * commits+persists immediately.
+ *
+ * Why extracted:
+ *   - The Test Connection flow has subtle v1.24.1 PATCH Phase 5.5.0
+ *     hotfix behavior (commit on success, rollback on failure,
+ *     mark llmReady) that is easy to break during future edits.
+ *     Isolating it makes the success/failure paths reviewable as a
+ *     single unit.
+ *
+ * Invariants preserved:
+ *   - On success: sync every field testLLMConnection may have mutated
+ *     into tempSettings; commitTempSettings + saveSettings immediately
+ *     so the new model takes effect without the user clicking Save.
+ *   - On failure: roll back to oldSettings, do NOT save (broken
+ *     config must not be persisted).
+ *   - Final llmReady is set to result.success regardless of branch.
+ */
+
+import { Setting, Notice } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { NOTICE_NORMAL, NOTICE_ERROR } from '../../constants';
+
+export function renderTestConnectionSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  // v1.25.1 Phase C-PR2 simplify pass: applySettings triad (assign
+  // plugin.settings + reinit LLM client + propagate to wikiEngine)
+  // extracted to a local helper. Used by both success and rollback paths.
+  const applySettings = (settings: typeof tab.plugin.settings): void => {
+    tab.plugin.settings = settings;
+    tab.plugin.initializeLLMClient();
+    tab.plugin.wikiEngine?.updateSettings(settings);
+  };
+
+  new Setting(containerEl)
+    .setName(tab.getText('testConnectionName'))
+    .setDesc(tab.getText('testConnectionDesc'))
+    .addButton(button => button
+      .setButtonText(tab.getText('testButton'))
+      .onClick(async () => {
+        button.setButtonText(tab.getText('testing'));
+        button.setDisabled(true);
+        const testSettings = { ...tab.tempSettings };
+        const oldSettings = tab.plugin.settings;
+        applySettings(testSettings);
+        const result = await tab.plugin.testLLMConnection();
+        if (!result.success) {
+          // Restore live settings on test failure - do not persist broken config.
+          applySettings(oldSettings);
+          await tab.plugin.saveSettings();
+        } else {
+          tab.tempSettings.thinkingControlCache = tab.plugin.settings.thinkingControlCache;
+          tab.commitTempSettings();
+          await tab.plugin.saveSettings();
+        }
+        tab.tempSettings.llmReady = result.success;
+        button.setButtonText(tab.getText('testButton'));
+        button.setDisabled(false);
+        tab.display();
+        new Notice(result.message, result.success ? NOTICE_NORMAL : NOTICE_ERROR);
+      }));
+}

--- a/src/ui/settings-sections/wiki-config-section.ts
+++ b/src/ui/settings-sections/wiki-config-section.ts
@@ -1,0 +1,279 @@
+/**
+ * v1.25.1 Phase C-PR2: Wiki Configuration section renderer.
+ *
+ * Extracted from `LLMWikiSettingTab.display()`. Renders the Wiki
+ * Configuration block:
+ *
+ *   - "Wiki Configuration" H2 heading
+ *   - Wiki Folder text input
+ *   - Write PDF Markdown to Vault toggle (v1.25.0 PR3)
+ *   - Slug Case dropdown
+ *   - Extraction Granularity dropdown + custom entity/concept limits
+ *   - Tag Vocabulary mode + custom entity/concept chip inputs
+ *   - Max Conversation History dropdown
+ *   - Schema Management buttons (View + Regenerate)
+ *   - Ingestion History button (Issue #122)
+ *
+ * Why extracted:
+ *   - 280 LOC of wiki-configuration side effects. Splitting makes the
+ *     storage / granularity / tagging / schema concerns navigable.
+ *
+ * v1.25.1 Phase C-PR2 simplify pass: visibility toggling uses the shared
+ * setSettingsVisible helper. The numeric-clamp inputs (customEntityLimit,
+ * customConceptLimit) keep their inline form because their
+ * clamp-notice-on-overflow pattern differs from auto-maintain's
+ * debounceMs (different Notice placement, different placeholder text);
+ * promoting them would force the helper to grow an onSetting callback
+ * that defeats the purpose of extraction.
+ */
+
+import { Setting, Notice, TFile, BaseComponent } from 'obsidian';
+import type { LLMWikiSettingTab } from '../settings';
+import { VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS } from '../../types';
+import { NOTICE_NORMAL, NOTICE_ERROR, NOTICE_SHORT, CUSTOM_LIMIT_MAX, CUSTOM_LIMIT_MIN } from '../../constants';
+import { HistoryModal } from '../history-modal';
+import { TagChipInputComponent } from '../tag-chip-input';
+import { setSettingsVisible } from '../settings-helpers';
+
+export function renderWikiConfigSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
+  const { tempSettings } = tab;
+
+  // Wiki Configuration heading
+  new Setting(containerEl).setName(tab.getText('wikiSection')).setHeading();
+
+  // Wiki Folder
+  new Setting(containerEl)
+    .setName(tab.getText('wikiFolderName'))
+    .setDesc(tab.getText('wikiFolderDesc'))
+    .addText(text => text
+      .setPlaceholder(tab.getText('wikiFolderPlaceholder'))
+      .setValue(tempSettings.wikiFolder)
+      .onChange((value) => { tempSettings.wikiFolder = value; }));
+
+  // v1.25.0 PR3: opt-in sidecar write. Always visible.
+  new Setting(containerEl)
+    .setName(tab.getText('writePdfMarkdownToVaultName'))
+    .setDesc(tab.getText('writePdfMarkdownToVaultDesc'))
+    .addToggle(toggle => toggle
+      .setValue(tempSettings.writePdfMarkdownToVault === true)
+      .onChange((value) => { tempSettings.writePdfMarkdownToVault = value; }));
+
+  // Slug Case
+  new Setting(containerEl)
+    .setName(tab.getText('slugCaseName'))
+    .setDesc(tab.getText('slugCaseDesc'))
+    .addDropdown(dropdown => {
+      dropdown.addOption('lower', tab.getText('slugCaseLower'));
+      dropdown.addOption('preserve', tab.getText('slugCasePreserve'));
+      dropdown.setValue(tempSettings.slugCase || 'lower');
+      dropdown.onChange((value: string) => {
+        tempSettings.slugCase = value as 'lower' | 'preserve';
+      });
+    });
+
+  // Granularity + custom limits
+  let customEntitySetting: Setting | null = null;
+  let customConceptSetting: Setting | null = null;
+
+  new Setting(containerEl)
+    .setName(tab.getText('extractionGranularityName'))
+    .setDesc(tab.getText('extractionGranularityDesc'))
+    .addDropdown(dropdown => {
+      dropdown.addOption('fine', tab.getText('extractionGranularityFine'));
+      dropdown.addOption('standard', tab.getText('extractionGranularityStandard'));
+      dropdown.addOption('coarse', tab.getText('extractionGranularityCoarse'));
+      dropdown.addOption('minimal', tab.getText('extractionGranularityMinimal'));
+      dropdown.addOption('custom', tab.getText('extractionGranularityCustom'));
+      dropdown.setValue(tempSettings.extractionGranularity || 'standard');
+      dropdown.onChange((value: string) => {
+        tempSettings.extractionGranularity = value as 'fine' | 'standard' | 'coarse' | 'minimal' | 'custom';
+        setSettingsVisible([customEntitySetting, customConceptSetting], value === 'custom');
+      });
+    });
+
+  // Custom entity limit (shown only when granularity=custom).
+  // Inline clamp logic kept (not extracted to renderClampedNumberInput)
+  // because the placeholder and clamping UX here differ from
+  // auto-maintain's debounceMs — the helper would need an onSetting
+  // callback that obscures the per-site config.
+  customEntitySetting = new Setting(containerEl)
+    .setName(tab.getText('customEntityLimitName'))
+    .setDesc(tab.getText('customEntityLimitDesc'))
+    .addText(text => {
+      text
+        .setPlaceholder('5')
+        .setValue(String(tempSettings.customEntityLimit ?? 5))
+        .onChange((value) => {
+          const parsed = parseInt(value);
+          if (parsed > CUSTOM_LIMIT_MAX) {
+            tempSettings.customEntityLimit = CUSTOM_LIMIT_MAX;
+            text.setValue(String(CUSTOM_LIMIT_MAX));
+            new Notice(tab.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MAX)), NOTICE_SHORT);
+          } else if (parsed < CUSTOM_LIMIT_MIN) {
+            tempSettings.customEntityLimit = CUSTOM_LIMIT_MIN;
+            text.setValue(String(CUSTOM_LIMIT_MIN));
+            new Notice(tab.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MIN)), NOTICE_SHORT);
+          } else if (!isNaN(parsed)) {
+            tempSettings.customEntityLimit = parsed;
+          }
+        });
+      text.inputEl.type = 'number';
+      text.inputEl.min = String(CUSTOM_LIMIT_MIN);
+      text.inputEl.max = String(CUSTOM_LIMIT_MAX);
+      text.inputEl.classList.add('llm-wiki-number-input');
+    });
+  customEntitySetting.settingEl.style.display =
+    tempSettings.extractionGranularity === 'custom' ? 'flex' : 'none';
+
+  customConceptSetting = new Setting(containerEl)
+    .setName(tab.getText('customConceptLimitName'))
+    .setDesc(tab.getText('customConceptLimitDesc'))
+    .addText(text => {
+      text
+        .setPlaceholder('5')
+        .setValue(String(tempSettings.customConceptLimit ?? 5))
+        .onChange((value) => {
+          const parsed = parseInt(value);
+          if (parsed > CUSTOM_LIMIT_MAX) {
+            tempSettings.customConceptLimit = CUSTOM_LIMIT_MAX;
+            text.setValue(String(CUSTOM_LIMIT_MAX));
+            new Notice(tab.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MAX)), NOTICE_SHORT);
+          } else if (parsed < CUSTOM_LIMIT_MIN) {
+            tempSettings.customConceptLimit = CUSTOM_LIMIT_MIN;
+            text.setValue(String(CUSTOM_LIMIT_MIN));
+            new Notice(tab.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MIN)), NOTICE_SHORT);
+          } else if (!isNaN(parsed)) {
+            tempSettings.customConceptLimit = parsed;
+          }
+        });
+      text.inputEl.type = 'number';
+      text.inputEl.min = String(CUSTOM_LIMIT_MIN);
+      text.inputEl.max = String(CUSTOM_LIMIT_MAX);
+      text.inputEl.classList.add('llm-wiki-number-input');
+    });
+  customConceptSetting.settingEl.style.display =
+    tempSettings.extractionGranularity === 'custom' ? 'flex' : 'none';
+
+  // Tag Vocabulary
+  let customEntityTagsSetting: Setting | null = null;
+  let customConceptTagsSetting: Setting | null = null;
+
+  const customEntities = (tempSettings.customEntityTags ?? '').trim();
+  const customConcepts = (tempSettings.customConceptTags ?? '').trim();
+  const hasCustomInput = customEntities.length > 0 || customConcepts.length > 0;
+  const effectiveEntityTags = customEntities.length > 0
+    ? customEntities.split(',').map(t => t.trim()).filter(Boolean)
+    : VALID_ENTITY_TAGS;
+  const effectiveConceptTags = customConcepts.length > 0
+    ? customConcepts.split(',').map(t => t.trim()).filter(Boolean)
+    : VALID_CONCEPT_TAGS;
+  const effectiveListDesc = hasCustomInput
+    ? `${effectiveEntityTags.join(', ')} (entities) / ${effectiveConceptTags.join(', ')} (concepts)${tempSettings.tagVocabularyMode === 'default' ? ' - custom values shown above (toggle to Custom to activate)' : ''}`
+    : `${VALID_ENTITY_TAGS.join(', ')} (entities) / ${VALID_CONCEPT_TAGS.join(', ')} (concepts)`;
+  const leadDesc = tab.getText('tagVocabularyInlineDesc');
+  const modeDesc = tempSettings.tagVocabularyMode === 'custom'
+    ? `${leadDesc}\n${tab.getText('tagVocabularyModeDescCustom')}`
+    : `${leadDesc}\n${tab.getText('tagVocabularyModeDescDefault').replace('{}', effectiveListDesc)}`;
+
+  new Setting(containerEl)
+    .setName(tab.getText('tagVocabularyModeName'))
+    .setDesc(modeDesc)
+    .addDropdown(dropdown => {
+      dropdown
+        .addOption('default', tab.getText('tagVocabularyModeDefault'))
+        .addOption('custom', tab.getText('tagVocabularyModeCustom'))
+        .setValue(tempSettings.tagVocabularyMode || 'default')
+        .onChange((value: string) => {
+          tempSettings.tagVocabularyMode = value as 'default' | 'custom';
+          tab.display();
+        });
+    });
+
+  customEntityTagsSetting = new Setting(containerEl)
+    .setName(tab.getText('customEntityTagsName'))
+    .setDesc(tab.getText('customEntityTagsDesc'))
+    .addComponent(el => new TagChipInputComponent({
+      controlEl: el,
+      initialTags: tempSettings.customEntityTags || '',
+      placeholder: tab.getText('customEntityTagsPlaceholder'),
+      ariaLabel: tab.getText('customEntityTagsName'),
+      duplicateHint: tab.getText('chipDuplicateHint'),
+      defaultTags: VALID_ENTITY_TAGS,
+      onChange: (csv) => { tempSettings.customEntityTags = csv; },
+    }) as unknown as BaseComponent);
+
+  customConceptTagsSetting = new Setting(containerEl)
+    .setName(tab.getText('customConceptTagsName'))
+    .setDesc(tab.getText('customConceptTagsDesc'))
+    .addComponent(el => new TagChipInputComponent({
+      controlEl: el,
+      initialTags: tempSettings.customConceptTags || '',
+      placeholder: tab.getText('customConceptTagsPlaceholder'),
+      ariaLabel: tab.getText('customConceptTagsName'),
+      duplicateHint: tab.getText('chipDuplicateHint'),
+      defaultTags: VALID_CONCEPT_TAGS,
+      onChange: (csv) => { tempSettings.customConceptTags = csv; },
+    }) as unknown as BaseComponent);
+
+  setSettingsVisible([customEntityTagsSetting, customConceptTagsSetting], tempSettings.tagVocabularyMode === 'custom');
+
+  // Max Conversation History
+  new Setting(containerEl)
+    .setName(tab.getText('maxConversationHistoryName'))
+    .setDesc(tab.getText('maxConversationHistoryDesc'))
+    .addDropdown(dropdown => {
+      const presets = [1, 10, 30, 50, 100, 500];
+      for (const n of presets) {
+        dropdown.addOption(n.toString(), n.toString());
+      }
+      const current = tempSettings.maxConversationHistory;
+      const currentStr = presets.includes(current) ? current.toString() : '50';
+      dropdown.setValue(currentStr);
+      dropdown.onChange((value) => {
+        const parsed = parseInt(value);
+        if (!isNaN(parsed) && parsed >= 1) {
+          tempSettings.maxConversationHistory = parsed;
+        }
+      });
+    });
+
+  // Schema Management
+  new Setting(containerEl)
+    .setName(tab.getText('schemaSection'))
+    .setDesc(tab.getText('enableSchemaDesc'))
+    .addButton(button => button
+      .setButtonText(tab.getText('viewSchemaButton'))
+      .onClick(() => {
+        const schemaPath = `${tempSettings.wikiFolder}/schema/config.md`;
+        const file = tab.app.vault.getAbstractFileByPath(schemaPath);
+        if (file instanceof TFile) void tab.app.workspace.getLeaf().openFile(file);
+        else new Notice(tab.getText('schemaNotFoundNotice'), NOTICE_NORMAL);
+      }))
+    .addButton(button => button
+      .setButtonText(tab.getText('regenerateSchemaButton'))
+      .onClick(async () => {
+        try {
+          if (!tab.isWikiInitialized()) {
+            await tab.plugin.wikiEngine.ensureWikiStructure();
+          }
+          await tab.plugin.wikiEngine.regenerateDefaultSchema();
+          new Notice(tab.getText('schemaRegeneratedNotice'), NOTICE_SHORT);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          new Notice(`${tab.getText('schemaRegenerateFailed') || 'Schema generation failed'}: ${msg}`, NOTICE_ERROR);
+        }
+      }));
+
+  // Ingestion History (#122)
+  new Setting(containerEl)
+    .setName(tab.getText('historyButton'))
+    .setDesc(tab.getText('historyButtonDesc'))
+    .addButton(button => button
+      .setButtonText(tab.getText('historyButtonOpen'))
+      .onClick(() => {
+        new HistoryModal(tab.app, {
+          language: tempSettings.language,
+          wikiFolder: tempSettings.wikiFolder || 'wiki',
+        }).open();
+      }));
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,23 +1,22 @@
-import { NOTICE_NORMAL, NOTICE_ERROR, NOTICE_SHORT, CUSTOM_LIMIT_MAX, CUSTOM_LIMIT_MIN } from '../constants';
 // Settings panel UI for LLM Wiki Plugin
 
-import { App, PluginSettingTab, Setting, Notice, TFile, requestUrl, BaseComponent } from 'obsidian';
+import { App, PluginSettingTab, Setting } from 'obsidian';
 import LLMWikiPlugin from '../main';
-import { PREDEFINED_PROVIDERS, LLMWikiSettings, WIKI_LANGUAGES, VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS } from '../types';
+import { LLMWikiSettings } from '../types';
 import { TEXTS } from '../texts';
-import { BEDROCK_REGIONS, BEDROCK_DEFAULT_REGION, NATIVE_PDF_PROVIDER_IDS } from '../constants';
-import { FolderSuggestModal } from './modals';
-import { HistoryModal } from './history-modal';
-import { classifyFetchError } from './settings-helpers';
 import {
-  resolveModelTaskUiMode,
   resolveDisplayedModelForTask,
   shouldRenderModelDropdown,
-  type ModelTaskUiMode,
   type ModelFieldKey,
 } from './settings-per-task-helpers';
-import { TagChipInputComponent } from './tag-chip-input';
-import { fetchModelsWithFallback } from '../core/url-fallback';
+import { renderLanguageSection } from './settings-sections/language-section';
+import { renderStatusSection } from './settings-sections/status-section';
+import { renderProviderSection } from './settings-sections/provider-section';
+import { renderModelSection } from './settings-sections/model-section';
+import { renderAdvancedSection } from './settings-sections/advanced-section';
+import { renderTestConnectionSection } from './settings-sections/test-connection-section';
+import { renderWikiConfigSection } from './settings-sections/wiki-config-section';
+import { renderAutoMaintainSection } from './settings-sections/auto-maintain-section';
 
 export class LLMWikiSettingTab extends PluginSettingTab {
   plugin: LLMWikiPlugin;
@@ -39,7 +38,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
   // Called by hide() (auto-save) and the explicit Save button. Adding
   // a new probe-mutated field only requires extending this one helper,
   // not every save site.
-  private commitTempSettings(): void {
+  public commitTempSettings(): void {
     // v1.24.1 PATCH Phase 5.5.0 hotfix fix: belt-and-suspenders cascade.
     // setFieldValue already triggers cascadeUnifiedModelChange on a
     // dropdown/text-input edit, but there are at least 3 other write
@@ -73,8 +72,23 @@ export class LLMWikiSettingTab extends PluginSettingTab {
   }
 
   getText(key: keyof typeof TEXTS.en): string {
+    // v1.25.1 Phase C-PR2: signature restored to `keyof typeof TEXTS.en`.
+    // The earlier widening to `string` removed compile-time protection
+    // from ~173 literal call sites for the sake of 1 dynamic site
+    // (model-section: `fetchError${category}`). Dynamic keys now route
+    // through `getTextDynamic` instead.
     const texts = TEXTS[this.tempSettings.language];
     return (texts[key] as string) ?? TEXTS.en[key] ?? key;
+  }
+
+  /**
+   * v1.25.1 Phase C-PR2: dynamic-key variant of getText. Use only when
+   * the key is constructed at runtime (e.g. `fetchError${category}`).
+   * Literal keys must go through `getText` so tsc can catch typos.
+   */
+  getTextDynamic(key: string): string {
+    const texts = TEXTS[this.tempSettings.language];
+    return (texts[key as keyof typeof texts] as string) ?? TEXTS.en[key as keyof typeof TEXTS.en] ?? key;
   }
 
   /**
@@ -95,7 +109,12 @@ export class LLMWikiSettingTab extends PluginSettingTab {
    * pickers). One helper, four call sites — see settings-per-task-helpers.ts
    * for the pure rendering policy (`shouldRenderModelDropdown`).
    */
-  private renderModelField(
+  // v1.25.1 Phase C-PR2: made public so section renderers (model-section,
+  // wiki-config-section, advanced-section) can invoke it. The helper is
+  // logically a section-level concern but is also used as a dispatch
+  // hook from the class. Public exposure keeps the section modules from
+  // needing to subclass or duplicate the renderer.
+  renderModelField(
     containerEl: HTMLElement,
     field: ModelFieldKey,
     options: {
@@ -180,7 +199,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
   }
 
   /** Read the current model string for any of the 4 model fields. */
-  private getCurrentModelValue(field: ModelFieldKey): string {
+  public getCurrentModelValue(field: ModelFieldKey): string {
     if (field === 'model') return this.tempSettings.model;
     const task = field === 'ingestModel' ? 'ingest' : field === 'lintModel' ? 'lint' : 'query';
     return resolveDisplayedModelForTask(this.tempSettings, task);
@@ -207,7 +226,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
    * not affected (those calls go through this same setter but bypass
    * the cascade block via the `field === 'model'` guard).
    */
-  private setFieldValue(field: ModelFieldKey, value: string): void {
+  public setFieldValue(field: ModelFieldKey, value: string): void {
     if (field === 'model') {
       this.tempSettings.model = value;
       if (value.trim()) {
@@ -231,13 +250,12 @@ export class LLMWikiSettingTab extends PluginSettingTab {
    * repeatedly with the overrides already empty is a no-op for both
    * the field writes and the Notice guard.
    */
-  private cascadeUnifiedModelChange(): void {
+  public cascadeUnifiedModelChange(): void {
     const fields: Array<'ingestModel' | 'lintModel' | 'queryModel'> = [
       'ingestModel',
       'lintModel',
       'queryModel',
     ];
-    let cleared = 0;
     for (const f of fields) {
       const current = (this.tempSettings as unknown as Record<string, string | undefined>)[f];
       if (current !== undefined && current !== '') {
@@ -245,16 +263,11 @@ export class LLMWikiSettingTab extends PluginSettingTab {
         // Per-task *UseCustom flag also cleared so the per-task dropdown
         // re-anchors on the unified model instead of stale free-form text.
         this.setUseCustomFlag(f, false);
-        cleared++;
       }
     }
-    // v1.24.1 PATCH Phase 5.5.0 hotfix: silent cascade (no Notice spam
-    // every time the user clicks Save). The fact that per-task values
-    // were cleared is already visible in the Settings UI (the per-task
-    // fields become empty), so an extra toast adds noise without
-    // information. If the user wants to verify, they can look at the
-    // per-task fields directly.
-    void cleared;
+    // v1.24.1 PATCH Phase 5.5.0 hotfix: silent cascade. The fact that
+    // per-task values were cleared is already visible in the Settings UI
+    // (the per-task fields become empty), so a toast would add noise.
   }
 
   /**
@@ -273,7 +286,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
    *  - Idempotent — re-running is a no-op when the per-task fields
    *    already match the unified value.
    */
-  private prefillPerTaskFromUnified(): void {
+  public prefillPerTaskFromUnified(): void {
     const unified = this.tempSettings.model.trim();
     const fields: Array<'ingestModel' | 'lintModel' | 'queryModel'> = [
       'ingestModel',
@@ -297,12 +310,12 @@ export class LLMWikiSettingTab extends PluginSettingTab {
    * Also clears `availableModels` since the fetched list is per-
    * provider; the next Test Connection will re-fetch.
    */
-  private markLLMConfigStale(): void {
+  public markLLMConfigStale(): void {
     this.tempSettings.llmReady = false;
   }
 
   /** Toggle the <field>UseCustom flag for per-task fields; no-op for unified. */
-  private setUseCustomFlag(field: ModelFieldKey, value: boolean): void {
+  public setUseCustomFlag(field: ModelFieldKey, value: boolean): void {
     if (field === 'model') return; // useCustomModel is owned by the unified picker
     const flagKey = `${field}UseCustom`;
     (this.tempSettings as unknown as Record<string, boolean | undefined>)[flagKey] = value;
@@ -312,7 +325,7 @@ export class LLMWikiSettingTab extends PluginSettingTab {
    * Check if wiki folder structure exists (entities, concepts, sources, schema).
    * Uses IO inspection — no persistent flag.
    */
-  private isWikiInitialized(): boolean {
+  public isWikiInitialized(): boolean {
     const wikiFolder = this.tempSettings.wikiFolder || 'wiki';
     return !!(
       this.app.vault.getAbstractFileByPath(`${wikiFolder}/entities`) &&
@@ -323,1118 +336,36 @@ export class LLMWikiSettingTab extends PluginSettingTab {
   }
 
   display() {
+    // v1.25.1 Phase C-PR2: split the monolithic display() into 8 focused
+    // section renderers under src/ui/settings-sections/. Each section
+    // owns a self-contained slice of the Settings tab UI. The orchestrator
+    // here only:
+    //   - clears containerEl
+    //   - invokes each section in user-visible order
+    //   - delegates to the shared helpers on this class (renderModelField,
+    //     cascadeUnifiedModelChange, etc.) which the section modules need.
+    //
+    // Why orchestrator ordering matters:
+    //   - Status section (Section 2.5) must come BEFORE LLM Provider
+    //     (Section 3) so the user sees the ready indicator when reading
+    //     about provider config.
+    //   - Test Connection sits inside Section 3 right after the Advanced
+    //     block, NOT at the end of the tab - matching pre-PR2 layout
+    //     users have muscle memory for.
     const { containerEl } = this;
     containerEl.empty();
 
-    // ==========================================
-    // 1. Language Settings
-    // ==========================================
-
-    new Setting(containerEl)
-      .setName(this.getText('languageTitle'))
-      .setDesc(this.getText('languageDesc'))
-      .addDropdown(dropdown => {
-        // v1.22.0: use WIKI_LANGUAGES (BCP-47 → native name) as the single
-        // source of truth for BOTH dropdowns. Previously the Interface
-        // Language dropdown hardcoded 9 `addOption('xx', getText('languageXxx'))`
-        // lines, which (a) required manual sync when a locale was added, and
-        // (b) could show locale-translated labels (e.g. '日文') that didn't
-        // match the canonical name used in Wiki Output Language. Sharing
-        // WIKI_LANGUAGES means a single edit covers both dropdowns and every
-        // label is the language's own native name — same convention as
-        // BCP-47 + IANA subtag registry.
-        for (const [key, label] of Object.entries(WIKI_LANGUAGES)) {
-          dropdown.addOption(key, label);
-        }
-        dropdown.setValue(this.tempSettings.language);
-        dropdown.onChange((value: 'en' | 'zh' | 'zh-Hant' | 'ja' | 'ko' | 'de' | 'fr' | 'es' | 'pt' | 'it') => {
-          this.tempSettings.language = value;
-          this.display();
-        });
-      })
-      .addButton(button => button
-        .setButtonText(this.getText('saveButton'))
-        .setCta()
-        .onClick(() => {
-          void (async () => {
-            this.commitTempSettings();
-            await this.plugin.saveSettings();
-            new Notice(this.getText('savedNotice'), NOTICE_SHORT);
-          })();
-        }));
-
-    // ==========================================
-    // 2. Wiki Output Language
-    // ==========================================
-    new Setting(containerEl).setName(this.getText('wikiLanguageName')).setHeading();
-
-    new Setting(containerEl)
-      .setName(this.getText('wikiLanguageName'))
-      .setDesc(this.getText('wikiLanguageDesc'))
-      .addDropdown(dropdown => {
-        for (const [key, label] of Object.entries(WIKI_LANGUAGES)) dropdown.addOption(key, label);
-        dropdown.addOption('__custom__', this.getText('customWikiLanguageOption'));
-        // Priority: if custom mode is active, show '__custom__' regardless of wikiLanguage value
-        if (this.tempSettings.useCustomWikiLanguage) {
-          dropdown.setValue('__custom__');
-        } else {
-          const currentLang = this.tempSettings.wikiLanguage;
-          if (currentLang && WIKI_LANGUAGES[currentLang]) dropdown.setValue(currentLang);
-          else if (currentLang) dropdown.setValue('__custom__');
-          else dropdown.setValue('en');
-        }
-        dropdown.onChange((value: string) => {
-          if (value === '__custom__') {
-            this.tempSettings.useCustomWikiLanguage = true;
-            // Keep existing wikiLanguage value for display in custom input, or clear if it was a standard language
-            if (WIKI_LANGUAGES[this.tempSettings.wikiLanguage || '']) {
-              this.tempSettings.wikiLanguage = '';
-            }
-          } else {
-            this.tempSettings.wikiLanguage = value;
-            this.tempSettings.useCustomWikiLanguage = false;
-          }
-          this.display();
-        });
-      });
-
-    if (this.tempSettings.useCustomWikiLanguage) {
-      new Setting(containerEl)
-        .setName(this.getText('wikiLanguageName') + ' (Custom)')
-        .setDesc(this.getText('customWikiLanguageHint'))
-        .addText(text => text
-          .setPlaceholder(this.getText('customWikiLanguagePlaceholder'))
-          .setValue(this.tempSettings.wikiLanguage && !WIKI_LANGUAGES[this.tempSettings.wikiLanguage] ? this.tempSettings.wikiLanguage : '')
-          .onChange((value) => { this.tempSettings.wikiLanguage = value.trim(); }));
-    }
-
-    // ==========================================
-    // 2.5 LLM-Wiki Status indicators (inline, before LLM Configuration)
-    // ==========================================
-    const readyStatus = this.tempSettings.llmReady
-      ? '✅ ' + (this.getText('statusReady') || 'Ready')
-      : '⚠️ ' + (this.getText('statusNotReady') || 'Not configured — please complete setup below');
-    const clientStatus = this.plugin.llmClient ? this.getText('statusInitialized') : this.getText('statusNotInitialized');
-    const wikiInitCheck = this.isWikiInitialized();
-    const wikiInitStatus = wikiInitCheck
-      ? '✅ ' + (this.getText('wikiInitStatusReady') || 'Wiki initialized')
-      : '⚠️ ' + (this.getText('wikiInitStatusNotReady') || 'Wiki not initialized — will auto-create on first ingestion');
-
-    // Use a Setting row with description for native Obsidian styling (matches other settings)
-    new Setting(containerEl)
-      .setName(this.getText('llmWikiStatusSection'))
-      .setDesc(`${readyStatus} | ${clientStatus}  •  ${wikiInitStatus}`);
-
-    // ==========================================
-    // 3. LLM Provider (highest priority — must configure first)
-    // ==========================================
-    new Setting(containerEl).setName(this.getText('providerSection')).setHeading();
-
-    const providerConfig = PREDEFINED_PROVIDERS[this.tempSettings.provider];
-    const isOllama = this.tempSettings.provider === 'ollama';
-    const isLmStudio = this.tempSettings.provider === 'lmstudio';
-    const isBedrock = this.tempSettings.provider === 'bedrock-anthropic'
-      || this.tempSettings.provider === 'bedrock-openai';
-
-    // Provider Dropdown
-    new Setting(containerEl)
-      .setName(this.getText('providerName'))
-      .setDesc(this.getText('providerDesc'))
-      .addDropdown(dropdown => {
-        Object.values(PREDEFINED_PROVIDERS).forEach(config => {
-          // Provider name i18n: use nameZh for Chinese, nameEn for all other languages.
-          // English provider names (Anthropic, OpenAI, DeepSeek, etc.) are international
-          // technical conventions — no per-language translation needed.
-          const lang = this.tempSettings.language;
-          const displayName = lang === 'zh' ? config.nameZh : config.nameEn;
-          dropdown.addOption(config.id, displayName);
-        });
-        dropdown.setValue(this.tempSettings.provider);
-        dropdown.onChange((value) => {
-          this.tempSettings.provider = value;
-          this.tempSettings.llmReady = false;
-          this.tempSettings.availableModels = [];
-          this.tempSettings.useCustomModel = false;
-          this.tempSettings.model = '';
-          const config = PREDEFINED_PROVIDERS[value];
-          if (config && value !== 'custom') this.tempSettings.baseUrl = config.baseUrl;
-          // v1.25.0 PR3: if the user just switched to a native-PDF provider
-          // (anthropic / openai / bedrock-*), reset forcePdfSupport so they
-          // don't carry a stale escape-hatch value that no longer applies.
-          // The toggle auto-hides in this case (see render condition below),
-          // so leaving it true would be a ghost setting.
-          if ((NATIVE_PDF_PROVIDER_IDS as readonly string[]).includes(value)) {
-            this.tempSettings.forcePdfSupport = false;
-          }
-          this.display();
-        });
-      });
-
-    // API Key
-    if (!isOllama && !isLmStudio) {
-      new Setting(containerEl)
-        .setName(this.getText('apiKeyName'))
-        .setDesc(this.getText('apiKeyDesc'))
-        .addText(text => {
-          text.setPlaceholder(this.getText('apiKeyPlaceholder'))
-            .setValue(this.tempSettings.apiKey)
-            .onChange((value) => { this.tempSettings.apiKey = value; this.tempSettings.llmReady = false; });
-          text.inputEl.type = 'password';
-        });
-    } else if (isLmStudio) {
-      containerEl.createEl('p', {
-        text: this.getText('lmstudioHint'),
-        cls: 'llm-wiki-ollama-hint'
-      });
-    } else {
-      containerEl.createEl('p', {
-        text: this.getText('ollamaHint'),
-        cls: 'llm-wiki-ollama-hint'
-      });
-    }
-
-    // Base URL
-    if (this.tempSettings.provider === 'custom' || this.tempSettings.provider === 'anthropic-compatible' || (providerConfig && this.tempSettings.baseUrl !== providerConfig.baseUrl)) {
-      new Setting(containerEl)
-        .setName(this.getText('baseUrlName'))
-        .setDesc(this.tempSettings.provider === 'custom' || this.tempSettings.provider === 'anthropic-compatible'
-          ? this.getText('baseUrlDescCustom') : this.getText('baseUrlDescOverride'))
-        .addText(text => text
-          .setPlaceholder(providerConfig?.baseUrl || 'https://api.example.com/v1')
-          .setValue(this.tempSettings.baseUrl)
-          .onChange((value) => { this.tempSettings.baseUrl = value; this.tempSettings.llmReady = false; }));
-    }
-
-    // v1.24.1 PATCH Bedrock Stage 1 — region selector (only when provider
-    // is one of the two bedrock-* ids). Region drives the baseURL the
-    // factory resolves; the user does NOT edit baseURL for Bedrock.
-    if (isBedrock) {
-      const currentRegion = this.tempSettings.bedrockRegion || BEDROCK_DEFAULT_REGION;
-      new Setting(containerEl)
-        .setName(this.getText('bedrockRegionName'))
-        .setDesc(`${this.getText('bedrockRegionDesc')} ${this.getText('bedrockRegionHint')}`)
-        .addDropdown(dropdown => {
-          BEDROCK_REGIONS.forEach(region => {
-            dropdown.addOption(region, region);
-          });
-          dropdown.setValue(currentRegion);
-          dropdown.onChange((value) => {
-            // Region change alters the resolved baseURL → models fetched
-            // for the previous region are now stale (mirror the provider
-            // dropdown's reset).
-            this.tempSettings.bedrockRegion = value;
-            this.tempSettings.llmReady = false;
-            this.tempSettings.availableModels = [];
-            this.tempSettings.useCustomModel = false;
-            this.tempSettings.model = '';
-          });
-        });
-    }
-
-    // LLM execution controls (concurrency + batch delay) — Issue #81 layout refactor
-    // Page Generation Concurrency
-    const concurrencyValue = this.tempSettings.pageGenerationConcurrency ?? 3;
-    const concurrencyDesc = concurrencyValue === 1
-      ? this.getText('concurrencyValueSingular').replace('{}', String(concurrencyValue))
-      : this.getText('concurrencyValuePlural').replace('{}', String(concurrencyValue));
-
-    let concurrencySetting: Setting;
-    new Setting(containerEl)
-      .setName(this.getText('pageGenerationConcurrencyName'))
-      .setDesc(this.getText('pageGenerationConcurrencyDesc') + ' ' + concurrencyDesc)
-      .addSlider(slider => slider
-        .setLimits(1, 5, 1)
-        .setValue(concurrencyValue)
-        .setDynamicTooltip()
-        .onChange((value) => {
-          this.tempSettings.pageGenerationConcurrency = value;
-          const desc = value === 1
-            ? this.getText('concurrencyValueSingular').replace('{}', String(value))
-            : this.getText('concurrencyValuePlural').replace('{}', String(value));
-          concurrencySetting.setDesc(this.getText('pageGenerationConcurrencyDesc') + ' ' + desc);
-        }))
-      .then(s => { concurrencySetting = s; });
-
-    // Batch Delay
-    const batchDelayValue = this.tempSettings.batchDelayMs ?? 300;
-    let batchDelaySetting: Setting;
-    new Setting(containerEl)
-      .setName(this.getText('batchDelayName'))
-      .setDesc(this.getText('batchDelayDesc').replace('{}', String(batchDelayValue)))
-      .addSlider(slider => slider
-        .setLimits(100, 2000, 50)
-        .setValue(batchDelayValue)
-        .setDynamicTooltip()
-        .onChange((value) => {
-          this.tempSettings.batchDelayMs = value;
-          batchDelaySetting.setDesc(this.getText('batchDelayDesc').replace('{}', String(value)));
-        }))
-      .then(s => { batchDelaySetting = s; });
-
-    // Model section
-    new Setting(containerEl).setName(this.getText('modelSection')).setHeading();
-
-    // Fetch Models button
-    new Setting(containerEl)
-      .setName(this.getText('fetchModelsName'))
-      .setDesc(this.getText('fetchModelsDesc'))
-      .addButton(button => button
-        .setButtonText(this.getText('fetchModelsButton'))
-        .onClick(async () => {
-          button.setButtonText(this.getText('fetchingModels'));
-          button.setDisabled(true);
-          try {
-            const apiKey = isOllama ? 'ollama' : this.tempSettings.apiKey.trim();
-            const baseUrl = this.tempSettings.baseUrl?.trim() || providerConfig?.baseUrl || undefined;
-
-            // Smart filter based on provider: OpenRouter allows '/', Ollama allows ':'
-            const getModelFilter = (provider: string) => {
-              if (provider === 'openrouter') {
-                return (id: string) => !id.includes(':'); // Keep '/', filter ':'
-              } else if (provider === 'ollama') {
-                return (id: string) => !id.includes('/'); // Keep ':', filter '/'
-              } else {
-                return (id: string) => !id.includes(':') && !id.includes('/'); // Filter both
-              }
-            };
-            const modelFilter = getModelFilter(this.tempSettings.provider);
-
-            // v1.23.0 P1.5: use fetchModelsWithFallback for all providers
-            // (anthropic-compatible, openai-compatible, openai, anthropic).
-            // Unified fallback handles missing /v1 suffix (Kimi Anthropic
-            // case) — Test Connection and Fetch Models share the same
-            // module-level cache, so a resolved URL from one path
-            // applies to the other.
-            const providerForFallback =
-              this.tempSettings.provider === 'openai' ? 'openai' :
-              this.tempSettings.provider === 'anthropic' ? 'anthropic' :
-              this.tempSettings.provider as 'openai-compatible' | 'anthropic-compatible';
-
-            const fetchOneUrl = async (modelsUrl: string): Promise<string[]> => {
-              try {
-                const response = await requestUrl({
-                  url: modelsUrl,
-                  method: 'GET',
-                  headers: this.tempSettings.provider === 'anthropic' || this.tempSettings.provider === 'anthropic-compatible'
-                    ? { 'x-api-key': apiKey, 'Anthropic-Version': '2023-06-01' }
-                    : { 'Authorization': `Bearer ${apiKey}` },
-                  throw: false,
-                });
-                if (response.status >= 200 && response.status < 300) {
-                  const data = response.json as { data?: Array<{ id: string }> };
-                  if (data.data?.length) {
-                    return data.data.map((m: { id: string }) => m.id);
-                  }
-                }
-                return [];
-              } catch {
-                return [];
-              }
-            };
-
-            const effectiveBaseUrl = baseUrl ?? (
-              this.tempSettings.provider === 'anthropic' ? 'https://api.anthropic.com/v1' :
-              this.tempSettings.provider === 'openai' ? 'https://api.openai.com/v1' :
-              ''
-            );
-
-            let models: string[];
-            try {
-              models = await fetchModelsWithFallback({
-                baseUrl: effectiveBaseUrl,
-                provider: providerForFallback,
-                fetchFn: fetchOneUrl,
-              });
-              if (models.length === 0) throw new Error('empty model list');
-            } catch {
-              throw new Error('All URL candidates failed');
-            }
-
-            this.tempSettings.availableModels = models.filter(modelFilter).sort();
-            if (this.tempSettings.availableModels.length > 0) {
-              new Notice(this.getText('fetchSuccess').replace('{}', this.tempSettings.availableModels.length.toString()), NOTICE_NORMAL);
-              if (!this.tempSettings.model || !this.tempSettings.availableModels.includes(this.tempSettings.model)) {
-                // v1.24.1 PATCH Phase 5.5.0 hotfix fix: route the auto-pick
-                // through setFieldValue so the unified-model cascade fires
-                // (clears stale per-task overrides). Previously this
-                // direct assignment bypassed the cascade, leaving old
-                // per-task model values pinned after Fetch Models.
-                this.setFieldValue('model', this.tempSettings.availableModels[0]);
-              }
-              // Auto-switch from text input to dropdown on successful fetch
-              this.tempSettings.useCustomModel = false;
-            } else {
-              new Notice(this.getText('fetchFailed'), NOTICE_NORMAL);
-              this.tempSettings.useCustomModel = true;
-            }
-            this.display();
-          } catch (error) {
-            const errorMsg = error instanceof Error ? error.message : String(error);
-            const category = classifyFetchError(errorMsg);
-            new Notice(this.getText(`fetchError${category}`), NOTICE_ERROR);
-            this.tempSettings.useCustomModel = true;
-            this.tempSettings.availableModels = [];
-            this.display();
-          }
-          button.setButtonText(this.getText('fetchModelsButton'));
-          button.setDisabled(false);
-        }));
-
-    // Model Selection — see renderModelField call below.
-    // v1.24.0 #208 unified picker is rendered by the shared helper used
-    // for all 4 model fields (model / ingestModel / lintModel / queryModel).
-    // Sentinel mapping:
-    //   unified:  '__custom__' → useCustomModel=true (switch to text input)
-    //   per-task: '__unified__' → field = '' (fall back to settings.model)
-    // Hidden per-task values are preserved on toggle off.
-
-    // v1.24.0 #208: "Model Scope" dropdown — unified vs per-task mode.
-    // In unified mode, only the unified model picker is shown.
-    // In per-task mode, the unified picker re-labels to "Ingest model"
-    // and 2 additional (lint + query) pickers render below.
-    new Setting(containerEl)
-      .setName(this.getText('modelTaskModeName'))
-      .setDesc(this.getText('modelTaskModeDesc'))
-      .addDropdown(dropdown => {
-        dropdown.addOption('unified', this.getText('modelTaskModeUnified'));
-        dropdown.addOption('per-task', this.getText('modelTaskModePerTask'));
-        dropdown.setValue(resolveModelTaskUiMode(this.tempSettings));
-        dropdown.onChange((value) => {
-          const nextMode: ModelTaskUiMode = value === 'per-task' ? 'per-task' : 'unified';
-          this.tempSettings.usePerTaskModels = nextMode === 'per-task';
-          // v1.24.1 PATCH Phase 5.5.0 hotfix: bidirectional sync between
-          // unified ↔ per-task modes.
-          //
-          // The previous behavior preserved per-task overrides across
-          // mode switches (rationale: user might toggle back). This was
-          // LOGICALLY WRONG: a per-task value silently overrides the
-          // unified model even after the user explicitly chose unified
-          // mode, producing a UI/value mismatch that the user couldn't
-          // see without inspecting data.json.
-          //
-          // New rules (per user direction, 2026-07-13):
-          //   1. per-task → unified: clear all 3 per-task overrides so
-          //      every task falls back to the unified model. Optional
-          //      safety: write the unified model value into the per-task
-          //      fields directly (so even an out-of-band read sees the
-          //      same value, no fallback indirection).
-          //   2. unified → per-task: prefill all 3 per-task fields with
-          //      the current unified model so the user sees consistent
-          //      starting state and can edit per-task values from there.
-          //   3. ANY model-field or provider change: set llmReady=false
-          //      so the user is prompted to re-test the connection
-          //      (instead of running with stale creds/model).
-          if (nextMode === 'unified') {
-            this.cascadeUnifiedModelChange();
-          } else {
-            this.prefillPerTaskFromUnified();
-          }
-          this.markLLMConfigStale();
-          this.display(); // re-render to show/hide per-task pickers
-        });
-      });
-
-    // Unified model picker — re-labeled as "Ingest model" when per-task
-    // mode is active. Per-task lint/query pickers render only in per-task
-    // mode. All 4 pickers share the same `renderModelField` helper.
-    this.renderModelField(containerEl, 'model', {
-      name: resolveModelTaskUiMode(this.tempSettings) === 'per-task'
-        ? this.getText('perTaskIngestModelName')
-        : this.getText('selectModelName'),
-      desc: resolveModelTaskUiMode(this.tempSettings) === 'per-task'
-        ? this.getText('perTaskIngestModelDesc')
-        : this.getText('selectModelDesc').replace('{}', String(this.tempSettings.availableModels?.length ?? 0)),
-      // Unified picker keeps "Custom input..." → switches to text mode.
-      // Per-task picker keeps "__unified__" → falls back to settings.model.
-      dropdownSentinel: '__custom__',
-      dropdownSentinelLabel: this.getText('customInputOption'),
-    });
-
-    if (resolveModelTaskUiMode(this.tempSettings) === 'per-task') {
-      // Lint + Query pickers (per-task only). Each carries its own
-      // <field>UseCustom flag so dropdown↔input switching is independent
-      // per field (no cross-talk with the unified picker).
-      //
-      // v1.24.0 #208 (UX fix): the sentinel option is `__custom__`
-      // ("Custom input...") — IDENTICAL to the unified picker — NOT
-      // `__unified__`. Picking it switches to a text input where the
-      // user can type any model ID (including "leave blank to fall back
-      // to settings.model"). The "use unified model" semantic is
-      // expressed by *leaving the text input empty*, not by a separate
-      // sentinel option. One dropdown shape across all 4 fields.
-      this.renderModelField(containerEl, 'lintModel', {
-        name: this.getText('perTaskLintModelName'),
-        desc: this.getText('perTaskLintModelDesc'),
-        dropdownSentinel: '__custom__',
-        dropdownSentinelLabel: this.getText('customInputOption'),
-      });
-      this.renderModelField(containerEl, 'queryModel', {
-        name: this.getText('perTaskQueryModelName'),
-        desc: this.getText('perTaskQueryModelDesc'),
-        dropdownSentinel: '__custom__',
-        dropdownSentinelLabel: this.getText('customInputOption'),
-      });
-    }
-
-    // Issue #75: max tokens per call — shown for local/custom providers only
-
-    // Issue #75: max tokens per call — shown for local/custom providers only Issue #75: max tokens per call — shown for local/custom providers only
-    const localLikeProviders = ['ollama', 'lmstudio', 'custom', 'anthropic-compatible'];
-    if (localLikeProviders.includes(this.tempSettings.provider)) {
-      const tokenOptions = [0, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576];
-      const tokenLabels = ['0 (No limit)', '4K', '8K', '16K', '32K', '64K', '128K', '256K', '512K', '1M'];
-      const currentVal = this.tempSettings.maxTokensPerCall ?? 0;
-      new Setting(containerEl)
-        .setName(this.getText('maxTokensPerCallName'))
-        .setDesc(this.getText('maxTokensPerCallDesc'))
-        .addDropdown(dropdown => {
-          tokenOptions.forEach((val, idx) => {
-            dropdown.addOption(String(val), tokenLabels[idx]);
-          });
-          dropdown.setValue(String(currentVal));
-          dropdown.onChange((value) => {
-            this.tempSettings.maxTokensPerCall = parseInt(value);
-          });
-        });
-    }
-
-    // Advanced LLM settings — hidden behind a Default/Custom dropdown
-    // v1.20.0 inverted semantics: default mode = no provider-specific
-    // overrides (provider decides its own behavior). Custom mode = user
-    // explicitly opts in to disable thinking / temperature / repetition
-    // penalty overrides.
-    new Setting(containerEl)
-      .setName(this.getText('advancedSettingsModeName'))
-      .setDesc(this.getText('advancedSettingsModeDesc'))
-      .addDropdown(dropdown => {
-        dropdown
-          .addOption('default', this.getText('advancedSettingsDefault'))
-          .addOption('custom', this.getText('advancedSettingsCustom'))
-          .setValue(this.tempSettings.advancedSettingsMode || 'default')
-          .onChange((value: string) => {
-            this.tempSettings.advancedSettingsMode = value as 'default' | 'custom';
-            if (value === 'default') {
-              // Default mode: no overrides — provider decides its own behavior
-              this.tempSettings.disableThinking = false;
-              this.tempSettings.extractionTemperature = undefined;
-              this.tempSettings.chatTemperature = undefined;
-              this.tempSettings.repetitionPenalty = undefined;
-              // v1.25.0 PR3: reset forcePdfSupport — it's rendered only inside
-              // the Advanced block, so hiding the block without resetting
-              // the value would leave users with a no-UI-affordance setting.
-              this.tempSettings.forcePdfSupport = false;
-              // writePdfMarkdownToVault lives in Wiki Configuration (always
-              // visible) and is NOT reset here.
-            }
-            this.display();
-          });
-      });
-
-    if (this.tempSettings.advancedSettingsMode === 'custom') {
-    new Setting(containerEl)
-      .setName(this.getText('disableThinkingName'))
-      .setDesc(this.getText('disableThinkingDesc'))
-      .addToggle(toggle => toggle
-        .setValue(this.tempSettings.disableThinking === true)
-        .onChange((value) => {
-          // v1.20.0: opt-in. When enabled, the LLM client walks the 3-tier
-          // dialect fallback (anthropic → openai → none) on 400.
-          this.tempSettings.disableThinking = value;
-        }));
-
-    new Setting(containerEl)
-      .setName(this.getText('extractionTemperatureName'))
-      .setDesc(this.getText('extractionTemperatureDesc'))
-      .addText(text => {
-        text
-          .setPlaceholder(this.getText('temperaturePlaceholder'))
-          .setValue(this.tempSettings.extractionTemperature?.toString() ?? '')
-          .onChange((value) => {
-            const trimmed = value.trim();
-            if (trimmed === '') {
-              this.tempSettings.extractionTemperature = undefined;
-            } else {
-              const parsed = parseFloat(trimmed);
-              if (!isNaN(parsed)) {
-                this.tempSettings.extractionTemperature = parsed;
-              }
-            }
-          });
-        text.inputEl.type = 'number';
-        text.inputEl.min = '0';
-        text.inputEl.max = '2';
-        text.inputEl.step = '0.05';
-        text.inputEl.classList.add('llm-wiki-number-input');
-      });
-
-    new Setting(containerEl)
-      .setName(this.getText('chatTemperatureName'))
-      .setDesc(this.getText('chatTemperatureDesc'))
-      .addText(text => {
-        text
-          .setPlaceholder(this.getText('temperaturePlaceholder'))
-          .setValue(this.tempSettings.chatTemperature?.toString() ?? '')
-          .onChange((value) => {
-            const trimmed = value.trim();
-            if (trimmed === '') {
-              this.tempSettings.chatTemperature = undefined;
-            } else {
-              const parsed = parseFloat(trimmed);
-              if (!isNaN(parsed)) {
-                this.tempSettings.chatTemperature = parsed;
-              }
-            }
-          });
-        text.inputEl.type = 'number';
-        text.inputEl.min = '0';
-        text.inputEl.max = '2';
-        text.inputEl.step = '0.05';
-        text.inputEl.classList.add('llm-wiki-number-input');
-      });
-
-    new Setting(containerEl)
-      .setName(this.getText('repetitionPenaltyName'))
-      .setDesc(this.getText('repetitionPenaltyDesc'))
-      .addText(text => {
-        text
-          .setPlaceholder(this.getText('temperaturePlaceholder'))
-          .setValue(this.tempSettings.repetitionPenalty?.toString() ?? '')
-          .onChange((value) => {
-            const trimmed = value.trim();
-            if (trimmed === '') {
-              this.tempSettings.repetitionPenalty = undefined;
-            } else {
-              const parsed = parseFloat(trimmed);
-              if (!isNaN(parsed)) {
-                this.tempSettings.repetitionPenalty = parsed;
-              }
-            }
-          });
-        text.inputEl.type = 'number';
-        text.inputEl.min = '0';
-        text.inputEl.max = '2';
-        text.inputEl.step = '0.05';
-        text.inputEl.classList.add('llm-wiki-number-input');
-      });
-
-    // v1.25.0 PR3: PDF force-support toggle — universal escape hatch.
-    // Gated by Advanced mode (default off; user must opt into Custom to see).
-    // Renders for ANY non-native provider (custom / anthropic-compatible /
-    // ollama / lmstudio / deepseek / glm / kimi / gemini / openrouter).
-    // When the user opts in, the converter attempts the LLM call; if the
-    // endpoint rejects PDF input, the error propagates as a localized
-    // `sourceRejectedPdfUnsupported` Notice guiding the user to disable
-    // the toggle or check their endpoint. Native-PDF providers
-    // (anthropic / openai / bedrock-*) hide this toggle since they
-    // already route through the native branch.
-    if (!(NATIVE_PDF_PROVIDER_IDS as readonly string[]).includes(this.tempSettings.provider)) {
-      new Setting(containerEl)
-        .setName(this.getText('forcePdfSupportName'))
-        .setDesc(this.getText('forcePdfSupportDesc'))
-        .addToggle(toggle => toggle
-          .setValue(this.tempSettings.forcePdfSupport === true)
-          .onChange((value) => { this.tempSettings.forcePdfSupport = value; }));
-    }
-    }
-
-    // Test Connection
-    new Setting(containerEl)
-      .setName(this.getText('testConnectionName'))
-      .setDesc(this.getText('testConnectionDesc'))
-      .addButton(button => button
-        .setButtonText(this.getText('testButton'))
-        .onClick(async () => {
-          button.setButtonText(this.getText('testing'));
-          button.setDisabled(true);
-          const testSettings = { ...this.tempSettings };
-          const oldSettings = this.plugin.settings;
-          this.plugin.settings = testSettings;
-          this.plugin.initializeLLMClient();
-          this.plugin.wikiEngine?.updateSettings(testSettings);
-          const result = await this.plugin.testLLMConnection();
-          if (!result.success) {
-            // Restore live settings on test failure — do not persist broken config
-            this.plugin.settings = oldSettings;
-            this.plugin.initializeLLMClient();
-            this.plugin.wikiEngine?.updateSettings(oldSettings);
-            await this.plugin.saveSettings();
-          } else {
-            // Issue #137: on test success, sync every field testLLMConnection
-            // may have written back into tempSettings so that the auto-save
-            // on tab close (and any later explicit Save click) preserves them.
-            // v1.23.0: thinkingControlCache is @deprecated (AI-SDK v6
-            // handles internally) but we still sync it here in case
-            // legacy code paths mutate it.
-            this.tempSettings.thinkingControlCache = this.plugin.settings.thinkingControlCache;
-            // v1.24.1 PATCH Phase 5.5.0 hotfix: commit + persist immediately
-            // on Test Connection success. Previously the test only synced
-            // a couple of probe-mutated fields (thinkingControlCache) into
-            // tempSettings; the user had to click Save (or close the tab to
-            // trigger hide() auto-save) before the new model became the
-            // live one. That mismatch caused confusion: the Settings UI
-            // showed the new model, but LLM calls still used the old model
-            // because plugin.settings.model hadn't been written.
-            //
-            // On success: commitTempSettings propagates the temp (already
-            // updated to the new model by the user's earlier edit) into
-            // plugin.settings; saveData() persists it to disk so the
-            // settings survive an Obsidian restart; initializeLLMClient()
-            // rebuilds the live client with the new model so subsequent
-            // queries/ingest calls use it without waiting for the user
-            // to click Save. Failure path above already rolls back, so
-            // this only fires on verified-good config.
-            this.commitTempSettings();
-            await this.plugin.saveSettings();
-          }
-          this.tempSettings.llmReady = result.success;
-          button.setButtonText(this.getText('testButton'));
-          button.setDisabled(false);
-          this.display();
-          new Notice(result.message, result.success ? NOTICE_NORMAL : NOTICE_ERROR);
-        }));
-
-    // ==========================================
-    // 4. Wiki Configuration
-    // ==========================================
-    new Setting(containerEl).setName(this.getText('wikiSection')).setHeading();
-
-    new Setting(containerEl)
-      .setName(this.getText('wikiFolderName'))
-      .setDesc(this.getText('wikiFolderDesc'))
-      .addText(text => text
-        .setPlaceholder(this.getText('wikiFolderPlaceholder'))
-        .setValue(this.tempSettings.wikiFolder)
-        .onChange((value) => { this.tempSettings.wikiFolder = value; }));
-
-    // v1.25.0 PR3: opt-in sidecar write. Lives under Wiki Configuration
-    // (alongside wikiFolder / slugCase) because it controls where converted
-    // PDF markdown lands on disk — a vault-storage decision, not an LLM
-    // configuration decision. Always visible (not gated by Advanced).
-    new Setting(containerEl)
-      .setName(this.getText('writePdfMarkdownToVaultName'))
-      .setDesc(this.getText('writePdfMarkdownToVaultDesc'))
-      .addToggle(toggle => toggle
-        .setValue(this.tempSettings.writePdfMarkdownToVault === true)
-        .onChange((value) => { this.tempSettings.writePdfMarkdownToVault = value; }));
-
-    new Setting(containerEl)
-      .setName(this.getText('slugCaseName'))
-      .setDesc(this.getText('slugCaseDesc'))
-      .addDropdown(dropdown => {
-        dropdown.addOption('lower', this.getText('slugCaseLower'));
-        dropdown.addOption('preserve', this.getText('slugCasePreserve'));
-        dropdown.setValue(this.tempSettings.slugCase || 'lower');
-        dropdown.onChange((value: string) => {
-          this.tempSettings.slugCase = value as 'lower' | 'preserve';
-        });
-      });
-
-    // Granularity setting with conditional custom inputs
-    let customEntitySetting: Setting | null = null;
-    let customConceptSetting: Setting | null = null;
-
-    const updateCustomVisibility = (value: string) => {
-      const isCustom = value === 'custom';
-      if (customEntitySetting) {
-        customEntitySetting.settingEl.style.display = isCustom ? 'flex' : 'none';
-      }
-      if (customConceptSetting) {
-        customConceptSetting.settingEl.style.display = isCustom ? 'flex' : 'none';
-      }
-    };
-
-    new Setting(containerEl)
-      .setName(this.getText('extractionGranularityName'))
-      .setDesc(this.getText('extractionGranularityDesc'))
-      .addDropdown(dropdown => {
-        dropdown.addOption('fine', this.getText('extractionGranularityFine'));
-        dropdown.addOption('standard', this.getText('extractionGranularityStandard'));
-        dropdown.addOption('coarse', this.getText('extractionGranularityCoarse'));
-        dropdown.addOption('minimal', this.getText('extractionGranularityMinimal'));
-        dropdown.addOption('custom', this.getText('extractionGranularityCustom'));
-        dropdown.setValue(this.tempSettings.extractionGranularity || 'standard');
-        dropdown.onChange((value: string) => {
-          this.tempSettings.extractionGranularity = value as 'fine' | 'standard' | 'coarse' | 'minimal' | 'custom';
-          updateCustomVisibility(value);
-        });
-      });
-
-    // Custom entity limit (shown only when custom is selected)
-    customEntitySetting = new Setting(containerEl)
-      .setName(this.getText('customEntityLimitName'))
-      .setDesc(this.getText('customEntityLimitDesc'))
-      .addText(text => {
-        text
-          .setPlaceholder('5')
-          .setValue(String(this.tempSettings.customEntityLimit ?? 5))
-          .onChange((value) => {
-            const parsed = parseInt(value);
-            if (parsed > CUSTOM_LIMIT_MAX) {
-              this.tempSettings.customEntityLimit = CUSTOM_LIMIT_MAX;
-              text.setValue(String(CUSTOM_LIMIT_MAX));
-              new Notice(this.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MAX)), NOTICE_SHORT);
-            } else if (parsed < CUSTOM_LIMIT_MIN) {
-              this.tempSettings.customEntityLimit = CUSTOM_LIMIT_MIN;
-              text.setValue(String(CUSTOM_LIMIT_MIN));
-              new Notice(this.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MIN)), NOTICE_SHORT);
-            } else if (!isNaN(parsed)) {
-              this.tempSettings.customEntityLimit = parsed;
-            }
-          });
-        text.inputEl.type = 'number';
-        text.inputEl.min = String(CUSTOM_LIMIT_MIN);
-        text.inputEl.max = String(CUSTOM_LIMIT_MAX);
-        text.inputEl.classList.add('llm-wiki-number-input');
-      });
-    customEntitySetting.settingEl.style.display =
-      this.tempSettings.extractionGranularity === 'custom' ? 'flex' : 'none';
-
-    // Custom concept limit (shown only when custom is selected)
-    customConceptSetting = new Setting(containerEl)
-      .setName(this.getText('customConceptLimitName'))
-      .setDesc(this.getText('customConceptLimitDesc'))
-      .addText(text => {
-        text
-          .setPlaceholder('5')
-          .setValue(String(this.tempSettings.customConceptLimit ?? 5))
-          .onChange((value) => {
-            const parsed = parseInt(value);
-            if (parsed > CUSTOM_LIMIT_MAX) {
-              this.tempSettings.customConceptLimit = CUSTOM_LIMIT_MAX;
-              text.setValue(String(CUSTOM_LIMIT_MAX));
-              new Notice(this.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MAX)), NOTICE_SHORT);
-            } else if (parsed < CUSTOM_LIMIT_MIN) {
-              this.tempSettings.customConceptLimit = CUSTOM_LIMIT_MIN;
-              text.setValue(String(CUSTOM_LIMIT_MIN));
-              new Notice(this.getText('numberRangeClamped').replace('{}', String(CUSTOM_LIMIT_MIN)), NOTICE_SHORT);
-            } else if (!isNaN(parsed)) {
-              this.tempSettings.customConceptLimit = parsed;
-            }
-          });
-        text.inputEl.type = 'number';
-        text.inputEl.min = String(CUSTOM_LIMIT_MIN);
-        text.inputEl.max = String(CUSTOM_LIMIT_MAX);
-        text.inputEl.classList.add('llm-wiki-number-input');
-      });
-    customConceptSetting.settingEl.style.display =
-      this.tempSettings.extractionGranularity === 'custom' ? 'flex' : 'none';
-
-    // Issue #85 v2: Tag Vocabulary (chip input UX, no separate heading)
-    // The single setting below fuses the previously-separate name
-    // ("Tag Vocabulary") and the mode-toggle row. The desc text is
-    // dynamic: default mode shows the concrete default list inline;
-    // custom mode is terse. Both modes prefix the same lead sentence
-    // that explains what tag vocabulary is.
-    let customEntityTagsSetting: Setting | null = null;
-    let customConceptTagsSetting: Setting | null = null;
-
-    const updateTagVocabularyVisibility = (mode: 'default' | 'custom') => {
-      const isCustom = mode === 'custom';
-      if (customEntityTagsSetting) {
-        customEntityTagsSetting.settingEl.style.display = isCustom ? 'flex' : 'none';
-      }
-      if (customConceptTagsSetting) {
-        customConceptTagsSetting.settingEl.style.display = isCustom ? 'flex' : 'none';
-      }
-    };
-
-    // v1.21.0 Phase 1.4: Settings UI description should reflect the active
-    // vocabulary, not just the hardcoded defaults. When the user has typed
-    // custom tags but hasn't yet toggled to Custom mode, show them in the
-    // Default-mode description as a preview (avoids the "settings UI drift"
-    // found in the v1.21.0 Schema audit).
-    const customEntities = (this.tempSettings.customEntityTags ?? '').trim();
-    const customConcepts = (this.tempSettings.customConceptTags ?? '').trim();
-    const hasCustomInput = customEntities.length > 0 || customConcepts.length > 0;
-    // Effective list shows user values whenever they've been typed,
-    // regardless of mode. The activation hint clarifies if the mode
-    // hasn't been switched yet (avoids Settings UI / runtime drift).
-    const effectiveEntityTags = customEntities.length > 0
-      ? customEntities.split(',').map(t => t.trim()).filter(Boolean)
-      : VALID_ENTITY_TAGS;
-    const effectiveConceptTags = customConcepts.length > 0
-      ? customConcepts.split(',').map(t => t.trim()).filter(Boolean)
-      : VALID_CONCEPT_TAGS;
-    const effectiveListDesc = hasCustomInput
-      ? `${effectiveEntityTags.join(', ')} (entities) / ${effectiveConceptTags.join(', ')} (concepts)${this.tempSettings.tagVocabularyMode === 'default' ? ' — custom values shown above (toggle to Custom to activate)' : ''}`
-      : `${VALID_ENTITY_TAGS.join(', ')} (entities) / ${VALID_CONCEPT_TAGS.join(', ')} (concepts)`;
-    const leadDesc = this.getText('tagVocabularyInlineDesc');
-    const modeDesc = this.tempSettings.tagVocabularyMode === 'custom'
-      ? `${leadDesc}\n${this.getText('tagVocabularyModeDescCustom')}`
-      : `${leadDesc}\n${this.getText('tagVocabularyModeDescDefault').replace('{}', effectiveListDesc)}`;
-
-    new Setting(containerEl)
-      .setName(this.getText('tagVocabularyModeName'))
-      .setDesc(modeDesc)
-      .addDropdown(dropdown => {
-        dropdown
-          .addOption('default', this.getText('tagVocabularyModeDefault'))
-          .addOption('custom', this.getText('tagVocabularyModeCustom'))
-          .setValue(this.tempSettings.tagVocabularyMode || 'default')
-          .onChange((value: string) => {
-            this.tempSettings.tagVocabularyMode = value as 'default' | 'custom';
-            // Re-render so the desc text refreshes and chip inputs re-init.
-            this.display();
-          });
-      });
-
-    customEntityTagsSetting = new Setting(containerEl)
-      .setName(this.getText('customEntityTagsName'))
-      .setDesc(this.getText('customEntityTagsDesc'))
-      .addComponent(el => new TagChipInputComponent({
-        controlEl: el,
-        initialTags: this.tempSettings.customEntityTags || '',
-        placeholder: this.getText('customEntityTagsPlaceholder'),
-        ariaLabel: this.getText('customEntityTagsName'),
-        duplicateHint: this.getText('chipDuplicateHint'),
-        defaultTags: VALID_ENTITY_TAGS,
-        onChange: (csv) => { this.tempSettings.customEntityTags = csv; },
-      }) as unknown as BaseComponent);
-
-    customConceptTagsSetting = new Setting(containerEl)
-      .setName(this.getText('customConceptTagsName'))
-      .setDesc(this.getText('customConceptTagsDesc'))
-      .addComponent(el => new TagChipInputComponent({
-        controlEl: el,
-        initialTags: this.tempSettings.customConceptTags || '',
-        placeholder: this.getText('customConceptTagsPlaceholder'),
-        ariaLabel: this.getText('customConceptTagsName'),
-        duplicateHint: this.getText('chipDuplicateHint'),
-        defaultTags: VALID_CONCEPT_TAGS,
-        onChange: (csv) => { this.tempSettings.customConceptTags = csv; },
-      }) as unknown as BaseComponent);
-
-    updateTagVocabularyVisibility(this.tempSettings.tagVocabularyMode || 'default');
-
-    // Max Conversation History — Issue #244 manual fix: switched from a free-form
-// text input (clamped to 1–50) to a dropdown of common presets (1/10/30/50/100/500).
-// The soft-cap behavior is unchanged: when history exceeds the limit during a
-// multi-turn conversation, the oldest messages are dropped (see query-engine.ts
-// history trim logic). The preset values let power users opt into much longer
-// context windows without typing arbitrary numbers.
-    new Setting(containerEl)
-      .setName(this.getText('maxConversationHistoryName'))
-      .setDesc(this.getText('maxConversationHistoryDesc'))
-      .addDropdown(dropdown => {
-        const presets = [1, 10, 30, 50, 100, 500];
-        for (const n of presets) {
-          dropdown.addOption(n.toString(), n.toString());
-        }
-        // Default to current value, but fall back to 50 if it's a legacy
-        // value not in the preset list (e.g. user typed 25 pre-update).
-        const current = this.tempSettings.maxConversationHistory;
-        const currentStr = presets.includes(current) ? current.toString() : '50';
-        dropdown.setValue(currentStr);
-        dropdown.onChange((value) => {
-          const parsed = parseInt(value);
-          if (!isNaN(parsed) && parsed >= 1) {
-            this.tempSettings.maxConversationHistory = parsed;
-          }
-        });
-      });
-
-    // Schema Management
-    new Setting(containerEl)
-      .setName(this.getText('schemaSection'))
-      .setDesc(this.getText('enableSchemaDesc'))
-      .addButton(button => button
-        .setButtonText(this.getText('viewSchemaButton'))
-        .onClick(() => {
-          const schemaPath = `${this.tempSettings.wikiFolder}/schema/config.md`;
-          const file = this.app.vault.getAbstractFileByPath(schemaPath);
-          if (file instanceof TFile) void this.app.workspace.getLeaf().openFile(file);
-          else new Notice(this.getText('schemaNotFoundNotice'), NOTICE_NORMAL);
-        }))
-      .addButton(button => button
-        .setButtonText(this.getText('regenerateSchemaButton'))
-        .onClick(async () => {
-          try {
-            // Ensure wiki structure exists before regenerating schema
-            if (!this.isWikiInitialized()) {
-              await this.plugin.wikiEngine.ensureWikiStructure();
-            }
-            await this.plugin.wikiEngine.regenerateDefaultSchema();
-            new Notice(this.getText('schemaRegeneratedNotice'), NOTICE_SHORT);
-          } catch (error) {
-            const msg = error instanceof Error ? error.message : String(error);
-            new Notice(`${this.getText('schemaRegenerateFailed') || 'Schema generation failed'}: ${msg}`, NOTICE_ERROR);
-          }
-        }));
-
-    // Ingestion History (#122) — sits inside Wiki Configuration (next to Schema
-    // Management) because it reads wiki/log.md, a wiki-internal artifact. Same
-    // visual style as its neighbors: name + desc + button, no emoji on the name.
-    new Setting(containerEl)
-      .setName(this.getText('historyButton'))
-      .setDesc(this.getText('historyButtonDesc'))
-      .addButton(button => button
-        .setButtonText(this.getText('historyButtonOpen'))
-        .onClick(() => {
-          new HistoryModal(this.app, {
-            language: this.tempSettings.language,
-            wikiFolder: this.tempSettings.wikiFolder || 'wiki',
-          }).open();
-        }));
-
-    // ==========================================
-    // 5. Auto Maintenance
-    // ==========================================
-    new Setting(containerEl).setName(this.getText('autoMaintainSection')).setHeading();
-
-    // 5.0 Startup quick fixes (Issue #81, refined v1.23.0) — first item in this section.
-    // v1.23.0: the `startupCheck` toggle is gone. The pipeline always runs;
-    // the user-facing control is now a "show result Notice" dropdown
-    // (silent / visible). Old users with `startupCheck: false` on disk
-    // were auto-migrated to 'silent' (see applySettingsMigrations).
-    new Setting(containerEl)
-      .setName(this.getText('startupCheckNoticeLevelName'))
-      .setDesc(this.getText('startupCheckNoticeLevelDesc'))
-      .addDropdown(dropdown => dropdown
-        .addOption('visible', this.getText('startupCheckNoticeVisible'))
-        .addOption('silent', this.getText('startupCheckNoticeSilent'))
-        .setValue(this.tempSettings.startupCheckNoticeLevel)
-        .onChange((value: 'visible' | 'silent') => { this.tempSettings.startupCheckNoticeLevel = value; }));
-
-    const betaDiv = containerEl.createDiv({
-      cls: 'llm-wiki-blue-infobox'
-    });
-    betaDiv.setText('🧪 ' + this.getText('autoMaintainBetaBadge'));
-
-    const warningDiv = containerEl.createDiv({
-      cls: 'llm-wiki-yellow-infobox'
-    });
-    warningDiv.setText(this.getText('autoMaintainCostWarning'));
-
-    new Setting(containerEl)
-      .setName(this.getText('autoWatchName'))
-      .setDesc(this.getText('autoWatchDesc'))
-      .addToggle(toggle => toggle
-        .setValue(this.tempSettings.autoWatchSources)
-        .onChange((value) => { this.tempSettings.autoWatchSources = value; this.display(); }));
-
-    if (this.tempSettings.autoWatchSources) {
-      if (!this.tempSettings.watchedFolders) this.tempSettings.watchedFolders = [];
-
-      new Setting(containerEl)
-        .setName(this.getText('watchedFoldersName'))
-        .setDesc(this.getText('watchedFoldersDesc'))
-        .addButton(button => button
-          .setButtonText(this.getText('addWatchedFolderButton'))
-          .setCta()
-          .onClick(() => {
-            new FolderSuggestModal(this.app, this.tempSettings.wikiFolder, (folder) => {
-              const folderPath = folder.path.endsWith('/') ? folder.path : `${folder.path}/`;
-              if (!this.tempSettings.watchedFolders.includes(folderPath)) {
-                this.tempSettings.watchedFolders.push(folderPath);
-                this.display();
-              }
-            }).open();
-          }));
-
-      if (this.tempSettings.watchedFolders.length === 0) {
-        containerEl.createEl('p', {
-          text: this.getText('noWatchedFoldersHint'),
-          cls: 'llm-wiki-section-hint'
-        });
-      }
-
-      for (let i = 0; i < this.tempSettings.watchedFolders.length; i++) {
-        const idx = i;
-        new Setting(containerEl)
-          .setName(this.tempSettings.watchedFolders[i])
-          .addButton(button => button
-            .setButtonText(this.getText('removeWatchedFolderButton'))
-            .onClick(() => { this.tempSettings.watchedFolders.splice(idx, 1); this.display(); }));
-      }
-
-      const hasClippings = this.tempSettings.watchedFolders.includes('Clippings/');
-      new Setting(containerEl)
-        .setName(this.getText('webClipperPresetName'))
-        .setDesc(this.getText('webClipperPresetDesc'))
-        .addToggle(toggle => toggle
-          .setValue(hasClippings)
-          .onChange((value) => {
-            if (value && !this.tempSettings.watchedFolders.includes('Clippings/')) this.tempSettings.watchedFolders.push('Clippings/');
-            else if (!value) { const ci = this.tempSettings.watchedFolders.indexOf('Clippings/'); if (ci >= 0) this.tempSettings.watchedFolders.splice(ci, 1); }
-            this.display();
-          }));
-
-      new Setting(containerEl)
-        .setName(this.getText('autoWatchModeName'))
-        .setDesc(this.getText('autoWatchModeDesc'))
-        .addDropdown(dropdown => {
-          dropdown.addOption('notify', this.getText('watchModeNotify'));
-          dropdown.addOption('auto', this.getText('watchModeAuto'));
-          dropdown.setValue(this.tempSettings.autoWatchMode);
-          dropdown.onChange((value: 'notify' | 'auto') => { this.tempSettings.autoWatchMode = value; this.display(); });
-        });
-
-      if (this.tempSettings.autoWatchMode === 'auto') {
-        new Setting(containerEl)
-          .setName(this.getText('autoIngestLevelName'))
-          .setDesc(this.getText('autoIngestLevelDesc'))
-          .addDropdown(dropdown => {
-            dropdown.addOption('notice', this.getText('autoIngestLevelNotice'));
-            dropdown.addOption('modal', this.getText('autoIngestLevelModal'));
-            dropdown.setValue(this.tempSettings.autoIngestNotificationLevel);
-            dropdown.onChange((value: 'notice' | 'modal') => { this.tempSettings.autoIngestNotificationLevel = value; });
-          });
-      }
-
-      new Setting(containerEl)
-        .setName(this.getText('autoWatchDebounceName'))
-        .setDesc(this.getText('autoWatchDebounceDesc'))
-        .addText(text => {
-        text
-          .setValue(String(Math.round(this.tempSettings.autoWatchDebounceMs / 1000)))
-          .onChange((value) => {
-            const parsed = parseInt(value);
-            if (parsed > 60) {
-              this.tempSettings.autoWatchDebounceMs = 60000;
-              text.setValue('60');
-              new Notice(this.getText('numberRangeClamped').replace('{}', '60'), NOTICE_SHORT);
-            } else if (parsed < 1) {
-              this.tempSettings.autoWatchDebounceMs = 1000;
-              text.setValue('1');
-              new Notice(this.getText('numberRangeClamped').replace('{}', '1'), NOTICE_SHORT);
-            } else if (!isNaN(parsed)) {
-              this.tempSettings.autoWatchDebounceMs = parsed * 1000;
-            }
-          });
-        text.inputEl.type = 'number';
-        text.inputEl.min = '1';
-        text.inputEl.max = '60';
-        text.inputEl.classList.add('llm-wiki-number-input');
-      });
-    }
-
-    new Setting(containerEl)
-      .setName(this.getText('periodicLintName'))
-      .setDesc(this.getText('periodicLintDesc'))
-      .addDropdown(dropdown => {
-        dropdown.addOption('off', this.getText('periodicLintOff'));
-        dropdown.addOption('daily', this.getText('periodicLintDaily'));
-        dropdown.addOption('weekly', this.getText('periodicLintWeekly'));
-        dropdown.addOption('monthly', this.getText('periodicLintMonthly'));
-        dropdown.setValue(this.tempSettings.periodicLint);
-        dropdown.onChange((value: 'off' | 'daily' | 'weekly' | 'monthly') => { this.tempSettings.periodicLint = value; });
-      });
-
-    new Setting(containerEl)
-      .setName(this.getText('autoSmartFixName'))
-      .setDesc(this.getText('autoSmartFixDesc'))
-      .addToggle(toggle => toggle
-        .setValue(this.tempSettings.autoSmartFix)
-        .onChange((value) => { this.tempSettings.autoSmartFix = value; }));
-
-    // v1.23.0 Phase 5.1.5: first-run Welcome note toggle. Sits next to
-    // autoSmartFix because both are "auto behaviors on plugin load" knobs.
-    new Setting(containerEl)
-      .setName(this.getText('welcomeNoteSettingsToggle'))
-      .setDesc(this.getText('welcomeNoteSettingsToggleDesc'))
-      .addToggle(toggle => toggle
-        .setValue(this.tempSettings.createWelcomeNote)
-        .onChange((value) => { this.tempSettings.createWelcomeNote = value; }));
-
+    renderLanguageSection(this, containerEl);
+    renderStatusSection(this, containerEl);
+    renderProviderSection(this, containerEl);
+    renderModelSection(this, containerEl);
+    renderAdvancedSection(this, containerEl);
+    renderTestConnectionSection(this, containerEl);
+    // The "Wiki Configuration" H2 heading is rendered INSIDE
+    // renderWikiConfigSection (matches pre-PR2 layout - the heading
+    // lived in the same Settings row block as the wiki folder input).
+    // Avoid double-rendering the heading here.
+    renderWikiConfigSection(this, containerEl);
+    renderAutoMaintainSection(this, containerEl);
   }
 }


### PR DESCRIPTION
## Summary

Splits `LLMWikiSettingTab.display()` from 1439 LOC into 8 focused section
renderers under `src/ui/settings-sections/`. The orchestrator
(`settings.ts`) shrinks to 370 LOC and now only clears `containerEl` and
invokes each section in user-visible order.

## Sections

| Module | LOC | Scope |
|--------|-----|-------|
| language-section | 104 | UI language + Wiki Output Language |
| status-section | 35 | inline ready/client/wikiInit indicator |
| provider-section | 164 | provider + API key + base URL + Bedrock + concurrency/batch |
| model-section | 211 | fetch models + Model Scope + 4 pickers + Max Tokens |
| advanced-section | 125 | advanced mode + 4 sub-controls + forcePdfSupport |
| test-connection-section | 65 | Test Connection + Phase 5.5.0 hotfix (commit-on-success / rollback-on-fail) |
| wiki-config-section | 279 | wiki folder + writePdf sidecar + slug + granularity + tags + max history + schema + history modal |
| auto-maintain-section | 200 | startup check + auto watch + periodic lint + auto smart fix + welcome note |

## Shared helpers (in `src/ui/settings-helpers.ts`)

- `renderRangeSlider` — eliminates 30 LOC of duplicate slider boilerplate
- `setSettingsVisible` — unifies the granularity + tag-vocabulary
  visibility-toggling pattern

## Type-safety fix

`getText` signature restored to `keyof typeof TEXTS.en` (was widened to
`string` to accommodate 1 dynamic call site). Dynamic sites now route
through a new `getTextDynamic(key: string)` so the 173 literal call sites
keep compile-time typo protection.

## Bug fixes folded in

- `providerSection` H2 heading was lost during extraction; restored in
  `provider-section.ts`.
- `wikiSection` H2 heading was rendered TWICE (orchestrator + section);
  orchestrator duplicate removed (caught by user e2e review).
- Dead `cleared` counter + `void cleared` in `cascadeUnifiedModelChange`
  removed (counter was incremented but never observed).

## Six-Gate

| Gate | Status |
|------|--------|
| 1 - Code correct | lint 0/0 + tsc 0 + 2236 tests + build + css-lint |
| 2 - No side effects | sections only mutate `tab.tempSettings` |
| 3 - No breaking changes | 9 helpers widened from private to public; no removed/renamed signatures |
| 4 - No perf regression | display() still rebuilds DOM once; shared helpers net ~40 LOC savings with identical behavior |
| 5 - Docs complete | no doc changes needed (refactor only) |
| 6 - Release clean | tests pass; no new deps |

Co-Authored-By: green-dalii <654534332@qq.com>
Co-Authored-By: Claude Code <noreply@anthropic.com>