### PR TITLE
refactor(main): split main.ts 1304→300 LOC (Phase C-PR3) + lint Fix All UX

### DIFF
--- a/src/__tests__/wiki/lint/fix-all-completion-notice.test.ts
+++ b/src/__tests__/wiki/lint/fix-all-completion-notice.test.ts
@@ -1,0 +1,46 @@
+// v1.25.1: regression tests for the Smart Fix All completion Notice.
+//
+// User-reported UX gap (manual lint → modal → Fix All button):
+//   Before: notice said "All fixes complete. See log for details.: 0 phases.
+//            View Operations History for details." when every phase failed
+//            silently — misleading, looked like a no-op.
+//   After: notice shows distinct "No changes were made" copy when phasesModified
+//            === 0; normal "N phases modified" otherwise.
+//
+// Also verified: NOTICE_NORMAL (5s) duration, NOT NOTICE_ERROR (8s) or sticky (0).
+
+import { describe, it, expect } from 'vitest';
+import { TEXTS } from '../../../texts';
+import { NOTICE_NORMAL, NOTICE_ERROR } from '../../../constants';
+
+describe('Smart Fix All completion Notice (v1.25.1)', () => {
+  const locales = ['en', 'zh', 'zh-Hant', 'ja', 'ko', 'de', 'fr', 'es', 'pt', 'it'] as const;
+
+  it.each(locales)('locale %s has lintFixAllComplete, lintFixAllNoChanges, lintFixPhasesLabel', (locale) => {
+    const t = TEXTS[locale];
+    expect(t.lintFixAllComplete, `lintFixAllComplete missing in ${locale}`).toBeTypeOf('string');
+    expect(t.lintFixAllComplete.length).toBeGreaterThan(0);
+    expect(t.lintFixAllNoChanges, `lintFixAllNoChanges missing in ${locale}`).toBeTypeOf('string');
+    expect(t.lintFixAllNoChanges.length).toBeGreaterThan(0);
+    expect(t.lintFixPhasesLabel, `lintFixPhasesLabel missing in ${locale}`).toBeTypeOf('string');
+    expect(t.lintFixPhasesLabel.length).toBeGreaterThan(0);
+  });
+
+  it('distinguishes 0-modified vs N-modified in summary copy', () => {
+    // Pure-function contract: the controller builds summary by branching on
+    // phasesModified === 0. Verify both branches render distinct, non-empty
+    // strings in the EN baseline.
+    const t = TEXTS.en;
+    expect(t.lintFixAllNoChanges).not.toBe(t.lintFixAllComplete);
+    expect(t.lintFixAllNoChanges).toMatch(/no changes|nothing/i);
+  });
+
+  it('uses NOTICE_NORMAL (5s) — non-blocking, auto-dismissing', () => {
+    // Sanity: the constant is a finite positive duration; explicitly NOT 0 (sticky).
+    expect(NOTICE_NORMAL).toBeGreaterThan(0);
+    expect(NOTICE_NORMAL).toBeLessThan(60_000);
+    // Regression guard against accidentally switching back to NOTICE_ERROR or 0.
+    expect(NOTICE_NORMAL).not.toBe(NOTICE_ERROR);
+    expect(NOTICE_NORMAL).not.toBe(0);
+  });
+});

--- a/src/core/create-plugin-llm-client.ts
+++ b/src/core/create-plugin-llm-client.ts
@@ -1,0 +1,31 @@
+/**
+ * v1.25.1 Phase C-PR3: Plugin-level LLM client factory.
+ *
+ * Extracted from main.ts to break the circular dependency between
+ * main.ts and main-commands/connection-commands.ts: the connection
+ * test commands need to call createLLMClient without main.ts
+ * importing from them in return.
+ *
+ * Pure function — no class or plugin state. Exists solely to inject
+ * user-configured advanced settings (temperature, repetitionPenalty)
+ * into the AI-SDK-backed client.
+ */
+
+import { wrapWithAdvancedSettings } from '../llm-client-wrapper';
+import { createLLMClientFromSettingsSync } from '../llm-sdk/create-llm-client';
+import type { LLMWikiSettings, LLMClient } from '../types';
+
+export function createLLMClient(settings: LLMWikiSettings): LLMClient {
+  const client: LLMClient = createLLMClientFromSettingsSync({
+    provider: settings.provider,
+    apiKey: settings.apiKey,
+    baseUrl: settings.baseUrl,
+  });
+
+  return wrapWithAdvancedSettings(client, {
+    maxTokensPerCall: settings.maxTokensPerCall,
+    extractionTemperature: settings.extractionTemperature,
+    chatTemperature: settings.chatTemperature,
+    repetitionPenalty: settings.repetitionPenalty,
+  });
+}

--- a/src/main-commands/command-registry.ts
+++ b/src/main-commands/command-registry.ts
@@ -1,0 +1,202 @@
+/**
+ * v1.25.1 Phase C-PR3: Command registry — wires `addCommand`, ribbon
+ * icons, status bar, and wiki-engine callbacks.
+ *
+ * Extracted from main.ts `onload()` to keep the plugin lifecycle
+ * hook focused on manager construction and startup orchestration.
+ *
+ * This is a plain function, NOT a mixin — it takes the plugin
+ * instance and applies side effects.
+ *
+ * Dedicated module to avoid circular deps with main.ts.
+ */
+
+import { Notice } from 'obsidian';
+import type { Plugin } from 'obsidian';
+import type { AutoMaintainManager } from '../schema/auto-maintain';
+import type { BatchProgress } from '../core/status-bar';
+import type { IngestQueue } from '../core/ingest-queue';
+import { getText } from '../core/i18n';
+import { buildIngestStatusBarText } from '../core/status-bar';
+import { TEXTS } from '../texts';
+import { HistoryModal } from '../ui/history-modal';
+import { LLMWikiSettingTab } from '../ui/settings';
+
+/** Minimal host interface — only what registerWikiCommands touches. */
+export interface CommandRegistryHost extends Plugin {
+  settings: {
+    language: string;
+    wikiFolder?: string;
+  };
+  wikiEngine: import('../wiki/wiki-engine').WikiEngine;
+  autoMaintainManager: AutoMaintainManager;
+  ingestQueue: IngestQueue;
+  batchProgress: BatchProgress | null;
+  ingestStatusBar: HTMLElement | null;
+  selectSourceToIngest(): void;
+  selectFolderToIngest(): void;
+  selectMultipleFilesToIngest(): void;
+  ingestActiveFile(): void;
+  queryWiki(): void;
+  lintWiki(trigger?: 'auto' | 'manual'): void;
+  clearPdfCache(): Promise<void>;
+}
+
+export function registerWikiCommands(plugin: CommandRegistryHost): void {
+  const t = (TEXTS as unknown as Record<string, Record<string, string>>)[plugin.settings.language];
+
+  plugin.addCommand({
+    id: 'ingest-source',
+    name: t.cmdIngestSource,
+    callback: () => plugin.selectSourceToIngest()
+  });
+
+  plugin.addCommand({
+    id: 'ingest-folder',
+    name: t.cmdIngestFolder,
+    callback: () => plugin.selectFolderToIngest()
+  });
+
+  plugin.addCommand({
+    id: 'ingest-multiple-files',
+    name: t.cmdIngestMultipleFiles,
+    callback: () => plugin.selectMultipleFilesToIngest()
+  });
+
+  plugin.addCommand({
+    id: 'query-wiki',
+    name: t.cmdQueryWiki,
+    callback: () => plugin.queryWiki()
+  });
+
+  plugin.addCommand({
+    id: 'lint-wiki',
+    name: t.cmdLintWiki,
+    callback: () => plugin.lintWiki()
+  });
+
+  plugin.addCommand({
+    id: 'regenerate-index',
+    name: t.cmdRegenerateIndex,
+    callback: () => {
+      void (async () => {
+        new Notice(getText(plugin.settings.language, 'regenerateIndexCompleted') + '...');
+        try {
+          await plugin.wikiEngine.generateIndexFromEngine();
+          new Notice(getText(plugin.settings.language, 'regenerateIndexCompleted'));
+        } catch (err) {
+          console.error('Regenerate index failed:', err);
+          new Notice(getText(plugin.settings.language, 'operationFailed') + (err instanceof Error ? err.message : String(err)));
+        }
+      })();
+    }
+  });
+
+  plugin.addCommand({
+    id: 'cancel-ingestion',
+    name: t.cmdCancelIngestion,
+    callback: () => {
+      if (plugin.wikiEngine.isIngesting()) {
+        plugin.wikiEngine.cancelIngestion();
+      } else if (plugin.wikiEngine.isLintRunning()) {
+        plugin.wikiEngine.cancelLint();
+      }
+    }
+  });
+
+  plugin.addCommand({
+    id: 'ingest-active-file',
+    name: t.cmdIngestActiveFile,
+    callback: () => plugin.ingestActiveFile()
+  });
+
+  plugin.addCommand({
+    id: 'view-ingestion-history',
+    name: t.cmdViewHistory,
+    callback: () => {
+      new HistoryModal(plugin.app, {
+        language: plugin.settings.language,
+        wikiFolder: plugin.settings.wikiFolder || 'wiki',
+      }).open();
+    }
+  });
+
+  plugin.addCommand({
+    id: 'recreate-welcome-note',
+    name: t.welcomeNoteRecreateCommand,
+    callback: () => void plugin.autoMaintainManager.recreateWelcomeNote(),
+  });
+
+  plugin.addCommand({
+    id: 'clear-pdf-cache',
+    name: getText(plugin.settings.language, 'clearPdfCacheCommand'),
+    icon: 'trash-2',
+    callback: () => void plugin.clearPdfCache(),
+  });
+
+  plugin.addRibbonIcon('sticker', t.cmdIngestActiveFile, () => {
+    plugin.ingestActiveFile();
+  });
+
+  plugin.addRibbonIcon('message-circle', t.cmdQueryWiki, () => {
+    plugin.queryWiki();
+  });
+
+  plugin.ingestStatusBar = plugin.addStatusBarItem();
+  plugin.ingestStatusBar.addClass('llm-wiki-status-bar');
+  plugin.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
+  plugin.ingestStatusBar.setText('LLM wiki');
+  plugin.ingestStatusBar.onclick = () => {
+    if (plugin.wikiEngine.isIngesting()) {
+      plugin.wikiEngine.cancelIngestion();
+    } else if (plugin.wikiEngine.isLintRunning()) {
+      plugin.wikiEngine.cancelLint();
+    }
+  };
+
+  plugin.wikiEngine.setIngestionCallbacks(
+    (filename?: string) => {
+      const label = getText(plugin.settings.language, 'ingestionStatusBar');
+      if (plugin.ingestStatusBar) {
+        plugin.ingestStatusBar.setText(
+          buildIngestStatusBarText(label, filename, plugin.batchProgress)
+        );
+        plugin.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
+      }
+    },
+    () => {
+      if (plugin.ingestStatusBar) {
+        plugin.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
+      }
+    }
+  );
+
+  plugin.wikiEngine.setLintCallbacks(
+    (filename?: string) => {
+      const label = getText(plugin.settings.language, 'lintStatusBar');
+      if (plugin.ingestStatusBar) {
+        const text = filename
+          ? `${filename} · ${label}`
+          : label;
+        plugin.ingestStatusBar.setText(text);
+        plugin.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
+      }
+    },
+    () => {
+      if (plugin.ingestStatusBar) {
+        plugin.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
+      }
+    }
+  );
+
+  plugin.wikiEngine.setStatusBarUpdateCallback(
+    (text: string) => {
+      if (plugin.ingestStatusBar) {
+        plugin.ingestStatusBar.setText(text);
+        plugin.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
+      }
+    }
+  );
+
+  plugin.addSettingTab(new LLMWikiSettingTab(plugin.app, plugin as never));
+}

--- a/src/main-commands/connection-commands.ts
+++ b/src/main-commands/connection-commands.ts
@@ -1,0 +1,147 @@
+/**
+ * v1.25.1 Phase C-PR3: Connection test commands.
+ *
+ * Extracted from main.ts. Probes the live LLM endpoint and checks
+ * wiki structure readiness.
+ *
+ * `testLLMConnection` is directly called by tests
+ * (test-connection-gate.test.ts) and settings test-connection-section
+ * via `plugin.testLLMConnection()` — the mixin pattern preserves
+ * this call surface with zero sites changed.
+ */
+
+import { Notice } from 'obsidian';
+import type { App } from 'obsidian';
+import type {
+  LLMWikiSettings,
+  LLMClient,
+} from '../types';
+import {
+  PREDEFINED_PROVIDERS,
+} from '../types';
+import type { LLMTask } from '../core/model-resolver';
+import { TEXTS } from '../texts';
+import { getText } from '../core/i18n';
+import { createLLMClient } from '../core/create-plugin-llm-client';
+import { allowsEmptyApiKey } from '../core/local-no-key-provider';
+import { resolveModelForTask } from '../core/model-resolver';
+import { TOKENS_QUERY_MODEL_DETECT, NOTICE_ERROR } from '../constants';
+
+/**
+ * Host interface: fields/methods these commands need from the Plugin
+ * instance. Declares the class-side methods they call so mixin
+ * `this: ConnectionCommandsHost` compiles correctly.
+ */
+export interface ConnectionCommandsHost {
+  app: App;
+  settings: LLMWikiSettings;
+  llmClient: LLMClient | null;
+  wikiEngine: import('../wiki/wiki-engine').WikiEngine;
+  initializeLLMClient(): void;
+  saveSettings(): Promise<void>;
+  isWikiInitialized(): Promise<boolean>;
+}
+
+/** Method signatures merged into LLMWikiPlugin via interface augmentation. */
+export interface ConnectionCommandsMethods {
+  testLLMConnection(): Promise<{ success: boolean; message: string }>;
+  requireLLMReady(): boolean;
+  isWikiInitialized(): Promise<boolean>;
+}
+
+export const connectionCommands = {
+  async testLLMConnection(
+    this: ConnectionCommandsHost,
+  ): Promise<{ success: boolean; message: string }> {
+    const t = TEXTS[this.settings.language] || TEXTS.en;
+
+    if (!allowsEmptyApiKey(this.settings.provider, this.settings.apiKey)) {
+      return { success: false, message: t.errorNoApiKey || 'API Key is not configured' };
+    }
+
+    const tasksToProbe: LLMTask[] = this.settings.usePerTaskModels === true
+      ? ['ingest', 'lint', 'query']
+      : [];
+    const probePlan: Array<{ label: string; model: string }> = tasksToProbe.length === 0
+      ? [{ label: 'unified', model: this.settings.model }]
+      : tasksToProbe.map(task => ({ label: task, model: resolveModelForTask(this.settings, task) }));
+
+    console.debug('[testLLMConnection] probe plan:', probePlan.map(p => `${p.label}=${p.model}`).join(', '));
+
+    try {
+      const testClient = createLLMClient(this.settings);
+
+      for (const probe of probePlan) {
+        await testClient.createMessage({
+          model: probe.model,
+          max_tokens: TOKENS_QUERY_MODEL_DETECT,
+          messages: [{
+            role: 'user',
+            content: 'Test connection. Please reply "Connection successful".'
+          }]
+        });
+      }
+
+      this.settings.llmReady = true;
+      void this.saveSettings();
+
+      // Auto-initialize wiki structure after first successful connection.
+      // Preserved from original main.ts — defensive: ensures the expected
+      // folder tree exists before the user attempts their first ingest.
+      if (this.wikiEngine) {
+        const isInit = await this.isWikiInitialized();
+        if (!isInit) {
+          try {
+            await this.wikiEngine.ensureWikiStructure();
+            console.debug('Wiki structure auto-initialized');
+          } catch (initError) {
+            console.warn('Auto wiki init failed:', initError);
+          }
+        }
+      }
+
+      const providerName = (PREDEFINED_PROVIDERS[this.settings.provider]?.nameEn || this.settings.provider);
+
+      this.initializeLLMClient();
+
+      const probeSummary = probePlan.length === 1
+        ? `${providerName} (${probePlan[0].model})`
+        : `${providerName} (ingest=${probePlan[0].model}, lint=${probePlan[1].model}, query=${probePlan[2].model})`;
+
+      return {
+        success: true,
+        message: `✅ ${t.testConnectionSuccessful || 'Connection successful'}: ${probeSummary}`
+      };
+    } catch (error) {
+      console.error('Connection test failed:', error);
+      this.settings.llmReady = false;
+      await this.saveSettings();
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        message: `❌ ${t.testConnectionFailed || 'Connection failed'}: ${errorMsg || t.errorUnknown || 'Unknown error'}`
+      };
+    }
+  },
+
+  requireLLMReady(this: ConnectionCommandsHost): boolean {
+    if (this.settings.llmReady) return true;
+    new Notice(getText(this.settings.language, 'llmNotReady'), NOTICE_ERROR);
+    return false;
+  },
+
+  async isWikiInitialized(this: ConnectionCommandsHost): Promise<boolean> {
+    const wikiFolder = this.settings.wikiFolder || 'wiki';
+    const requiredFolders = [
+      `${wikiFolder}/entities`,
+      `${wikiFolder}/concepts`,
+      `${wikiFolder}/sources`,
+      `${wikiFolder}/schema`
+    ];
+    for (const folder of requiredFolders) {
+      const folderObj = this.app.vault.getAbstractFileByPath(folder);
+      if (!folderObj) return false;
+    }
+    return true;
+  },
+};

--- a/src/main-commands/ingest-commands.ts
+++ b/src/main-commands/ingest-commands.ts
@@ -1,0 +1,294 @@
+/**
+ * v1.25.1 Phase C-PR3: Ingest commands.
+ *
+ * Extracted from main.ts (lines 587-927). Covers the 5 ingest
+ * entry points and the batch pipeline.
+ *
+ * Cross-mixin dependencies:
+ *   - requireLLMReady()          → ConnectionCommandsHost
+ *   - preparePdfCacheForBatchIngest()  → PdfCacheHost
+ *   - showProgressFor / dismissProgress → core methods (main retains)
+ *   - ingestQueue / batchProgress        → core fields (promoted to public)
+ *
+ * WARNING: batchProgress = { current: i+1, total: ingestCount } is
+ * read by the status-bar callback (registered in command-registry).
+ * The shared mutation across async boundaries is intentional.
+ */
+
+import { Notice, TFile } from 'obsidian';
+import type { App } from 'obsidian';
+import type { LLMWikiSettings, LLMClient, IngestReport } from '../types';
+import type { WikiEngine } from '../wiki/wiki-engine';
+import type { IngestQueue } from '../core/ingest-queue';
+import type { BatchProgress } from '../core/status-bar';
+import { TEXTS } from '../texts';
+import { getText } from '../core/i18n';
+import { slugify } from '../core/slug';
+import { parseFrontmatter } from '../core/frontmatter';
+import { COMPATIBLE_SOURCE_EXTENSIONS, NOTICE_NORMAL, NOTICE_ERROR } from '../constants';
+import { FileSuggestModal, FolderSuggestModal, MultiFileSuggestModal, IngestReportModal } from '../ui/modals';
+import { ProgressScope } from '../core/progress-notification';
+
+export interface IngestHost {
+  app: App;
+  settings: LLMWikiSettings;
+  llmClient: LLMClient | null;
+  wikiEngine: WikiEngine;
+  ingestQueue: IngestQueue;
+  batchProgress: BatchProgress | null;
+  requireLLMReady(): boolean;
+  showProgressFor(scope: ProgressScope, msg: string): void;
+  dismissProgress(): void;
+  preparePdfCacheForBatchIngest(): Promise<void>;
+  /** Self-references: co-members of this mixin. */
+  runBatchIngest?(files: TFile[], jobIds: string[], sourceLabel: string): Promise<void>;
+  isAlreadyIngested?(sourceFile: TFile): Promise<boolean>;
+}
+
+export interface IngestMethods {
+  selectSourceToIngest(): void;
+  ingestActiveFile(): void;
+  selectFolderToIngest(): void;
+  selectMultipleFilesToIngest(): void;
+}
+
+export const ingestCommands = {
+  async isAlreadyIngested(this: IngestHost, sourceFile: TFile): Promise<boolean> {
+    const slug = slugify(sourceFile.basename, this.settings.slugCase === 'preserve');
+    const wikiPath = `${this.settings.wikiFolder}/sources/${slug}.md`;
+
+    try {
+      const file = this.app.vault.getAbstractFileByPath(wikiPath);
+      if (!(file instanceof TFile)) return false;
+
+      try {
+        const content = await this.app.vault.read(file);
+        const fm = parseFrontmatter(content);
+        if (fm && fm.sources) {
+          const normalizedSources = fm.sources.map(s => {
+            const trimmed = s.trim();
+            if (trimmed.startsWith('[[') && trimmed.endsWith(']]')) {
+              return trimmed.slice(2, -2).trim();
+            }
+            return trimmed;
+          });
+          return normalizedSources.includes(sourceFile.path);
+        }
+        return true;
+      } catch {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  },
+
+  selectSourceToIngest(this: IngestHost): void {
+    if (!this.requireLLMReady()) return;
+    if (!this.llmClient) {
+      new Notice(TEXTS[this.settings.language].errorNoApiKey);
+      return;
+    }
+
+    new FileSuggestModal(this.app, this.settings.wikiFolder, (file: TFile) => {
+      this.showProgressFor(ProgressScope.IngestManual, `Ingesting: ${file.basename}`);
+      this.wikiEngine.ingestSource(file, { interactive: true }).catch(e => {
+        console.error('Single ingest failed:', e);
+        const errMsg = e instanceof Error ? e.message : String(e);
+        new Notice(TEXTS[this.settings.language].errorIngestFailed + errMsg, NOTICE_ERROR);
+        this.dismissProgress();
+      });
+    }).open();
+  },
+
+  ingestActiveFile(this: IngestHost): void {
+    if (!this.requireLLMReady()) return;
+    if (!this.llmClient) {
+      new Notice(TEXTS[this.settings.language].errorNoApiKey);
+      return;
+    }
+
+    const activeFile = this.app.workspace.getActiveFile();
+    if (!activeFile) {
+      new Notice(getText(this.settings.language, 'noActiveFile'), NOTICE_NORMAL);
+      return;
+    }
+
+    this.showProgressFor(ProgressScope.IngestManual, `Ingesting: ${activeFile.basename}`);
+    this.wikiEngine.ingestSource(activeFile, { interactive: true }).catch(e => {
+      console.error('Ingest active file failed:', e);
+      const errMsg = e instanceof Error ? e.message : String(e);
+      new Notice(TEXTS[this.settings.language].errorIngestFailed + errMsg, NOTICE_ERROR);
+      this.dismissProgress();
+    });
+  },
+
+  selectFolderToIngest(this: IngestHost): void {
+    if (!this.requireLLMReady()) return;
+    if (!this.llmClient) {
+      new Notice(TEXTS[this.settings.language].errorNoApiKey);
+      return;
+    }
+
+    new FolderSuggestModal(this.app, this.settings.wikiFolder, (folder) => {
+      const allowedExts: readonly string[] = COMPATIBLE_SOURCE_EXTENSIONS;
+      const files = this.app.vault.getFiles()
+        .filter(f => f.path.startsWith(folder.path) && allowedExts.includes(f.extension.toLowerCase()));
+
+      if (files.length === 0) {
+        const msg = TEXTS[this.settings.language].selectFolderNoMdFiles.replace('{path}', folder.path);
+        new Notice(msg);
+        return;
+      }
+
+      void this.runBatchIngest!(files, [], `${files.length} files from ${folder.path}`);
+    }).open();
+  },
+
+  selectMultipleFilesToIngest(this: IngestHost): void {
+    if (!this.requireLLMReady()) return;
+    if (!this.llmClient) {
+      new Notice(TEXTS[this.settings.language].errorNoApiKey);
+      return;
+    }
+
+    new MultiFileSuggestModal(
+      this.app,
+      this.settings,
+      this.ingestQueue,
+      (ids: string[], files: TFile[]) => {
+        if (files.length === 0 || ids.length === 0) return;
+        void this.runBatchIngest!(files, ids, `${files.length} manually-selected files`);
+      },
+    ).open();
+  },
+
+  async runBatchIngest(this: IngestHost, files: TFile[], jobIds: string[], sourceLabel: string): Promise<void> {
+    void this.preparePdfCacheForBatchIngest();
+
+    this.showProgressFor(ProgressScope.IngestManual, 'Checking for already-ingested files...');
+    const alreadyIngestedFiles: TFile[] = [];
+    const newFiles: TFile[] = [];
+    const alignedJobIds: string[] = [];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      const jobId = jobIds[i] ?? '';
+      if (await this.isAlreadyIngested!(file)) {
+        alreadyIngestedFiles.push(file);
+      } else {
+        newFiles.push(file);
+        alignedJobIds.push(jobId);
+      }
+    }
+
+    const totalFiles = files.length;
+    const skippedCount = alreadyIngestedFiles.length;
+    const ingestCount = newFiles.length;
+
+    if (skippedCount > 0) {
+      const texts = TEXTS[this.settings.language];
+      new Notice(
+        texts.batchIngestSkipNotice
+          .replace('{skipped}', String(skippedCount))
+          .replace('{total}', String(totalFiles))
+          .replace('{new}', String(ingestCount)),
+        6000
+      );
+    }
+
+    if (ingestCount === 0) {
+      const texts = TEXTS[this.settings.language];
+      new Notice(texts.batchIngestAllIngested.replace('{total}', String(totalFiles)), NOTICE_NORMAL);
+      return;
+    }
+
+    const reports: IngestReport[] = [];
+
+    this.wikiEngine.setDoneCallback((report: IngestReport) => {
+      reports.push(report);
+    });
+
+    const texts = TEXTS[this.settings.language];
+    this.showProgressFor(ProgressScope.IngestManual, texts.batchIngestStarting
+      .replace('{count}', String(ingestCount))
+      .replace('{folder}', sourceLabel));
+
+    const batchCtx = this.wikiEngine.createBatchContext();
+
+    let resolvedJobIds: string[];
+    if (jobIds.length > 0) {
+      resolvedJobIds = alignedJobIds;
+    } else {
+      resolvedJobIds = this.ingestQueue.enqueue(newFiles);
+    }
+
+    for (let i = 0; i < newFiles.length; i++) {
+      const file = newFiles[i];
+      const jobId = resolvedJobIds[i];
+
+      try {
+        if (jobId) {
+          this.ingestQueue.start(jobId);
+        }
+        this.batchProgress = { current: i + 1, total: ingestCount };
+        this.showProgressFor(ProgressScope.IngestManual, `[${i + 1}/${ingestCount}] ${file.basename}`);
+        await this.wikiEngine.ingestSource(file, { batchCtx });
+        if (this.wikiEngine.wasCancelled) {
+          if (jobId) {
+            this.ingestQueue.complete(jobId, false, 'Cancelled by user');
+          }
+          break;
+        }
+        if (jobId) {
+          this.ingestQueue.complete(jobId, true);
+        }
+      } catch (error) {
+        console.error(`(${i + 1}/${ingestCount}) ingestion failed: ${file.path}`, error);
+        const errMsg = error instanceof Error ? error.message : String(error);
+        new Notice(texts.errorIngestFailed + file.basename + ': ' + errMsg, NOTICE_ERROR);
+        if (jobId) this.ingestQueue.complete(jobId, false, errMsg);
+      }
+    }
+
+    this.batchProgress = null;
+    this.dismissProgress();
+
+    if (reports.length > 0) {
+      const allCreated = [...new Set(reports.flatMap(r => r.createdPages))];
+      const allUpdated = [...new Set(reports.flatMap(r => r.updatedPages))];
+      const totalEntities = reports.reduce((sum, r) => sum + r.entitiesCreated, 0);
+      const totalConcepts = reports.reduce((sum, r) => sum + r.conceptsCreated, 0);
+      const totalContradictions = reports.reduce((sum, r) => sum + r.contradictionsFound, 0);
+      const totalElapsed = reports.reduce((sum, r) => sum + (r.elapsedSeconds || 0), 0);
+      const allFailedItems = reports.flatMap(r => r.failedItems);
+      const allCollisions = reports.flatMap(r => r.collisions || []);
+      const allRejectedFiles = reports.flatMap(r => r.rejectedFiles || []);
+      const allSuccess = reports.every(r => r.success);
+
+      const aggregated: IngestReport = {
+        sourceFile: sourceLabel,
+        createdPages: allCreated,
+        updatedPages: allUpdated,
+        entitiesCreated: totalEntities,
+        conceptsCreated: totalConcepts,
+        failedItems: allFailedItems,
+        collisions: allCollisions,
+        contradictionsFound: totalContradictions,
+        success: allSuccess,
+        elapsedSeconds: totalElapsed,
+        skippedFiles: skippedCount,
+        totalFilesInFolder: totalFiles,
+        rejectedFiles: allRejectedFiles,
+      };
+
+      new IngestReportModal(this.app, aggregated, this.settings.language).open();
+    } else {
+      const texts2 = TEXTS[this.settings.language];
+      new Notice(texts2.batchIngestComplete
+        .replace('{success}', '0')
+        .replace('{total}', String(ingestCount))
+        .replace('{fail}', String(ingestCount)), 10000);
+    }
+  },
+};

--- a/src/main-commands/pdf-cache-commands.ts
+++ b/src/main-commands/pdf-cache-commands.ts
@@ -1,0 +1,77 @@
+/**
+ * v1.25.1 Phase C-PR3: PDF cache commands.
+ *
+ * Extracted from main.ts. Three async methods that manage the
+ * PdfConversionCache lifecycle. These are the only methods that
+ * directly import and use the dynamic pdf-cache module.
+ *
+ * Self-contained: no cross-dependencies on other mixins beyond
+ * `app` and `settings.language`.
+ *
+ * Method signatures declared via PdfCacheMethods interface for
+ * interface merging at the bottom of main.ts.
+ */
+
+import { Notice } from 'obsidian';
+import type { App } from 'obsidian';
+import type { LLMWikiSettings } from '../types';
+import { getText } from '../core/i18n';
+import { NOTICE_NORMAL } from '../constants';
+
+/** Host fields these methods need. Used as `this: PdfCacheHost` bound. */
+export interface PdfCacheHost {
+  app: App;
+  settings: LLMWikiSettings;
+}
+
+/** Method signatures merged into LLMWikiPlugin via interface augmentation. */
+export interface PdfCacheMethods {
+  clearPdfCache(): Promise<void>;
+  preparePdfCacheForBatchIngest(): Promise<void>;
+  performPdfCacheHousekeeping(): Promise<void>;
+}
+
+export const pdfCacheCommands = {
+  async clearPdfCache(this: PdfCacheHost): Promise<void> {
+    const { createPdfCache } = await import('../core/pdf-cache');
+    const cache = createPdfCache(this.app);
+    const result = await cache.clear();
+    new Notice(
+      getText(this.settings.language, 'pdfCacheCleared').replace('{count}', String(result.removed)),
+      NOTICE_NORMAL
+    );
+  },
+
+  async preparePdfCacheForBatchIngest(this: PdfCacheHost): Promise<void> {
+    try {
+      const { createPdfCache } = await import('../core/pdf-cache');
+      const cache = createPdfCache(this.app);
+      const { expired, size } = await cache.prepareBatchIngest();
+      if (expired.removed > 0 || size.removed > 0) {
+        console.debug(
+          `[pdf-cache] batch prep: purged ${expired.removed} expired, ` +
+          `evicted ${size.removed} oversized (${size.freedBytes} bytes freed)`
+        );
+      }
+    } catch (error) {
+      console.warn('[pdf-cache] batch prep failed:', error);
+    }
+  },
+
+  async performPdfCacheHousekeeping(this: PdfCacheHost): Promise<void> {
+    try {
+      const { createPdfCache } = await import('../core/pdf-cache');
+      const cache = createPdfCache(this.app);
+      const expired = await cache.purgeExpired();
+      const size = await cache.enforceSizeLimit();
+      if (expired.removed > 0 || size.removed > 0) {
+        console.debug(
+          `[pdf-cache] housekeeping: purged ${expired.removed} expired, ` +
+          `evicted ${size.removed} oversized (${size.freedBytes} bytes freed)`
+        );
+      }
+    } catch (error) {
+      console.warn('[pdf-cache] housekeeping failed:', error);
+    }
+  },
+};

--- a/src/main-commands/query-lint-commands.ts
+++ b/src/main-commands/query-lint-commands.ts
@@ -1,0 +1,91 @@
+/**
+ * v1.25.1 Phase C-PR3: Query and lint commands.
+ *
+ * Extracted from main.ts. Four methods that manage the Query view
+ * activation and linting pipeline.
+ *
+ * `queryWiki` / `lintWiki` are command callbacks (registered by
+ * command-registry). `activateQueryView` is a private helper for
+ * the query side. `invalidateAllQueryGraphs` is called by both
+ * `onIngestDoneDispatch` (main core) and `saveSettings`.
+ *
+ * Cross-mixin routing:
+ *   - requireLLMReady() → ConnectionCommandsHost
+ *   - suggestSchemaUpdate() → SchemaCommandsHost
+ */
+
+import { Notice } from 'obsidian';
+import type { App } from 'obsidian';
+import type { LLMWikiSettings, LLMClient } from '../types';
+import type { WikiEngine } from '../wiki/wiki-engine';
+import { TEXTS } from '../texts';
+import { runLintWiki } from '../wiki/lint/controller';
+import { QueryView, VIEW_TYPE_QUERY } from '../wiki/query-engine';
+
+/** Host interface: minimal surface for these methods to compile. */
+export interface QueryLintHost {
+  app: App;
+  settings: LLMWikiSettings;
+  llmClient: LLMClient | null;
+  wikiEngine: WikiEngine;
+  requireLLMReady(): boolean;
+  suggestSchemaUpdate(context?: string): Promise<void>;
+  /** activateQueryView is a co-member of this mixin. */
+  activateQueryView?(): Promise<void>;
+}
+
+export interface QueryLintMethods {
+  queryWiki(): void;
+  invalidateAllQueryGraphs(): void;
+  lintWiki(trigger?: 'auto' | 'manual'): Promise<void>;
+}
+
+export const queryLintCommands = {
+  queryWiki(this: QueryLintHost): void {
+    if (!this.requireLLMReady()) return;
+    if (!this.llmClient) {
+      new Notice(TEXTS[this.settings.language].errorNoApiKey);
+      return;
+    }
+
+    void this.activateQueryView!();
+  },
+  activateQueryView(this: QueryLintHost): Promise<void> {
+    const { workspace } = this.app;
+
+    const existing = workspace.getLeavesOfType(VIEW_TYPE_QUERY);
+    if (existing.length > 0) {
+      return workspace.revealLeaf(existing[0]);
+    }
+
+    const leaf = workspace.getRightLeaf(false);
+    if (!leaf) return Promise.resolve();
+    return leaf.setViewState({ type: VIEW_TYPE_QUERY, active: true })
+      .then(() => workspace.revealLeaf(leaf));
+  },
+
+  invalidateAllQueryGraphs(this: QueryLintHost): void {
+    const viewLeaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_QUERY);
+    for (const leaf of viewLeaves) {
+      if (leaf.view instanceof QueryView) {
+        leaf.view.invalidateGraph();
+      }
+    }
+  },
+
+  async lintWiki(this: QueryLintHost, trigger: 'auto' | 'manual' = 'manual'): Promise<void> {
+    if (!this.requireLLMReady()) return;
+    const signal = this.wikiEngine.startLintOperation();
+    try {
+      await runLintWiki({
+        app: this.app,
+        settings: this.settings,
+        llmClient: this.llmClient,
+        wikiEngine: this.wikiEngine,
+        onAnalyzeSchema: (context?: string) => { void this.suggestSchemaUpdate(context); },
+      }, signal, trigger);
+    } finally {
+      this.wikiEngine.endLintOperation();
+    }
+  },
+};

--- a/src/main-commands/schema-commands.ts
+++ b/src/main-commands/schema-commands.ts
@@ -1,0 +1,104 @@
+/**
+ * v1.25.1 Phase C-PR3: Schema commands.
+ *
+ * Extracted from main.ts. Three methods that manage schema analysis,
+ * diff modal, and regeneration.
+ *
+ * `suggestSchemaUpdate` is called by lintWiki via a callback
+ * (`onAnalyzeSchema`). `openSchemaDiffModal` and
+ * `regenerateSchemaWithHint` are private helpers used by
+ * `suggestSchemaUpdate`.
+ *
+ * The SchemaDiffModal JSDoc (the `.open()` + `setCurrentBody` pattern)
+ * is preserved from the original; the modal must open before its
+ * content loads so the user sees the LLM proposal immediately.
+ */
+
+import { Notice } from 'obsidian';
+import type { App } from 'obsidian';
+import type { LLMWikiSettings, SchemaSuggestion } from '../types';
+import type { SchemaManager as SchemaManagerType } from '../schema/schema-manager';
+import type { WikiEngine } from '../wiki/wiki-engine';
+import { TEXTS } from '../texts';
+import { runSchemaAnalyze } from '../schema/analyze';
+import { SchemaDiffModal } from '../ui/schema-diff-modal';
+import { applySchemaSuggestion } from '../schema/apply-suggestion';
+import { NOTICE_RATE_LIMIT, NOTICE_ERROR } from '../constants';
+
+/** Host fields these methods need from the Plugin instance. */
+export interface SchemaCommandsHost {
+  app: App;
+  settings: LLMWikiSettings;
+  llmClient: import('../types').LLMClient | null;
+  wikiEngine: WikiEngine;
+  schemaManager: SchemaManagerType;
+  requireLLMReady(): boolean;
+}
+
+export interface SchemaCommandsMethods {
+  suggestSchemaUpdate(context?: string): Promise<void>;
+}
+
+export const schemaCommands = {
+  async suggestSchemaUpdate(this: SchemaCommandsHost, context?: string): Promise<void> {
+    await runSchemaAnalyze({
+      settings: this.settings,
+      llmClient: this.llmClient,
+      wikiEngine: this.wikiEngine,
+      schemaManager: this.schemaManager,
+      requireLLMReady: () => this.requireLLMReady(),
+      /** v1.22.0 #97: inline callback — opens SchemaDiffModal with LLM suggestion. */
+      openSchemaDiffModal: (suggestion: SchemaSuggestion): void => {
+        const t = (TEXTS as unknown as Record<string, Record<string, string>>)[this.settings.language]
+          ?? TEXTS.en as unknown as Record<string, string>;
+        console.debug('[SchemaDiffModal] suggestion.suggestions =', JSON.stringify(suggestion.suggestions), 'changes_needed =', suggestion.changes_needed, 'newSchemaBody length =', suggestion.newSchemaBody?.length);
+
+        const isEmpty = !suggestion.changes_needed;
+        const modal = new SchemaDiffModal(this.app, {
+          currentBody: '',
+          newBody: suggestion.newSchemaBody ?? '',
+          language: this.settings.language,
+          isEmpty,
+          rationale: suggestion.suggestions,
+          onOpenFile: () => {
+            const path = `${this.settings.wikiFolder}/schema/config.md`;
+            void this.app.workspace.openLinkText(path, '', false);
+          },
+          onApply: async () => {
+            const result = await applySchemaSuggestion({
+              app: this.app,
+              currentPath: `${this.settings.wikiFolder}/schema/config.md`,
+              newBody: suggestion.newSchemaBody ?? '',
+              onCacheInvalidate: () => this.schemaManager.invalidateCache(),
+            });
+            if (result.success) {
+              const restore = t.schemaDiffRestoreHint
+                ? t.schemaDiffRestoreHint.replace('{path}', result.backupPath)
+                : `Backup saved to ${result.backupPath}. To restore, rename that file back to wiki/schema/config.md in your file explorer.`;
+              new Notice(restore, NOTICE_RATE_LIMIT);
+            } else {
+              new Notice(t.schemaDiffFailed ?? 'Schema apply failed: ' + result.reason, NOTICE_ERROR);
+            }
+          },
+          onRegenerate: async (userHint: string) => {
+            const ctx = `${suggestion.suggestions || ''}\n\nUser refinement: ${userHint || '(none)'}`;
+            const newSuggestion = await this.schemaManager.suggestSchemaUpdate(ctx);
+            if (newSuggestion?.newSchemaBody) {
+              modal.setNewBody(newSuggestion.newSchemaBody, {
+                rationale: newSuggestion.suggestions,
+                isEmpty: !newSuggestion.changes_needed,
+              });
+            } else {
+              new Notice(t.schemaRegenerateNoBody ?? 'Regeneration succeeded but the LLM did not return a new body.', NOTICE_ERROR);
+            }
+          },
+        });
+        modal.open();
+        void this.schemaManager.loadSchema().then((loaded) => {
+          modal.setCurrentBody(loaded?.body ?? '');
+        });
+      },
+      lintAnalysisContext: context,
+    });
+  },
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,14 @@
-import { Plugin, Notice, TFile } from 'obsidian';
+import { Plugin, Notice } from 'obsidian';
 
 import {
-  PREDEFINED_PROVIDERS,
   LLMWikiSettings,
   LLMClient,
-  IngestReport
+  IngestReport,
 } from './types';
-import { TOKENS_QUERY_MODEL_DETECT, NOTICE_NORMAL, NOTICE_ERROR, NOTICE_ABORT, NOTICE_RATE_LIMIT, COMPATIBLE_SOURCE_EXTENSIONS } from './constants';
-import { wrapWithAdvancedSettings } from './llm-client-wrapper';
-import { createLLMClientFromSettingsSync, preloadLLMClientModules } from './llm-sdk/create-llm-client';
-import { runSchemaAnalyze } from './schema/analyze';
+import { NOTICE_NORMAL, NOTICE_ABORT } from './constants';
+import { preloadLLMClientModules } from './llm-sdk/create-llm-client';
 import { allowsEmptyApiKey } from './core/local-no-key-provider';
+import { createLLMClient } from './core/create-plugin-llm-client';
 
 // v1.23.0 P1-7: AI-SDK migration. Eagerly preload SDK modules on plugin
 // load so sync `createLLMClient` works without blocking. Failure is
@@ -19,83 +17,44 @@ const aiSdkModulesLoaded: Promise<void> = preloadLLMClientModules();
 void aiSdkModulesLoaded.catch((err) => {
   console.warn('[v1.23.0 LLM migration] Failed to preload AI-SDK modules:', err);
 });
-
-// Exported for unit tests (see src/__tests__/root/main.test.ts).
-// Issue #99 / #128 / #128 follow-up: thin wrapper that injects only the
-// advanced settings the user has configured; otherwise the call passes
-// through unchanged to preserve the provider default.
-//
-// v1.23.0 P1-7: AI-SDK migration. The provider dispatch logic was
-// rewritten to use Vercel AI-SDK v6 — see src/llm-sdk/create-llm-client.ts.
-// The old hand-rolled OpenAICompatibleClient / Anthropic* classes are
-// retained as legacy fallbacks in src/llm-client.ts for v1.23.0 backward
-// compat (will be removed in v1.24.0 once we've validated the new path
-// in production).
-export function createLLMClient(settings: LLMWikiSettings): LLMClient {
-  // v1.23.0 P1-7: use the AI-SDK-backed factory. Sync shim delegates
-  // to the preloaded SDK modules (loaded by preloadLLMClientModules
-  // at module-load time above). No more legacy hand-rolled classes.
-  const client: LLMClient = createLLMClientFromSettingsSync({
-    provider: settings.provider,
-    apiKey: settings.apiKey,
-    baseUrl: settings.baseUrl,
-  });
-
-  // Wrap createMessage so user-configured advanced settings are applied.
-  // v1.20.0: by default the plugin does NOT inject any thinking-control
-  // field. The provider decides its own reasoning behavior. The wrapper
-  // only injects the explicit opt-in fields (temperature, repetitionPenalty)
-  // when the user has configured a value in Custom Advanced Settings.
-  return wrapWithAdvancedSettings(client, {
-    maxTokensPerCall: settings.maxTokensPerCall,
-    extractionTemperature: settings.extractionTemperature,
-    chatTemperature: settings.chatTemperature,
-    repetitionPenalty: settings.repetitionPenalty,
-  });
-}
 import { TEXTS } from './texts';
 import { getText } from './core/i18n';
-import { slugify } from './core/slug';
-import { parseFrontmatter } from './core/frontmatter';
 import { applySettingsMigrations } from './core/settings-migrations';
 import { normalizeVocabularyCsv } from './core/tag-vocab';
 import { detectStaleWikiFolders } from './core/query-history-migration-check';
-import { buildIngestStatusBarText, BatchProgress } from './core/status-bar';
+import { BatchProgress } from './core/status-bar';
 import { IngestQueue } from './core/ingest-queue';
 import { decideProgressDisplay, ProgressScope } from './core/progress-notification';
-import { LLMWikiSettingTab } from './ui/settings';
-import { resolveModelForTask, type LLMTask } from './core/model-resolver';
 import { WikiEngine } from './wiki/wiki-engine';
 import { QueryView, VIEW_TYPE_QUERY } from './wiki/query-engine';
-import { FileSuggestModal, FolderSuggestModal, MultiFileSuggestModal, IngestReportModal, ConfirmModal } from './ui/modals';
-import { HistoryModal } from './ui/history-modal';
-import { SchemaDiffModal } from './ui/schema-diff-modal';
-import { applySchemaSuggestion } from './schema/apply-suggestion';
+import { IngestReportModal, ConfirmModal } from './ui/modals';
 import { SchemaManager } from './schema/schema-manager';
 import { AutoMaintainManager } from './schema/auto-maintain';
-import { runLintWiki } from './wiki/lint/controller';
 
-export default class LLMWikiPlugin extends Plugin {
+// v1.25.1 Phase C-PR3: Mixin method implementations.
+import { pdfCacheCommands } from './main-commands/pdf-cache-commands';
+import type { PdfCacheMethods } from './main-commands/pdf-cache-commands';
+import { connectionCommands } from './main-commands/connection-commands';
+import type { ConnectionCommandsMethods } from './main-commands/connection-commands';
+import { schemaCommands } from './main-commands/schema-commands';
+import type { SchemaCommandsMethods } from './main-commands/schema-commands';
+import { queryLintCommands } from './main-commands/query-lint-commands';
+import type { QueryLintMethods } from './main-commands/query-lint-commands';
+import { ingestCommands } from './main-commands/ingest-commands';
+import type { IngestMethods } from './main-commands/ingest-commands';
+import { registerWikiCommands } from './main-commands/command-registry';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- C-PR3: intentional interface+class merge for mixin pattern
+export class LLMWikiPlugin extends Plugin {
   settings: LLMWikiSettings;
   llmClient: LLMClient | null = null;
   wikiEngine: WikiEngine;
   schemaManager: SchemaManager;
   autoMaintainManager: AutoMaintainManager;
-  /**
-   * v1.23.0 Phase 5.1.5: single source of truth for the current
-   * ingest session. Replaces the old "selected: TFile[]" inside the
-   * Multi-File Suggest modal. The modal subscribes to this queue to
-   * render a real-time right pane (pending / running / completed /
-   * failed). The ingest pipeline (runBatchIngest) calls start() /
-   * complete() / remove() around each file's wikiEngine.ingestSource
-   * call. Pure data layer; no IO lives here.
-   */
-  private ingestQueue: IngestQueue = new IngestQueue();
-  private progressNotice: Notice | null = null;
-  private ingestStatusBar: HTMLElement | null = null;
-  // Tracks the current document position during a folder batch ingest so the
-  // status bar can show "[current/total] <doc> · …". Null for single-file ingest.
-  private batchProgress: BatchProgress | null = null;
+  ingestQueue: IngestQueue = new IngestQueue();
+  progressNotice: Notice | null = null;
+  ingestStatusBar: HTMLElement | null = null;
+  batchProgress: BatchProgress | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -114,19 +73,10 @@ export default class LLMWikiPlugin extends Plugin {
       () => this.llmClient,
       this.schemaManager,
       // Delayed evaluation: this closure captures autoMaintainManager by reference,
-      // but the variable is assigned at :68 below. By the time wikiEngine calls
+      // but the variable is assigned below. By the time wikiEngine calls
       // this callback (during file writes), autoMaintainManager is guaranteed
       // to exist. This is intentional — reordering the assignments would break it.
       (path: string) => this.autoMaintainManager.watchWrite(path),
-      // v1.25.0 PR3 follow-up #7 (Bug C, e2e 2026-07-17): the wikiEngine
-      // calls `onProgress` for inline progress messages (e.g. PDF
-      // "Reading PDF: paper.pdf"). Previously this only updated the
-      // persistent Notice via showProgressFor, leaving the status bar
-      // frozen on the initial placeholder text. We now ALSO mirror the
-      // same text into the status bar so the user sees both surfaces
-      // advancing in lockstep, with the text itself acting as
-      // "current operation" cue. Status bar text is overwritten by the
-      // ingestion-start callback when a new file begins.
       (msg: string) => {
         if (this.ingestStatusBar) {
           this.ingestStatusBar.setText(msg);
@@ -134,12 +84,7 @@ export default class LLMWikiPlugin extends Plugin {
         }
         this.showProgressFor(ProgressScope.IngestAutoWatch, msg);
       },
-      // v1.22.6 #204: Dispatch based on report.trigger so watch-mode
-      // auto-ingest goes through onAutoIngestDone (Notice) while
-      // manual ingest keeps the legacy IngestReportModal behavior.
       (report: IngestReport) => this.onIngestDoneDispatch(report),
-      // v1.25.0 PR2: inject SubtleCrypto from Obsidian's popout-window-aware
-      // activeWindow so the PDF cache can hash without accessing bare `window`.
       (typeof activeWindow !== 'undefined' ? activeWindow.crypto : undefined)?.subtle
     );
 
@@ -161,28 +106,15 @@ export default class LLMWikiPlugin extends Plugin {
       this.settings,
       this.wikiEngine,
       this,
-      // v1.22.6 #204: pass trigger='auto' so periodic/auto lint
-      // completion routes to Notice, not LintReportModal.
       () => this.lintWiki('auto')
     );
 
-    // v1.25.0 PR2 fix: fire-and-forget PDF cache housekeeping on startup.
-    // Without this hook, the three-defense-layer design collapses — set()
-    // only triggers defense layer 2 (size cap), but layers 1 (per-write
-    // cap) and 3 (purgeExpired) never run. Over months, the cache would
-    // grow until the cap, then evict the user's most-valuable oldest
-    // entries on every new PDF ingest (cache hit rate collapses).
-    // Errors are swallowed inside performPdfCacheHousekeeping — never blocks startup.
     void this.performPdfCacheHousekeeping();
 
     if (this.settings.autoWatchSources) {
       this.autoMaintainManager.startWatching();
     }
     this.autoMaintainManager.schedulePeriodicLint();
-    // v1.23.0: QuickFixes (Phase 0-4.5) always run on plugin start.
-    // The user-facing control is `startupCheckNoticeLevel` (visible/silent)
-    // — see settings.ts. The old `startupCheck: boolean` toggle is now
-    // permanently on (migrated from any historical false → true).
     void this.autoMaintainManager.runStartupCheck();
 
     this.registerView(
@@ -190,223 +122,20 @@ export default class LLMWikiPlugin extends Plugin {
       (leaf) => new QueryView(leaf, this)
     );
 
-    const t = TEXTS[this.settings.language];
-    this.addCommand({
-      id: 'ingest-source',
-      name: t.cmdIngestSource,
-      callback: () => this.selectSourceToIngest()
-    });
+    // v1.25.1 Phase C-PR3: command registration, ribbon icons, status
+    // bar, and wiki-engine callbacks extracted to command-registry.ts.
+    registerWikiCommands(this);
 
-    this.addCommand({
-      id: 'ingest-folder',
-      name: t.cmdIngestFolder,
-      callback: () => this.selectFolderToIngest()
-    });
-
-    // v1.23.0 (#130): multi-file picker. User selects N specific
-    // source notes from a two-pane modal (no folder containment),
-    // toggles each, then runs them through the same batch pipeline
-    // as folder ingest. Fixes the "move notes to a staging folder"
-    // workaround: the in-place queue doesn't relocate anything, so
-    // the source-path provenance in generated wiki pages stays
-    // stable across re-ingest cycles.
-    this.addCommand({
-      id: 'ingest-multiple-files',
-      name: t.cmdIngestMultipleFiles,
-      callback: () => this.selectMultipleFilesToIngest()
-    });
-
-    this.addCommand({
-      id: 'query-wiki',
-      name: t.cmdQueryWiki,
-      callback: () => this.queryWiki()
-    });
-
-    this.addCommand({
-      id: 'lint-wiki',
-      name: t.cmdLintWiki,
-      callback: () => this.lintWiki()
-    });
-
-    this.addCommand({
-      id: 'regenerate-index',
-      name: t.cmdRegenerateIndex,
-      callback: () => {
-        void (async () => {
-          new Notice(getText(this.settings.language, 'regenerateIndexCompleted') + '...');
-          try {
-            await this.wikiEngine.generateIndexFromEngine();
-            new Notice(getText(this.settings.language, 'regenerateIndexCompleted'));
-          } catch (err) {
-            console.error('Regenerate index failed:', err);
-            new Notice(getText(this.settings.language, 'operationFailed') + (err instanceof Error ? err.message : String(err)));
-          }
-        })();
-      }
-    });
-
-    // v1.22.0 #97: command entry removed — Schema suggestion MUST
-    // follow a Lint analysis so the LLM has real data to work with.
-    // Direct invocation from the command palette always produces
-    // changes_needed=false (no context), which is a confusing no-op.
-    // The only valid entry point is the Lint Report Modal's "Suggest
-    // Schema Updates" button, which supplies lint findings as context.
-
-    this.addCommand({
-      id: 'cancel-ingestion',
-      name: t.cmdCancelIngestion,
-      callback: () => {
-        if (this.wikiEngine.isIngesting()) {
-          this.wikiEngine.cancelIngestion();
-        } else if (this.wikiEngine.isLintRunning()) {
-          this.wikiEngine.cancelLint();
-        }
-      }
-    });
-
-    this.addCommand({
-      id: 'ingest-active-file',
-      name: t.cmdIngestActiveFile,
-      callback: () => this.ingestActiveFile()
-    });
-
-    // Ingestion History (#122) — command palette entry.
-    // Most discoverable way to reach the history panel; the Settings-tab button
-    // is a secondary entry point for users exploring configuration.
-    this.addCommand({
-      id: 'view-ingestion-history',
-      name: t.cmdViewHistory,
-      callback: () => {
-        new HistoryModal(this.app, {
-          language: this.settings.language,
-          wikiFolder: this.settings.wikiFolder || 'wiki',
-        }).open();
-      }
-    });
-
-    // v1.23.0 Phase 5.1.5: Recreate Welcome Note. Useful for users who
-    // want to re-run onboarding after changing their domain focus, or
-    // who just want to see a freshly-localized copy. Existing file is
-    // trashed first so ensure-welcome-note re-creates with current
-    // candidates + LLM config. Implementation lives in auto-maintain.ts
-    // (the Phase 0 owner).
-    this.addCommand({
-      id: 'recreate-welcome-note',
-      name: t.welcomeNoteRecreateCommand,
-      callback: () => void this.autoMaintainManager.recreateWelcomeNote(),
-    });
-
-    // v1.25.0 PR2: explicit "Ingest PDF" command. Useful when the user has
-    // v1.25.0 PR2: clear the PDF conversion cache. Useful when switching
-    // models and wanting to force re-conversion without invalidating by
-    // deleting the source PDF. PR2 redo: the `ingest-pdf` command was a
-    // pure duplicate of `ingest-active-file` and is removed — PDFs are
-    // detected automatically by ingestSource when the active file is a PDF.
-    this.addCommand({
-      id: 'clear-pdf-cache',
-      name: getText(this.settings.language, 'clearPdfCacheCommand'),
-      icon: 'trash-2',
-      callback: () => void this.clearPdfCache(),
-    });
-
-    this.addRibbonIcon('sticker', t.cmdIngestActiveFile, () => {
-      this.ingestActiveFile();
-    });
-
-    this.addRibbonIcon('message-circle', t.cmdQueryWiki, () => {
-      this.queryWiki();
-    });
-
-    this.ingestStatusBar = this.addStatusBarItem();
-    this.ingestStatusBar.addClass('llm-wiki-status-bar');
-    this.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
-    this.ingestStatusBar.setText('LLM wiki');
-    this.ingestStatusBar.onclick = () => {
-      if (this.wikiEngine.isIngesting()) {
-        this.wikiEngine.cancelIngestion();
-      } else if (this.wikiEngine.isLintRunning()) {
-        this.wikiEngine.cancelLint();
-      }
-    };
-
-    this.wikiEngine.setIngestionCallbacks(
-      (filename?: string) => {
-        const label = getText(this.settings.language, 'ingestionStatusBar');
-        if (this.ingestStatusBar) {
-          this.ingestStatusBar.setText(
-            buildIngestStatusBarText(label, filename, this.batchProgress)
-          );
-          this.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
-        }
-      },
-      () => {
-        if (this.ingestStatusBar) {
-          this.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
-        }
-      }
-    );
-
-    this.wikiEngine.setLintCallbacks(
-      (filename?: string) => {
-        const label = getText(this.settings.language, 'lintStatusBar');
-        if (this.ingestStatusBar) {
-          const text = filename
-            ? `${filename} · ${label}`
-            : label;
-          this.ingestStatusBar.setText(text);
-          this.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
-        }
-      },
-      () => {
-        if (this.ingestStatusBar) {
-          this.ingestStatusBar.addClass('llm-wiki-status-bar-hidden');
-        }
-      }
-    );
-
-    // v1.23.2: Wire wikiEngine.updateStatusBar() so fix-runners' dynamic
-    // progress messages (e.g. "[3/10] fixing: path/to/file") reach the
-    // status bar, not just the static lint label.
-    this.wikiEngine.setStatusBarUpdateCallback(
-      (text: string) => {
-        if (this.ingestStatusBar) {
-          this.ingestStatusBar.setText(text);
-          this.ingestStatusBar.removeClass('llm-wiki-status-bar-hidden');
-        }
-      }
-    );
-
-    this.addSettingTab(new LLMWikiSettingTab(this.app, this));
-
-    // v1.23.0: First-run Welcome note is now Phase 0 of runStartupCheck
-    // (see auto-maintain.ts). Triggered by the unconditional
-    // runStartupCheck() above. The standalone runOnboarding() method
-    // is gone — single owner = single source of truth.
-
-    // v1.24.0 (Bug C 3.4 / plan C): gradual migration. Pre-v1.24.0
-    // chat history contains real wikiFolder-prefixed links. The
-    // placeholder scheme (Bug C 3.0) handles new turns correctly, but
-    // legacy entries still render the old path. We do NOT auto-migrate
-    // (guessing all historical folders is fragile); we show a one-time
-    // Notice so the user can decide whether to Clear history.
     this.checkQueryHistoryForStaleFolders();
 
     console.debug('LLM Wiki Plugin loaded - Karpathy implementation');
   }
 
-  /**
-   * Show a one-time Notice when persisted query history contains
-   * wiki-link prefixes from a wikiFolder the user is no longer using.
-   * Pure check + side-effect free except for the Notice itself; safe
-   * to call once on startup.
-   */
   private checkQueryHistoryForStaleFolders(): void {
     const history = this.settings.queryHistory;
     if (!Array.isArray(history) || history.length === 0) return;
-
     const detection = detectStaleWikiFolders(history, this.settings.wikiFolder);
     if (!detection || !detection.hasStale) return;
-
     new Notice(getText(this.settings.language, 'queryHistoryMigrationNotice'), NOTICE_NORMAL);
   }
 
@@ -430,29 +159,15 @@ export default class LLMWikiPlugin extends Plugin {
       console.debug('loadSettings: watchedFolders was not an array, reset to []');
     }
 
-    // v1.18.3 migration REMOVED in v1.22.1 (#199). Previous code at this
-    // location unconditionally forced `savedData.startupCheck === false`
-    // back to `true` on every plugin load, silently undoing the user's
-    // toggle for ~2 years. Migration logic moved to
-    // `core/settings-migrations.ts` and then removed entirely. Anyone with
-    // `startupCheck: false` on disk today has explicitly chosen that
-    // value and we respect it.
-    //
-    // v1.20.0 migration (disableThinking default flip) now lives in
-    // `applySettingsMigrations`. See that file for the version-key gate.
     if (applied.length > 0) {
       console.debug(`loadSettings: applied migrations: ${applied.join(', ')}`);
     }
 
-    // v1.23.0 P2: Diagnostic — log actual queryHistory state on plugin
-    // load. Helps confirm whether the persisted history is reaching
-    // settings correctly on restart. Will be removed in v1.24.0.
     console.debug(
       '[main.loadSettings] settings.queryHistory =',
       Array.isArray(this.settings.queryHistory) ? `${this.settings.queryHistory.length} messages` : 'NOT an array'
     );
 
-    // Migrate existing users: if they already have a working config, trust it
     if (savedData && !('llmReady' in savedData)) {
       const hasConfig = savedData.provider
         && allowsEmptyApiKey(savedData.provider, savedData.apiKey)
@@ -464,13 +179,6 @@ export default class LLMWikiPlugin extends Plugin {
     }
   }
 
-  /**
-   * Issue #85 v2: Migrate v1 textarea CSV (which may contain untrimmed
-   * whitespace, empty entries, or case-variant duplicates from manual
-   * editing) into the canonical form the chip input uses. Idempotent.
-   * Called once on onload() before any UI renders so users see clean
-   * chips immediately on first reload after upgrade.
-   */
   private cleanupVocabularyTags(): void {
     const fields: ('customEntityTags' | 'customConceptTags')[] = [
       'customEntityTags',
@@ -496,14 +204,8 @@ export default class LLMWikiPlugin extends Plugin {
     if (this.wikiEngine) {
       const wikiFolderChanged = this.wikiEngine.updateSettings(this.settings);
       console.debug('[saveSettings] wikiEngine provider updated to:', this.settings.provider);
-      // Bug C 3.1: extend wikiFolder-change invalidation to open QueryView
-      // PPR graphs (engine handles its own path-keyed caches).
       if (wikiFolderChanged) {
         this.invalidateAllQueryGraphs();
-        // Bug C 3.4 / plan C: when the user changes wikiFolder mid-session,
-        // the onload Notice won't fire (already shown at startup). Re-run
-        // the detection so the user gets the "stale history" prompt
-        // immediately, not after the next Obsidian restart.
         this.checkQueryHistoryForStaleFolders();
       }
     }
@@ -518,15 +220,10 @@ export default class LLMWikiPlugin extends Plugin {
   }
 
   initializeLLMClient() {
-    // Local providers (ollama, lmstudio) do not require an API key —
-    // same gate as testLLMConnection (#223). Leaving llmClient null here
-    // is what made ingest show errorNoApiKey after a successful LM Studio
-    // connection test.
     if (!allowsEmptyApiKey(this.settings.provider, this.settings.apiKey)) {
       this.llmClient = null;
       return;
     }
-
     try {
       this.llmClient = createLLMClient(this.settings);
       console.debug('LLM Client initialized:', this.settings.provider);
@@ -536,8 +233,9 @@ export default class LLMWikiPlugin extends Plugin {
     }
   }
 
+  // ==================== Progress helpers ====================
+
   private showProgress(msg: string): void {
-    // Backward-compatible alias: callers without a scope default to manual ingest.
     this.showProgressFor(ProgressScope.IngestManual, msg);
   }
 
@@ -560,37 +258,10 @@ export default class LLMWikiPlugin extends Plugin {
     }
   }
 
-  // v1.22.6 #204: Dispatch ingest completion by trigger. Routes
-  // watch-mode auto-ingest (trigger='auto') to onAutoIngestDone
-  // (Notice, respects autoIngestNotificationLevel), and manual
-  // ingest (trigger='manual' or undefined) to the legacy
-  // IngestReportModal. Keeps backward compatibility — legacy
-  // callers without trigger default to 'manual'.
-  /**
-   * Drop the engine-level PPR graph cache in WikiEngine and the last-retrieval
-   * state in every open QueryView. Used by `onIngestDoneDispatch` (v1.23.2
-   * review-C P0) and by `saveSettings` when `wikiFolder` changes (Bug C 3.1).
-   * v1.24.0 Bug A: the graph cache is now engine-level (shared), so the engine
-   * invalidation is the critical call; per-view invalidation only clears UI state.
-   */
-  private invalidateAllQueryGraphs(): void {
-    const viewLeaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_QUERY);
-    for (const leaf of viewLeaves) {
-      if (leaf.view instanceof QueryView) {
-        leaf.view.invalidateGraph();
-      }
-    }
-  }
+  // ==================== Ingest dispatch ====================
 
   private onIngestDoneDispatch(report: IngestReport): void {
-    // v1.23.2 (review-C P0): any ingest that touches wiki/ invalidates the
-    // cached PPR graph in every open QueryView. Without this, a user who
-    // ingests new content and then asks a query in the same session
-    // answers against the pre-ingest graph (and its pre-ingest neighbors).
-    // We walk all leaves of VIEW_TYPE_QUERY because Obsidian lets the user
-    // dock multiple Query panels in the workspace.
     this.invalidateAllQueryGraphs();
-
     if (report.trigger === 'auto') {
       this.onAutoIngestDone(report);
     } else {
@@ -599,10 +270,6 @@ export default class LLMWikiPlugin extends Plugin {
     }
   }
 
-  // v1.22.2 #204: notification-level done callback for watch-mode auto-ingest.
-  // When autoIngestNotificationLevel === 'notice' (default), summary is a
-  // transient Notice with History Panel hint rather than a blocking modal.
-  // When 'modal', opens the full IngestReportModal (unchanged legacy behaviour).
   private onAutoIngestDone(report: IngestReport): void {
     this.dismissProgress();
     const level = this.settings.autoIngestNotificationLevel;
@@ -610,7 +277,6 @@ export default class LLMWikiPlugin extends Plugin {
       new IngestReportModal(this.app, report, this.settings.language).open();
       return;
     }
-    // 'notice' (default): transient notification + pointer to history panel
     const texts = TEXTS[this.settings.language];
     const summary = report.createdPages?.length > 0
       ? texts.ingestionCreatedPages.replace('{count}', String(report.createdPages.length))
@@ -618,687 +284,17 @@ export default class LLMWikiPlugin extends Plugin {
     const hint = getText(this.settings.language, 'ingestionNoticeHistoryHint');
     new Notice(`✅ ${report.sourceFile}: ${summary}. ${hint}`, NOTICE_ABORT);
   }
-
-  // ==================== Ingestion ====================
-
-  private async isAlreadyIngested(sourceFile: TFile): Promise<boolean> {
-    const slug = slugify(sourceFile.basename, this.settings.slugCase === 'preserve');
-    const wikiPath = `${this.settings.wikiFolder}/sources/${slug}.md`;
-
-    try {
-      const file = this.app.vault.getAbstractFileByPath(wikiPath);
-      if (!(file instanceof TFile)) return false;
-
-      try {
-        const content = await this.app.vault.read(file);
-        const fm = parseFrontmatter(content);
-        if (fm && fm.sources) {
-          const normalizedSources = fm.sources.map(s => {
-            const trimmed = s.trim();
-            if (trimmed.startsWith('[[') && trimmed.endsWith(']]')) {
-              return trimmed.slice(2, -2).trim();
-            }
-            return trimmed;
-          });
-          return normalizedSources.includes(sourceFile.path);
-        }
-        return true;
-      } catch {
-        return true;
-      }
-    } catch {
-      return false;
-    }
-  }
-
-  selectSourceToIngest() {
-    if (!this.requireLLMReady()) return;
-    if (!this.llmClient) {
-      new Notice(TEXTS[this.settings.language].errorNoApiKey);
-      return;
-    }
-
-    new FileSuggestModal(this.app, this.settings.wikiFolder, (file) => {
-      this.showProgressFor(ProgressScope.IngestManual, `Ingesting: ${file.basename}`);
-      this.wikiEngine.ingestSource(file, { interactive: true }).catch(e => {
-        console.error('Single ingest failed:', e);
-        const errMsg = e instanceof Error ? e.message : String(e);
-        new Notice(TEXTS[this.settings.language].errorIngestFailed + errMsg, NOTICE_ERROR);
-        // v1.25.0 PR3 follow-up #5: dismiss the persistent "Ingesting:" Notice.
-        // For failures that bypass `reportSkip` (e.g. transient network errors,
-        // vault IO failures, unexpected exceptions thrown out of ingestSource),
-        // the progressNotice is the only persistent Notice tied to this call —
-        // without this hide() it would remain on screen until the next ingest.
-        this.dismissProgress();
-      });
-    }).open();
-  }
-
-  ingestActiveFile() {
-    if (!this.requireLLMReady()) return;
-    if (!this.llmClient) {
-      new Notice(TEXTS[this.settings.language].errorNoApiKey);
-      return;
-    }
-
-    const activeFile = this.app.workspace.getActiveFile();
-    if (!activeFile) {
-      new Notice(getText(this.settings.language, 'noActiveFile'), NOTICE_NORMAL);
-      return;
-    }
-
-    // File-type validation is handled centrally by the ingest gate (#164),
-    // which accepts the text allowlist (.md, .txt, …) and shows a localized
-    // notice for anything else. v1.25.0 PR2: PDFs are now first-class sources
-    // — the PDF ingest branch in WikiEngine.ingestSource handles them.
-    this.showProgressFor(ProgressScope.IngestManual, `Ingesting: ${activeFile.basename}`);
-    this.wikiEngine.ingestSource(activeFile, { interactive: true }).catch(e => {
-      console.error('Ingest active file failed:', e);
-      const errMsg = e instanceof Error ? e.message : String(e);
-      new Notice(TEXTS[this.settings.language].errorIngestFailed + errMsg, NOTICE_ERROR);
-      // v1.25.0 PR3 follow-up #5: see sibling comment in ingestSourceViaModal —
-      // dismiss the persistent "Ingesting:" Notice on failure paths that
-      // bypass reportSkip (network/IO/throw).
-      this.dismissProgress();
-    });
-  }
-
-  /**
-   * v1.25.0 PR2: clear the PDF conversion cache. Useful when the user
-   * switches models and wants to force re-conversion without deleting the
-   * source PDF. Returns a localized count for the user-facing Notice.
-   */
-  async clearPdfCache(): Promise<void> {
-    const { createPdfCache } = await import('./core/pdf-cache');
-    const cache = createPdfCache(this.app);
-    const result = await cache.clear();
-    new Notice(
-      getText(this.settings.language, 'pdfCacheCleared').replace('{count}', String(result.removed)),
-      NOTICE_NORMAL
-    );
-  }
-
-  /**
-   * v1.25.0 PR2: PDF cache housekeeping on plugin load — purges expired
-   * entries and enforces hard size caps. Cheap on plugin startup; never
-   * blocks the user (errors are logged and swallowed).
-   *
-   * Called from onload() (fire-and-forget) so the three-defense-layer
-   * design doesn't collapse to just defense layer 2 (per-set cap).
-   */
-  /**
-   * v1.25.0 PR3 follow-up #2 (P1 #2): run TTL purge + size enforcement
-   * before a batch ingest starts. Cheaper than the per-write cap because
-   * `enforceSizeLimit` after each new write evicts in proportion to that
-   * single write — pre-running it evicts once for the whole batch, so the
-   * user's most-valuable oldest entries don't get kicked out one write
-   * at a time as the batch progresses.
-   */
-  async preparePdfCacheForBatchIngest(): Promise<void> {
-    try {
-      const { createPdfCache } = await import('./core/pdf-cache');
-      const cache = createPdfCache(this.app);
-      const { expired, size } = await cache.prepareBatchIngest();
-      if (expired.removed > 0 || size.removed > 0) {
-        console.debug(
-          `[pdf-cache] batch prep: purged ${expired.removed} expired, ` +
-          `evicted ${size.removed} oversized (${size.freedBytes} bytes freed)`
-        );
-      }
-    } catch (error) {
-      console.warn('[pdf-cache] batch prep failed:', error);
-    }
-  }
-
-  async performPdfCacheHousekeeping(): Promise<void> {
-    try {
-      const { createPdfCache } = await import('./core/pdf-cache');
-      const cache = createPdfCache(this.app);
-      const expired = await cache.purgeExpired();
-      const size = await cache.enforceSizeLimit();
-      if (expired.removed > 0 || size.removed > 0) {
-        console.debug(
-          `[pdf-cache] housekeeping: purged ${expired.removed} expired, ` +
-          `evicted ${size.removed} oversized (${size.freedBytes} bytes freed)`
-        );
-      }
-    } catch (error) {
-      console.warn('[pdf-cache] housekeeping failed:', error);
-    }
-  }
-
-  selectFolderToIngest() {
-    if (!this.requireLLMReady()) return;
-    if (!this.llmClient) {
-      new Notice(TEXTS[this.settings.language].errorNoApiKey);
-      return;
-    }
-
-    new FolderSuggestModal(this.app, this.settings.wikiFolder, (folder) => {
-      // #164: scan the compatible text-file allowlist (not just .md), so .txt
-      // sources in the folder are picked up too. The ingest gate is the final
-      // arbiter of type/empty/duplicate.
-      const allowedExts: readonly string[] = COMPATIBLE_SOURCE_EXTENSIONS;
-      const files = this.app.vault.getFiles()
-        .filter(f => f.path.startsWith(folder.path) && allowedExts.includes(f.extension.toLowerCase()));
-
-      if (files.length === 0) {
-        const msg = TEXTS[this.settings.language].selectFolderNoMdFiles.replace('{path}', folder.path);
-        new Notice(msg);
-        return;
-      }
-
-      void this.runBatchIngest(files, [], `${files.length} files from ${folder.path}`);
-    }).open();
-  }
-
-  /**
-   * v1.23.0 (#130): open the multi-file picker modal. User selects
-   * individual source notes via checkbox, dedup happens automatically
-   * (toggling a checked file un-checks it). The "Start Ingest" button
-   * then runs the same `runBatchIngest` pipeline that folder ingest
-   * uses, so the per-file loop, dedup context, and IngestReportModal
-   * are shared (no code duplication).
-   */
-  selectMultipleFilesToIngest() {
-    if (!this.requireLLMReady()) return;
-    if (!this.llmClient) {
-      new Notice(TEXTS[this.settings.language].errorNoApiKey);
-      return;
-    }
-
-    new MultiFileSuggestModal(
-      this.app,
-      this.settings,
-      this.ingestQueue,
-      // v1.23.0 Phase 5.1.5 stage 5: pass the already-issued job
-      // ids to runBatchIngest. The modal does the enqueue (it
-      // owns the queue UI), and the worker uses those ids to
-      // publish start/complete transitions. Without passing the
-      // ids, runBatchIngest used to call enqueue() itself — but
-      // enqueue is idempotent against in-flight jobs, so the
-      // second call returned no ids and the loop never updated
-      // job statuses, leaving every job stuck in 'pending'.
-      (ids: string[], files: TFile[]) => {
-        if (files.length === 0 || ids.length === 0) return;
-        void this.runBatchIngest(files, ids, `${files.length} manually-selected files`);
-      },
-    ).open();
-  }
-
-  /**
-   * Shared batch-ingest pipeline used by:
-   *   - selectFolderToIngest (folder batch)
-   *   - selectMultipleFilesToIngest (#130 — picker)
-   *   - (any future entry point that has a flat list of TFile)
-   *
-   * Responsibilities:
-   *   1. Filter out already-ingested files (#184 skip check) and
-   *      surface a Notice if any were skipped.
-   *   2. Run each remaining file through wikiEngine.ingestSource with
-   *      a SHARED batch context (#164: catches in-batch content
-   *      duplicates and cross-batch duplicates against existing wiki).
-   *   3. Aggregate per-file IngestReports into a single
-   *      IngestReportModal at the end (or a Notice when no work was
-   *      done). Cancellation between files is respected.
-   *
-   * `sourceLabel` is the human-readable identifier for the
-   * aggregated report (e.g. "12 files from notes/2024" or
-   * "3 manually-selected files"). It is NOT used for any file system
-   * operation — the in-place ingest path leaves source notes
-   * untouched (per #130, fixes the original "move to staging folder"
-   * workaround).
-   */
-  private async runBatchIngest(files: TFile[], jobIds: string[], sourceLabel: string): Promise<void> {
-    // v1.25.0 PR3 follow-up #2 (P1 #2): batch-start housekeeping.
-    // Fire-and-forget — never blocks ingest on cache maintenance.
-    void this.preparePdfCacheForBatchIngest();
-
-    this.showProgressFor(ProgressScope.IngestManual, 'Checking for already-ingested files...');
-    const alreadyIngestedFiles: TFile[] = [];
-    const newFiles: TFile[] = [];
-    // Aligned with `files` by index — only entries whose id is in
-    // jobIds keep their jobId; already-ingested files map to ''.
-    // The modal pre-issued the ids; this method is now the
-    // single consumer of those ids (it used to enqueue itself,
-    // which was a no-op once the modal had already enqueued).
-    const alignedJobIds: string[] = [];
-
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      const jobId = jobIds[i] ?? '';
-      if (await this.isAlreadyIngested(file)) {
-        alreadyIngestedFiles.push(file);
-      } else {
-        newFiles.push(file);
-        alignedJobIds.push(jobId);
-      }
-    }
-
-    const totalFiles = files.length;
-    const skippedCount = alreadyIngestedFiles.length;
-    const ingestCount = newFiles.length;
-
-    if (skippedCount > 0) {
-      const texts = TEXTS[this.settings.language];
-      new Notice(
-        texts.batchIngestSkipNotice
-          .replace('{skipped}', String(skippedCount))
-          .replace('{total}', String(totalFiles))
-          .replace('{new}', String(ingestCount)),
-        6000
-      );
-    }
-
-    if (ingestCount === 0) {
-      const texts = TEXTS[this.settings.language];
-      new Notice(texts.batchIngestAllIngested.replace('{total}', String(totalFiles)), NOTICE_NORMAL);
-      return;
-    }
-
-    const reports: IngestReport[] = [];
-
-    this.wikiEngine.setDoneCallback((report: IngestReport) => {
-      reports.push(report);
-    });
-
-    const texts = TEXTS[this.settings.language];
-    this.showProgressFor(ProgressScope.IngestManual, texts.batchIngestStarting
-      .replace('{count}', String(ingestCount))
-      .replace('{folder}', sourceLabel));
-
-    // #164: shared dedup context for this batch — catches content duplicates
-    // within the run and against pages already in the wiki.
-    const batchCtx = this.wikiEngine.createBatchContext();
-
-    // v1.23.0 Phase 5.1.5 stage 5: resolve the job ids for this
-    // batch. Two paths:
-    //
-    //   - Modal path: caller already issued ids via
-    //     ingestQueue.enqueue (so the modal's "Add to queue" click
-    //     immediately reflects in the queue snapshot). Use those
-    //     ids directly. alignedJobIds[] was built above aligned by
-    //     index with newFiles[] (already-ingested files drop out,
-    //     keeping the alignment).
-    //
-    //   - Folder / "everything else" path: caller passed an empty
-    //     jobIds array (the call site doesn't know ids yet). Issue
-    //     them here. enqueue() is idempotent against in-flight
-    //     duplicates, so re-enqueueing during an active batch is
-    //     safe.
-    let resolvedJobIds: string[];
-    if (jobIds.length > 0) {
-      resolvedJobIds = alignedJobIds;
-      console.debug(
-        `[runBatchIngest] using pre-issued ids (${sourceLabel}):`,
-        resolvedJobIds.length, 'jobs'
-      );
-    } else {
-      resolvedJobIds = this.ingestQueue.enqueue(newFiles);
-      console.debug(
-        `[runBatchIngest] enqueued ${resolvedJobIds.length}/${newFiles.length} jobs (${sourceLabel})`
-      );
-    }
-
-    for (let i = 0; i < newFiles.length; i++) {
-      const file = newFiles[i];
-      const jobId = resolvedJobIds[i];
-
-      try {
-        // Mark running BEFORE the await so the modal (if open) sees
-        // a 'running' state for this file rather than a 'pending' that
-        // never resolves. The job is the only way to address the
-        // record across this await boundary.
-        if (jobId) {
-          this.ingestQueue.start(jobId);
-          console.debug(
-            `[runBatchIngest] [${i + 1}/${newFiles.length}] start ${file.path} (jobId=${jobId})`
-          );
-        }
-        this.batchProgress = { current: i + 1, total: ingestCount };
-        this.showProgressFor(ProgressScope.IngestManual, `[${i + 1}/${ingestCount}] ${file.basename}`);
-        console.debug(`(${i + 1}/${ingestCount}) ingesting: ${file.path}`);
-        await this.wikiEngine.ingestSource(file, { batchCtx });
-        if (this.wikiEngine.wasCancelled) {
-          console.debug(`Batch ingestion cancelled at file ${i + 1}/${ingestCount}`);
-          // Mark the cancelled job as failed so the right pane
-          // shows the cancellation rather than leaving it as 'running'.
-          if (jobId) {
-            this.ingestQueue.complete(jobId, false, 'Cancelled by user');
-            console.debug(`[runBatchIngest] cancelled ${file.path} (jobId=${jobId})`);
-          }
-          break;
-        }
-        console.debug(`(${i + 1}/${ingestCount}) ingestion success: ${file.path}`);
-        if (jobId) {
-          this.ingestQueue.complete(jobId, true);
-          console.debug(
-            `[runBatchIngest] [${i + 1}/${newFiles.length}] complete ${file.path} (jobId=${jobId})`
-          );
-        }
-      } catch (error) {
-        console.error(`(${i + 1}/${ingestCount}) ingestion failed: ${file.path}`, error);
-        const errMsg = error instanceof Error ? error.message : String(error);
-        new Notice(texts.errorIngestFailed + file.basename + ': ' + errMsg, NOTICE_ERROR);
-        if (jobId) this.ingestQueue.complete(jobId, false, errMsg);
-      }
-    }
-
-    this.batchProgress = null;
-    this.dismissProgress();
-
-    if (reports.length > 0) {
-      const allCreated = [...new Set(reports.flatMap(r => r.createdPages))];
-      const allUpdated = [...new Set(reports.flatMap(r => r.updatedPages))];
-      const totalEntities = reports.reduce((sum, r) => sum + r.entitiesCreated, 0);
-      const totalConcepts = reports.reduce((sum, r) => sum + r.conceptsCreated, 0);
-      const totalContradictions = reports.reduce((sum, r) => sum + r.contradictionsFound, 0);
-      const totalElapsed = reports.reduce((sum, r) => sum + (r.elapsedSeconds || 0), 0);
-      const allFailedItems = reports.flatMap(r => r.failedItems);
-      const allCollisions = reports.flatMap(r => r.collisions || []);
-      const allRejectedFiles = reports.flatMap(r => r.rejectedFiles || []);
-      const allSuccess = reports.every(r => r.success);
-
-      const aggregated: IngestReport = {
-        sourceFile: sourceLabel,
-        createdPages: allCreated,
-        updatedPages: allUpdated,
-        entitiesCreated: totalEntities,
-        conceptsCreated: totalConcepts,
-        failedItems: allFailedItems,
-        collisions: allCollisions,
-        contradictionsFound: totalContradictions,
-        success: allSuccess,
-        elapsedSeconds: totalElapsed,
-        skippedFiles: skippedCount,
-        totalFilesInFolder: totalFiles,
-        rejectedFiles: allRejectedFiles,
-      };
-
-      new IngestReportModal(this.app, aggregated, this.settings.language).open();
-    } else {
-      const texts = TEXTS[this.settings.language];
-      new Notice(texts.batchIngestComplete
-        .replace('{success}', '0')
-        .replace('{total}', String(ingestCount))
-        .replace('{fail}', String(ingestCount)), 10000);
-    }
-  }
-
-  // ==================== Query ====================
-
-  queryWiki() {
-    if (!this.requireLLMReady()) return;
-    if (!this.llmClient) {
-      new Notice(TEXTS[this.settings.language].errorNoApiKey);
-      return;
-    }
-
-    void this.activateQueryView();
-  }
-
-  private async activateQueryView(): Promise<void> {
-    const { workspace } = this.app;
-
-    const existing = workspace.getLeavesOfType(VIEW_TYPE_QUERY);
-    if (existing.length > 0) {
-      await workspace.revealLeaf(existing[0]);
-      return;
-    }
-
-    const leaf = workspace.getRightLeaf(false);
-    if (!leaf) return;
-    await leaf.setViewState({ type: VIEW_TYPE_QUERY, active: true });
-    await workspace.revealLeaf(leaf);
-  }
-
-  // ==================== Lint ====================
-
-  async lintWiki(trigger: 'auto' | 'manual' = 'manual'): Promise<void> {
-    if (!this.requireLLMReady()) return;
-    const signal = this.wikiEngine.startLintOperation();
-    try {
-      await runLintWiki({
-        app: this.app,
-        settings: this.settings,
-        llmClient: this.llmClient,
-        wikiEngine: this.wikiEngine,
-        onAnalyzeSchema: (context?: string) => { void this.suggestSchemaUpdate(context); },
-      }, signal, trigger);
-    } finally {
-      this.wikiEngine.endLintOperation();
-    }
-  }
-
-  // ==================== Schema ====================
-
-  async suggestSchemaUpdate(context?: string) {
-    // ROADMAP v1.17.0 P1 #1: delegate to runSchemaAnalyze so the status bar's
-    // "click to cancel" works for both this call site and the Lint Report
-    // Modal's "Suggest Schema Updates" button (both ultimately reach here).
-    //
-    // v1.22.0 #97: when the LLM returns new_schema_body, the orchestrator
-    // opens the SchemaDiffModal (IDE-style diff + Apply / Regenerate / Cancel).
-    await runSchemaAnalyze({
-      settings: this.settings,
-      llmClient: this.llmClient,
-      wikiEngine: this.wikiEngine,
-      schemaManager: this.schemaManager,
-      requireLLMReady: () => this.requireLLMReady(),
-      openSchemaDiffModal: (suggestion) => this.openSchemaDiffModal(suggestion),
-      lintAnalysisContext: context,
-    });
-  }
-
-  /** v1.22.0 #97: open the SchemaDiffModal with the LLM's proposed new body. */
-  private openSchemaDiffModal(suggestion: import('./types').SchemaSuggestion): Promise<void> | void {
-    const t = (TEXTS as unknown as Record<string, Record<string, string>>)[this.settings.language]
-      ?? TEXTS.en as unknown as Record<string, string>;
-    // TEMP DEBUG
-    console.debug('[SchemaDiffModal] suggestion.suggestions =', JSON.stringify(suggestion.suggestions), 'changes_needed =', suggestion.changes_needed, 'newSchemaBody length =', suggestion.newSchemaBody?.length);
-    // v1.22.0 #97: when the LLM reports changes_needed=false, we still
-    // open the Modal (so the user can read the LLM's rationale) but
-    // disable the Apply button (nothing to apply). The Modal hands
-    // back Regenerate (re-prompt) and Cancel as alternatives.
-    const isEmpty = !suggestion.changes_needed;
-    const modal = new SchemaDiffModal(this.app, {
-      currentBody: '',
-      newBody: suggestion.newSchemaBody ?? '',
-      language: this.settings.language,
-      isEmpty,
-      rationale: suggestion.suggestions,
-      onOpenFile: () => {
-        // v1.22.0 #97: hand-edit path. Opens wiki/schema/config.md in
-        // the active Obsidian leaf and closes the Modal. The user
-        // can tweak the file and then either re-run Suggest Schema
-        // Updates or just save — either way the change sticks
-        // because the file IS the schema.
-        const path = `${this.settings.wikiFolder}/schema/config.md`;
-        void this.app.workspace.openLinkText(path, '', false);
-      },
-      onApply: async () => {
-        const result = await applySchemaSuggestion({
-          app: this.app,
-          currentPath: `${this.settings.wikiFolder}/schema/config.md`,
-          newBody: suggestion.newSchemaBody ?? '',
-          onCacheInvalidate: () => this.schemaManager.invalidateCache(),
-        });
-        if (result.success) {
-          // v1.22.0 #97: persistent Notice with the backup path so the
-          // user has a clear way to recover. The path is what
-          // applySchemaSuggestion returned (it contains the ISO timestamp),
-          // and a short hint tells them how to restore.
-          const restore = t.schemaDiffRestoreHint
-            ? t.schemaDiffRestoreHint.replace('{path}', result.backupPath)
-            : `Backup saved to ${result.backupPath}. To restore, rename that file back to wiki/schema/config.md in your file explorer.`;
-          new Notice(restore, NOTICE_RATE_LIMIT);
-        } else {
-          new Notice(t.schemaDiffFailed ?? 'Schema apply failed: ' + result.reason, NOTICE_ERROR);
-        }
-      },
-      onRegenerate: async (userHint: string) => {
-        const newSuggestion = await this.regenerateSchemaWithHint(suggestion, userHint);
-        if (newSuggestion?.newSchemaBody) {
-          // v1.22.0 #97: also sync the rationale + isEmpty flag so the
-          // modal re-renders both the "why" section and the dual-pane
-          // diff. The LLM may have changed its reasoning or decided
-          // (this round) that no changes are needed at all.
-          modal.setNewBody(newSuggestion.newSchemaBody, {
-            rationale: newSuggestion.suggestions,
-            isEmpty: !newSuggestion.changes_needed,
-          });
-        } else {
-          new Notice(t.schemaRegenerateNoBody ?? 'Regeneration succeeded but the LLM did not return a new body.', NOTICE_ERROR);
-        }
-      },
-    });
-    // Load the current body asynchronously, then push it into the modal.
-    // The modal opens immediately with currentBody='' so the user can
-    // see the LLM's proposal right away; when loadSchema() resolves the
-    // diff is recomputed against the real current body.
-    modal.open();
-    void this.schemaManager.loadSchema().then((loaded) => {
-      modal.setCurrentBody(loaded?.body ?? '');
-    });
-  }
-
-  /** v1.22.0 #97: re-call the LLM with the user's refinement hint. */
-  private async regenerateSchemaWithHint(
-    baseSuggestion: import('./types').SchemaSuggestion,
-    userHint: string
-  ): Promise<import('./types').SchemaSuggestion | null> {
-    const ctx = `${baseSuggestion.suggestions || ''}\n\nUser refinement: ${userHint || '(none)'}`;
-    return await this.schemaManager.suggestSchemaUpdate(ctx);
-  }
-
-  // ==================== Connection Test ====================
-
-  async testLLMConnection(): Promise<{ success: boolean; message: string }> {
-    const t = TEXTS[this.settings.language] || TEXTS.en;
-
-    if (!allowsEmptyApiKey(this.settings.provider, this.settings.apiKey)) {
-      return { success: false, message: t.errorNoApiKey || 'API Key is not configured' };
-    }
-
-    // v1.24.0 #208: when per-task models are enabled, probe every task's
-    // model separately. The unified mode probes only settings.model. If
-    // ANY task's probe fails, the whole Test Connection returns failure
-    // — there is no point claiming "Connection successful" when 2 out
-    // of 3 tasks would actually 400 on first real call.
-    const tasksToProbe: LLMTask[] = this.settings.usePerTaskModels === true
-      ? ['ingest', 'lint', 'query']
-      : [];
-    const probePlan: Array<{ label: string; model: string }> = tasksToProbe.length === 0
-      ? [{ label: 'unified', model: this.settings.model }]
-      : tasksToProbe.map(task => ({ label: task, model: resolveModelForTask(this.settings, task) }));
-
-    // v1.24.0 #208: log the probe plan so e2e verification of per-task
-    // routing is visible from console — the user can see which models
-    // will be probed before any API call lands.
-    console.debug('[testLLMConnection] probe plan:', probePlan.map(p => `${p.label}=${p.model}`).join(', '));
-
-    try {
-      const testClient = createLLMClient(this.settings);
-
-      // Sequential probes — preserve order so error messages identify
-      // which task broke (ingest → lint → query). Each probe uses the
-      // same probe prompt; only `model` differs. Probe response text is
-      // discarded (success = no throw).
-      for (const probe of probePlan) {
-        await testClient.createMessage({
-          model: probe.model,
-          max_tokens: TOKENS_QUERY_MODEL_DETECT,
-          messages: [{
-            role: 'user',
-            content: 'Test connection. Please reply "Connection successful".'
-          }]
-        });
-      }
-
-      // v1.23.0 P1-7: AI-SDK migration. The 3-tier thinking-control
-      // probe (v1.20.0) and advanced-parameter probe (v1.20.0) were
-      // hand-rolled to discover per-provider field names. AI-SDK
-      // handles this internally (OpenAISdkClient sends
-      // reasoningEffort: 'low' for enableThinking=false, AI-SDK
-      // abstracts field name selection per model). The probes are
-      // no longer needed and have been removed.
-      // The Test Connection simply verifies the client returns a
-      // 200 (already validated by the createMessage call above).
-      this.settings.llmReady = true;
-      void this.saveSettings();
-
-      // Auto-initialize wiki structure after first successful connection
-      if (this.wikiEngine) {
-        const isInit = await this.isWikiInitialized();
-        if (!isInit) {
-          try {
-            await this.wikiEngine.ensureWikiStructure();
-            console.debug('Wiki structure auto-initialized');
-          } catch (initError) {
-            console.warn('Auto wiki init failed:', initError);
-            // Non-fatal: user can still use plugin, just needs manual init
-          }
-        }
-      }
-
-      const providerName = (PREDEFINED_PROVIDERS[this.settings.provider]?.nameEn || this.settings.provider);
-
-      // v1.23.0: re-create the shared client so any settings change takes
-      // effect immediately. The testClient is a temporary instance that
-      // only lives for the probe; the shared client used by wiki-engine,
-      // page-factory, query-engine, etc. must also reflect the change.
-      // (Previously this comment mentioned "freshly-cached
-      // thinkingControlDialect" — that field is @deprecated in v1.23.0
-      // because AI-SDK v6 handles thinking-control internally per
-      // provider/model. The shared client re-init is still useful for
-      // non-thinking-control settings changes like baseURL/apiKey.)
-      this.initializeLLMClient();
-
-      // v1.24.0 #208: per-task probe summary. In unified mode, the
-      // message names the unified model. In per-task mode, it names
-      // each probed model so the user knows which task each one covers.
-      const probeSummary = probePlan.length === 1
-        ? `${providerName} (${probePlan[0].model})`
-        : `${providerName} (ingest=${probePlan[0].model}, lint=${probePlan[1].model}, query=${probePlan[2].model})`;
-
-      return {
-        success: true,
-        message: `✅ ${t.testConnectionSuccessful || 'Connection successful'}: ${probeSummary}`
-      };
-    } catch (error) {
-      console.error('Connection test failed:', error);
-      this.settings.llmReady = false;
-      await this.saveSettings();
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      return {
-        success: false,
-        message: `❌ ${t.testConnectionFailed || 'Connection failed'}: ${errorMsg || t.errorUnknown || 'Unknown error'}`
-      };
-    }
-  }
-
-  /**
-   * Check if wiki structure exists by IO inspection (no persistent flag).
-   * Handles custom wikiFolder changes gracefully.
-   */
-  private async isWikiInitialized(): Promise<boolean> {
-    const wikiFolder = this.settings.wikiFolder || 'wiki';
-    const requiredFolders = [
-      `${wikiFolder}/entities`,
-      `${wikiFolder}/concepts`,
-      `${wikiFolder}/sources`,
-      `${wikiFolder}/schema`
-    ];
-    for (const folder of requiredFolders) {
-      const folderObj = this.app.vault.getAbstractFileByPath(folder);
-      if (!folderObj) return false;
-    }
-    return true;
-  }
-
-  private requireLLMReady(): boolean {
-    if (this.settings.llmReady) return true;
-    new Notice(getText(this.settings.language, 'llmNotReady'), NOTICE_ERROR);
-    return false;
-  }
 }
+
+// v1.25.1 Phase C-PR3: Interface merge — makes tsc see mixed-in
+// method signatures on the LLMWikiPlugin instance type.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- C-PR3 mixin pattern
+export interface LLMWikiPlugin extends PdfCacheMethods, ConnectionCommandsMethods,
+  SchemaCommandsMethods, QueryLintMethods, IngestMethods {}
+
+// v1.25.1 Phase C-PR3: prototype injection — copies runtime
+// implementations from each mixin module onto the class prototype.
+Object.assign(LLMWikiPlugin.prototype, pdfCacheCommands, connectionCommands,
+  schemaCommands, queryLintCommands, ingestCommands);
+
+export default LLMWikiPlugin;

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -559,6 +559,8 @@ export const DE_TEXTS = {
     regenerateIndexCompleted: 'Index neu generiert',
     operationFailed: 'Fehlgeschlagen: ', 
     lintFixAllComplete: 'Alle Behebungen abgeschlossen. Details im Protokoll.',
+    lintFixAllNoChanges: 'Keine Änderungen — alle Phasen meldeten 0 Behebungen. Details in wiki/log.md.',
+    lintFixPhasesLabel: 'Phasen geändert',
 
     // Lint Report Modal
     lintModalActionsTitle: 'Behebungsvorschläge (benötigt LLM-Tokens):',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -557,6 +557,8 @@ export const EN_TEXTS = {
     lintFixNoAction: 'No action taken (no client)',
     lintFixIndexUpdated: 'Wiki index and log updated.',
     lintFixAllComplete: 'All fixes complete. See log for details.',
+    lintFixAllNoChanges: 'No changes were made — all phases reported 0 fixes. Check wiki/log.md for details.',
+    lintFixPhasesLabel: 'phases modified',
     lintPollutedFixed: 'Polluted pages fixed: {fixed}/{total}. Index regenerated.',
     regenerateIndexCompleted: 'Index regenerated',
     operationFailed: 'Failed: ',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -559,6 +559,8 @@ export const ES_TEXTS = {
     regenerateIndexCompleted: 'Índice regenerado',
     operationFailed: 'Error: ', 
     lintFixAllComplete: 'Todas las correcciones completadas. Consulta el registro para más detalles.',
+    lintFixAllNoChanges: 'Sin cambios — todas las fases reportaron 0 correcciones. Detalles en wiki/log.md.',
+    lintFixPhasesLabel: 'fases modificadas',
 
     // Lint Report Modal
     lintModalActionsTitle: 'Sugerencias de corrección (requiere tokens LLM):',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -541,6 +541,8 @@ export const FR_TEXTS = {
     regenerateIndexCompleted: 'Index régénéré',
     operationFailed: 'Échec : ', 
     lintFixAllComplete: 'Toutes les réparations sont terminées. Consultez le journal pour les détails.',
+    lintFixAllNoChanges: 'Aucun changement — toutes les phases ont signalé 0 réparation. Détails dans wiki/log.md.',
+    lintFixPhasesLabel: 'phases modifiées',
 
     // Lint Report Modal
     lintModalActionsTitle: 'Suggestions de réparation (nécessite des tokens LLM) :',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -566,6 +566,8 @@ export const IT_TEXTS = {
     lintFixNoAction: 'Nessuna azione intrapresa (nessun client)',
     lintFixIndexUpdated: 'Indice e log della Wiki aggiornati.',
     lintFixAllComplete: 'Tutte le correzioni completate. Vedi il log per i dettagli.',
+    lintFixAllNoChanges: 'Nessuna modifica — tutte le fasi hanno riportato 0 correzioni. Dettagli in wiki/log.md.',
+    lintFixPhasesLabel: 'fasi modificate',
     lintPollutedFixed: 'Pagine inquinate corrette: {fixed}/{total}. Indice rigenerato.',
     regenerateIndexCompleted: 'Indice rigenerato',
     operationFailed: 'Fallito: ',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -539,6 +539,8 @@ export const JA_TEXTS = {
     regenerateIndexCompleted: 'インデックス再構築済み',
     operationFailed: '失敗：',
     lintFixAllComplete: 'すべての修復が完了しました。詳細はログを確認してください。',
+    lintFixAllNoChanges: '変更はありません — すべてのフェーズで 0 件でした。詳細は wiki/log.md を確認してください。',
+    lintFixPhasesLabel: 'フェーズが変更',
 
     // Lint Report Modal
     lintModalActionsTitle: '修復提案（LLMトークンを消費）：',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -558,6 +558,8 @@ export const KO_TEXTS = {
     regenerateIndexCompleted: '인덱스 재생성됨',
     operationFailed: '실패: ', 
     lintFixAllComplete: '모든 수정이 완료되었습니다. 자세한 내용은 로그를 확인하세요.',
+    lintFixAllNoChanges: '변경 없음 — 모든 단계에서 0건이 보고되었습니다. 자세한 내용은 wiki/log.md를 확인하세요.',
+    lintFixPhasesLabel: '단계가 수정됨',
 
     // Lint Report Modal
     lintModalActionsTitle: '수정 제안 (LLM 토큰 필요):',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -559,6 +559,8 @@ export const PT_TEXTS = {
     regenerateIndexCompleted: 'Índice regenerado',
     operationFailed: 'Falha: ', 
     lintFixAllComplete: 'Todas as correções concluídas. Consulte o log para detalhes.',
+    lintFixAllNoChanges: 'Nenhuma alteração — todas as fases reportaram 0 correções. Detalhes em wiki/log.md.',
+    lintFixPhasesLabel: 'fases modificadas',
 
     // Lint Report Modal
     lintModalActionsTitle: 'Sugestões de correção (requer tokens LLM):',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -532,6 +532,8 @@ export const ZH_HANT_TEXTS = {
     regenerateIndexCompleted: '索引已重建',
     operationFailed: '失敗：',
     lintFixAllComplete: '所有修復已完成。詳情見日誌。',
+    lintFixAllNoChanges: '未做任何修改 — 所有階段回報 0 修復。詳情見 wiki/log.md。',
+    lintFixPhasesLabel: '個階段已修改',
 
     // 维护报告弹窗
     lintModalActionsTitle: '修復建議（需消耗LLM Token）：',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -534,6 +534,8 @@ export const ZH_TEXTS = {
     regenerateIndexCompleted: '索引已重建',
     operationFailed: '失败：',
     lintFixAllComplete: '所有修复已完成。详情见日志。',
+    lintFixAllNoChanges: '未做任何修改 — 所有阶段报告 0 修复。详情见 wiki/log.md。',
+    lintFixPhasesLabel: '个阶段已修改',
 
     // 维护报告弹窗
     lintModalActionsTitle: '修复建议（需消耗LLM Token）：',

--- a/src/wiki/lint/controller.ts
+++ b/src/wiki/lint/controller.ts
@@ -675,14 +675,19 @@ export async function runLintWiki(
               detail: `${emptyPagesFilled}/${emptyPages.length}`
             });
           }
-          // v1.22.2 #204: Auto Smart Fix — show Notice with hint to History Panel
-          // rather than blocking FixReportModal.
+          // v1.25.1: smarter completion summary.
+          // - phasesRun = phases the user kicked off (input lengths > 0).
+          // - phasesModified = phases that actually wrote changes.
+          // If phasesModified === 0, every phase failed silently — surface
+          // that distinctly so the user doesn't think Fix All did nothing.
+          // Also: NOTICE_NORMAL (5s) instead of NOTICE_ERROR (8s) to match
+          // the non-blocking convention of other fix callbacks.
           const historyHint = getText(ctx.settings.language, 'ingestionNoticeHistoryHint');
-          const phaseCount = allResults.filter(r => r !== 'skipped').length;
-          new Notice(
-            `${t.lintFixAllComplete}: ${phaseCount} phases. ${historyHint}`,
-            NOTICE_ERROR
-          );
+          const phasesModified = allResults.filter(r => r !== 'skipped').length;
+          const summary = phasesModified === 0
+            ? `${t.lintFixAllComplete}: ${t.lintFixAllNoChanges}`
+            : `${t.lintFixAllComplete}: ${phasesModified} ${t.lintFixPhasesLabel}. ${historyHint}`;
+          new Notice(summary, NOTICE_NORMAL);
           } finally {
             // Issue: status bar must persist throughout all 6 phases. Match the
             // startLintOperation call above so the user can click "cancel" at any point.


### PR DESCRIPTION
## Summary

**v1.25.1 Phase C-PR3** — split `src/main.ts` (1304 LOC) into 6 mixin modules under `src/main-commands/` plus one supporting helper in `src/core/`. main.ts drops 77% (1304 → 300 LOC) with zero behavior change.

Also includes a small **UX fix** for the Smart Fix All completion Notice (user-reported during manual e2e).

### PR3: main.ts refactor (main work)

**Mixin pattern** (user-confirmed 2026-07-19): `Object.assign(LLMWikiPlugin.prototype, mixinObj)` + `export interface LLMWikiPlugin extends MixinMethods` interface merging. Preserves the `plugin.method()` call surface used by 10 existing tests (zero test changes).

| File | LOC | Role |
|---|---|---|
| `src/main.ts` | 300 (-77%) | Settings lifecycle, progress helpers, ingest dispatch, manager construction |
| `src/main-commands/pdf-cache-commands.ts` | 77 | 3 pdf-cache methods |
| `src/main-commands/connection-commands.ts` | 147 | testLLMConnection + requireLLMReady + isWikiInitialized |
| `src/main-commands/schema-commands.ts` | 104 | suggestSchemaUpdate (with inline diff/regenerate callbacks) |
| `src/main-commands/query-lint-commands.ts` | 91 | queryWiki + lintWiki + invalidateAllQueryGraphs |
| `src/main-commands/ingest-commands.ts` | 294 | 5 ingest entry points + runBatchIngest |
| `src/main-commands/command-registry.ts` | 202 | Free function — 11 addCommand + 2 ribbon + 3 callbacks + settingTab |
| `src/core/create-plugin-llm-client.ts` | 31 | Extracted from main.ts to break circular dep |

**Bug caught by code-review during refactor**: `testLLMConnection` extraction initially dropped the `isWikiInitialized + ensureWikiStructure` block that runs after first successful connection. Restored so first-time users still get wiki folder auto-creation on Test Connection.

### UX fix: lint Smart Fix All completion Notice

**User report (manual e2e)**: "After Fix All runs, no Notice seems to appear — silent."

**Root cause**: phaseCount was computed as `allResults.filter(...).length`. The `allResults` array only pushes entries when `fixed > 0`, so if every phase ran but produced 0 fixes (e.g. all LLM-fixable items were already clean), `phaseCount === 0` and the Notice read "All fixes complete. See log for details.: 0 phases." — users read "0 phases" as "nothing happened."

**Fix** (`src/wiki/lint/controller.ts:678-693`):
- Branch summary on `phasesModified === 0` with distinct "No changes were made" copy that points to `wiki/log.md` for diagnosis.
- Duration: `NOTICE_ERROR` (8s) → `NOTICE_NORMAL` (5s) to match other fix callbacks (non-blocking convention).

**i18n**: 10 locales × 2 new keys (`lintFixAllNoChanges`, `lintFixPhasesLabel`).

### Verification (Gate 1)

| Check | Result |
|---|---|
| `pnpm lint` | 0 errors, 0 warnings |
| `npx tsc --noEmit` | 0 errors |
| `pnpm test` | **2248 passed** (+12 new from `fix-all-completion-notice.test.ts`) |
| `pnpm build` | clean |
| `pnpm css-lint` | 0 violations |
| `pnpm build:dev` | clean exit + base64 sourcemap tail |

### Independent audit (diff-traced)

- ✅ 11 addCommand IDs unchanged (diff = empty).
- ✅ onload 22-step order preserved (`registerWikiCommands(this)` is a pure bundling call that replaces the inline block; order-sensitive `registerView` stays in onload **before** the bundle).
- ✅ All public method signatures preserved (interface merge + prototype injection).
- ✅ Cross-mixin self-references (e.g. `runBatchIngest!`) use optional `?:` fields on host interfaces.
- ✅ No new LLM calls / IO / prompts. Memory: `batchProgress` shared mutation pattern preserved.
- ⚠️ Known (non-blocking): same name `isWikiInitialized` exists on `LLMWikiPlugin` (async, plugin instance) and `LLMWikiSettingTab` (sync, settings-tab instance). Different instances, different signatures — no collision in current callers. Future-proofing: rename plugin-side to `checkWikiInitializedAsync()` in a follow-up.

### Risk assessment

| Dimension | Status | Notes |
|---|---|---|
| CPU | ✅ N/A | Pure module split, no new loops. |
| Memory | ✅ N/A | Mixin injection happens at module load; no runtime closures added. |
| IO | ✅ N/A | No new file reads/writes. |
| Network | ✅ N/A | No new LLM calls. |
| Token | ✅ N/A | No prompt changes. |
| Side effects | ✅ None | 11 commands + 2 ribbons + 3 callbacks registered exactly once. |
| Breaking | ✅ None | All public APIs preserved; mixin call surface identical. |