### PR TITLE
refactor: v1.25.1 PATCH post-merge simplify + correctness fixes

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -98,6 +98,17 @@ describe('classifyHeader (canonical-or-foreign, tolerant of a parenthetical suff
   it('does not treat nested parentheses as a suffix', () => {
     expect(classifyHeader('Beschreibung (a (b))', DE)).toBeNull();
   });
+
+  it('[fix] treats whitespace inside the suffix as the same identity', () => {
+    // The page carries ' (Silent Inflammation)' but the model re-emits
+    // ' ( Silent Inflammation )' — both must collapse to one section,
+    // otherwise the rewrite is read as dropping the old block and a duplicate
+    // gets appended on the next merge.
+    const a = classifyHeader('Neue Informationen (Silent Inflammation)', DE);
+    const b = classifyHeader('Neue Informationen ( Silent Inflammation )', DE);
+    expect(a).toEqual(b);
+    expect(a?.suffix).toBe('Silent Inflammation');
+  });
 });
 
 describe('preserveExistingSections (re-assert schema sections the LLM dropped)', () => {
@@ -109,7 +120,7 @@ describe('preserveExistingSections (re-assert schema sections the LLM dropped)',
   it('restores a canonical section the rewrite dropped entirely', () => {
     const oldBody = '## Beschreibung\nalter Text\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
     const newBody = '## Verwandte Konzepte\n- [[concepts/X|X]]';
-    const out = preserveExistingSections(oldBody, newBody, DE);
+    const out = preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle');
     expect(out).toContain('## Beschreibung');
     expect(out).toContain('alter Text');
   });
@@ -117,7 +128,7 @@ describe('preserveExistingSections (re-assert schema sections the LLM dropped)',
   it('leaves a section the model rewrote untouched — content is the model\'s call', () => {
     const oldBody = '## Beschreibung\nalter Text';
     const newBody = '## Beschreibung\nneuer, besserer Text';
-    const out = preserveExistingSections(oldBody, newBody, DE);
+    const out = preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle');
     expect(out).toBe(newBody);
     expect(out).not.toContain('alter Text');
   });
@@ -137,7 +148,7 @@ describe('preserveExistingSections (re-assert schema sections the LLM dropped)',
       '## Beschreibung', 'Text',
       '', '## Neue Informationen (Quercetin)', '- neuer Befund',
     ].join('\n');
-    const out = preserveExistingSections(oldBody, newBody, DE);
+    const out = preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle');
     expect(out).toContain('## Neue Informationen (Quercetin)');
     expect(out).toContain('## Neue Informationen (Silent Inflammation)');
     expect(out).toContain('- alter Befund');
@@ -145,19 +156,19 @@ describe('preserveExistingSections (re-assert schema sections the LLM dropped)',
 
   it('keeps an identical suffixed section exactly once', () => {
     const body = '## Neue Informationen (SIBO)\n- Befund';
-    expect(preserveExistingSections(body, body, DE)).toBe(body);
+    expect(preserveExistingSections(body, body, DE, 'Erwähnungen in der Quelle')).toBe(body);
   });
 
   it('does not restore a section that carried no content', () => {
     const oldBody = '## Beschreibung\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
     const newBody = '## Verwandte Konzepte\n- [[concepts/X|X]]';
-    expect(preserveExistingSections(oldBody, newBody, DE)).toBe(newBody);
+    expect(preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle')).toBe(newBody);
   });
 
   it('never restores a foreign section — only the schema is re-asserted', () => {
     const oldBody = '## Active Tag Vocabulary\n- leak\n\n## Beschreibung\nText';
     const newBody = '## Beschreibung\nText';
-    const out = preserveExistingSections(oldBody, newBody, DE);
+    const out = preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle');
     expect(out).toBe(newBody);
     expect(out).not.toContain('Active Tag Vocabulary');
   });
@@ -165,11 +176,44 @@ describe('preserveExistingSections (re-assert schema sections the LLM dropped)',
   it('ignores the lead paragraph and H1 — only `##` sections are candidates', () => {
     const oldBody = '# Titel\n\nEinleitung\n\n## Beschreibung\nText';
     const newBody = '## Beschreibung\nText';
-    expect(preserveExistingSections(oldBody, newBody, DE)).toBe(newBody);
+    expect(preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle')).toBe(newBody);
   });
 
   it('is a no-op when the rewrite kept everything', () => {
     const body = '## Beschreibung\nText\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
-    expect(preserveExistingSections(body, body, DE)).toBe(body);
+    expect(preserveExistingSections(body, body, DE, 'Erwähnungen in der Quelle')).toBe(body);
+  });
+
+  it('strips the Mentions section from the existing body internally', () => {
+    // The Mentions label is passed in by the caller (so it lives in the locale
+    // files, not a hardcoded English literal) and the helper removes it before
+    // diffing. assembleFinalContent re-attaches it programmatically.
+    const oldBody = [
+      '## Beschreibung', 'Text',
+      '', '## Erwähnungen in der Quelle', '- quote 1', '- quote 2',
+      '', '## Verwandte Konzepte', '- [[concepts/X|X]]',
+    ].join('\n');
+    const newBody = '## Verwandte Konzepte\n- [[concepts/X|X]]';
+    const out = preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle');
+    // Beschreibung restored, Mentions NOT (handled by assembleFinalContent).
+    expect(out).toContain('## Beschreibung');
+    expect(out).not.toContain('## Erwähnungen in der Quelle');
+    expect(out).not.toContain('- quote 1');
+  });
+
+  it('also strips a hallucinated Mentions section from the rewrite', () => {
+    // The LLM sometimes hallucinates a Mentions header back even though the
+    // prompt body was mentions-stripped. Without stripping the rewrite too,
+    // the section would collide with the programmatic injection below and the
+    // user would see TWO Mentions sections in the output.
+    const oldBody = '## Beschreibung\nText';
+    const newBody = [
+      '## Beschreibung', 'Text',
+      '', '## Erwähnungen in der Quelle', '- lost quote',
+    ].join('\n');
+    const out = preserveExistingSections(oldBody, newBody, DE, 'Erwähnungen in der Quelle');
+    // Hallucinated Mentions gone — assembleFinalContent will add the real one.
+    expect(out).not.toContain('## Erwähnungen in der Quelle');
+    expect(out).not.toContain('- lost quote');
   });
 });

--- a/src/core/mentions-parser.ts
+++ b/src/core/mentions-parser.ts
@@ -158,16 +158,6 @@ export function parseMentionsSection(body: string, sectionLabel: string): Parsed
   // group they sit under.
   let legacyGroupPath: string | null = null;
 
-  const push = (quote: string, translation: string | undefined, sourcePath: string) => {
-    mentions.push({
-      quote,
-      ...(translation && translation.trim() ? { translation: translation.trim() } : {}),
-      source_path: sourcePath,
-      source_slug: '',
-      extracted_at: '',
-    });
-  };
-
   for (const rawLine of content.split('\n')) {
     const line = rawLine.trim();
     if (!line) continue;
@@ -175,7 +165,13 @@ export function parseMentionsSection(body: string, sectionLabel: string): Parsed
     const flat = BULLET_RE.exec(line);
     if (flat) {
       const [, quote, translation, leftPath] = flat;
-      push(quote, translation, leftPath);
+      mentions.push({
+        quote,
+        ...(translation && translation.trim() ? { translation: translation.trim() } : {}),
+        source_path: leftPath,
+        source_slug: '',
+        extracted_at: '',
+      });
       continue;
     }
 
@@ -191,7 +187,13 @@ export function parseMentionsSection(body: string, sectionLabel: string): Parsed
     const legacyQuote = LEGACY_QUOTE_RE.exec(line);
     if (legacyQuote && legacyGroupPath) {
       const [, quote, translation] = legacyQuote;
-      push(quote, translation, legacyGroupPath);
+      mentions.push({
+        quote,
+        ...(translation && translation.trim() ? { translation: translation.trim() } : {}),
+        source_path: legacyGroupPath,
+        source_slug: '',
+        extracted_at: '',
+      });
       continue;
     }
 

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -1,5 +1,6 @@
 // Section-header canonicalizer — deterministic repair of LLM-garbled section headers.
 // Pure, no LLM, O(lines × labels).
+import { stripMentionsSection } from './mentions-parser';
 //
 // The generation/merge prompts hand the model the exact section labels
 // (`## {{section_...}}` resolved via applySectionLabels) and it is expected to copy
@@ -113,12 +114,11 @@ export function classifyHeader(
   const m = /^(.*?)\s*\(([^()]*)\)\s*$/.exec(header);
   if (!m) return null;
   const base = snapHeaderToCanonical(m[1].trim(), canonicalLabels);
-  return base === null ? null : { label: base, suffix: m[2] };
-}
-
-/** Stable key for a section identity — canonical label plus suffix. */
-export function sectionIdentityKey(id: SectionIdentity): string {
-  return id.suffix === null ? id.label : `${id.label} (${id.suffix})`;
+  if (base === null) return null;
+  // Trim the suffix so whitespace inside the parens does not split what is
+  // logically one section: the model may emit " ( Silent Inflammation )" and
+  // the page may carry " (Silent Inflammation)" — same identity either way.
+  return { label: base, suffix: m[2].trim() };
 }
 
 export function canonicalizeSectionHeaders(content: string, canonicalLabels: string[]): string {
@@ -157,7 +157,7 @@ function canonicalSectionBlocks(
     if (m) {
       flush();
       const id = classifyHeader(m[1], canonicalLabels);
-      key = id ? sectionIdentityKey(id) : null;
+      key = id ? (id.suffix === null ? id.label : `${id.label} (${id.suffix})`) : null;
       lines = key ? [line] : [];
       continue;
     }
@@ -178,8 +178,8 @@ function canonicalSectionBlocks(
  * for good.
  *
  * The schema, not the model, decides which sections must exist, so restore any
- * canonical section that carried content in `oldBody` and is wholly absent from
- * `newBody`. Conservative by construction: it only ever APPENDS a dropped
+ * canonical section that carried content in `existingBody` and is wholly absent
+ * from `rewrite`. Conservative by construction: it only ever APPENDS a dropped
  * section back (at the end, in first-seen order) — it never edits or removes
  * what the model produced, so a section the model legitimately rewrote (its
  * identity still present, however much its content changed) is left untouched.
@@ -190,17 +190,22 @@ function canonicalSectionBlocks(
  * one section that repeats: emitting `## New Information (Source B)` must not
  * count as keeping `## New Information (Source A)`.
  *
- * `oldBody` must be mentions-stripped so the Mentions label is never a candidate
- * here — that section is re-attached separately by assembleFinalContent. Pure,
- * O(lines × labels).
+ * The Mentions section is stripped from BOTH sides before diffing: from the
+ * existing body so it is never a candidate here, and from the rewrite too,
+ * because the model occasionally hallucinates a Mentions header back even
+ * though the prompt body was mentions-stripped. assembleFinalContent re-attaches
+ * it programmatically below — once, at the right anchor. Pure, O(lines × labels).
  */
 export function preserveExistingSections(
-  oldBody: string,
-  newBody: string,
+  existingBody: string,
+  rewrite: string,
   canonicalLabels: string[],
+  mentionsLabel: string,
 ): string {
-  const oldBlocks = canonicalSectionBlocks(oldBody, canonicalLabels);
-  const newBlocks = canonicalSectionBlocks(newBody, canonicalLabels);
+  const strippedExisting = stripMentionsSection(existingBody, mentionsLabel);
+  const strippedRewrite = stripMentionsSection(rewrite, mentionsLabel);
+  const oldBlocks = canonicalSectionBlocks(strippedExisting, canonicalLabels);
+  const newBlocks = canonicalSectionBlocks(strippedRewrite, canonicalLabels);
 
   const restored: string[] = [];
   for (const [key, block] of oldBlocks) {
@@ -211,6 +216,6 @@ export function preserveExistingSections(
       restored.push(block.join('\n').replace(/\s+$/, ''));
     }
   }
-  if (restored.length === 0) return newBody;
-  return `${newBody.replace(/\s+$/, '')}\n\n${restored.join('\n\n')}\n`;
+  if (restored.length === 0) return strippedRewrite;
+  return `${strippedRewrite.replace(/\s+$/, '')}\n\n${restored.join('\n\n')}\n`;
 }

--- a/src/wiki/page-factory/complementary-appends.ts
+++ b/src/wiki/page-factory/complementary-appends.ts
@@ -171,9 +171,11 @@ export function spliceAfterSection(
 }
 
 /**
- * Build a "## New Information ({{source}})" section for failed groups
- * whose section could not be resolved or the per-section LLM returned
- * NO_NEW_CONTENT. Collects all items from all failed groups.
+ * Build a "## {{newInformationLabel}} ({{sourceBasename}})" section for failed
+ * groups whose section could not be resolved or the per-section LLM returned
+ * NO_NEW_CONTENT. Collects all items from all failed groups. The label is the
+ * locale's localized `new_information` value, so non-English vaults emit a
+ * canonical header on first write.
  */
 export function makeFallbackNewInfoSection(
   failedGroups: string[],

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -39,7 +39,6 @@ import {
   canonicalizeSectionHeaders,
   preserveExistingSections,
 } from '../../core/section-header-canonicalizer';
-import { stripMentionsSection } from '../../core/mentions-parser';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
@@ -181,12 +180,12 @@ export async function mergePage(
     );
     // Completeness is the schema's call, not the model's: restore any canonical
     // section that carried content before the rewrite and is wholly absent from
-    // it. The old body is mentions-stripped first so that section is never a
-    // candidate here — assembleFinalContent re-attaches it below.
+    // it. The Mentions section is re-attached by assembleFinalContent below.
     const guardedBody = preserveExistingSections(
-      stripMentionsSection(existingBody, labels.mentions_in_source),
+      existingBody,
       correctedBody,
       Object.values(labels),
+      labels.mentions_in_source,
     );
     await ctx.createOrUpdateFile(
       path,

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -149,13 +149,12 @@ export async function updateRelatedPage(
 
   // Completeness is the schema's call, not the model's: restore any canonical
   // section that carried content before the rewrite and is wholly absent from
-  // it. `promptBody` is the mentions-stripped body the model actually saw, so
-  // the Mentions section is never a candidate here — assembleFinalContent
-  // re-attaches it below.
+  // it. The Mentions section is re-attached by assembleFinalContent below.
   const guardedBody = preserveExistingSections(
     promptBody,
     correctedBody,
     Object.values(labels),
+    labels.mentions_in_source,
   );
 
   // 2. Assemble: programmatic frontmatter + LLM body + Mentions section.


### PR DESCRIPTION
Follow-up to PRs #303 and #302 (both squash-merged to main).

## What this PR does

Two correctness fixes discovered during independent audit + simplify, plus four simplification of the merged code.

### Correctness

1. **`classifyHeader` trims whitespace inside the suffix** — without this, a model that emits `( Silent Inflammation )` would be read as a different section and a duplicate would be appended on the next merge.

2. **`preserveExistingSections` strips Mentions from BOTH sides** and returns the stripped rewrite. The LLM occasionally hallucinates a Mentions header back into the body even though the prompt body was mentions-stripped. Without this, that hallucinated section collides with `assembleFinalContent`'s programmatic injection and the user sees two Mentions sections in the output.

### Simplification

3. **`stripMentionsSection` lifted into `preserveExistingSections`** (4-arg signature: existingBody, rewrite, labels, mentionsLabel). Removes the caller-filters-then-helper pattern that leaked the Mentions-strip precondition across merge-page.ts and related-page.ts.

4. **`sectionIdentityKey` inlined** (one call site, trivial format string).

5. **`push()` closure in `parseMentionsSection` inlined** (two call sites, no reuse benefit).

6. **`makeFallbackNewInfoSection` docstring updated** to reflect the localized-label parameter (was still claiming `New Information` literal).

## Tests

- +3 regression tests (suffix whitespace, Mentions strip on existing body, Mentions strip on hallucinated rewrite)
- All 2271 existing tests still pass
- Total: 2274 tests pass

## Gate 1

```
lint        0 errors, 0 warnings
tsc         0 errors
test        2274/2274 passed
build       esbuild clean exit
css-lint    0 violations
```

## Diff stat

```
6 files changed, 99 insertions(+), 48 deletions(-)
```

## Relationship to squash-merged PRs

PRs #303 and #302 are squash-merged to main as `8852d0a` and `2b821d4` respectively. This PR is based on `origin/main` (which includes both) and adds the post-merge cleanup as a follow-up commit. DocTpoint retains author credit for the original work; the cleanup is by green-dalii.