### PR TITLE
fix(analyzer): route truncated responses into the halving retry (#305)

### DIFF
--- a/src/__tests__/wiki/source-analyzer-truncation-retry.test.ts
+++ b/src/__tests__/wiki/source-analyzer-truncation-retry.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { SourceAnalyzer } from '../../wiki/source-analyzer';
+import { normalizeFinishReason } from '../../llm-sdk/finish-reason';
+import type { LLMClient, LLMFinishReason } from '../../types';
+import { TFile } from 'obsidian';
+
+// Issue #305 — a truncated batch response is not an error.
+//
+// An OpenAI-compatible provider that hits the token limit returns HTTP 200
+// with a body that stops mid-token. The call does not throw, so the halving
+// retry that lived in the `catch` block never ran: `parseJsonResponse`
+// returned null and the batch was dropped silently (`break`), or the whole
+// ingest failed (`return null` on the first batch).
+//
+// These tests drive the analyzer through a client that reports
+// `finishReason: 'length'`, which is what the SDK normalizes the provider's
+// `finish_reason` field into.
+
+const TEST_PATH = 'sources/truncation.md';
+
+/** A response body cut off mid-token: valid JSON prefix, no closing braces. */
+const TRUNCATED = '{"source_title": "Protein misfolding", "entities": [{"name": "Amyloid", "summary": "Aggregation occurs spontane';
+
+const VALID = JSON.stringify({
+  source_title: 'Protein misfolding',
+  summary: 'A note about protein misfolding.',
+  entities: [{ name: 'Amyloid', type: 'other', summary: 'An aggregate', mentions_in_source: [] }],
+});
+
+interface ScriptedReply {
+  text: string;
+  /** Omitted for clients/paths that report nothing — the pre-#305 situation. */
+  finishReason?: LLMFinishReason;
+}
+
+/**
+ * Client that replays a script of *extraction* replies and reports
+ * `finishReason` through the optional `onFinish` out-channel, the way the
+ * SDK-backed clients do.
+ *
+ * `parseJsonResponse` may issue a JSON-repair call on the same client. Those
+ * are identified by their prompt and answered by echoing the broken text
+ * back unchanged — a repair cannot reconstruct content that was never
+ * emitted (that is the point of #305), and they carry no finish reason
+ * because the repair call site does not pass `onFinish`. Keeping them out of
+ * the script means the script indexes extraction attempts only.
+ */
+function scriptedClient(replies: ScriptedReply[]): {
+  client: LLMClient;
+  prompts: string[];
+} {
+  const prompts: string[] = [];
+  let idx = 0;
+  let lastText = '';
+  const client: LLMClient = {
+    createMessage: async (params) => {
+      const first = params.messages[0];
+      const prompt = typeof first.content === 'string' ? first.content : '';
+      if (prompt.startsWith('Fix the following malformed JSON')) return lastText;
+      prompts.push(prompt);
+      const reply = replies[idx++];
+      if (!reply) throw new Error(`unscripted extraction call #${idx}`);
+      if (reply.finishReason) params.onFinish?.({ finishReason: reply.finishReason });
+      lastText = reply.text;
+      return reply.text;
+    },
+  };
+  return { client, prompts };
+}
+
+function analyzerWith(client: LLMClient): SourceAnalyzer {
+  const { ctx } = createMockContext({
+    vaultFiles: { [TEST_PATH]: '# Protein misfolding\nA note with content to extract.' },
+  });
+  ctx.getClient = () => client;
+  return new SourceAnalyzer(ctx);
+}
+
+function run(analyzer: SourceAnalyzer) {
+  // The SourceAnalyzer only reads file.path and file.basename.
+  // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+  return analyzer.analyzeSource(createMockFile(TEST_PATH) as unknown as TFile);
+}
+
+/** `Output at most N items` — how the batch size reaches the model. */
+function batchSizeOf(prompt: string): number | null {
+  const m = prompt.match(/at most (\d+) items/);
+  return m ? Number(m[1]) : null;
+}
+
+describe('SourceAnalyzer truncation retry (#305)', () => {
+  it('retries with a halved batch instead of dropping a truncated first batch', async () => {
+    // 1st extraction: truncated + finish_reason=length
+    // 2nd extraction: succeeds, after the batch was halved
+    const { client, prompts } = scriptedClient([
+      { text: TRUNCATED, finishReason: 'length' },
+      { text: VALID, finishReason: 'stop' },
+    ]);
+
+    const result = await run(analyzerWith(client));
+
+    // Before the fix this returned null: the parse failure hit `return null`
+    // on the first batch and the halving retry was never reached.
+    expect(result).not.toBeNull();
+    expect(result!.entities.map(e => e.name)).toEqual(['Amyloid']);
+
+    const mainPrompts = prompts.filter(p => batchSizeOf(p) !== null);
+    expect(mainPrompts.length).toBeGreaterThanOrEqual(2);
+    expect(batchSizeOf(mainPrompts[1])!).toBeLessThan(batchSizeOf(mainPrompts[0])!);
+  });
+
+  it('does not retry when the parse failed for a reason other than truncation', async () => {
+    // Malformed but complete: halving the batch would not help, so the
+    // pre-#305 behavior (give up on this batch) must be preserved.
+    const { client, prompts } = scriptedClient([
+      { text: '{"entities": [oops]}', finishReason: 'stop' },
+    ]);
+
+    const result = await run(analyzerWith(client));
+
+    expect(result).toBeNull();
+    expect(prompts.filter(p => batchSizeOf(p) !== null)).toHaveLength(1);
+  });
+
+  it('does not retry when the client reports no finish reason (pre-#305 clients)', async () => {
+    // A client that never calls `onFinish` must behave exactly as before:
+    // no signal, no retry.
+    const { client, prompts } = scriptedClient([
+      { text: TRUNCATED },
+    ]);
+
+    const result = await run(analyzerWith(client));
+
+    expect(result).toBeNull();
+    expect(prompts.filter(p => batchSizeOf(p) !== null)).toHaveLength(1);
+  });
+
+  it('halves only once — a second truncation is not retried again', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { client, prompts } = scriptedClient([
+      { text: TRUNCATED, finishReason: 'length' },
+      { text: TRUNCATED, finishReason: 'length' },
+    ]);
+
+    const result = await run(analyzerWith(client));
+
+    expect(result).toBeNull();
+    expect(prompts.filter(p => batchSizeOf(p) !== null)).toHaveLength(2);
+    expect(warn.mock.calls.filter(c => String(c[0]).includes('halving batch size'))).toHaveLength(1);
+    warn.mockRestore();
+  });
+});
+
+describe('normalizeFinishReason (#305)', () => {
+  it.each([
+    ['stop', 'stop'],
+    ['length', 'length'],
+    ['content-filter', 'content-filter'],
+    ['tool-calls', 'tool-calls'],
+    ['error', 'error'],
+    ['other', 'other'],
+  ] as const)('passes through the known reason %s', (raw, expected) => {
+    expect(normalizeFinishReason(raw)).toBe(expected);
+  });
+
+  it.each([
+    [undefined],
+    [null],
+    [''],
+    ['LENGTH'],
+    ['max_tokens'],
+    [42],
+    [{}],
+  ])('maps unrecognized input %o to unknown', (raw) => {
+    // Total on purpose: an unrecognized value must not be mistaken for
+    // 'length', so the worst case is "no signal", i.e. pre-#305 behavior.
+    expect(normalizeFinishReason(raw)).toBe('unknown');
+  });
+});

--- a/src/llm-sdk/anthropic-sdk-client.ts
+++ b/src/llm-sdk/anthropic-sdk-client.ts
@@ -28,6 +28,7 @@ import {
   resolveBaseUrlWithFallback,
   isUrlError,
 } from '../core/url-fallback';
+import { reportFinish } from './finish-reason';
 
 // Re-export for callers that import from anthropic-sdk-client only.
 // Reuse the same error mapper as OpenAI — AI-SDK's APICallError shape is
@@ -104,7 +105,7 @@ export class AnthropicSdkClient implements LLMClient {
   }
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
-    const { model, max_tokens, system, messages, temperature, repetition_penalty, enableThinking } = params;
+    const { model, max_tokens, system, messages, temperature, repetition_penalty, enableThinking, onFinish } = params;
 
     try {
       const languageModel = this.getProvider(model, this.fetchImpl);
@@ -122,6 +123,7 @@ export class AnthropicSdkClient implements LLMClient {
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
         ...(temperature !== undefined ? { temperature } : {}),
       });
+      reportFinish(onFinish, result.finishReason);
       return result.text;
     } catch (err) {
       // v1.23.0 P1.5: URL fallback for custom baseURLs (Kimi / z.ai / GLM).
@@ -150,6 +152,7 @@ export class AnthropicSdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
+        reportFinish(onFinish, result.finishReason);
         return result.text;
       }
       throw mapAiSdkError(err);

--- a/src/llm-sdk/finish-reason.ts
+++ b/src/llm-sdk/finish-reason.ts
@@ -1,0 +1,49 @@
+// Issue #305: surface *why* the provider stopped generating.
+//
+// An OpenAI-compatible provider does not throw when it hits the token limit.
+// It returns HTTP 200 and a body that stops mid-token, so a caller that only
+// sees the response text cannot distinguish "the model finished" from "the
+// model was cut off". The AI SDK already normalizes this into
+// `result.finishReason`; every client here simply dropped it on `return
+// result.text`. These helpers carry it to callers that opt in.
+
+import type { LLMFinishReason } from '../types';
+
+const KNOWN_FINISH_REASONS: readonly LLMFinishReason[] = [
+  'stop',
+  'length',
+  'content-filter',
+  'tool-calls',
+  'error',
+  'other',
+  'unknown',
+];
+
+/**
+ * Map an SDK-reported finish reason onto our union.
+ *
+ * Deliberately total: anything unrecognized (including `undefined`, which is
+ * what a provider that omits the field yields) becomes `'unknown'` rather
+ * than throwing. A caller acting on `'length'` therefore never fires on a
+ * value it did not understand — the failure mode is "no signal", which is
+ * exactly the pre-#305 behavior.
+ */
+export function normalizeFinishReason(raw: unknown): LLMFinishReason {
+  return typeof raw === 'string' && (KNOWN_FINISH_REASONS as readonly string[]).includes(raw)
+    ? (raw as LLMFinishReason)
+    : 'unknown';
+}
+
+/**
+ * Invoke the optional `onFinish` callback with a normalized reason.
+ *
+ * No-op when the caller did not pass one, which keeps every existing call
+ * site and every mock client unchanged.
+ */
+export function reportFinish(
+  onFinish: ((meta: { finishReason: LLMFinishReason }) => void) | undefined,
+  raw: unknown,
+): void {
+  if (!onFinish) return;
+  onFinish({ finishReason: normalizeFinishReason(raw) });
+}

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -29,6 +29,7 @@ import {
   isUrlError,
 } from '../core/url-fallback';
 import { TokenKeyProber } from './token-key-probe';
+import { reportFinish } from './finish-reason';
 
 export interface OpenAICompatSdkClientOptions {
   apiKey: string;
@@ -138,7 +139,7 @@ export class OpenAICompatSdkClient implements LLMClient {
   }
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
-    const { model, max_tokens, system, messages, temperature, repetition_penalty, enableThinking, response_format } = params;
+    const { model, max_tokens, system, messages, temperature, repetition_penalty, enableThinking, response_format, onFinish } = params;
 
     try {
       const languageModel = this.getProvider(model, this.fetchImpl);
@@ -156,6 +157,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
         ...(temperature !== undefined ? { temperature } : {}),
       });
+      reportFinish(onFinish, result.finishReason);
       return result.text;
     } catch (err) {
       // v1.23.0 P1.5: URL fallback for custom baseURLs.
@@ -183,6 +185,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
+        reportFinish(onFinish, result.finishReason);
         return result.text;
       }
 
@@ -214,6 +217,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
+        reportFinish(onFinish, result.finishReason);
         return result.text;
       }
 

--- a/src/llm-sdk/openai-sdk-client.ts
+++ b/src/llm-sdk/openai-sdk-client.ts
@@ -37,6 +37,7 @@ import {
   resolveBaseUrlWithFallback,
   isUrlError,
 } from '../core/url-fallback';
+import { reportFinish } from './finish-reason';
 
 export interface OpenAISdkClientOptions {
   apiKey: string;
@@ -123,7 +124,7 @@ export class OpenAISdkClient implements LLMClient {
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
     // Type-safe params destructure (LLMClient.createMessage signature).
-    const { model, max_tokens, system, messages, temperature, repetition_penalty, enableThinking, response_format } = params;
+    const { model, max_tokens, system, messages, temperature, repetition_penalty, enableThinking, response_format, onFinish } = params;
 
     try {
       const languageModel = this.getProvider(model, this.fetchImpl);
@@ -150,6 +151,7 @@ export class OpenAISdkClient implements LLMClient {
         ...(temperature !== undefined ? { temperature } : {}),
         // Top-level repetition_penalty is non-standard for OpenAI; pass via providerOptions.
       });
+      reportFinish(onFinish, result.finishReason);
       return result.text;
     } catch (err) {
       // v1.23.0 P1.5: URL fallback for custom baseURLs (Kimi / z.ai / GLM).
@@ -177,6 +179,7 @@ export class OpenAISdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
+        reportFinish(onFinish, result.finishReason);
         return result.text;
       }
       throw mapAiSdkError(err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -480,6 +480,25 @@ export type MessageContentPart =
   | { type: 'text'; text: string }
   | { type: 'file'; data: string; mediaType: 'application/pdf'; filename?: string };
 
+/**
+ * Why the provider stopped generating. Mirrors the AI SDK v6 `FinishReason`
+ * union, which normalizes the OpenAI `finish_reason` field and the Anthropic
+ * `stop_reason` field into one vocabulary.
+ *
+ * Issue #305: `'length'` is the only reliable truncation signal. An
+ * OpenAI-compatible provider does not throw on truncation — it returns HTTP
+ * 200 with a body that stops mid-token — so callers that only observe the
+ * response text cannot tell a truncated answer from a complete one.
+ */
+export type LLMFinishReason =
+  | 'stop'
+  | 'length'
+  | 'content-filter'
+  | 'tool-calls'
+  | 'error'
+  | 'other'
+  | 'unknown';
+
 export interface LLMClient {
   createMessage(params: {
     model: string;
@@ -500,6 +519,13 @@ export interface LLMClient {
     // finishing the post-conversion phase. AI SDK v6 accepts this
     // natively; legacy clients ignore it.
     abortSignal?: AbortSignal;
+    // Issue #305: optional out-channel for response metadata. The SDK-backed
+    // clients invoke this once, immediately before returning the text. It is
+    // additive on purpose — `createMessage` keeps returning `Promise<string>`,
+    // so every existing caller and every mock client is unaffected. Callers
+    // that need to distinguish "the model finished" from "the model ran out
+    // of tokens" opt in; callers that do not, see no change.
+    onFinish?: (meta: { finishReason: LLMFinishReason }) => void;
   }): Promise<string>;
 
   createMessageStream?(params: {

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -28,6 +28,7 @@ import {
   ContradictionInfo,
   MentionWithProvenance,
   WIKI_LANGUAGES,
+  LLMFinishReason,
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { parseJsonResponse } from '../core/json';
@@ -217,6 +218,22 @@ export class SourceAnalyzer {
     let batchSizeHalved = false;
     let retryingBatch = false; // one retry on truncation: halve batch size
 
+    // Issue #305: the halving retry below used to live only in the catch
+    // block, so it required the provider call to *throw*. An
+    // OpenAI-compatible provider does not throw on truncation — it returns
+    // HTTP 200 with a body that stops mid-token — so the batch fell through
+    // to the parse-failure `break` and was dropped silently. Hoisted into a
+    // closure so the parse-failure path and the catch path share one
+    // implementation. Returns whether the caller should re-run this batch;
+    // the caller owns the loop control (`batchNum--; continue;`).
+    const halveBatchAndRetry = (batchLabel: string, cause: string): boolean => {
+      if (retryingBatch || currentBatchSize <= limits.minBatchSize) return false;
+      currentBatchSize = Math.max(limits.minBatchSize, Math.floor(currentBatchSize * 0.5));
+      console.warn(`${batchLabel} Truncation detected (${cause}), halving batch size to ${currentBatchSize} and retrying`);
+      retryingBatch = true;
+      return true;
+    };
+
     // Initialize batch accumulation using pure function (Phase 3)
     const accumulation = createEmptyAccumulation();
 
@@ -325,6 +342,11 @@ export class SourceAnalyzer {
         // per-task routing would be impossible from console alone.
         const resolvedModel = resolveModelForTask(this.ctx.settings, 'ingest');
         console.debug(`[Batch ${batchNum + 1}] Provider:`, this.ctx.settings.provider, '| Model:', resolvedModel, '| Prompt:', finalPrompt.length, 'chars', '| max_tokens:', batchMaxTokens);
+        // Issue #305: record why generation stopped. Clients that do not
+        // report it leave this at 'unknown', which keeps pre-#305 behavior.
+        // Held in an object rather than a bare `let` so control-flow analysis
+        // does not narrow it to its initializer across the callback.
+        const finish: { reason: LLMFinishReason } = { reason: 'unknown' };
         const response = await client.createMessage({
           model: resolvedModel,
           max_tokens: batchMaxTokens,
@@ -333,6 +355,7 @@ export class SourceAnalyzer {
           response_format: { type: 'json_object' },
           cacheBreakpoint: staticPrefix.length,
           maxTokensPerCall: retryCap,
+          onFinish: (meta) => { finish.reason = meta.finishReason; },
         });
 
         console.debug(`[Batch ${batchNum + 1}] Response length:`, response.length);
@@ -351,6 +374,19 @@ export class SourceAnalyzer {
         }, { silentOnEmpty: true }) as Partial<SourceAnalysis> | null;
 
         if (!analysisData) {
+          // Issue #305: a truncated response is not malformed JSON, it is
+          // *incomplete* JSON — the repair callback above cannot restore
+          // content that was never emitted, and it re-hits the same limit
+          // trying. When the provider tells us it ran out of tokens, halve
+          // the batch and re-run instead of dropping it. Applies to the
+          // first batch too: the alternative there is `return null`, i.e.
+          // the whole ingest fails, so one bounded retry is strictly
+          // better. `retryingBatch` and `minBatchSize` bound it to a single
+          // extra attempt.
+          if (finish.reason === 'length' && halveBatchAndRetry(`[Batch ${batchNum + 1}]`, 'finish_reason=length')) {
+            batchNum--;
+            continue;
+          }
           console.error(`[Batch ${batchNum + 1}] JSON parse failed, skipping batch`);
           if (isFirstBatch) return null;
           break;
@@ -474,10 +510,7 @@ export class SourceAnalyzer {
 
         const errMsg = error instanceof Error ? error.message : String(error);
         const isTruncation = errMsg.toLowerCase().includes('truncated') || errMsg.toLowerCase().includes('max_tokens');
-        if (!retryingBatch && isTruncation && currentBatchSize > limits.minBatchSize) {
-          currentBatchSize = Math.max(limits.minBatchSize, Math.floor(currentBatchSize * 0.5));
-          console.warn(`[Batch ${batchNum + 1}] Truncation detected, halving batch size to ${currentBatchSize} and retrying`);
-          retryingBatch = true;
+        if (isTruncation && halveBatchAndRetry(`[Batch ${batchNum + 1}]`, 'provider error')) {
           batchNum--;
           continue;
         }


### PR DESCRIPTION
Fixes #305.

## The signal was already arriving

The halving retry lived only in the `catch` block, so it required the provider call to throw. An OpenAI-compatible provider does not throw on truncation — it returns HTTP 200 with a body that stops mid-token. The batch then failed to parse and fell through to `break`, or to `return null` on the first batch.

What I did not expect when I opened the issue: the information needed to tell "finished" from "ran out of tokens" was already in the process. The AI SDK normalizes the provider's `finish_reason` into `result.finishReason`, and all three SDK-backed clients discarded it on the next line:

```ts
const result = await generateText({ ... });
return result.text;              // openai-compat:159, :186, :217
```

`finish_reason` appears nowhere in `src/` today, so no caller in the plugin can currently see why a generation ended. That is a wider gap than #305 — truncation is invisible everywhere, not just in the analyzer — but this PR only wires the one path the issue is about.

## What changed

- `LLMFinishReason` + an optional `onFinish` callback on the `createMessage` params (`types.ts`). **Additive on purpose:** the return type stays `Promise<string>`, so every existing caller and every mock client is untouched. Changing the return type would have reached every call site in the plugin, which felt wrong for a PATCH.
- The three SDK clients report it at every return site through one shared normalizer (`llm-sdk/finish-reason.ts`). `normalizeFinishReason` is total — anything unrecognized becomes `'unknown'`, so an unfamiliar value can never be mistaken for `'length'`. A client that never calls `onFinish` leaves the analyzer at `'unknown'`, i.e. exactly the pre-#305 behavior.
- In the analyzer's parse-failure branch: when the provider reported `length`, halve the batch and re-run instead of dropping it. The JSON-repair callback cannot help here — truncated JSON is missing content, not malformed syntax, and the repair call re-hits the same limit trying to re-emit everything.
- The halving block is hoisted out of the `catch` into a closure both paths call, as you suggested. The closure returns whether to re-run; the caller keeps the loop control (`batchNum--; continue;`) since a closure cannot `continue`.

## Two deviations from your suggested fix path, flagged deliberately

**1. I did not implement the response-length heuristic.** You suggested capturing raw length and comparing it against `maxTokensPerCall`. I left that out: the response is measured in characters and the cap in tokens, and the ratio between them varies by language — a German vault and a Chinese one would need different thresholds. That would be a tunable constant to maintain, which is the same trade you declined on the auto-curve in #168. `finishReason` is the provider's own statement and needs no constant, so I used it alone. Happy to add the heuristic as a fallback if you want coverage for providers that report nothing.

**2. The retry now also covers the first batch.** Your step 2 spoke of routing the parse-failure branch into the retry without distinguishing batches. On the first batch the current alternative is `return null`, i.e. the whole ingest fails, so one bounded attempt is strictly better. `retryingBatch` and `minBatchSize` bound it to a single extra call either way. Say the word if you want it narrowed to later batches.

## Scope left out

The second half of the issue — marking a partially-extracted source page so a coverage check can see it needs a re-run — is not in this PR. That is a design decision about frontmatter or logging, and I still have no strong opinion on the shape.

The streaming path (`createMessageStream`) is untouched; the analyzer does not use it.

## Tests

17 new tests. Four drive the analyzer through a client that reports `finishReason`, covering: truncation retried with a halved batch; a complete-but-malformed response *not* retried; a client that reports nothing behaving exactly as before; and the halving firing only once. The remaining 13 cover `normalizeFinishReason` against known and unrecognized inputs.

Gate 1 on `3578a9d`: lint 0/0, tsc 0, build clean, css-lint 0, **2296 tests passing — baseline `upstream/main` measured separately at 2279, so the delta is exactly the 17 tests added here.**
