### PR TITLE
fix(lint): match dead-link targets against slug-normalized titles and aliases (#308)

### DIFF
--- a/src/core/dead-link-detector.test.ts
+++ b/src/core/dead-link-detector.test.ts
@@ -41,8 +41,16 @@ describe('Dead Link Detector — Pure Functions', () => {
     });
 
     it('handles path in target (extracts basename)', () => {
+      // #308: the basename is still extracted; it now also resolves, because
+      // "attention-mechanism" and "Attention Mechanism" are the slugified and
+      // the unslugified form of the same name. Before #308 this returned
+      // undefined and the caller paid an LLM round trip for it.
       const result = findDeadLinkTarget(mockPages, 'concepts/attention-mechanism');
-      // Should extract "attention-mechanism" and not match any title
+      expect(result?.title).toBe('Attention Mechanism');
+    });
+
+    it('extracts the basename and does not match the folder part', () => {
+      const result = findDeadLinkTarget(mockPages, 'attention-mechanism/nonexistent');
       expect(result).toBeUndefined();
     });
 
@@ -79,6 +87,88 @@ describe('Dead Link Detector — Pure Functions', () => {
       ];
       const result = findDeadLinkTarget(pages, 'Shared');
       expect(result?.title).toBe('Page 1');
+    });
+
+    // #308: a wiki link carries the slugified name, a title or alias carries the
+    // written one. The pre-check compared them raw, so hyphen never met space.
+    describe('slug-normalized matching (#308)', () => {
+      const slugPages: PageRef[] = [
+        {
+          path: 'wiki/concepts/systemische-inflammation.md',
+          title: 'Systemische-Inflammation',
+          aliases: ['Systemische Inflammation'],
+        },
+        { path: 'wiki/entities/nervus-vagus.md', title: 'Nervus vagus' },
+        {
+          path: 'wiki/concepts/kurzkettige-fettsäuren.md',
+          title: 'Kurzkettige Fettsäuren',
+          aliases: ['SCFA'],
+        },
+        { path: 'wiki/entities/chain-of-thought.md', title: 'Chain of Thought' },
+      ];
+
+      it.each([
+        // link target                  | expected page title        | why
+        ['systemische-inflammation', 'Systemische-Inflammation'], // exact title, unchanged
+        ['Systemische-Inflammation', 'Systemische-Inflammation'], // case-insensitive title, unchanged
+        ['nervus-vagus', 'Nervus vagus'], // hyphen vs. space in the title
+        ['Nervus-Vagus', 'Nervus vagus'], // hyphen vs. space, different case
+        ['kurzkettige-fettsäuren', 'Kurzkettige Fettsäuren'], // umlaut survives slugify
+        ['chain-of-thought', 'Chain of Thought'], // multi-word English case
+        ['SCFA', 'Kurzkettige Fettsäuren'], // alias, exact — unchanged path
+      ])('resolves %j to %j', (linkTarget, expectedTitle) => {
+        expect(findDeadLinkTarget(slugPages, linkTarget)?.title).toBe(
+          expectedTitle
+        );
+      });
+
+      it.each([
+        ['nervus-vagus-dorsalis'], // near miss, not the same name
+        ['systemische'], // prefix only
+        ['völlig-unbekannt'], // nothing like it in the vault
+      ])('leaves %j unresolved', linkTarget => {
+        expect(findDeadLinkTarget(slugPages, linkTarget)).toBeUndefined();
+      });
+
+      it('resolves a slugified link to an unslugified alias', () => {
+        const pages: PageRef[] = [
+          {
+            path: 'wiki/concepts/scfa.md',
+            title: 'SCFA',
+            aliases: ['Kurzkettige Fettsäuren'],
+          },
+        ];
+        const result = findDeadLinkTarget(pages, 'Kurzkettige-Fettsäuren');
+        expect(result?.title).toBe('SCFA');
+      });
+
+      it('prefers an exact alias match over a slug title match on another page', () => {
+        // Tier order matters: the exact match is the stronger evidence, so the
+        // slug tiers must not overtake it just because they run over the same
+        // page list.
+        const pages: PageRef[] = [
+          {
+            path: 'wiki/concepts/other.md',
+            title: 'Other',
+            aliases: ['nervus-vagus'],
+          },
+          { path: 'wiki/entities/nervus-vagus.md', title: 'Nervus vagus' },
+        ];
+        const result = findDeadLinkTarget(pages, 'nervus-vagus');
+        expect(result?.title).toBe('Other');
+      });
+
+      it('does not let an empty alias match a link to "untitled"', () => {
+        const pages: PageRef[] = [
+          { path: 'wiki/entities/page.md', title: 'Page', aliases: ['', '  '] },
+        ];
+        expect(findDeadLinkTarget(pages, 'untitled')).toBeUndefined();
+      });
+
+      it('does not let an empty title match a link to "untitled"', () => {
+        const pages: PageRef[] = [{ path: 'wiki/entities/page.md', title: '' }];
+        expect(findDeadLinkTarget(pages, 'untitled')).toBeUndefined();
+      });
     });
   });
 

--- a/src/core/dead-link-detector.ts
+++ b/src/core/dead-link-detector.ts
@@ -2,15 +2,31 @@
 // Extracted from lint-fixes.ts::fixDeadLink()
 // Zero side effects, fully testable
 
+import { computeSlug } from './slug';
+
 export interface PageRef {
   path: string;
   title: string;
   aliases?: string[];
 }
 
+// #308: a link target is slugified ("Systemische-Inflammation"), titles and
+// aliases are not ("Systemische Inflammation"). toLowerCase() alone leaves the
+// hyphen different from the space, so the two forms of the same name never
+// compare equal. computeSlug is the pure variant of slugify (no console.warn on
+// the hot path) and already lowercases, which keeps this comparable regardless
+// of the user's slugCase setting.
+// Empty input is mapped to '' rather than to computeSlug's 'untitled'
+// placeholder, so a page with an empty alias cannot match a link to "untitled".
+function slugKey(text: string | undefined): string {
+  if (!text || text.trim().length === 0) return '';
+  return computeSlug(text);
+}
+
 /**
  * Find matching page for a dead link target.
- * Searches by title (case-insensitive) first, then by aliases.
+ * Searches by title (case-insensitive) first, then by aliases, then repeats
+ * both with slug normalization on either side (#308).
  *
  * @param pages - Available wiki pages from getExistingWikiPages
  * @param targetName - The dead link target (e.g., "思维链" or "CoT")
@@ -20,6 +36,7 @@ export interface PageRef {
  * const pages = [{ title: 'Chain of Thought', aliases: ['CoT', '思维链'] }];
  * findDeadLinkTarget(pages, '思维链') // => { title: 'Chain of Thought', ... }
  * findDeadLinkTarget(pages, 'cot') // => { title: 'Chain of Thought', ... }
+ * findDeadLinkTarget(pages, 'chain-of-thought') // => { title: 'Chain of Thought', ... }
  * findDeadLinkTarget(pages, 'nonexistent') // => undefined
  */
 export function findDeadLinkTarget(
@@ -38,6 +55,21 @@ export function findDeadLinkTarget(
   if (!match) {
     match = pages.find(p =>
       p.aliases?.some(a => a.toLowerCase() === lowerTarget)
+    );
+  }
+
+  // Third and fourth (#308): same two lookups over slug-normalized forms.
+  // Kept as separate tiers instead of one combined find() so that an exact
+  // title match still outranks a slug alias match on a different page.
+  const targetSlug = slugKey(targetBasename);
+
+  if (!match && targetSlug) {
+    match = pages.find(p => slugKey(p.title) === targetSlug);
+  }
+
+  if (!match && targetSlug) {
+    match = pages.find(p =>
+      p.aliases?.some(a => slugKey(a) === targetSlug)
     );
   }
 


### PR DESCRIPTION
Closes #308.

Branched from current `main` (`54bc128`) rather than `3578a9d` — `main` moved with the Codex OAuth merge (#273) while the issue was being triaged. No overlap with that change.

## What changed

`findDeadLinkTarget` (`src/core/dead-link-detector.ts`) gets two more lookup tiers: title and alias again, this time slug-normalized on both sides. Everything else in the function is untouched.

## Three deviations from the sketch in the issue thread

**1. `computeSlug` instead of `slugify`.** The safety net at `fix-dead-link.ts:190-196` runs on one string; the pre-check runs over every page in the vault. `slugify` logs a `console.warn` on empty input, and the comment at `slug.ts:12-16` marks `computeSlug` as the variant intended for exactly this ("matching 2141 existing pages"). It also lowercases already, so the comparison stays independent of the user's `slugCase` setting. Empty titles and aliases are mapped to `''` rather than to `computeSlug`'s `'untitled'` placeholder — otherwise a page with an empty alias would match a link to "untitled".

**2. Four tiers instead of one combined `find()`.** The safety net evaluates all four conditions inside a single `find()`, so the first *page* wins regardless of match quality. In the pre-check that would let a slug alias match on page B overtake an exact title match on page A. The slug tiers therefore run only after both exact tiers. There is a test for that ordering.

**3. One existing test asserted the defect and had to change.** `handles path in target (extracts basename)` expected `concepts/attention-mechanism` *not* to resolve to the page "Attention Mechanism" — that is the German hyphen-vs-space case in English clothing. Its expectation is updated; a second test keeps basename extraction itself covered. Flagging this because the issue estimated "4 lines + 1 test", and a reviewer would otherwise meet a changed assertion without explanation.

## Tests

A parameterized suite over `(link_target, expected_page_title)` as requested, including the German cases directly: `nervus-vagus` → "Nervus vagus", `kurzkettige-fettsäuren` → "Kurzkettige Fettsäuren" (umlaut survives), plus case variants. A second parameterized block asserts that near misses (`nervus-vagus-dorsalis`, `systemische`) stay unresolved, and single tests cover tier order and the two empty-string cases.

## Re-measured with this implementation

The issue declared a caveat: the measurement script approximated `slugify()` in Python. This run uses the real function on the reporting vault (2796 pages, German content). Same vault, but after a link-repair pass since the issue was filed, so the absolute numbers are lower than the ones in the issue text.

| pre-check matching | targets resolved | links resolved |
|---|---:|---:|
| before (`toLowerCase`) | 74 | 280 |
| after (slug-normalized) | 245 | 727 |

752 unresolved targets / 1507 links in total. **No target that resolved before resolves to a different page now** — the change is additive over the previous behavior; the script checked every target for that explicitly.

Examples that only the new tiers resolve: `concepts/Systemische-Inflammation` (22 links) via an alias, `entities/Nervus-vagus` (7) via the title, `entities/Akkermansia muciniphila` (5) — a link that carries a space where the page name carries a hyphen.

## Gate 1

`pnpm lint --max-warnings=0` 0 · `npx tsc --noEmit` 0 · `pnpm build` clean · `pnpm css-lint` 0 violations · `pnpm test` **2468 passed / 185 files**.

Baseline counted separately on `54bc128`: **2453 / 185** → +15, which is exactly the number of tests added here. One note on the baseline: `openai-codex-loopback-flow.test.ts` asserts against the built `main.js`, so a `pnpm build` has to precede `pnpm test` on a fresh checkout, otherwise that test fails on a stale bundle.

Diff: 2 files, +124/−2.
