### PR TITLE
fix(ingest): let the related-link corrector see the prefixes it is meant to repair (#307)

### DIFF
--- a/src/__tests__/core/related-link-corrector.test.ts
+++ b/src/__tests__/core/related-link-corrector.test.ts
@@ -97,4 +97,80 @@ describe('correctRelatedLinkPrefixes (root-cause fix for sources/-prefixed relat
     const r = correctRelatedLinkPrefixes(c, [], ['Exekutive Funktionen'], ENT, CON, true);
     expect(r).toContain('[[concepts/Exekutive-Funktionen|Exekutive Funktionen]]');
   });
+
+  // --- #307: the matcher used to accept only already-correct prefixes, so the links
+  //     this function exists to repair never entered the rewrite. ---
+
+  describe('wrong-prefix links (#307)', () => {
+    it('rewrites singular entity/ to entities/', () => {
+      const c = '## Related Entities\n- [[entity/Hippocampus|Hippocampus]]';
+      const r = correctRelatedLinkPrefixes(c, ['Hippocampus'], [], ENT, CON, true);
+      expect(r).toContain('- [[entities/Hippocampus|Hippocampus]]');
+    });
+
+    it('rewrites singular concept/ to concepts/', () => {
+      const c = '## Related Concepts\n- [[concept/Abruf|Abruf]]';
+      const r = correctRelatedLinkPrefixes(c, [], ['Abruf'], ENT, CON, true);
+      expect(r).toContain('- [[concepts/Abruf|Abruf]]');
+    });
+
+    it('routes a type-wrong singular link by known type, not by prefix substitution', () => {
+      // [[concept/Kardiogener-Schock]] is an entity in this ingest. A plain
+      // concept/ → concepts/ substitution would produce a link that is well-formed
+      // and still wrong; folderBySlug knows the type and wins over both the written
+      // prefix and the section.
+      const c = '## Related Concepts\n- [[concept/Kardiogener-Schock|Kardiogener Schock]]';
+      const r = correctRelatedLinkPrefixes(c, ['Kardiogener Schock'], [], ENT, CON, true);
+      expect(r).toContain('- [[entities/Kardiogener-Schock|Kardiogener Schock]]');
+    });
+
+    it('falls back to the section folder when the name is in neither related list', () => {
+      const c = '## Related Entities\n- [[concept/Unbekannt|Unbekannt]]';
+      const r = correctRelatedLinkPrefixes(c, [], [], ENT, CON, true);
+      expect(r).toContain('- [[entities/Unbekannt|Unbekannt]]');
+    });
+
+    it('leaves tag-as-folder links untouched', () => {
+      // A vault-specific tag used as a folder. The function cannot know whether the
+      // user meant it, so it stays out of the matcher entirely.
+      const c = [
+        '## Related Entities',
+        '- [[Arzneimittel/Metformin|Metformin]]',
+        '- [[Laborwerte/CRP|CRP]]',
+        '## Related Concepts',
+        '- [[Biochemie/Glykolyse|Glykolyse]]',
+      ].join('\n');
+      const r = correctRelatedLinkPrefixes(
+        c, ['Metformin', 'CRP'], ['Glykolyse'], ENT, CON, true,
+      );
+      expect(r).toBe(c);
+    });
+
+    it('is a no-op on already-correct prefixes', () => {
+      const c = [
+        '## Related Entities',
+        '- [[entities/Hippocampus|Hippocampus]]',
+        '## Related Concepts',
+        '- [[concepts/Abruf|Abruf]]',
+        '## Mentions in Source',
+        '> **Source: [[sources/Gedächtnis|Gedächtnis]]**',
+      ].join('\n');
+      const r = correctRelatedLinkPrefixes(
+        c, ['Hippocampus'], ['Abruf'], ENT, CON, true,
+      );
+      expect(r).toBe(c);
+    });
+
+    it('does not rewrite a wrong-prefix link outside the Related sections', () => {
+      const c = '## Description\nProse about [[concept/Abruf|Abruf]].';
+      const r = correctRelatedLinkPrefixes(c, [], ['Abruf'], ENT, CON, true);
+      expect(r).toBe(c);
+    });
+
+    it('rewrites a bare singular link without a display alias', () => {
+      const c = '## Related Concepts\n- [[concept/Abruf]]';
+      const r = correctRelatedLinkPrefixes(c, [], ['Abruf'], ENT, CON, true);
+      expect(r).toContain('- [[concepts/Abruf]]');
+    });
+  });
 });

--- a/src/core/related-link-corrector.ts
+++ b/src/core/related-link-corrector.ts
@@ -52,7 +52,17 @@ export function correctRelatedLinkPrefixes(
   for (const h of [relatedEntitiesLabel.trim(), 'Related Entities']) sectionFolder.set(h, 'entities');
   for (const h of [relatedConceptsLabel.trim(), 'Related Concepts']) sectionFolder.set(h, 'concepts');
 
-  const linkRe = /\[\[(entities|concepts|sources)\/([^\]|]+)(\|[^\]]*)?\]\]/g;
+  // #307: the pattern used to accept only the three correct folder names, so a link
+  // whose prefix was wrong — the very thing this function repairs — never entered the
+  // rewrite at all. The singular forms are added because the model emits them despite
+  // the plural in the prompt; they exist nowhere in the project's path generation
+  // (`WIKI_SUBFOLDERS` is hardcoded plural), so accepting them cannot shadow a real
+  // folder. Plural alternatives come first so `concepts/` matches without backtracking
+  // through `concept`.
+  // Any other prefix stays out on purpose: a link like `[[Arzneimittel/X]]` uses a
+  // vault-specific tag as a folder, and rewriting it would overwrite a user intent this
+  // function cannot read.
+  const linkRe = /\[\[(entities|entity|concepts|concept|sources)\/([^\]|]+)(\|[^\]]*)?\]\]/g;
   let current: 'entities' | 'concepts' | undefined;
   return content.split('\n').map(line => {
     const header = /^#{1,6}\s+(.*?)\s*$/.exec(line);


### PR DESCRIPTION
Closes #307. Built to the shape you specified in the issue thread.

Branched from current `main` (`54bc128`) rather than `3578a9d`, same as #322 — `main` moved with #273 in the meantime. Independent of #322: different file, no overlap.

## What changed

One line of behavior: the matcher in `correctRelatedLinkPrefixes` now accepts the five forms `(entities|entity|concepts|concept|sources)` instead of only the three correct ones. Plural alternatives come first so `concepts/` matches without backtracking through `concept`.

Everything downstream is untouched. `folderBySlug` remains the source of truth, the section remains the fallback when a name is in neither related list, and the tag-as-folder forms stay outside the matcher — exactly the three points from your comment.

Because the rewrite goes through `folderBySlug` rather than through prefix substitution, the type-wrong cases resolve correctly: `[[concept/Kardiogener-Schock]]` becomes `[[entities/Kardiogener-Schock]]` when the name is a known entity, not `[[concepts/…]]`. There is a test for that.

## Tests

Eight, covering your three plus the neighbours that make the scope explicit:

| # | case | expectation |
|---|---|---|
| a | `[[entity/X]]`, `[[concept/X]]` in the matching section | rewritten to plural |
| b | `[[Arzneimittel/X]]`, `[[Laborwerte/X]]`, `[[Biochemie/X]]` | output identical to input |
| c | already-correct prefixes incl. a `sources/` citation in Mentions | output identical to input |
| — | `[[concept/X]]` where X is a known **entity** | routed by type, not by prefix |
| — | `[[concept/X]]` where X is in neither list | section folder (current behavior) |
| — | `[[concept/X]]` in prose, outside the Related sections | unchanged |
| — | `[[concept/X]]` without a display alias | rewritten, alias-free form preserved |

For (b) and (c) the assertion is `toBe(input)` rather than a `toContain` on single links, so an unintended rewrite anywhere in the fixture fails the test.

## One scope note, so the expectation stays exact

Your net calculation — "56 of your 66 broken links resolve via `folderBySlug`" — is right about the folder, and I want to be precise about what that means downstream: this pass makes a link **well-formed**, not necessarily **valid**. It re-asserts the folder and carries the name over unchanged, so `[[concept/X]]` becomes `[[concepts/X]]` whether or not `concepts/X` exists. Whether the target resolves is the pre-check's business (#308), not this function's. No change to your fix shape — I only don't want to claim more for it than it does.

## Field data, honestly dated

The 66 links / 20 pages in the issue were measured on 19 July. I repaired them locally in that same session, so a fresh count today reflects the repair, not the generation rate:

| form | in the vault today | inside Related sections |
|---|---:|---:|
| `[[concept/X]]` | 7 | 5 |
| `[[entity/X]]` | 0 | 0 |
| tag-as-folder | 7 | 3 |

I cannot offer a post-fix generation rate without a full re-ingest, so I am not claiming one. The value of the fix is that the class stops being produced at generation time; the vault number only shows that it has not returned in bulk since the repair.

## Gate 1

`pnpm lint --max-warnings=0` 0 · `npx tsc --noEmit` 0 · `pnpm build` clean · `pnpm css-lint` 0 violations · `pnpm test` **2461 passed / 185 files**.

Baseline counted separately on `54bc128`: **2453 / 185** → +8, exactly the tests added here.

Diff: 2 files, +87/−1.
