### PR TITLE
fix(prompts): stop the page templates from closing on a bare horizontal rule (#310)

### DIFF
--- a/src/__tests__/core/markdown.test.ts
+++ b/src/__tests__/core/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cleanMarkdownResponse } from '../../core/markdown';
+import { cleanMarkdownResponse, stripTrailingSeparators } from '../../core/markdown';
 describe('cleanMarkdownResponse', () => {
   it('strips markdown code fence (```json...```)', () => {
     // Code only recognizes markdown/md language tags; json tag text remains
@@ -151,6 +151,48 @@ Body`;
 
   it('handles very short input without structural markers (regression)', () => {
     expect(cleanMarkdownResponse('short')).toBe('short');
+  });
+
+  it('drops the trailing rule the page templates used to end on (#310)', () => {
+    const input = '---\ntype: entity\n---\n\n# Rutosid\n\n## Description\nText.\n\n---';
+    expect(cleanMarkdownResponse(input)).toBe(
+      '---\ntype: entity\n---\n\n# Rutosid\n\n## Description\nText.',
+    );
+  });
+});
+
+describe('stripTrailingSeparators (#310)', () => {
+  it('removes a trailing horizontal rule from a generated page', () => {
+    const input = '---\ntype: entity\n---\n\n# Page\n\n## Description\nText.\n\n---';
+    expect(stripTrailingSeparators(input)).toBe(
+      '---\ntype: entity\n---\n\n# Page\n\n## Description\nText.',
+    );
+  });
+
+  it('removes several rules separated by blank lines', () => {
+    const input = '# Page\n\nText.\n\n---\n\n---\n\n';
+    expect(stripTrailingSeparators(input)).toBe('# Page\n\nText.');
+  });
+
+  it('keeps the frontmatter terminator of a frontmatter-only document', () => {
+    const input = '---\ntype: entity\naliases: ["X"]\n---';
+    expect(stripTrailingSeparators(input)).toBe(input);
+  });
+
+  it('keeps a setext H2 underline, which is a heading and not a rule', () => {
+    const input = '# Page\n\nSection title\n---';
+    expect(stripTrailingSeparators(input)).toBe(input);
+  });
+
+  it('keeps a rule inside the body', () => {
+    const input = '# Page\n\n---\n\n## Description\nText.';
+    expect(stripTrailingSeparators(input)).toBe(input);
+  });
+
+  it('returns content unchanged when there is nothing to strip', () => {
+    const input = '# Page\n\n## Description\nText.';
+    expect(stripTrailingSeparators(input)).toBe(input);
+    expect(stripTrailingSeparators('')).toBe('');
   });
 });
 

--- a/src/__tests__/wiki/prompts/generation-template-closure.test.ts
+++ b/src/__tests__/wiki/prompts/generation-template-closure.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { GENERATION_PROMPTS } from '../../../wiki/prompts/generation';
+
+/**
+ * #310: every page template used to close its output example with a bare `---`.
+ * Models copied that closing rule into the page body, where the schema has no
+ * section for it. These tests pin both halves of the contract: the closing rule
+ * is gone, and the frontmatter delimiters of the example — which are paired and
+ * must stay — are untouched.
+ */
+const PAGE_TEMPLATES = [
+  'generateEntityPage',
+  'generateConceptPage',
+  'generateSummaryPage',
+  'preserveReviewedEntityPage',
+  'preserveReviewedConceptPage',
+] as const;
+
+describe('generation templates — output example closure (#310)', () => {
+  for (const name of PAGE_TEMPLATES) {
+    it(`${name} does not end on a bare horizontal rule`, () => {
+      const template = GENERATION_PROMPTS[name];
+      const lines = template.trimEnd().split('\n');
+      expect(lines[lines.length - 1].trim()).not.toBe('---');
+    });
+
+    it(`${name} keeps the paired frontmatter delimiters of its example`, () => {
+      const template = GENERATION_PROMPTS[name];
+      const rules = template.split('\n').filter(l => l.trim() === '---').length;
+      // An open/close pair around the frontmatter example, and nothing else.
+      expect(rules).toBe(2);
+    });
+  }
+});

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -64,7 +64,52 @@ export function cleanMarkdownResponse(response: string): string {
     }
   }
 
-  return cleaned.trim();
+  return stripTrailingSeparators(cleaned.trim());
+}
+
+/**
+ * Remove horizontal rules left at the very end of generated content (#310).
+ *
+ * The page templates in `src/wiki/prompts/generation.ts` used to close their
+ * output example with a bare `---`. Models copied that closing rule into the
+ * page body, where the schema has no use for it. Removing it from the templates
+ * fixes the cause; this pass is the net for whatever a model still emits.
+ *
+ * Two things are deliberately out of scope, because both would destroy meaning
+ * the function cannot recover:
+ *  - the frontmatter terminator. On a frontmatter-only document it *is* the
+ *    last `---` in the file, so anything at or before it is off limits.
+ *  - a setext heading. `Title\n---` is an H2, not a rule, so a `---` is only
+ *    removed when a blank line separates it from the preceding content.
+ *
+ * A rule in the middle of a body is left alone: at the point where generated
+ * content is cleaned, the trailing position is the one the templates produced.
+ */
+export function stripTrailingSeparators(content: string): string {
+  const lines = content.split('\n');
+
+  let frontmatterEnd = -1;
+  if (lines[0]?.trim() === '---') {
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trim() === '---') {
+        frontmatterEnd = i;
+        break;
+      }
+    }
+  }
+
+  let end = lines.length;
+  for (;;) {
+    while (end > 0 && lines[end - 1].trim() === '') end--;
+    const last = end - 1;
+    if (last <= frontmatterEnd) break;
+    if (lines[last]?.trim() !== '---') break;
+    const previous = lines[last - 1];
+    if (previous !== undefined && previous.trim() !== '') break;
+    end = last;
+  }
+
+  return end === lines.length ? content : lines.slice(0, end).join('\n').trimEnd();
 }
 
 /**

--- a/src/wiki/prompts/generation.ts
+++ b/src/wiki/prompts/generation.ts
@@ -60,8 +60,7 @@ aliases: ["Alternative name or translation"]  # REQUIRED: at least 1 alias, must
 
 ## {{section_related_concepts}}
 [Reference related concepts using full paths from the list above]
-
----`,
+`,
 
   generateConceptPage: `You are a Wiki knowledge base maintainer. Create a Wiki page for the following concept.
 
@@ -129,8 +128,7 @@ aliases: ["Alternative name or translation"]  # REQUIRED: at least 1 alias, must
 
 ## {{section_related_entities}}
 [Reference related entities using full paths from the list above]
-
----`,
+`,
 
   generateSummaryPage: `You are a Wiki knowledge base maintainer. Create a summary page for the following source file.
 
@@ -184,8 +182,7 @@ aliases: ["Alternative title or translation"]  # REQUIRED: at least 1 alias, mus
 ## {{section_main_points}}
 - Point 1
 - Point 2
-
----`,
+`,
 
   // Variant used when the existing page has `reviewed: true` in frontmatter.
   preserveReviewedEntityPage: `You are a Wiki knowledge base maintainer. The following entity page has been manually reviewed by the user (reviewed: true).
@@ -225,8 +222,7 @@ reviewed: true
 
 ## {{section_new_information}} ({{date}})
 [Only add non-duplicate new information; write "No new information" if none]
-
----`,
+`,
 
   // Variant used when the existing concept page has `reviewed: true` in frontmatter.
   preserveReviewedConceptPage: `You are a Wiki knowledge base maintainer. The following concept page has been manually reviewed by the user (reviewed: true).
@@ -267,8 +263,7 @@ reviewed: true
 
 ## {{section_new_information}} ({{date}})
 [Only add non-duplicate new information; write "No new information" if none]
-
----`,
+`,
 
   suggestSchemaUpdate: `You are a Wiki Schema advisor. Review the current schema and the latest ingestion analysis.
 


### PR DESCRIPTION
Implements the fix from your comment. Two parts, as you proposed.

**The cause.** All five page templates in `src/wiki/prompts/generation.ts` closed their output example with a bare `---`. That line is now gone from `generateEntityPage`, `generateConceptPage`, `generateSummaryPage`, `preserveReviewedEntityPage` and `preserveReviewedConceptPage`.

**On the lines you listed — you were right, and they are untouched.** Lines 44/51, 106/113, 160/167, 214/222 and 256/264 are five open/close pairs around the frontmatter example. They are YAML delimiters and removing them would make the example invalid, exactly as you said.

The lines this issue is about are different ones: `64`, `133`, `188`, `229`, `271`, at the end of each template literal. They are easy to miss in a search, because they do not read as `---` on their own line — they read as ``---`,`` (rule, backtick, comma) where the literal closes. A search for `^---$` returns precisely the ten paired lines you listed and none of these five. A contract test now pins both halves per template: no closing rule, and exactly two `---` remaining — the frontmatter pair.

**The net.** `stripTrailingSeparators()` in `src/core/markdown.ts`, called at the end of `cleanMarkdownResponse()`. Pure function, deterministic, no LLM call.

Three deviations from your sketch, flagged so you can reject them:

1. **Placement.** You suggested `extractBody`/the write path. `extractBody` reads *source* files, not generated output, so a strip there would not see a generated page. `cleanMarkdownResponse` is the single point all three generation paths already funnel through (`create-page.ts:206`, `merge-page.ts:163`/`:242`, `related-page.ts:133`), so one call covers all of them.
2. **No prompt annotation.** Your first part was an annotation marking the rule as part of the example. With the rule removed there is nothing left to annotate, so I left the prompt text alone rather than adding an instruction about a line that no longer exists.
3. **Trailing position only.** The pass does not remove rules from the middle of a body. Doing so would delete legitimate separators from existing bodies on the merge path, and it is not needed: the 127 mid-list cases in the report come from the same copied closing rule, which the template change removes at the source.

**Two things the pass deliberately does not touch,** because their meaning cannot be recovered afterwards:

- the **frontmatter terminator** — on a frontmatter-only document that is the last `---` in the file;
- a **setext heading** — `Title\n---` is an H2, not a horizontal rule. A rule is therefore only removed when a blank line separates it from the content above it.

**Field data, dated honestly.** The 969/2797 figure in the issue is from a full-corpus run on 19 July. I re-checked yesterday on a fresh single-note ingest with the current build: the rule reappeared on 2 of the 4 pages I inspected. Small sample, one vault, one model — it confirms the mechanism is still live, not the rate.

**Gate:** `npx tsc --noEmit` 0 · `pnpm build` clean · `pnpm test` **2511 / 187** against a self-counted baseline of **2494 / 186** on `2524bc3` (+17 = the new tests) · `pnpm css-lint` 0.

One observation on lint, in case it is useful: `pnpm lint --max-warnings=0` reports 57 problems (18 errors) on `2524bc3` itself, unchanged by this PR and none of them in the files it touches. The errors are in `src/__tests__` support files and `src/llm-sdk/openai-codex/loopback-flow.ts`, so the "0 errors" for production code in #327 holds — the script just also lints the test tree.
