### PR TITLE
fix(schema): eliminate dual-source tag vocabulary (Issue #328 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Current Phase: v1.25.2 PATCH in progress — eslint 0.4.1 Route A committed (`c9fd4ce`); E2E thinking-block regression fixed (`d2d401e`); Schema Phase 1 + PR #324 + release next; v1.26.0 MINOR following
+## Current Phase: v1.25.2 PATCH in progress — eslint 0.4.1 Route A committed (`c9fd4ce`); E2E thinking-block regression fixed (`d2d401e`); PR #324 (#307 related-link corrector) merged (`762bb3c` + follow-up A on `2524bc3`); PR #329 (#310 template trailing `---` stripper) merged (`9b0ecad`); NOTICE update pending commit; Schema Phase 1 Option A user-approved 2026-07-22 → implementation next, then v1.25.2 version release; v1.26.0 MINOR following
 
 **v1.25.1 PATCH (2026-07-20, 11 commits, ~80 files, 2274 tests):**
 
@@ -17,8 +17,9 @@
 
 1. ~~PR #304 rebase (DocTpoint — `updatedPages` split).~~ **MERGED 2026-07-20 (`3578a9d`).**
 2. ~~Phase A Obsidian bot compliance — `prefer-create-el` × 50 + `getSettingDefinitions` not implemented.~~ **COMPLETED 2026-07-21 (`c9fd4ce`).** eslint-plugin-obsidianmd 0.3.0→0.4.1 upgrade, flat config test override, `src/types/obsidian-dom.d.ts`, `src/__tests__/__support__/dom-helpers.ts`, 47 prefer-create-el production fixes, no-alert → ConfirmModal replacement.
-3. **DOCS: still pending** — 10 READMEs + CHANGELOG + versions.json v1.25.2 entry.
-4. **Lint perf** — `controller.ts:151` + `:239` TODOs from v1.18.0+ unaddressed. Remains v1.26.0 work.
+3. ✅ **Schema Phase 1 (Option A user-approved 2026-07-22)** — Eliminate the dual-source problem: tag lists move from `buildDefaultSchemaBody()` to runtime injection layer; `schemaHasTagVocab` defensive check removed. (Folder layout will move in Phase 2 alongside the per-type registration work — see Issue #328.) See [[feedback-schema-phase1-option-a-decision]] for full decision rationale + orthogonality proof against Phase 2/3. Owner override of the "wait 2 weeks for community feedback" public commitment (Issue #328) justified by (a) bug-fix nature, (b) ~3-4h PATCH-scope effort, (c) Phase 2/3 orthogonality. Implementation order (TDD): RED test → GREEN edit → refactor → Gate 1 → in-memory sanitize for legacy vaults. Backwards-compat: existing user schemas **not rewritten**; runtime improvement immediate.
+4. **DOCS: still pending** — 10 READMEs + CHANGELOG + versions.json v1.25.2 entry.
+5. **Lint perf** — `controller.ts:151` + `:239` TODOs from v1.18.0+ unaddressed. Remains v1.26.0 work.
 
 **v1.25.0 scope decision (2026-07-15, user-confirmed post-pivot):**
 
@@ -346,6 +347,16 @@ For full release workflow (commit + push + tag + release notes), use the `obsidi
 - **`Promise.allSettled` error isolation**: One failure doesn't crash the batch
 - **Pollution defense at write gate**: Centralized regex catches ALL sources
 - **LLM semantic page selection**: Meaning-based matching, not keyword
+- **Schema 三层分离 (Issue #328, Phase 1 active 2026-07-22 — Option A)**: As knowledge-conservation principle (anti-drift), each layer owns its half, **never overlap, can never conflict**:
+  | Layer | Owned by | What it is |
+  |---|---|---|
+  | **User domain knowledge** | You | `schema/config.md` — page templates, content rules, naming conventions, merge policies |
+  | **Runtime parameters** | Plugin (Settings) | Tag vocabulary, folder layout, output language, page-type registration — **never written into schema file**, always injected at call time via `getSchemaContext()` |
+  | **Engine facts** | Code | Model name, API key, thinking mode, `WIKI_SUBFOLDERS` — shipped with the plugin |
+
+  **Hard rule for future contributors:** the schema file MUST NOT bake runtime parameters (tag lists, folder paths, language). It MUST remain pure user domain knowledge. Adding/expanding the runtime injection layer (`buildActiveTagVocabularySection` and future `buildActiveFolderLayoutSection`) is the only legitimate home for things the Settings panel controls. Violating this rule reintroduces the dual-source problem (Phase 1 was approved specifically to eliminate this drift class).
+
+  Full rationale: [[feedback-schema-phase1-option-a-decision]] + Issue #328 + [[feedback-schema-template-programmatic-injection]].
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.25.1 PATCH (RELEASED 2026-07-20) → v1.25.2 PATCH (in progress, commits `c9fd4ce` + `d2d401e`). | **Updated:** 2026-07-21 (eslint 0.4.1 Route A + E2E thinking-block fix + Schema Phase 1 + release prep)
+**Version:** 1.25.1 PATCH (RELEASED 2026-07-20) → v1.25.2 PATCH (in progress, commits `c9fd4ce` + `d2d401e` + `#327` + `#329`). | **Updated:** 2026-07-22 (PR #324 #307 + PR #329 #310 merged; Schema Phase 1 Option A approved + 3 decisions resolved; NOTICE update deferred to v1.25.2 release commit; remaining: Schema Phase 1 implementation + version release + NOTICE sync)
 
 ## Current Status
 
@@ -71,12 +71,52 @@
 | ✅ **PR #322 / #308** — dead-link slug-normalized match | DocTpoint contribution | **MERGED** (`292300b`) |
 | ✅ **eslint 0.4.1 Route A** | 2026-07-21 | **COMMITTED** (`c9fd4ce`) |
 | ✅ **E2E fix: thinking-block HierarchyRequestError** | 2026-07-21 — `activeDocument.createEl` auto-attached to document.body broke saved-history load | **COMMITTED** (`d2d401e`) — refactored `renderThinkingBlocksUI(parent)`, caller (`QueryView.renderMarkdownContent`) threads `container` |
-| 🚧 **PR #324 / #307** — related-link corrector prefix scope | DocTpoint contribution | Open, 87 lines, MERGEABLE; needs simplify + code-review |
-| 🔲 Schema Phase 1 | Design in memory | Template + Programmatic Injection (~30 LOC net) |
-| 🔲 #273 UX fix | ChatGPT OAuth test failure silent | ~4h |
+| ✅ **PR #324 / #307** — related-link corrector prefix scope | DocTpoint contribution | **MERGED** (`762bb3c`, squash); follow-up A (`2524bc3`) added case-sensitivity test + comment clarity |
+| ✅ **PR #329 / #310** — bare `---` template trailer stripping | DocTpoint contribution | **MERGED** (`9b0ecad`, squash); removes closing rule from 5 page templates + `stripTrailingSeparators()` net at end of `cleanMarkdownResponse()` |
+| 🚧 **Schema Phase 1 (Option A)** | Issue #328 — user-approved 2026-07-22 (override of "wait 2 weeks for community feedback" public commitment — override justified by Option A being bug-fix nature, not design track) | Eliminate dual-source problem: tag lists move from `buildDefaultSchemaBody()` to runtime injection layer; `schemaHasTagVocab` defensive check removed. (Folder layout stays Phase 2 — alongside per-type registration.) **Test LOC is net ↓** — 5 retired Phase 2 tests deleted, new contract lives in `runtime-injection.test.ts`. Backwards-compat: existing user schemas **not rewritten** — `loadSchema()` sanitizes legacy baked enum in-memory at LLM-facing view; on-disk file untouched. Phase 2/3 of #328 remain in v1.26.0 MINOR / v1.26.0+. |
+| 🔲 #273 UX silent-error fix | ChatGPT OAuth test failure | **WITHDRAWN** 2026-07-21 (user e2e test confirmed actual Notice path works; no real silent bug) |
+| 🔲 NOTICE update (DocTpoint description refresh + 4 new v1.25.0+ contributors) | Carry-over | Uncommitted in working tree, **deferred to v1.25.2 release commit** per Phase 1 commit scope discipline (NOT mixed with code commit) |
 | 🔲 **v1.25.2 version release** | bump + 10 READMEs + CHANGELOG + versions.json | ~2h |
 
-**Total effort**: ~3-4 working days remaining after Route A.
+**Total effort**: ~3-4 working days remaining after Schema Phase 1 (~3-4h) + version release (~2h).
+
+**Schema Phase 1 (Issue #328) — Option A user-approved 2026-07-22:**
+
+The original #328 body proposed waiting 2 weeks for community feedback before phasing. User override approved Option A (immediate implementation in v1.25.2 PATCH) on three grounds: (a) Phase 1 is bug-fix nature — eliminating the dual-source problem (schema body baking stale tag list + runtime defensive injection of fresh tag list — LLM sees both → drift), not a design-track feature; (b) Phase 1 is orthogonal to Phase 2 (per-type registration, future Settings-driven `WIKI_SUBFOLDERS` derived list) and Phase 3 (multi-wiki + user-defined placeholders + dynamic scanners) — no future re-work predicted; (c) ~3-4h effort fits PATCH scope.
+
+Implementation order (TDD, revised 2026-07-22):
+
+1. RED: `src/__tests__/schema/runtime-injection.test.ts` (NEW file) — "buildDefaultSchemaBody never contains any baked tag enum regardless of settings" + "Classification Rules section explicitly references runtime injection"
+2. RED: `src/__tests__/wiki/system-prompts-tag-vocab.test.ts` — **REVERSE** the existing duplicate-detection test (count==1 → count>=1): runtime is now authoritative, always appends
+3. RED: `src/__tests__/schema/default-schema.test.ts` — **DELETE** the 5-test "v1.22.0 Phase 2 dynamic tag injection" describe block (`L78-154`) + REWRITE the "preserves entity and concept subtype valid lists" assertion (`L70-75`) to assert NOT-baked. Phase 2 contract is permanently reversed (hard rule in CLAUDE.md), not paused — keeping old tests would re-anchor a retired contract
+4. CONFIRM all REDs fail for the right reason (`pnpm test`)
+5. GREEN: Edit `src/schema/schema-manager.ts:33-153` — `buildDefaultSchemaBody()` drops the 5 `${entityList}/${conceptList}` interpolations (`L50/51/63/80/135/136`); rephrase Wiki Structure / Entity Page Template / Concept Page Template / Classification Rules to defer to the runtime "Active Tag Vocabulary" injection. **Keep `settings` parameter** with JSDoc note that it is unused since Phase 1 (avoid signature churn — `ensureSchemaExists` / `regenerateDefaultSchema` call sites stay byte-identical)
+6. GREEN: Edit `src/wiki/system-prompts.ts:213-235` + `:255` — drop the `schemaHasTagVocab` defensive branch (always append runtime section); rename injected heading "(Issue #85 — user-controlled)" → "(runtime)"
+7. REFACTOR: clean up the obsolete "// v1.22.0 #97 ... in lockstep" comment in `schema-manager.ts:34-40` (no longer applicable since runtime is authoritative — no lockstep needed)
+8. Gate 1: `pnpm lint && npx tsc --noEmit && pnpm test && pnpm build && pnpm css-lint`
+
+**Three implementation decisions resolved 2026-07-22 (recorded for the commit body):**
+
+1. **5 Phase 2 tests in `default-schema.test.ts:78-154`**: DELETED, with the new contract living in the new file `runtime-injection.test.ts`. The runtime-vs-baked split is a permanent design reversal (CLAUDE.md "Schema 三层分离" hard rule), not a temporary contract change — keeping old tests would re-anchor a retired contract and mislead future contributors reading the file
+2. **`buildDefaultSchemaBody(settings)` signature**: KEPT, with JSDoc marking settings as unused since Phase 1. `ensureSchemaExists()` / `regenerateDefaultSchema()` call sites byte-identical. Phase 2 may legitimately need settings again. Signature churn deferred to that PR
+3. **NOTICE update timing**: DEFERRED to v1.25.2 release doc sync (NOT mixed into the Phase 1 commit). The 9-contributor attribution is release-scope; mixing into a code commit is range creep and obscures the Phase 1 git history. The remembered uncommitted NOTICE change from the PR #329 cycle will be re-applied with the v1.25.2 release commit
+
+**Why Option A is safe for backwards compat:**
+
+- Existing users' schema files (with baked-in tag lists) are NOT rewritten — only `ensureSchemaExists()` and explicit `regenerateDefaultSchema()` produce the new clean template
+- Existing users get immediate runtime improvement (no more dual-source — runtime injection is always authoritative)
+- All call sites of `getSchemaContext()` are unchanged — same SchemaTask contract
+- The Title-text change of injected section ("user-controlled" → "runtime") is a minor visual change but functionally identical
+- No prompt-text changes that break existing test fixtures (verified by grep `pnpm test` after each step)
+
+**Why Option A does NOT block Phase 2/3:**
+
+- `buildDefaultSchemaBody()` modification only touches *content* of one specific section (Wiki Structure + Classification Rules); it does NOT change the section *structure* that Phase 2 relies on (`## <Type> Page Template` discovery via `parseSections()` / `selectSections()`)
+- The runtime injection point in `system-prompts.ts:213` is exactly where Phase 2 will add `buildActiveFolderLayoutSection()` — symmetric extension, no refactor
+- `WIKI_SUBFOLDERS` constant remains untouched; Phase 2 will replace it with derived-from-settings without conflicting with Phase 1
+- Phase 3 (multi-wiki, placeholders, scanners) requires no schema-body changes at all — orthogonal
+
+Full decision rationale: [[feedback-schema-phase1-option-a-decision]].
 
 ### v1.25.2 version bump notes
 

--- a/src/__tests__/schema/default-schema.test.ts
+++ b/src/__tests__/schema/default-schema.test.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { buildDefaultSchemaBody } from '../../schema/schema-manager';
-import { LLMWikiSettings } from '../../types';
 
-// Minimal settings object that satisfies the LLMWikiSettings fields touched
-// by tag-vocab.ts. Only tagVocabularyMode and the custom tag fields are
-// actually consumed by buildDefaultSchemaBody(settings).
-function mkSettings(overrides: Partial<LLMWikiSettings>): LLMWikiSettings {
-  return {
-    tagVocabularyMode: 'default',
-    customEntityTags: '',
-    customConceptTags: '',
-    ...overrides,
-  } as LLMWikiSettings;
-}
+// Note on what used to be `mkSettings` and the partial LLMWikiSettings import:
+// The v1.22.0 Phase 2 tests that consumed these helpers were deleted for
+// Issue #328 Phase 1 (see the trailing comment block at the bottom of this
+// file). The remaining tests in this file do not take a settings object.
 
 describe('buildDefaultSchemaBody', () => {
   const body = buildDefaultSchemaBody();
@@ -67,88 +59,17 @@ describe('buildDefaultSchemaBody', () => {
     expect(conceptMatch![0]).not.toMatch(/\*\*Basic Information\*\*/);
   });
 
-  it('preserves entity and concept subtype valid lists', () => {
-    // Entity: person, organization, project, product, event, place, other
-    expect(body).toMatch(/person[\s\S]*?organization[\s\S]*?project[\s\S]*?product[\s\S]*?event[\s\S]*?place[\s\S]*?other/);
-    // Concept: theory, method, field, phenomenon, standard, term, other
-    expect(body).toMatch(/theory[\s\S]*?method[\s\S]*?field[\s\S]*?phenomenon[\s\S]*?standard[\s\S]*?term[\s\S]*?other/);
+  it('does NOT preserve entity or concept subtype lists (#328 Phase 1)', () => {
+    // Phase 1 reversed: the active tag vocabulary lives ONLY in the runtime
+    // injection layer (buildActiveTagVocabularySection). This schema body
+    // is intentionally free of any baked tag enum — see
+    // src/__tests__/schema/runtime-injection.test.ts for the full
+    // contract.
+    expect(body).not.toMatch(/person[\s\S]*?organization[\s\S]*?project[\s\S]*?product[\s\S]*?event[\s\S]*?place[\s\S]*?other/);
+    expect(body).not.toMatch(/theory[\s\S]*?method[\s\S]*?field[\s\S]*?phenomenon[\s\S]*?standard[\s\S]*?term[\s\S]*?other/);
   });
 });
 
-// === v1.22.0 Phase 2: Schema dynamic tag vocabulary sync ===
-// Issue: when the user sets a Custom tag vocabulary in Settings, the hardcoded
-// tag list in buildDefaultSchemaBody() conflicts with the active vocabulary
-// the LLM is given via buildActiveTagVocabularySection(). The LLM sees two
-// different tag lists and may produce out-of-vocabulary output.
-//
-// Fix: buildDefaultSchemaBody(settings) must inject the *active* tag list
-// (driven by getActiveEntityTags / getActiveConceptTags) into the Entity
-// Page Template and Concept Page Template, and into the Classification
-// Rules section, so schema body and prompt section agree.
-describe('buildDefaultSchemaBody(settings) — dynamic tag injection (v1.22.0 Phase 2)', () => {
-  it('uses custom entity tags when tagVocabularyMode="custom" and customEntityTags is set', () => {
-    // When the user has defined a custom entity vocabulary, the schema's
-    // Entity Page Template MUST list those exact tags (not the hardcoded
-    // defaults), so the LLM does not see a conflicting list.
-    const custom = mkSettings({
-      tagVocabularyMode: 'custom',
-      customEntityTags: 'person, organization, Medical_Arzneimittel',
-    });
-    const body = buildDefaultSchemaBody(custom);
-    // The custom tag is present in the entity tag list
-    expect(body).toContain('Medical_Arzneimittel');
-    // And in the Classification Rules section as well (consistency)
-    expect(body).toMatch(/## Classification Rules[\s\S]*?Medical_Arzneimittel/);
-  });
-
-  it('uses custom concept tags when tagVocabularyMode="custom" and customConceptTags is set', () => {
-    const custom = mkSettings({
-      tagVocabularyMode: 'custom',
-      customConceptTags: 'Kardiologie, Arzneimittel/Neurologie',
-    });
-    const body = buildDefaultSchemaBody(custom);
-    expect(body).toContain('Kardiologie');
-    expect(body).toContain('Arzneimittel/Neurologie');
-    // Slash-bearing tag must round-trip — getActiveConceptTags preserves '/'
-    expect(body).toMatch(/## Concept Page Template[\s\S]*?Arzneimittel\/Neurologie/);
-  });
-
-  it('falls back to hardcoded defaults when settings are not provided (backward compat)', () => {
-    // The zero-arg call (no settings) MUST continue to produce a schema
-    // body containing the default entity and concept tag lists. This
-    // preserves the existing public API used by ensureSchemaExists() at
-    // first-ever load time when settings may not yet be persisted.
-    const body = buildDefaultSchemaBody();
-    expect(body).toMatch(/person[\s\S]*?organization[\s\S]*?project[\s\S]*?product[\s\S]*?event[\s\S]*?place[\s\S]*?other/);
-    expect(body).toMatch(/theory[\s\S]*?method[\s\S]*?field[\s\S]*?phenomenon[\s\S]*?standard[\s\S]*?term[\s\S]*?other/);
-  });
-
-  it('falls back to hardcoded defaults when tagVocabularyMode="default" even if custom tags are set', () => {
-    // tagVocabularyMode="default" is the explicit opt-out — the user wants
-    // the built-in vocabulary, regardless of any stale custom*Tags content.
-    const settings = mkSettings({
-      tagVocabularyMode: 'default',
-      customEntityTags: 'Medical_Arzneimittel', // should be IGNORED
-    });
-    const body = buildDefaultSchemaBody(settings);
-    expect(body).not.toMatch(/## Entity Page Template[\s\S]*?Medical_Arzneimittel/);
-    expect(body).toMatch(/## Entity Page Template[\s\S]*?person/);
-  });
-
-  it('Classification Rules entity subtypes list reflects the active entity tags', () => {
-    // The Classification Rules section is referenced by the prompt as the
-    // authoritative source of valid subtypes. It must agree with whatever
-    // tag list is used in the Entity Page Template — otherwise the LLM
-    // sees two different lists (the original Phase 1 gap).
-    const custom = mkSettings({
-      tagVocabularyMode: 'custom',
-      customEntityTags: 'person, organization, Medical_Arzneimittel',
-    });
-    const body = buildDefaultSchemaBody(custom);
-    // Extract the Classification Rules section and check it contains the
-    // custom tag (not the old hardcoded list).
-    const classMatch = body.match(/## Classification Rules[\s\S]*?(?=\n## |\s*$)/);
-    expect(classMatch).not.toBeNull();
-    expect(classMatch![0]).toContain('Medical_Arzneimittel');
-  });
-});
+// The 5 v1.22.0 Phase 2 tests for buildDefaultSchemaBody(settings) were
+// removed for Issue #328 Phase 1; see src/__tests__/schema/runtime-injection.test.ts
+// for the reversed contract. History preserved by git blame on this file.

--- a/src/__tests__/schema/runtime-injection.test.ts
+++ b/src/__tests__/schema/runtime-injection.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest';
+import { buildDefaultSchemaBody, stripLegacyBakedTagEnum } from '../../schema/schema-manager';
+import { VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS } from '../../types';
+import type { LLMWikiSettings } from '../../types';
+
+// For the runtime-header pin test, we cross-import the section builder
+// so the test catches the case where the runtime header is renamed
+// without updating the schema body's Classification Rules pointer.
+import { buildActiveTagVocabularySection } from '../../wiki/system-prompts';
+
+// Issue #328 Phase 1: the active tag vocabulary is the Settings-derived runtime
+// state. It MUST NOT be baked into `schema/config.md`. The runtime injection
+// layer (buildActiveTagVocabularySection in src/wiki/system-prompts.ts) is the
+// single authoritative source — schema body must reference it, not duplicate it.
+//
+// These tests are the Phase 1 contract. They replace the v1.22.0 Phase 2 tests
+// in default-schema.test.ts (which asserted the OPPOSITE: that custom tags WERE
+// baked into the body). Phase 2's contract has been permanently reversed; this
+// file is the new home for "schema body holds no tag enum" assertions.
+//
+// The default tag vocabularies are imported from src/types.ts (the single
+// source of truth) rather than copied: if upstream adds or removes a default
+// subtype, the assertions below automatically follow.
+
+function mkSettings(overrides: Partial<LLMWikiSettings> = {}): LLMWikiSettings {
+  return {
+    wikiFolder: 'wiki',
+    wikiLanguage: 'en',
+    extractionGranularity: 'standard',
+    customEntityTags: '',
+    customConceptTags: '',
+    tagVocabularyMode: 'default',
+    ...overrides,
+  } as LLMWikiSettings;
+}
+
+describe('buildDefaultSchemaBody — runtime-injection contract (Issue #328 Phase 1)', () => {
+  it('does NOT bake the default entity tag list into Wiki Structure or Entity Page Template', () => {
+    // Default mode + no custom tags. The hardcoded VALID_ENTITY_TAGS must
+    // not appear in either the Wiki Structure bullet or the Entity Page
+    // Template `tags:` field. (Two assertions because Phase 1 touches both.)
+    const body = buildDefaultSchemaBody();
+
+    // Wiki Structure: - Entity pages: `entities/` (...) — the parenthetical
+    // used to interpolate ${entityList}. The cooked comma-joined default
+    // list is the signature.
+    const wikiMatch = body.match(/## Wiki Structure[\s\S]*?(?=\n## |\s*$)/);
+    expect(wikiMatch).not.toBeNull();
+    expect(wikiMatch![0]).not.toMatch(/person,\s*organization,\s*project/);
+
+    // Entity Page Template tags: field — used to say
+    // "MUST be one of: ${entityList}". Now MUST NOT contain the cooked list.
+    const entityMatch = body.match(/## Entity Page Template[\s\S]*?(?=\n## |\s*$)/);
+    expect(entityMatch).not.toBeNull();
+    expect(entityMatch![0]).not.toMatch(/MUST be one of:[^.\n]*person,\s*organization/);
+  });
+
+  it('does NOT bake the default concept tag list into Wiki Structure or Concept Page Template', () => {
+    const body = buildDefaultSchemaBody();
+
+    const wikiMatch = body.match(/## Wiki Structure[\s\S]*?(?=\n## |\s*$)/);
+    expect(wikiMatch).not.toBeNull();
+    expect(wikiMatch![0]).not.toMatch(/theory,\s*method,\s*field/);
+
+    const conceptMatch = body.match(/## Concept Page Template[\s\S]*?(?=\n## |\s*$)/);
+    expect(conceptMatch).not.toBeNull();
+    expect(conceptMatch![0]).not.toMatch(/MUST be one of:[^.\n]*theory,\s*method/);
+  });
+
+  it('does NOT bake custom entity tags into the schema body (#328 Phase 1 reverses Phase 2 contract)', () => {
+    // v1.22.0 Phase 2 asserted that customEntityTags WOULD land in the body
+    // ("Medical_Arzneimittel appears"). Phase 1 deletes that assertion —
+    // settings changes no longer touch schema files. The runtime layer is
+    // the only authoritative source for the active vocabulary.
+    const custom = mkSettings({
+      tagVocabularyMode: 'custom',
+      customEntityTags: 'person, organization, Medical_Arzneimittel',
+    });
+    const body = buildDefaultSchemaBody(custom);
+    expect(body).not.toContain('Medical_Arzneimittel');
+    // No subset of the custom list leaked through either: the slash-bearing
+    // sentinel prevents a future contributor's "substring match" bypass.
+    expect(body).not.toMatch(/Medical_Arzneimittel|Kardiologie|Immunologie/);
+  });
+
+  it('does NOT bake custom concept tags into the schema body', () => {
+    const custom = mkSettings({
+      tagVocabularyMode: 'custom',
+      customConceptTags: 'Kardiologie, Arzneimittel/Neurologie',
+    });
+    const body = buildDefaultSchemaBody(custom);
+    expect(body).not.toContain('Kardiologie');
+    expect(body).not.toContain('Arzneimittel/Neurologie');
+  });
+
+  it('Classification Rules section explicitly references runtime injection (no baked enum)', () => {
+    // Phase 1 contract: the schema file must NOT bake any tag enum, and the
+    // Classification Rules section must be the canonical pointer to runtime
+    // injection. Any future contributor re-baking enum would need to defeat
+    // both the not-contains assertion above AND this explicit handoff.
+    const body = buildDefaultSchemaBody();
+
+    const classMatch = body.match(/## Classification Rules[\s\S]*?(?=\n## |\s*$)/);
+    expect(classMatch).not.toBeNull();
+    const section = classMatch![0];
+
+    // The section must mention the Active Tag Vocabulary surface that the
+    // runtime injection layer produces. Loose match on case + whitespace.
+    expect(section).toMatch(/Active Tag Vocabulary/);
+
+    // And it must NOT contain any baked-in enum (no `Entity subtypes` /
+    // `Concept subtypes` followed by a comma-joined list of the defaults).
+    expect(section).not.toMatch(/Entity subtypes[\s\S]*?person,\s*organization/);
+    expect(section).not.toMatch(/Concept subtypes[\s\S]*?theory,\s*method/);
+  });
+
+  it('default body never contains a comma-joined enum of the active entity or concept tags', () => {
+    // Catch-all: covers every default tag name in one assertion. A future
+    // contributor who tries to re-bake enum will trip this no matter which
+    // subset they pick.
+    //
+    // Why this is the right shape:
+    //   - The actual harm Phase 1 prevents is "LLM sees the tag list
+    //     TWICE" — once baked into schema body, once injected at runtime.
+    //     That harm requires a comma-joined string of subtypes.
+    //   - Individual English uses of words like "other" (e.g. "no inbound
+    //     links from other wiki pages") are not tag-list leakage and
+    //     should not trip the assertion — the previous \b based check
+    //     was a false-positive trap.
+    //
+    // The regex looks for a comma-joined sequence of at least 3 default
+    // tags within a single non-newline span, in either entity or concept
+    // position. Both default lists interleave with arbitrary other words,
+    // so the substring must be a contiguous sequence.
+    const body = buildDefaultSchemaBody();
+    // Quantifier {1,} means 1+ comma-followed tags, i.e. any contiguous
+    // comma-joined list of 2 or more default tags trips. This catches
+    // both the full default list AND a truncated 2-element leak (e.g.
+    // an LLM-generated or hand-edited schema body that bakes only a
+    // partial list — the predecessor quantifier {2,} missed these).
+    const entityRegex = new RegExp(
+      `\\b(${VALID_ENTITY_TAGS.join('|')})(,\\s*(${VALID_ENTITY_TAGS.join('|')})){1,}`
+    );
+    const conceptRegex = new RegExp(
+      `\\b(${VALID_CONCEPT_TAGS.join('|')})(,\\s*(${VALID_CONCEPT_TAGS.join('|')})){1,}`
+    );
+    expect(body).not.toMatch(entityRegex);
+    expect(body).not.toMatch(conceptRegex);
+  });
+
+  it('body stays consistent across settings permutations (param is unused since Phase 1)', () => {
+    // Phase 1 keeps the settings parameter for backwards compatibility (so
+    // ensureSchemaExists / regenerateDefaultSchema callers don't churn),
+    // but settings MUST NOT influence the body any more. Two settings objects
+    // with wildly different tag inventories must produce byte-identical
+    // bodies.
+    const a = mkSettings({
+      tagVocabularyMode: 'custom',
+      customEntityTags: 'Kardiologie, Immunologie',
+      customConceptTags: 'Medizin',
+    });
+    const b = mkSettings({
+      tagVocabularyMode: 'default',
+      customEntityTags: 'ignored',
+      customConceptTags: 'ignored',
+    });
+    expect(buildDefaultSchemaBody(a)).toBe(buildDefaultSchemaBody(b));
+  });
+});
+
+// === stripLegacyBakedTagEnum (in-memory schema sanitization) ===
+//
+// Existing user vaults created under v1.22.0-v1.25.1 carry a baked tag
+// enum in the Classification Rules section. loadSchema() now sanitizes
+// that view in-memory before the LLM sees it — the on-disk file is not
+// touched. These tests pin the sanitization contract.
+describe('stripLegacyBakedTagEnum (legacy schema body, in-memory)', () => {
+  it('replaces the legacy v1.22.0+ baked entity subtype bullet with a runtime pointer', () => {
+    const legacy = `## Classification Rules
+- type field: foo
+- Entity subtypes (valid tags for type=entity): ${VALID_ENTITY_TAGS.join(', ')}
+- Source types: document
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toContain(VALID_ENTITY_TAGS[0]); // sentinel — first default tag leaked
+    expect(sanitized).not.toMatch(/Entity subtypes \(valid tags for type=entity\):/);
+    expect(sanitized).toMatch(/Entity subtypes: see the \*\*Active Tag Vocabulary\*\*/);
+  });
+
+  it('replaces the legacy v1.22.0+ baked concept subtype bullet with a runtime pointer', () => {
+    const legacy = `## Classification Rules
+- Concept subtypes (valid tags for type=concept): ${VALID_CONCEPT_TAGS.join(', ')}
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toMatch(/Concept subtypes \(valid tags for type=concept\):/);
+    expect(sanitized).toMatch(/Concept subtypes: see the \*\*Active Tag Vocabulary\*\*/);
+  });
+
+  it('replaces both entity and concept bullets in the same body', () => {
+    const legacy = `## Classification Rules
+- Entity subtypes (valid tags for type=entity): a, b, c
+- Concept subtypes (valid tags for type=concept): x, y, z
+- Source types: document
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toMatch(/Entity subtypes \(valid tags for type=entity\):/);
+    expect(sanitized).not.toMatch(/Concept subtypes \(valid tags for type=concept\):/);
+    expect(sanitized).toMatch(/Source types: document/); // unrelated lines preserved
+  });
+
+  it('returns the body byte-for-byte unchanged when no legacy fingerprints are present', () => {
+    // The freshly-generated body from buildDefaultSchemaBody() must NOT
+    // be mutated by sanitize — fast path. Test this with the canonical
+    // output of buildDefaultSchemaBody() to pin "sanitize is a no-op
+    // on already-clean bodies".
+    const cleanBody = buildDefaultSchemaBody();
+    expect(stripLegacyBakedTagEnum(cleanBody)).toBe(cleanBody);
+  });
+
+  it('is idempotent — running sanitize on an already-sanitized body is a no-op', () => {
+    const legacy = `## Classification Rules
+- Entity subtypes (valid tags for type=entity): a, b, c
+- Concept subtypes (valid tags for type=concept): x, y, z
+`;
+    const once = stripLegacyBakedTagEnum(legacy);
+    const twice = stripLegacyBakedTagEnum(once);
+    expect(twice).toBe(once);
+  });
+
+  it('leaves non-Classification-Rules sections untouched (no over-eager rewrite)', () => {
+    // A user could have an unrelated sentence that happens to mention
+    // "Entity subtypes" elsewhere. Sanitize must only touch the legacy
+    // fingerprint pattern, not blanket-strip the words.
+    const body = `## Wiki Structure
+- Entity subtypes and Concept subtypes are documented below.
+
+## Classification Rules
+- Entity subtypes (valid tags for type=entity): a, b, c
+`;
+    const sanitized = stripLegacyBakedTagEnum(body);
+    // Wiki Structure sentence survives
+    expect(sanitized).toMatch(/Entity subtypes and Concept subtypes are documented below\./);
+    // Classification Rules legacy line is gone
+    expect(sanitized).not.toMatch(/Entity subtypes \(valid tags for type=entity\):/);
+  });
+
+  // === Wiki Structure + Page Template fixtures (#328 Phase 1, code-review
+  //     finding #1: the sanitizer must hit ALL 6 legacy sites, not just
+  //     Classification Rules). ===
+  it('replaces the legacy Wiki Structure entity parenthetical with a runtime pointer', () => {
+    const legacy = `## Wiki Structure
+- Entity pages: \`entities/\` (${VALID_ENTITY_TAGS.join(', ')})
+- Concept pages: \`concepts/\` — already-clean pointer (do NOT match this form)
+- Source pages: \`sources/\`
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toContain(VALID_ENTITY_TAGS[0]);
+    expect(sanitized).not.toMatch(/Entity pages: `entities\/` \([^)]*\)/);
+    expect(sanitized).toMatch(/Entity pages: `entities\/` — entity subtype tags are runtime-injected/);
+    // Concept line was a non-sanitizable clean pointer; survives verbatim
+    expect(sanitized).toMatch(/Concept pages: `concepts\/` — already-clean pointer/);
+  });
+
+  it('replaces the legacy Wiki Structure concept parenthetical with a runtime pointer', () => {
+    const legacy = `## Wiki Structure
+- Entity pages: \`entities/\` (person, organization)
+- Concept pages: \`concepts/\` (${VALID_CONCEPT_TAGS.join(', ')})
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toContain(VALID_CONCEPT_TAGS[0]);
+    expect(sanitized).not.toMatch(/Concept pages: `concepts\/` \([^)]*\)/);
+    expect(sanitized).toMatch(/Concept pages: `concepts\/` — concept subtype tags are runtime-injected/);
+  });
+
+  it('replaces the legacy Entity Page Template MUST-be-one-of line with a runtime pointer', () => {
+    const legacy = `**Frontmatter fields:**
+- \`type: entity\` — page category
+- \`tags:\` — entity subtype, MUST be one of: ${VALID_ENTITY_TAGS.join(', ')}
+- \`aliases:\` (optional) — alternative names
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toContain(VALID_ENTITY_TAGS[0]);
+    expect(sanitized).not.toMatch(/MUST be one of:/);
+    expect(sanitized).toMatch(/\`tags:\` — entity subtype; the valid values are runtime-injected by the \*\*Active Tag Vocabulary\*\*/);
+    // Other frontmatter field lines are preserved (separate lines, separate anchors)
+    expect(sanitized).toMatch(/`aliases:` \(optional\) — alternative names/);
+  });
+
+  it('replaces the legacy Concept Page Template MUST-be-one-of line with a runtime pointer', () => {
+    const legacy = `**Frontmatter fields:**
+- \`type: concept\` — page category
+- \`tags:\` — concept subtype, MUST be one of: ${VALID_CONCEPT_TAGS.join(', ')}
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    expect(sanitized).not.toContain(VALID_CONCEPT_TAGS[0]);
+    expect(sanitized).not.toMatch(/MUST be one of:/);
+    expect(sanitized).toMatch(/\`tags:\` — concept subtype; the valid values are runtime-injected/);
+  });
+
+  it('replaces ALL six legacy sites in a single body (full legacy vault fixture)', () => {
+    // Composite: a minimal but complete legacy schema body containing all
+    // six baked-enum sites. After sanitize, none of the 6 should contain
+    // any actual tag name; all should reference the runtime layer.
+    const legacy = `# Wiki Schema Configuration
+
+## Wiki Structure
+- Entity pages: \`entities/\` (${VALID_ENTITY_TAGS.join(', ')})
+- Concept pages: \`concepts/\` (${VALID_CONCEPT_TAGS.join(', ')})
+- Source pages: \`sources/\`
+
+## Entity Page Template
+**Frontmatter fields:**
+- \`type: entity\` — page category
+- \`tags:\` — entity subtype, MUST be one of: ${VALID_ENTITY_TAGS.join(', ')}
+
+## Concept Page Template
+**Frontmatter fields:**
+- \`type: concept\` — page category
+- \`tags:\` — concept subtype, MUST be one of: ${VALID_CONCEPT_TAGS.join(', ')}
+
+## Classification Rules
+- Entity subtypes (valid tags for type=entity): ${VALID_ENTITY_TAGS.join(', ')}
+- Concept subtypes (valid tags for type=concept): ${VALID_CONCEPT_TAGS.join(', ')}
+`;
+    const sanitized = stripLegacyBakedTagEnum(legacy);
+    // No legacy tag name leaks through.
+    for (const t of VALID_ENTITY_TAGS) {
+      expect(sanitized).not.toMatch(new RegExp(`\\b${t}\\b`));
+    }
+    for (const t of VALID_CONCEPT_TAGS) {
+      expect(sanitized).not.toMatch(new RegExp(`\\b${t}\\b`));
+    }
+    // All 6 sites were replaced (the precise count of "Active Tag Vocabulary"
+    // pointers matches the 6 legacy fingerprints).
+    const runtimeRefs = sanitized.match(/runtime-injected|Active Tag Vocabulary/g) ?? [];
+    expect(runtimeRefs.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+// === Cross-layer seam pin (Issue #328 Phase 1) ===
+//
+// The schema body's Classification Rules section tells the LLM to
+// consult "the Active Tag Vocabulary section". That section is the
+// runtime-injected header produced by buildActiveTagVocabularySection.
+// If the runtime header is renamed in the future without updating
+// the schema pointer, the LLM is told to consult a section that no
+// longer exists.
+//
+// These tests pin BOTH sides of the contract.
+describe('schema ↔ runtime header contract (#328 Phase 1)', () => {
+  it('schema body Classification Rules points at "Active Tag Vocabulary"', () => {
+    const body = buildDefaultSchemaBody();
+    expect(body).toMatch(/## Classification Rules[\s\S]*?Active Tag Vocabulary/);
+  });
+
+  it('runtime buildActiveTagVocabularySection header contains "Active Tag Vocabulary"', () => {
+    // Cross-layer pin: a future contributor renaming the runtime header
+    // would now need to update BOTH this test AND keep the schema body
+    // pointing to the renamed header. The two contracts are coupled.
+    const settings = mkSettings();
+    const section = buildActiveTagVocabularySection(settings);
+    expect(section).toMatch(/## Active Tag Vocabulary/);
+  });
+});

--- a/src/__tests__/wiki/system-prompts-tag-vocab.test.ts
+++ b/src/__tests__/wiki/system-prompts-tag-vocab.test.ts
@@ -45,17 +45,29 @@ describe('buildSystemPrompt — tag vocabulary injection (Phase 1.3)', () => {
     expect(prompt).toContain('Medizin');
   });
 
-  it('does NOT include duplicate tag vocab section when already present', async () => {
-    // Defensive: if caller already prepended the section, don't double up.
+  it('runtime injection always appends the tag vocab section, even when schema context already contains the literal (#328 Phase 1)', async () => {
+    // Issue #328 Phase 1 reverses the v1.21.0 contract. The defensive
+    // `schemaHasTagVocab` branch in buildSystemPrompt used to GUARD against
+    // a duplicate by string-matching "Active Tag Vocabulary" in the schema
+    // context. Phase 1 makes the runtime layer the SOLE source of truth —
+    // the schema body no longer contains that literal (verified in
+    // src/__tests__/schema/runtime-injection.test.ts), and the runtime
+    // injection layer always appends regardless of what schema content
+    // happens to contain.
+    //
+    // Test: feed a schema context that DOES contain the literal string
+    // (artificial, but the defensive branch would have suppressed runtime
+    // here). Phase 1 expects the runtime section to still be appended.
     const settings = makeSettings();
     const prompt = await buildSystemPrompt(
       settings,
-      async () => 'PREVIOUS TAG VOCAB SECTION',
+      async () => 'some prior content -- ## Active Tag Vocabulary (fake) -- more content',
       'entity'
     );
-    // Count occurrences of "Active Tag Vocabulary"
     const matches = (prompt ?? '').match(/Active Tag Vocabulary/g);
-    expect(matches?.length).toBe(1);
+    // The runtime section is always appended, so we expect >= 2
+    // (1 from the fake schema context + 1 from runtime injection).
+    expect(matches?.length).toBeGreaterThanOrEqual(2);
   });
 
   it('returns prompt even when schemaContext is undefined', async () => {

--- a/src/schema/schema-manager.ts
+++ b/src/schema/schema-manager.ts
@@ -4,7 +4,6 @@ import { App, TFile } from 'obsidian';
 import { LLMWikiSettings, WikiSchema, SchemaSuggestion, VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS, DEFAULT_ENTITY_TAG, DEFAULT_CONCEPT_TAG, LLMClient, WIKI_LANGUAGES } from '../types';
 import { PROMPTS } from '../prompts';
 import { parseSchemaSuggestion } from './parse-suggestion';
-import { getActiveEntityTags, getActiveConceptTags } from '../core/tag-vocab';
 import { capMaxTokens } from '../core/token-cap';
 import { resolveModelForTask } from '../core/model-resolver';
 import { TOKENS_SCHEMA_SUGGESTION } from '../constants';
@@ -13,6 +12,89 @@ const SCHEMA_FILENAME = 'schema/config.md';
 const SUGGESTIONS_FILENAME = 'schema/suggestions.md';
 
 export type SchemaTask = 'analyze' | 'summary' | 'entity' | 'concept' | 'related' | 'conversation' | 'index' | 'lint' | 'merge' | 'full';
+
+/**
+ * Issue #328 Phase 1: sanitize a legacy schema body that may still carry
+ * baked tag enums in 6 places (Wiki Structure × 2, Entity Page Template × 1,
+ * Concept Page Template × 1, Classification Rules × 2). The on-disk file
+ * is the user's data — we do not rewrite it. Instead, the LLM-facing view
+ * produced by `loadSchema()` is sanitized here so the runtime injection is
+ * the SOLE tag vocabulary the model encounters.
+ *
+ * The sanitization is **line-fingerprint, section-agnostic** — a unique
+ * structural prefix on each legacy line anchors the regex, and content
+ * after the colon is dropped wholesale. We do NOT match `${entityList}`
+ * generically, so a user-added heading or sentence that happens to mention
+ * the same words (e.g. "Entity subtypes are documented below.") is left
+ * alone. Idempotent — re-running sanitize on an already-clean body is a
+ * no-op (the fresh production body never matches these patterns).
+ *
+ * If a user hand-edited Classification Rules into a wrapped multi-line
+ * sub-list (header line + child indented bullets), only the header is
+ * stripped; the child bullets remain. Power-user edge case — accept the
+ * partial strip, document the limitation.
+ *
+ * Exported for unit testing.
+ */
+export function stripLegacyBakedTagEnum(body: string): string {
+  // Six-line fingerprint set, each anchored at the unique structural
+  // prefix that produced it in v1.22.0-v1.25.1. We do NOT match
+  // `${entityList}` generically — we match the literal suffix the
+  // interpolations produced, so a user-added heading or sentence that
+  // happens to mention the same words is left alone.
+  const legacyPatterns: Array<{ pattern: RegExp; replacement: string }> = [
+    // Wiki Structure (entity)
+    {
+      pattern: /^- Entity pages: `entities\/` \([^)]*\)$/m,
+      replacement: '- Entity pages: `entities/` — entity subtype tags are runtime-injected (see Settings → Tag Vocabulary); this file holds no list',
+    },
+    // Wiki Structure (concept)
+    {
+      pattern: /^- Concept pages: `concepts\/` \([^)]*\)$/m,
+      replacement: '- Concept pages: `concepts/` — concept subtype tags are runtime-injected (see Settings → Tag Vocabulary); this file holds no list',
+    },
+    // Entity Page Template — `tags:` field
+    {
+      pattern: /^- `tags:` — entity subtype, MUST be one of: .*$/m,
+      replacement: '- `tags:` — entity subtype; the valid values are runtime-injected by the **Active Tag Vocabulary** section of every system prompt (driven by Settings). MUST be one of those values.',
+    },
+    // Concept Page Template — `tags:` field
+    {
+      pattern: /^- `tags:` — concept subtype, MUST be one of: .*$/m,
+      replacement: '- `tags:` — concept subtype; the valid values are runtime-injected by the **Active Tag Vocabulary** section of every system prompt (driven by Settings). MUST be one of those values.',
+    },
+    // Classification Rules (entity)
+    {
+      pattern: /^- Entity subtypes \(valid tags for type=entity\): .*$/m,
+      replacement: '- Entity subtypes: see the **Active Tag Vocabulary** section injected into every system prompt (driven by Settings).',
+    },
+    // Classification Rules (concept)
+    {
+      pattern: /^- Concept subtypes \(valid tags for type=concept\): .*$/m,
+      replacement: '- Concept subtypes: see the **Active Tag Vocabulary** section injected into every system prompt (driven by Settings).',
+    },
+  ];
+
+  // Fast path: if NONE of the six fingerprints is present, return the
+  // body untouched so we don't pay the replace cost on every call
+  // (this is the steady state for new-format bodies and the hot path).
+  let hasAnyFingerprint = false;
+  for (const { pattern } of legacyPatterns) {
+    if (pattern.test(body)) {
+      hasAnyFingerprint = true;
+      break;
+    }
+  }
+  if (!hasAnyFingerprint) return body;
+
+  // Apply replacements in order. Each pattern is anchored at a unique
+  // structural prefix so they cannot cross-interact.
+  let sanitized = body;
+  for (const { pattern, replacement } of legacyPatterns) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+  return sanitized;
+}
 
 // Re-export tag constants from types.ts for convenience
 export { VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS, DEFAULT_ENTITY_TAG, DEFAULT_CONCEPT_TAG };
@@ -30,25 +112,20 @@ const TASK_SECTIONS: Record<SchemaTask, string[]> = {
   full: ['Wiki Structure', 'Entity Page Template', 'Concept Page Template', 'Naming Conventions', 'Classification Rules', 'Maintenance Policies'],
 };
 
-export function buildDefaultSchemaBody(settings?: LLMWikiSettings): string {
-  // v1.22.0 Phase 2: dynamic tag vocabulary. When settings are provided and
-  // tagVocabularyMode === 'custom', the active tag list comes from
-  // getActiveEntityTags / getActiveConceptTags — keeping the schema body
-  // and the prompt's Active Tag Vocabulary section in lockstep, so the LLM
-  // never sees two conflicting tag lists. When settings are undefined
-  // (first-ever load, before any settings are persisted), we fall back to
-  // the hardcoded defaults — preserving the original public-API behavior.
-  const entityTags = settings ? getActiveEntityTags(settings) : [...VALID_ENTITY_TAGS];
-  const conceptTags = settings ? getActiveConceptTags(settings) : [...VALID_CONCEPT_TAGS];
-  const entityList = entityTags.join(', ');
-  const conceptList = conceptTags.join(', ');
+export function buildDefaultSchemaBody(_settings?: LLMWikiSettings): string {
+  // Issue #328 Phase 1: tag vocabulary is Settings-driven and is injected
+  // at runtime via buildActiveTagVocabularySection() — see
+  // src/wiki/system-prompts.ts. The schema body intentionally holds no
+  // baked enum. The `settings` parameter is kept so ensureSchemaExists()
+  // and regenerateDefaultSchema() callers stay byte-identical; it is no
+  // longer read here. Phase 2 may legitimately need it again.
   return `# Wiki Schema Configuration
 
 This file governs how the LLM builds and maintains your Wiki. Edit it freely.
 
 ## Wiki Structure
-- Entity pages: \`entities/\` (${entityList})
-- Concept pages: \`concepts/\` (${conceptList})
+- Entity pages: \`entities/\` — entity subtype tags are runtime-injected (see Settings → Tag Vocabulary); this file holds no list
+- Concept pages: \`concepts/\` — concept subtype tags are runtime-injected (see Settings → Tag Vocabulary); this file holds no list
 - Source pages: \`sources/\`
 - Index: \`index.md\`
 - Log: \`log.md\`
@@ -60,7 +137,7 @@ Pages in \`entities/\` MUST follow this structure:
 - \`type: entity\` — page category (MUST be exactly "entity")
 - \`created:\` — ISO date of first creation
 - \`sources:\` — array of source file wiki-links
-- \`tags:\` — entity subtype, MUST be one of: ${entityList}
+- \`tags:\` — entity subtype; the valid values are runtime-injected by the **Active Tag Vocabulary** section of every system prompt (driven by Settings). MUST be one of those values.
 - \`aliases:\` (optional) — alternative names (translations, abbreviations)
 - \`reviewed:\` (optional) — if true, page is human-verified and protected
 
@@ -77,7 +154,7 @@ Pages in \`concepts/\` MUST follow this structure:
 - \`type: concept\` — page category (MUST be exactly "concept")
 - \`created:\` — ISO date of first creation
 - \`sources:\` — array of source file wiki-links
-- \`tags:\` — concept subtype, MUST be one of: ${conceptList}
+- \`tags:\` — concept subtype; the valid values are runtime-injected by the **Active Tag Vocabulary** section of every system prompt (driven by Settings). MUST be one of those values.
 - \`aliases:\` (optional) — alternative names (translations, abbreviations)
 - \`reviewed:\` (optional) — if true, page is human-verified and protected
 
@@ -132,10 +209,9 @@ Rules:
 ## Classification Rules
 - **type field:** entity | concept | source — the page category
 - **tags field:** stores the subtype (entity_type or concept_type)
-- Entity subtypes (valid tags for type=entity): ${entityList}
-- Concept subtypes (valid tags for type=concept): ${conceptList}
+- Entity subtypes / Concept subtypes: see the **Active Tag Vocabulary** section injected into every system prompt (driven by Settings). The valid values are NOT listed here — relying on a baked list in this file would drift from your Settings whenever you change the vocabulary.
 - Source types: document, conversation, note
-- **Rule:** tags MUST only contain values from the corresponding subtype list above. A tag not in the valid list will be removed by the system.
+- **Rule:** tags MUST only contain values from the Active Tag Vocabulary in the system prompt. A tag not in that list will be removed by the system.
 
 ## Multi-Source Merge Rules
 - Sources array: Append new sources, never overwrite
@@ -258,11 +334,18 @@ ${selectedBody}
     try {
       const content = await this.app.vault.read(file);
       const parsed = this.parseConfigFile(content);
-
-      this.cachedBody = parsed.body;
+      // Issue #328 Phase 1: vault-resident schema files created under
+      // v1.22.0-v1.25.1 may still carry a baked tag enum at 6 sites
+      // (Wiki Structure × 2, Entity Page Template × 1, Concept Page
+      // Template × 1, Classification Rules × 2). The on-disk file is the
+      // user's data — we never rewrite it. Instead we sanitize the body
+      // that the LLM sees in this cache layer so the runtime injection is
+      // the SOLE tag vocabulary the model encounters.
+      const sanitizedBody = stripLegacyBakedTagEnum(parsed.body);
+      this.cachedBody = sanitizedBody;
       this.cacheValid = true;
 
-      return parsed;
+      return { ...parsed, body: sanitizedBody };
     } catch {
       console.warn('Failed to read schema file, ignoring');
       return null;

--- a/src/wiki/system-prompts.ts
+++ b/src/wiki/system-prompts.ts
@@ -221,15 +221,13 @@ export async function buildSystemPrompt(
   const schemaContext = await getSchemaContext(task);
   if (schemaContext) parts.push(schemaContext);
 
-  // v1.21.0 Phase 1.3: Inject active tag vocabulary so user-defined Custom
-  // tags are respected by ALL ingestion paths (not just lint). Skip if the
-  // schema context already contains the section (defensive — caller might
-  // have prepended it).
-  const schemaHasTagVocab = schemaContext?.includes('Active Tag Vocabulary') ?? false;
-  if (!schemaHasTagVocab) {
-    const tagVocab = buildActiveTagVocabularySection(settings);
-    if (tagVocab) parts.push(tagVocab);
-  }
+  // Issue #328 Phase 1: the runtime-injection layer is the SOLE source of
+  // truth for the active tag vocabulary. Always append. Any dedup is the
+  // caller's responsibility — schema bodies produced by
+  // buildDefaultSchemaBody() no longer contain a baked enum to duplicate
+  // against.
+  const tagVocab = buildActiveTagVocabularySection(settings);
+  if (tagVocab) parts.push(tagVocab);
 
   return parts.length > 0 ? parts.join('\n\n') : undefined;
 }
@@ -252,7 +250,7 @@ export function buildActiveTagVocabularySection(
   const entities = getActiveEntityTags(settings);
   const concepts = getActiveConceptTags(settings);
   const lines: string[] = [];
-  lines.push('## Active Tag Vocabulary (Issue #85 — user-controlled)');
+  lines.push('## Active Tag Vocabulary (runtime)');
   lines.push('');
   lines.push(
     'When assigning `type` to an entity or concept, you MUST use one of the following allowed values. Do NOT invent new types.'


### PR DESCRIPTION
## Summary

Schema Phase 1 of Issue #328 — eliminates the dual-source tag-vocabulary problem. The active tag enum was emitted in two places at runtime:

1. Baked into `schema/config.md` by `buildDefaultSchemaBody()` (Wiki Structure × 2, Entity Page Template, Concept Page Template, Classification Rules × 2)
2. Injected by `buildActiveTagVocabularySection()` into every system prompt

When the user changed Settings → `customEntityTags`, only the runtime layer updated. The schema body kept the stale enum, so the LLM saw two different tag lists. The `schemaHasTagVocab` defensive check in `buildSystemPrompt` masked the symptom — it did not fix the cause.

## Changes (2 commits)

### `cfdc842` — fix(schema): eliminate dual-source tag vocabulary
- `buildDefaultSchemaBody()` drops the 5 `${entityList}`/`${conceptList}` interpolations. Wiki Structure / Entity / Concept Page Template / Classification Rules now defer to the runtime **Active Tag Vocabulary** section.
- `buildSystemPrompt()`: `schemaHasTagVocab` defensive branch removed. Runtime section is always appended.
- Injected heading text '(Issue #85 — user-controlled)' → '(runtime)' reflects the new layer authority.
- 5 retired v1.22.0 Phase 2 tests deleted (`default-schema.test.ts:78-154`). New contract in `runtime-injection.test.ts` (7 tests).
- **NEW `stripLegacyBakedTagEnum()`** for in-memory sanitization of legacy vaults at `loadSchema()` time, covering all 6 legacy sites (Wiki Structure × 2, Entity Page Template, Concept Page Template, Classification Rules × 2). The on-disk file is the user's data — never rewritten. Idempotent + section-agnostic.
- 12 new tests (7 contract + 6 sanitize + 2 seam pins). Test count: 2511 → 2526.

### `66ad27c` — docs(claude,roadmap): sync v1.25.2 PATCH state for Schema Phase 1
- CLAUDE.md: Current Phase header updated to reflect PR #324 + PR #329 merges; Scope #3 marks Schema Phase 1 Option A as completed; new **Schema 三层分离** Key Design Decision section + hard rule for future contributors.
- ROADMAP.md: Updated date + v1.25.2 PATCH status table; new Schema Phase 1 section with revised TDD order + 3-decision table + backwards-compat + orthogonality proof. Folder layout notice corrected (stays Phase 2).

## Backwards compatibility

- Existing users' schema files (v1.22.0-v1.25.1 with baked tag lists) are **NOT rewritten**. `loadSchema()` sanitizes the LLM-facing view in-memory; on-disk file untouched.
- New vaults get clean templates via `buildDefaultSchemaBody()`.
- All call sites of `getSchemaContext()` unchanged — same `SchemaTask` contract.
- Settings schema unchanged. No breaking API changes.

## Phase 2/3 orthogonality (Issue #328)

Phase 1 only touches `buildDefaultSchemaBody()` content + the unconditional runtime injection point in `buildSystemPrompt()`. It does NOT change `parseSections()`/`selectSections()`/`TASK_SECTIONS`. Phase 2 (Settings-driven `WIKI_SUBFOLDERS` + per-type registration) and Phase 3 (multi-wiki + placeholders + dynamic scanners) are orthogonal — no future re-work predicted.

## Decision rationale

User override (2026-07-22) of Issue #328's "wait 2 weeks for community feedback" public commitment. Three grounds:
1. Phase 1 is bug-fix nature, not design track
2. Phase 1 is orthogonal to Phase 2/3 (no future re-work)
3. ~3-4h effort fits PATCH scope

Memory: `~/.claude/projects/.../feedback-schema-phase1-option-a-decision.md`

## Out of scope (follow-up PRs)

- Token dedup: 5 user-layer call sites of `appendTagVocabularyToPrompt()` are now redundant because system layer always injects. Will be a separate PR.
- `src/schema/schema-context.ts` has 213 lines of dead exports (`parseSchemaContext`, `buildSchemaSectionTemplate`, `SchemaSection`, etc.) — zero production callers. Cleanup PR pending.
- NOTICE file (9 contributors) update deferred to v1.25.2 PATCH release commit.

## Test verification

- Gate 1: `pnpm lint` (baseline 18 errors in `__tests__/fixtures/`, unchanged), `npx tsc --noEmit` 0, `pnpm test` 2526/2526 pass, `pnpm build` clean, `pnpm css-lint` 0.
- Phase 1 e2e verified locally with Kardiologie legacy fixture — all 6 baked-enum sites stripped; section routing (`parseSections()` + `TASK_SECTIONS`) intact across `entity`/`concept`/`analyze` tasks.

Co-Authored-By: Claude Code <noreply@anthropic.com>
