### PR TITLE
perf(dedup): remove redundant user-layer Active Tag Vocabulary injection

### DIFF
--- a/src/__tests__/wiki/source-analyzer.test.ts
+++ b/src/__tests__/wiki/source-analyzer.test.ts
@@ -204,3 +204,26 @@ describe('buildCompactSlugList (#116)', () => {
     expect(prompt).toContain('**Existing Wiki pages — use ONLY these exact paths when creating [[links]]:**');
   });
 });
+
+// === Token dedup — #328 Phase 1 follow-up ===
+// source-analyzer user-layer no longer appends Active Tag Vocabulary section
+// (system layer injects once via buildSystemPrompt).
+describe('SourceAnalyzer — user-layer tag-vocab dedup (#328 Phase 1 follow-up)', () => {
+  it('does NOT append the Active Tag Vocabulary section in the user prompt', async () => {
+    const { ctx } = createMockContext({
+      vaultFiles: { 'sources/dedup.md': '# Dedup\nSome content.' },
+      llmResponses: [JSON.stringify({
+        source_title: 'Dedup',
+        summary: 'A test summary.',
+        entities: [{ name: 'Foo', type: 'other', summary: 'bar', mentions_in_source: [] }],
+        concepts: [],
+      })],
+    });
+    const spy = vi.spyOn(ctx.getClient()!, 'createMessage');
+    const analyzer = new SourceAnalyzer(ctx);
+    // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+    await analyzer.analyzeSource(createMockFile('sources/dedup.md') as unknown as TFile);
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][0].messages[0].content).not.toContain('## Active Tag Vocabulary');
+  });
+});

--- a/src/wiki/lint/llm-phases/analysis-phase.ts
+++ b/src/wiki/lint/llm-phases/analysis-phase.ts
@@ -15,7 +15,7 @@
 import { getText } from '../../../core/i18n';
 import { TEXTS } from '../../../texts';
 import { cleanMarkdownResponse } from '../../../core/markdown';
-import { appendGranularityToPrompt, appendTagVocabularyToPrompt } from '../../system-prompts';
+import { appendGranularityToPrompt } from '../../system-prompts';
 import { TOKENS_LINT_DEDUP_LLM } from '../../../constants';
 import { resolveModelForTask } from '../../../core/model-resolver';
 import type { LintPhaseContext, ScannerPage } from '../types';
@@ -78,10 +78,8 @@ export function buildAnalysisPrompt(
     .replace('{contentSample}', contentSample)
     .replace('{progReport}', progReport || emptySentinel);
 
-  return appendTagVocabularyToPrompt(
-    appendGranularityToPrompt(withPlaceholders, settings),
-    settings,
-  );
+  // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
+  return appendGranularityToPrompt(withPlaceholders, settings);
 }
 
 /**

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -28,7 +28,7 @@ import { canonicalizeSectionHeaders } from '../../core/section-header-canonicali
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { parseFrontmatter, enforceFrontmatterConstraints } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
-import { applySectionLabels, appendTagVocabularyToPrompt, getSectionLabels } from '../system-prompts';
+import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { resolvePagePath, buildPagesListForPrompt, type PathResolutionContext } from './path-resolution';
 import { mergePage } from './merge-page';
 import { appendToReviewedPage } from './merge-page';
@@ -190,10 +190,8 @@ export async function createNewPage(
       // through unchanged.
       .replace(/\{\{source_file\}\}/g, sourceSlug ? `sources/${sourceSlug}` : sourceFile.path);
 
-    const finalPrompt = appendTagVocabularyToPrompt(
-      applySectionLabels(prompt, ctx.settings),
-      ctx.settings,
-    );
+    // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
+    const finalPrompt = applySectionLabels(prompt, ctx.settings);
 
     const pageContent = await client.createMessage({
       model: resolveModelForTask(ctx.settings, 'ingest'),

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -42,7 +42,7 @@ import {
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
-import { applySectionLabels, appendTagVocabularyToPrompt, getSectionLabels } from '../system-prompts';
+import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { UNIVERSAL_LINK_CONSTRAINTS } from '../prompts/constraints';
 import { buildPagesListForPrompt } from './path-resolution';
 import { classifyMergeNeed } from './merge-triage';
@@ -150,7 +150,8 @@ export async function mergePage(
       .replace('{{key_details}}', firstQuotesForPrompt(info))
       .replace('{{existing_pages}}', await buildPagesListForPrompt(ctx, extraPagePaths));
 
-    const finalPrompt = appendTagVocabularyToPrompt(applySectionLabels(prompt, ctx.settings), ctx.settings);
+    // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
+    const finalPrompt = applySectionLabels(prompt, ctx.settings);
 
     const mergedBody = await client.createMessage({
       model: resolveModelForTask(ctx.settings, 'ingest'),
@@ -229,7 +230,8 @@ export async function appendToReviewedPage(
       .replace('{{key_details}}', firstQuotesForPrompt(info))
       .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
 
-    const finalPrompt = appendTagVocabularyToPrompt(applySectionLabels(prompt, ctx.settings), ctx.settings);
+    // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
+    const finalPrompt = applySectionLabels(prompt, ctx.settings);
 
     const newContent = await client.createMessage({
       model: resolveModelForTask(ctx.settings, 'ingest'),

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -21,8 +21,7 @@ import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { TOKENS_MERGE_TRIAGE } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
-import { getSectionLabels } from '../system-prompts';
-import { applySectionLabels, appendTagVocabularyToPrompt } from '../system-prompts';
+import { getSectionLabels, applySectionLabels } from '../system-prompts';
 import { firstQuotesForPrompt } from './contextualize';
 
 /** Strategy selected by the LLM for handling new information vs. an existing page. */
@@ -92,10 +91,9 @@ export async function classifyMergeNeed(
     .replace('{{new_info}}', buildNewInfoSummary(info, sourceFile))
     .replace('{{section_labels}}', `- ${sectionLabelsList}`);
 
-  const finalPrompt = appendTagVocabularyToPrompt(
-    applySectionLabels(triagePrompt, ctx.settings),
-    ctx.settings,
-  );
+  // Issue #328 Phase 1 follow-up: removed appendTagVocabularyToPrompt wrapper
+  // because the system layer now always injects the same section once.
+  const finalPrompt = applySectionLabels(triagePrompt, ctx.settings);
 
   const response = await client.createMessage({
     model: resolveModelForTask(ctx.settings, 'ingest'),

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -37,7 +37,7 @@ import { coerceToArray } from '../core/arrays';
 import { isBlankSource } from '../core/frontmatter';
 import { MAX_TOKENS_BATCH, TOKENS_PER_ITEM_BUDGET, SOURCE_ANALYZER_RETRY_MULTIPLIER } from '../constants';
 import { getExistingWikiPages } from './lint/get-existing-pages';
-import { getGranularityInstruction, buildActiveTagVocabularySection } from './system-prompts';
+import { getGranularityInstruction } from './system-prompts';
 import { resolveModelForTask } from '../core/model-resolver';
 import { calculateBatchLimits, adjustBatchSizeForResponse, getCustomTypeCaps } from '../core/batch-limits';
 import { detectConvergence, checkCumulativeLimits, checkEmptyBatch, formatConvergenceStatus } from '../core/convergence-detector';
@@ -243,12 +243,9 @@ export class SourceAnalyzer {
     // Build granularity instruction from shared definitions
     const granularityInstruction = getGranularityInstruction(this.ctx.settings)
 
-    // Issue #85 v6: inject the active tag vocabulary so the LLM knows
-    // exactly which entity/concept types are accepted by the frontmatter
-    // validator. Without this, the LLM invents its own types that get
-    // silently dropped at write time.
-    const tagVocabularySection = buildActiveTagVocabularySection(this.ctx.settings)
-
+    // Issue #85 v6 / #328 Phase 1 follow-up: user-layer tag-vocab removed
+    // (system layer append once, see comments at the injection site below).
+    //
     // Issue #116: inject a compact slug-only list of existing wiki pages so
     // the LLM uses exact paths when generating [[links]]. The verbose index
     // is capped at 40K chars and causes dead-link slug mismatches; a slug-only
@@ -318,11 +315,8 @@ export class SourceAnalyzer {
       const translationHint = wikiLang !== 'en'
         ? `\n\nTRANSLATION (cross-language wikis): For each entry in mentions_with_provenance, ALSO add a 'translation' field containing a ${wikiLangName} translation of the quote text. The 'quote' field MUST stay verbatim in the source's original language; the translation goes in a separate 'translation' field. Example: {"quote": "Machine learning is fun", "translation": "机器学习很有趣", "source_path": "...", ...}`
         : '';
-      // Issue #85 v6: inject the active tag vocabulary so the LLM emits
-      // type values that match the user's custom vocabulary (or the
-      // hardcoded defaults). Without this, the LLM invents its own types
-      // and the frontmatter validator silently drops them.
-      const finalPrompt = prompt + langHint + translationHint + '\n\n' + tagVocabularySection;
+      // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer (buildSystemPrompt) always injects once.
+      const finalPrompt = prompt + langHint + translationHint;
 
       console.debug(`[Batch ${batchNum + 1}/${limits.maxBatches}] LLM call started (batch_size=${currentBatchSize})...`);
       console.debug(`[Batch ${batchNum + 1}] Prompt length:`, prompt.length);


### PR DESCRIPTION
## Summary

**Phase 1 follow-up: remove redundant user-layer `appendTagVocabularyToPrompt()` calls.**

Phase 1 (`0b5171d`) made `buildSystemPrompt()` always append the `## Active Tag Vocabulary` section in every system prompt. Five call sites were still injecting the same section a second time via the user prompt — producing a stable double-inject of the ~600-char section per LLM call.

### Changes (6 files, +44/-31)

Removed `appendTagVocabularyToPrompt()` wrapper from:

| File | Prompt type | System prompt path |
|---|---|---|
| `source-analyzer.ts` | Ingest batch prompt | `ctx.buildSystemPrompt('analyze')` |
| `page-factory/create-page.ts` | Page generation prompt | `ctx.buildSystemPrompt(pageType)` |
| `page-factory/merge-page.ts` ×2 | Merge + append-to-reviewed prompts | `ctx.buildSystemPrompt('merge')` |
| `page-factory/merge-triage.ts` | Merge-triage prompt | `system` (via client wiring) |
| `lint/llm-phases/analysis-phase.ts` | Lint analysis prompt | `ctx.buildSystemPrompt('lint')` |

### Token savings

Each removed wrapper saved ~600 chars per LLM call. For ingests with default `maxBatches=5`, this saves ~3KB per batch.

### Remaining caller: `appendTagVocabularyToPrompt` kept for retag

`runRetagViolations` (fix-runners.ts) is the only path without a `buildSystemPrompt` call — its LLM call has no system prompt, so the user-layer tag injection stays. A follow-up PR will migrate retag to `buildSystemPrompt` and delete the dead helper entirely.

### Tests

- New RED test in `source-analyzer.test.ts` asserting user prompt does NOT contain `## Active Tag Vocabulary` (2527 tests passing)
- No behavior changes: every deduped call site has both user prompt AND system prompt in the same `client.createMessage()` call — the section moves from user layer to system layer, same LLM input

## Gate 1

- tsc 0 errors
- 2527/2527 tests passing
- Build clean
- eslint: no new errors
- css-lint 0 violations

Co-Authored-By: green-dalii <654534332@qq.com>
Co-Authored-By: Claude Code <noreply@anthropic.com>
PRXEOF && gh pr create --base main --head feat/token-dedup --title "perf(dedup): remove redundant user-layer Active Tag Vocabulary injection" --body-file /tmp/prx-body.md 2>&1 | tail -10