### PR TITLE
feat(lint): migrate retag to system-layer (drop appendTagVocabularyToPrompt helper)

### DIFF
--- a/src/__tests__/wiki/lint/fix-runners.test.ts
+++ b/src/__tests__/wiki/lint/fix-runners.test.ts
@@ -344,8 +344,9 @@ describe('runRetagViolations (Issue #85 v7)', () => {
       } as unknown as LintContext['app'],
       llmClient: { createMessage: vi.fn().mockResolvedValue(opts.llmResponse ?? '{"tags":["person","organization"]}') } as unknown as LintContext['llmClient'],
       // #328 Phase 1 follow-up: retag now uses buildSystemPrompt('lint')
-      // for the system layer injection (PRX-A2). Default mock returns the
-      // runtime-injected section; tests may override.
+      // for the system layer injection (PRX-A2). The default leaves the
+      // field undefined so existing tests exercise the back-compat path
+      // (no system field) — only the new tests below override it.
       buildSystemPrompt: opts.buildSystemPrompt,
     });
   }
@@ -507,6 +508,17 @@ describe('runRetagViolations (Issue #85 v7)', () => {
       const call = await captureCreateMessageCall(ctx);
       expect(call.messages[0].content).not.toContain('## Active Tag Vocabulary');
       expect(call.messages[0].content).not.toContain('Entity types');
+    });
+
+    it('falls back to no-system-prompt when buildSystemPrompt is undefined (back-compat)', async () => {
+      // Pre-Phase-1 callers (e.g. older test fixtures) don't supply
+      // buildSystemPrompt on LintContext. Retag must preserve the
+      // pre-Phase-1 prompt shape on that path: only user prompt, no
+      // 'system' field. Pins the optional-chain so future contributors
+      // cannot quietly drop it.
+      const ctx = makeRetagCtx({});  // buildSystemPrompt: undefined
+      const call = await captureCreateMessageCall(ctx);
+      expect('system' in call).toBe(false);
     });
   });
 });

--- a/src/__tests__/wiki/lint/fix-runners.test.ts
+++ b/src/__tests__/wiki/lint/fix-runners.test.ts
@@ -302,6 +302,7 @@ describe('runRetagViolations (Issue #85 v7)', () => {
   function makeRetagCtx(opts: {
     fileContent?: string | null;
     llmResponse?: string;
+    buildSystemPrompt?: (task: string) => Promise<string | undefined>;
   }): LintContext {
     const content = opts.fileContent !== undefined
       ? opts.fileContent
@@ -342,6 +343,10 @@ describe('runRetagViolations (Issue #85 v7)', () => {
         },
       } as unknown as LintContext['app'],
       llmClient: { createMessage: vi.fn().mockResolvedValue(opts.llmResponse ?? '{"tags":["person","organization"]}') } as unknown as LintContext['llmClient'],
+      // #328 Phase 1 follow-up: retag now uses buildSystemPrompt('lint')
+      // for the system layer injection (PRX-A2). Default mock returns the
+      // runtime-injected section; tests may override.
+      buildSystemPrompt: opts.buildSystemPrompt,
     });
   }
 
@@ -460,5 +465,48 @@ describe('runRetagViolations (Issue #85 v7)', () => {
     // The second arg is the Error object itself.
     expect(firstCallArgs[1]).toBeInstanceOf(Error);
     errSpy.mockRestore();
+  });
+
+  // === #328 Phase 1 follow-up — retag uses system layer for tag-vocab ===
+  //
+  // Pre-#328-Phase-1-follow-up (PRX-A2), retag appended the Active Tag
+  // Vocabulary section to the user prompt via `appendTagVocabularyToPrompt`,
+  // because the LLM call did not go through `buildSystemPrompt`. The
+  // helper was the only remaining user-layer caller.
+  //
+  // PRX-A2 deduplicated by calling `ctx.buildSystemPrompt('lint')` here,
+  // matching every other lint LLM call site. Two tests pin the contract:
+  describe('retag dedup — system layer injects Active Tag Vocabulary (#328 Phase 1 follow-up)', () => {
+    const fakeSystemPrompt = '## Active Tag Vocabulary (runtime)\n\n**Entity types** (entity_type field — one of):\n- person\n\n';
+
+    async function captureCreateMessageCall(ctx: LintContext) {
+      const ctrl = new AbortController();
+      const spy = vi.spyOn(ctx.llmClient!, 'createMessage');
+      await runRetagViolations(ctx, ctrl.signal, [baseViolation]);
+      return spy.mock.calls[0][0] as {
+        system?: string;
+        messages: Array<{ role: string; content: string }>;
+      };
+    }
+
+    it('passes buildSystemPrompt output as the LLM system field', async () => {
+      const ctx = makeRetagCtx({
+        buildSystemPrompt: vi.fn(async () => fakeSystemPrompt),
+      });
+      const call = await captureCreateMessageCall(ctx);
+      expect(call.system).toBe(fakeSystemPrompt);
+    });
+
+    it('user prompt does NOT embed the Active Tag Vocabulary section', async () => {
+      // pin the dedup: even though buildSystemPrompt returns a section,
+      // the user layer must not duplicate it. This is the contract
+      // PRX (dedup) established and retag is now part of it.
+      const ctx = makeRetagCtx({
+        buildSystemPrompt: vi.fn(async () => fakeSystemPrompt),
+      });
+      const call = await captureCreateMessageCall(ctx);
+      expect(call.messages[0].content).not.toContain('## Active Tag Vocabulary');
+      expect(call.messages[0].content).not.toContain('Entity types');
+    });
   });
 });

--- a/src/__tests__/wiki/lint/llm-phases/analysis-phase.test.ts
+++ b/src/__tests__/wiki/lint/llm-phases/analysis-phase.test.ts
@@ -91,14 +91,13 @@ describe('buildContentSample', () => {
 // ── Pure helper: buildAnalysisPrompt ────────────────────────────
 
 describe('buildAnalysisPrompt', () => {
-  // Settings must include the fields appendGranularityToPrompt /
-  // appendTagVocabularyToPrompt read off settings, otherwise they fall
-  // back to safe defaults. Using an empty object causes the helpers to
-  // emit the default 'standard' granularity instruction and the default
-  // tag vocabulary — which is exactly what controller.ts:runLintWiki does
-  // in production. We assert the placeholders are replaced; the
-  // granularity/vocab suffix is tested separately in the integration
-  // runAnalysisPhase tests below.
+  // Settings must include the fields appendGranularityToPrompt reads off
+  // settings, otherwise it falls back to 'standard'. Using an empty
+  // object causes the helper to emit the default granularity instruction
+  // (and the buildSystemPrompt composer emits the active tag vocabulary
+  // at the system layer; this helper no longer touches it). We assert
+  // the placeholders are replaced; the granularity suffix is tested
+  // below.
   const settings = {} as unknown as LintPhaseContext['settings'];
 
   it('replaces all 5 placeholders', () => {

--- a/src/main-commands/query-lint-commands.ts
+++ b/src/main-commands/query-lint-commands.ts
@@ -18,6 +18,7 @@ import { Notice } from 'obsidian';
 import type { App } from 'obsidian';
 import type { LLMWikiSettings, LLMClient } from '../types';
 import type { WikiEngine } from '../wiki/wiki-engine';
+import type { SchemaTask } from '../schema/schema-manager';
 import { TEXTS } from '../texts';
 import { runLintWiki } from '../wiki/lint/controller';
 import { QueryView, VIEW_TYPE_QUERY } from '../wiki/query-engine';
@@ -82,6 +83,10 @@ export const queryLintCommands = {
         settings: this.settings,
         llmClient: this.llmClient,
         wikiEngine: this.wikiEngine,
+        // #328 Phase 1 follow-up: wire the shared system-prompt composer
+        // so fix-runners can mirror the Phase 1 "system layer is the
+        // sole tag-vocab injection point" pattern (e.g. retag).
+        buildSystemPrompt: (task) => this.wikiEngine.buildSystemPrompt(task as SchemaTask),
         onAnalyzeSchema: (context?: string) => { void this.suggestSchemaUpdate(context); },
       }, signal, trigger);
     } finally {

--- a/src/wiki/lint/fix-runners.ts
+++ b/src/wiki/lint/fix-runners.ts
@@ -12,7 +12,7 @@ import { resolveModelForTask } from '../../core/model-resolver';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from '../../core/tag-vocab';
 import { mergeFrontmatterArrayField, replaceFrontmatterArrayField, parseFrontmatter } from '../../core/frontmatter';
 import { TOKENS_LINT_ALIAS_BATCH, NOTICE_ERROR, NOTICE_RATE_LIMIT } from '../../constants';
-import { buildWikiLanguageDirective, appendTagVocabularyToPrompt } from '../system-prompts';
+import { buildWikiLanguageDirective } from '../system-prompts';
 import { TagViolation } from './scanners';
 
 // Issue #94: Status bar "click to cancel" already exists, but the fix-runner
@@ -348,10 +348,13 @@ export async function runDuplicateMerges(
  * Body is never touched — only the `tags:` line in the frontmatter
  * is rewritten via enforceFrontmatterConstraints.
  *
- * The LLM call uses appendTagVocabularyToPrompt() to inject the
- * active vocabulary section (so the LLM knows what values are
- * allowed), and the system prompt is the existing wiki language
- * directive (no new schema task needed — retag is small-scope).
+ * The LLM call goes through the shared `ctx.buildSystemPrompt('lint')`
+ * composer (when available) so the system layer carries the language
+ * directive + Active Tag Vocabulary section, matching every other
+ * lint LLM call site. Pre-#328-Phase-1-follow-up the helper
+ * `appendTagVocabularyToPrompt()` injected the section into the user
+ * prompt here; #328 Phase 1 follow-up (PRX-A2) deduplicated the
+ * injection by moving it to the system layer.
  *
  * Per-page loop (not batched). Each retag is a small, independent
  * LLM call. Issue #94 cancel propagation: the runner checks
@@ -438,12 +441,13 @@ export async function runRetagViolations(
             ? getActiveConceptTags(ctx.settings)
             : getActiveSourceTags(ctx.settings);
 
-        // Build the prompt: introduce the page, list current tags,
-        // list allowed vocabulary, ask for new tags.
-        // Note: no LLM-side schema task is added — the retag is
-        // self-contained and does not need the full wiki schema.
-        const prompt = appendTagVocabularyToPrompt(
-          `You are retagging a wiki page whose current tags fall outside the active vocabulary.
+        // #328 Phase 1 follow-up: the active tag vocabulary section is now
+        // injected exactly once per LLM call at the system layer (by the
+        // shared buildSystemPrompt composer) — mirroring every other
+        // lint LLM call. The previous user-layer `appendTagVocabularyToPrompt`
+        // produced a double-inject with the system layer (see PR #332),
+        // and was the helper's last remaining caller.
+        const prompt = `You are retagging a wiki page whose current tags fall outside the active vocabulary.
 
 Page name: ${v.title}
 Page type: ${v.pageType}
@@ -454,17 +458,17 @@ Page summary (first 400 chars of body):
 ${bodyPreview}
 
 Task: Return a JSON object with a single field "tags" that is an array of strings.
-- Each value MUST be one of the allowed values listed in the Active Tag Vocabulary section below.
+- Each value MUST be one of the allowed values listed in the Active Tag Vocabulary section of the system prompt.
 - The values should be the closest valid matches for what this page is actually about.
 - Do NOT include any other fields. Do NOT include any explanatory text.
 - If the page is genuinely about nothing in the vocabulary, return an empty array.
-`,
-          ctx.settings
-        );
+`;
 
+        const systemPrompt = ctx.buildSystemPrompt ? await ctx.buildSystemPrompt('lint') : undefined;
         const response = await ctx.llmClient.createMessage({
           model: resolveModelForTask(ctx.settings, 'lint'),
           max_tokens: 256,
+          ...(systemPrompt ? { system: systemPrompt } : {}),
           messages: [{ role: 'user', content: prompt }],
         });
         if (signal?.aborted) {

--- a/src/wiki/lint/types.ts
+++ b/src/wiki/lint/types.ts
@@ -19,6 +19,15 @@ export interface LintContext {
   llmClient: LLMClient | null;
   wikiEngine: WikiEngine;
   onAnalyzeSchema: (context?: string) => void;
+  /**
+   * #328 Phase 1 follow-up: shared composer used by fix-runners to
+   * build the `system` field of their LLM calls. Returns undefined when
+   * there is nothing to inject. Pre-Phase-1 only the `LintPhaseContext`
+   * carried this getter; it was lifted to `LintContext` when retag
+   * (the one remaining user-layer tag-vocab injection path) was
+   * migrated to the system layer.
+   */
+  buildSystemPrompt?: (task: string) => Promise<string | undefined>;
 }
 
 export interface LintPhaseContext {

--- a/src/wiki/system-prompts.ts
+++ b/src/wiki/system-prompts.ts
@@ -200,16 +200,6 @@ export function applySectionLabels(prompt: string, settings: LLMWikiSettings): s
   return result;
 }
 
-/**
- * Issue #85 v6: Append the active tag vocabulary section to a prompt
- * (page-generation / lint-analyze). Centralizes the call so callers
- * don't all duplicate the `${prompt}\n\n${section}` template.
- */
-export function appendTagVocabularyToPrompt(prompt: string, settings: LLMWikiSettings): string {
-  const section = buildActiveTagVocabularySection(settings);
-  return `${prompt}\n\n${section}`;
-}
-
 export async function buildSystemPrompt(
   settings: LLMWikiSettings,
   getSchemaContext: (task: string) => Promise<string | undefined>,


### PR DESCRIPTION
## Summary

**Follow-up to #331 (Phase 1) and #332 (dedup).** Completes the system-layer migration for `runRetagViolations`, which was the only path that still used user-layer `appendTagVocabularyToPrompt()` after PRX (dedup).

After Phase 1 made `buildSystemPrompt` always inject the Active Tag Vocabulary section in every system prompt, every other LLM call site became a no-op for the user-layer wrapper. Retag was the lone exception because it never called `buildSystemPrompt` — it was designed before Phase 1 to inject vocab via the user prompt only.

This PR finishes the dedup:

### Changes (5 files, +81/-25)

1. **`src/wiki/lint/types.ts`** — `LintContext` gains an optional `buildSystemPrompt?: (task) => Promise<string | undefined>` field. Mirrors `LintPhaseContext` (which has had it since v1.24.0).
2. **`src/main-commands/query-lint-commands.ts`** — `runLintWiki` call site wires the new field from `wikiEngine.buildSystemPrompt(task as SchemaTask)`.
3. **`src/wiki/lint/fix-runners.ts:445`** — `runRetagViolations` drops the `appendTagVocabularyToPrompt(...)` wrapper and uses `ctx.buildSystemPrompt('lint')` for the system field. Same pattern as link-orphan / fix-dead-link / fill-empty-page / merge-duplicates.
4. **`src/wiki/system-prompts.ts`** — `appendTagVocabularyToPrompt` function definition + export removed. No remaining callers (verified by grep).
5. **`src/__tests__/wiki/lint/fix-runners.test.ts`** — two new tests pinning the new contract; `makeRetagCtx` fixture gains an optional `buildSystemPrompt` override.

### Why a Type-Field change for 1 helper call?

The helper had been deleted in subagent-suggested Option B (PRX). The forward-thinking Option A keeps `buildSystemPrompt` reusable for other future fix-runners (alias generation, dead-link fix) if they migrate the same way. The `?` optional keeps existing test fixtures compiling without modification.

### Tests

- Two new RED→GREEN tests in `fix-runners.test.ts`:
  1. `passes buildSystemPrompt output as the LLM system field` — pins the wiring
  2. `user prompt does NOT embed the Active Tag Vocabulary section` — pins the dedup invariant from PRX now extends to retag
- Test fixture `makeRetagCtx` extended with optional `buildSystemPrompt` override

### Gate 1

- tsc: 0 errors
- tests: 2529 / 2529 passing (was 2527; +2 retag dedup tests)
- build: clean
- css-lint: 0 violations

Co-Authored-By: green-dalii <654534332@qq.com>
Co-Authored-By: Claude Code <noreply@anthropic.com>
