### PR TITLE
docs(notice): add ingest reliability fixes to the DocTpoint attribution line

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,8 @@ This product includes software developed by the following contributors,
 listed in alphabetical order by GitHub handle:
 
 - DocTpoint — hub-retirement crystallization signal, knn baseline,
-  peer-link quality analysis, and cold-start A/B evaluation
+  peer-link quality analysis, cold-start A/B evaluation, and ingest
+  reliability fixes
 - dmarchevsky — code contributions and review feedback
 - FrancoTampieri — code contributions
 - Greener-Dalii (green-dalii) — project maintainer and primary author


### PR DESCRIPTION
Small attribution refresh.

My `NOTICE` line still describes the research work from the #198 round. Five fixes have merged since, all with my authorship:

| Commit | Issue |
|---|---|
| `34a358a` | #305 — truncated batch routed into the halving retry |
| `292300b` | #308 — dead-link targets matched against slug-normalized titles |
| `762bb3c` | #307 — related-link corrector sees the prefixes it repairs |
| `9b0ecad` | #310 — page templates no longer close on a bare horizontal rule |
| `3578a9d` | #290 — created vs updated pages split by the pre-write check |

The added phrase is deliberately generic ("ingest reliability fixes") to match the descriptive style of the neighbouring entries — no issue numbers in the file itself. Alphabetical order unchanged, no other lines touched.

Signed off per the DCO policy in CONTRIBUTING.md.