### PR TITLE
docs: README restructure + MODEL-GUIDE + PDF-OCR-GUIDE + loopback-flow bot compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,491 +2,331 @@
 
 # 🧠 Karpathy LLM Wiki Plugin for Obsidian
 
-> AI-powered structured knowledge base that ingests your notes and generates a connected Wiki — based on [Andrej Karpathy's LLM Wiki concept](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+> An Obsidian plugin that turns your notes into a connected, queryable knowledge base — the [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) idea, built into the editor where you already write.
 
-> **Obsidian official score 95/100 | Native support for 10 languages | Zero-embedding graph retrieval | Full data sovereignty | Works with every provider**
+> **Zero-embedding graph retrieval • 10-language native • Works with every provider**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 **English** | [简体中文](docs/README_CN.md) | [繁體中文](docs/README_ZH-Hant.md) | [日本語](docs/README_JA.md) | [한국어](docs/README_KO.md) | [Deutsch](docs/README_DE.md) | [Français](docs/README_FR.md) | [Español](docs/README_ES.md) | [Português](docs/README_PT.md) | [Italiano](docs/README_IT.md)
 
-[Official Site](https://llmwiki.greenerai.top/) | [Obsidian Marketplace](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback & Discussion](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[Official Site](https://llmwiki.greenerai.top/) | [Obsidian Marketplace](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [Quick Start](#-quick-start) | ✨ [Features](#-features) | 🤖 [Model Selection Guide](#-model-selection-guide) | 🔒 [Transparency & Compliance](#-transparency--compliance) | ❓ [FAQ](#-faq)
+📑 [Contents](#-contents) • 🚀 [Quick Start](#-quick-start) • ✨ [Features](#-features) • 🔍 [How Retrieval Works](#-how-retrieval-works) • 🤖 [Models](#-models) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← If this plugin has helped you, feel free to buy me a coffee♥️ or drop a star🌟↗
 
 ---
 
-> **⚡ Quick Update Reminder:** This project evolves rapidly with frequent bug fixes, performance improvements, new features, and UX optimizations. We recommend updating to the latest version regularly in Obsidian (**Settings → Community plugins → Check for updates**), or enabling automatic plugin updates to ensure the best experience.
-
 ## 📑 Contents
 
-- [🧠 Karpathy LLM Wiki Plugin for Obsidian](#-karpathy-llm-wiki-plugin-for-obsidian)
-  - [📑 Contents](#-contents)
-  - [💡 What is LLM-Wiki?](#-what-is-llm-wiki)
-  - [⚡ Why Obsidian + LLM-Wiki?](#-why-obsidian--llm-wiki)
-  - [🚀 Quick Start](#-quick-start)
-    - [📦 Installation](#-installation)
-    - [🔄 Updating](#-updating)
-    - [🔑 Configure an LLM Provider](#-configure-an-llm-provider)
-    - [🎮 Usage](#-usage)
-    - [⚠️ Upgrading from an Older Version?](#️-upgrading-from-an-older-version)
-  - [⚡ What's New in v1.25.x](#-whats-new-in-v125x)
-  - [✨ Features](#-features)
-    - [📊 Knowledge Quality](#-knowledge-quality)
-    - [📄 PDF Ingest (v1.25.0)](#-pdf-ingest-v1250)
-    - [💬 Query \& Feedback](#-query--feedback)
-    - [🛠️ Maintenance](#️-maintenance)
-    - [🌐 LLM \& Language](#-llm--language)
-    - [🏗️ Architecture \& Performance](#️-architecture--performance)
-    - [🔒 Privacy \& Security](#-privacy--security)
-  - [📖 Example](#-example)
-  - [🤖 Model Selection Guide](#-model-selection-guide)
-    - [☁️ Cloud Model Picks](#️-cloud-model-picks)
-    - [🦙 Local Model Recommendations (Ollama / LM Studio)](#-local-model-recommendations-ollama--lm-studio)
-    - [📄 Local PDF OCR Path (v1.25.0+)](#-local-pdf-ocr-path-v1250)
-  - [🏗️ Architecture](#️-architecture)
-  - [❓ FAQ](#-faq)
-  - [🔒 Transparency \& Compliance](#-transparency--compliance)
-  - [💖 Support the Project](#-support-the-project)
-    - [Sponsors](#sponsors)
-  - [📜 License](#-license)
-  - [🙏 Acknowledgments](#-acknowledgments)
-  - [Star History](#star-history)
----
-
-## 💡 What is LLM-Wiki?
-
-You write. AI organizes. You ask. That's it.
-
-**🎯 The problem.** Your notes are a goldmine — people, concepts, ideas, connections. But right now they're just files in folders. Finding what relates to what means searching, tagging, and hoping you remember the thread.
-
-**✨ The fix.** [Andrej Karpathy suggested](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) something elegant: treat your notes as raw material, and let an LLM do the architect work. It reads what you write, pulls out entities and concepts, and weaves them into a structured Wiki — complete with `[[bidirectional links]]`, an auto-generated index, and a chat interface that answers questions from *your* knowledge.
-
-**📚 So you don't have to be the librarian.** No deciding what deserves a page. No maintaining cross-links. No wondering if something is out of date. Pick any note (or folder, or selection) from your vault — the LLM reads, extracts, writes, links, and even flags contradictions — while you stay in flow.
-
-**🤖 And it's not another chatbot.** ChatGPT knows the internet. LLM-Wiki knows *you* — or rather, what you've taught it. Every answer carries `[[wiki-links]]` back into your knowledge graph. Every response is a trailhead, not a dead end.
-
-**🏆 Key differentiator — Graph-powered retrieval at zero embedding cost.** Most knowledge-base plugins use vector embeddings (expensive, per-provider, internet-dependent). LLM-Wiki runs Personalized PageRank over your existing `[[wiki-link]]` graph — matching embedding-grade retrieval quality with zero API calls, no new dependencies, and full local-model support. Add **zero-LLM Tier B section extraction** (i18n-aware, 10 languages) and you get a knowledge engine that works for every user, on every provider.
-
+- [Why this plugin?](#-why-this-plugin)
+- [Is it for me?](#-is-it-for-me)
+- [Quick Start](#-quick-start)
+- [Features](#-features)
+- [How retrieval works](#-how-retrieval-works)
+- [Models](#-models)
+- [FAQ](#-faq)
+- [Privacy](#-privacy)
+- [Support](#-support)
+- [License & Credits](#-license--credits)
 
 ---
 
-## ⚡ Why Obsidian + LLM-Wiki?
+## 🤔 Why this plugin?
 
-Obsidian is brilliant at linked thinking. But there's a catch: you're the one doing all the linking.
+You write notes. They sit in folders. Finding what relates to what means remembering threads you forgot months ago.
 
-LLM-Wiki flips that. Instead of you building the graph by hand, the AI grows it with you. Add a note about a new concept — it finds the connections you'd miss. Ask a question — it walks your own knowledge graph and brings back answers with citations.
+**Other open-source reimplementations of Karpathy's LLM Wiki idea exist — but none of them ships as a one-click Obsidian plugin.** Most are CLI tools, Claude Code skills, or separate desktop apps. We are the only one with native UI, in-vault storage, and Obsidian's own Graph View built in.
 
-- **🔗 Your Graph View comes alive.** New notes don't just sit there — they sprout links to entities, concepts, and sources. The graph grows organically, and the plugin maintains it: detecting duplicates, fixing dead links, bridging languages with aliases.
-- **💬 Your notes learn to talk back.** Search becomes conversation. "What did I write about X?" becomes a dialogue, with streaming responses and `[[wiki-links]]` as breadcrumbs. Every answer is a path deeper into your own knowledge.
-- **🧠 Obsidian becomes a thinking partner.** It stops being a cabinet for notes and starts being something that helps you *think* — surfacing hidden connections, flagging contradictions, remembering what you forgot you knew.
+### How we compare
+
+|  | Karpathy LLM Wiki (this plugin) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **Delivery form** | ✅ One-click Obsidian plugin | ❌ Separate Tauri desktop app | ❌ Claude Code skill | ❌ Claude Code / Codex skill | ❌ CLI + SDK + MCP server |
+| **Setup effort** | ✅ **5 minutes** — Community Plugins → Install → pick provider → Ingest | ❌ 30 min+ — compile/download binary, configure CLI | ❌ 15 min — needs Claude Code subscription + skill install | ❌ 10 min — needs Claude Code/Codex subscription + skill setup | ❌ 30 min+ — pip install + SDK + MCP config |
+| **Install path** | ✅ Obsidian → Community Plugins → search → Install | ❌ Compile or download a separate binary, then configure CLI | ❌ Needs Claude Code subscription + install guide | ❌ Needs Claude Code or Codex subscription + setup steps | ❌ pip install + Python SDK + local server |
+| **Architecture complexity** | ✅ **Zero dependencies** — no vector DB, no embedding model, no external processes | 🟡 Embeds its own Python runtime + sigma.js + sqlite | 🟡 Uses Claude Code's environment — not self-contained | 🟡 Requires separate platform runtime | ❌ Requires Python, embedding model, vector DB |
+| **i18n (UI + wiki output)** | ✅ 10 languages (independent UI / output) | 🟡 2 (EN / 中文) | ❌ English only | ❌ English only | ❌ English only |
+| **LLM providers** | ✅ 12+ (incl. Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-compatible, Kimi, GLM, MiniMax, DeepSeek) | 🟡 OpenAI-compatible | 🟡 Subscription via Claude Code | 🟡 Subscription via Claude Code / Codex | 🟡 OpenAI-compatible |
+| **Retrieval algorithm** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 4-signal heuristic (Adamic-Adar + 2-hop decay) | ❌ Louvain community detection only | ❌ Louvain + k-hop previews | ❌ Hybrid: BM25 + semantic + wikilink |
+| **Query pipeline (5-stage cascade)** | ✅ Lex → LLM keyword → substring scan → LLM KB fallback → PPR expansion (truncates on first sufficient signal) | 🟡 2-hop decay only | ❌ Louvain clustering only | ❌ k-hop previews (no LLM augment) | ❌ BM25 + semantic over chunks (no graph) |
+| **Embeddings required** | ✅ No (zero embedding cost, by design) | 🟡 Optional, off by default | ✅ No | ✅ No | ❌ **Yes — mandatory** |
+| **Graph visualization** | ✅ Obsidian's native Graph View (built in, zero extra size) | ❌ Custom sigma.js + graphology in desktop app | 🟡 vis.js graph.html (separate file) | ❌ Custom sigma.js offline HTML | ❌ Read-only browser viewer |
+| **Wiki honesty** | ✅ "Stage FALLBACK" banner when no wiki source matches your query | ❌ No equivalent | ❌ No equivalent | ❌ No equivalent | ❌ No equivalent |
+| **Published retrieval benchmark** | ✅ PPR @5 = 27.1% vs pure-kNN 24.1% (only published number in this space) | ❌ 58% → 71% *only with embeddings enabled*, not in our apples-to-apples format | ❌ Not published | ❌ Not published | ❌ Not published |
+
+### Three things we chose on purpose, not by accident
+
+- **🪟 Obsidian is the runtime.** No terminal, no separate app, no Docker, no Python. Install from Community Plugins, click Ingest, the wiki lives in your vault from the first second. Obsidian's native Graph View renders your `[[wiki-link]]` graph — built in, zero extra bundle size.
+- **🧭 Clean and self-contained.** Zero dependencies. No embedding model, no vector database, no pip package — a single plugin that reads your notes, talks to an LLM, and writes wiki pages. Everything lives inside Obsidian.
+- **🔌 Any model you already pay for.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-compatible, custom endpoint — twelve-plus providers, none of them required to have an embedding endpoint.
+
+---
+
+## 🎯 Is it for me?
+
+**✅ Yes, if you:**
+
+- **Want a 5-minute setup, not a 5-hour project.** Install from Community Plugins → pick a provider → Ingest one note. No CLI, no Python, no separate runtime, no vector DB. You see wiki pages in `wiki/` within seconds.
+- **Want something clean and self-contained.** The plugin has exactly zero external dependencies: no embedding model, no vector database, no pip package, no Docker container. It's a single Obsidian plugin that reads your notes, talks to an LLM, and writes wiki pages into your vault. Everything lives inside Obsidian.
+- **Want a queryable chat that answers from *your* notes** — not the internet — with every answer carrying `[[wiki-links]]` back into your knowledge graph.
+- **Care about data sovereignty** — runs fully local with Ollama or LM Studio, never touching the internet.
+- **Write in or read from any of 10 supported languages** — the UI and wiki output language are independent (your wiki can be in Chinese while the interface is in English).
+- **Maintain the graph by writing `[[wiki-links]]`** — every link you write already enriches retrieval; no separate tagging/embedding/indexing step.
+- **Want one-click maintenance** — Lint health scan + Smart Fix All keep duplicates, dead links, and orphan pages in check without you hand-curating.
+
+**❌ No, if you:**
+
+- **Want a general-purpose ChatGPT replacement** — this plugin answers from *your* knowledge only.
+- **Need a RAG pipeline over PDFs / web pages / external corpora** — we focus on the in-vault path (PDFs are supported as of v1.25.0).
+- **Are looking for a hosted SaaS** — there's no backend, no server, no account.
 
 ---
 
 ## 🚀 Quick Start
 
-### 📦 Installation
+1. **Install.** Obsidian → Settings → Community plugins → Browse → search "Karpathy LLM Wiki" → Install → Enable. Or visit the [Community Plugin page](https://community.obsidian.md/plugins/karpathywiki) and click **Add to Obsidian**.
+2. **Configure a provider.** Open Settings → Karpathy LLM Wiki → pick a provider (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth), etc.) → enter API key (not needed for local) → click **Test Connection** → Save.
+3. **Ingest one note.** `Cmd+P/Ctrl+P` → "Ingest single source" → pick any Markdown (or PDF, v1.25.0+) file. Your first wiki pages appear in `wiki/sources/`, `wiki/entities/`, `wiki/concepts/` within seconds.
 
-**🌟 Recommended — Obsidian Community Plugin Market:**
+That's it. The plugin modifies nothing in your original notes — only creates new pages under `wiki/`. To chat with your wiki: `Cmd+P/Ctrl+P` → "Query wiki". (`Cmd` on macOS, `Ctrl` on Windows/Linux.)
 
-1. In Obsidian, go to **Settings → Community plugins**
-2. Click **Browse** and search for "Karpathy LLM Wiki"
-3. Click **Install**, then **Enable**
+### Core commands
 
-**🌐 Or from the Community Plugin website —** visit [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) and click **Add to Obsidian** to install directly.
+| Command | What it does |
+|---------|--------------|
+| **📥 Ingest single source** | `Cmd+P/Ctrl+P` → "Ingest single source" — pick a Markdown or **PDF (v1.25.0+)** file, get entity/concept/wiki pages |
+| **📂 Ingest from folder** | `Cmd+P/Ctrl+P` → "Ingest from folder" — batch-ingest every note in a folder, with smart batch skip |
+| **📑 Ingest multiple files** | `Cmd+P/Ctrl+P` → "Ingest multiple files" — pick a subset via a two-pane file tree (with live queue + per-file cancel) |
+| **🔍 Query wiki** | `Cmd+P/Ctrl+P` → "Query wiki" — chat with your wiki in a right-docked side panel; answers carry `[[wiki-links]]` |
+| **🛠️ Lint wiki** | `Cmd+P/Ctrl+P` → "Lint wiki" — full health scan: duplicates, dead links, empty pages, orphans, missing aliases, contradictions |
+| **⚡ Smart Fix All** | inside Lint Modal — one-click causal-order repair with per-phase report |
+| **📋 Regenerate index** | `Cmd+P/Ctrl+P` → "Regenerate index" — rebuild `wiki/index.md` with current pages and aliases |
+| **⏹ Cancel** | `Cmd+P/Ctrl+P` → "Cancel current ingestion" or click the status bar — stops cleanly at the next batch boundary |
+| **📊 Ingestion history** | `Cmd+P/Ctrl+P` → "View Ingestion History" — searchable UI for past ingestions, lint reports, maintenance runs |
 
-**⚙️ Manual (alternative):**
+| Before | After |
+|--------|-------|
+| `notes/machine-learning.md` (a flat file) | `wiki/concepts/supervised-learning.md` with `[[bidirectional links]]`, aliases, source attribution, and an entry in `wiki/index.md` |
 
-1. Download `main.js`, `manifest.json`, `styles.css` from [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
-2. In Obsidian, go to Settings → Community plugins. On the **Installed plugins** tab, click the folder icon to open your plugins directory
-3. Create a folder named `karpathywiki`, drop the three files inside
-4. Back in Obsidian, click the refresh icon — **Karpathy LLM Wiki** will appear under Installed plugins
-5. Toggle it on to enable
+> 💡 **Stay updated.** New features, fixes, and performance improvements ship frequently. Settings → Community plugins → Check for updates, or enable automatic plugin updates.
+> 📖 Detailed walkthroughs (installation, PDF setup, multi-provider notes, upgrades) are maintained in [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides).
 
-**🔨 Development:** `git clone`, `pnpm install`, `pnpm build`.
-
-### 🔄 Updating
-
-This project evolves rapidly — new features, bug fixes, and improvements are shipped frequently. We recommend keeping up to date:
-
-**Option A — Manual update (recommended):**
-1. Go to **Settings → Community plugins**
-2. Click **Check for updates**
-3. Find **Karpathy LLM Wiki** in the list and click **Update**
-
-**Option B — Enable auto-update:**
-1. Go to **Settings → Community plugins**
-2. Toggle on **Automatically check for plugins updates**
-3. New versions will be detected automatically; update manually at your convenience
-
-> 💡 **Why stay updated?** Each release may include new features, performance improvements, and important bug fixes. We actively maintain this plugin — missing updates means missing out on a better experience.
-
-### 🔑 Configure an LLM Provider
-
-1. Open Settings → Karpathy LLM Wiki
-2. Pick a provider from the dropdown (including OpenAI or ChatGPT Plan (Codex OAuth))
-3. For API providers, enter the provider API key (not needed for Ollama, LM Studio, or ChatGPT Plan (Codex OAuth))
-4. For non-Codex providers, click **Fetch Models** or type a model name manually; ChatGPT Plan (Codex OAuth) synchronizes its account model catalog after sign-in and provides **Refresh account models**
-5. Click **Test Connection**, then **Save Settings**
-
-**🦙 Ollama (local, no API key):** Install [Ollama](https://ollama.com), pull a model (`ollama pull gemma4` or `ollama pull qwen3.5:27b`), select "Ollama (Local)" in the provider dropdown.
-
-**🎛️ LM Studio (local, no API key):** Install [LM Studio](https://lmstudio.ai), start its local server (default `http://localhost:1234/v1`), select "LM Studio (Local)" in the provider dropdown. LM Studio runs a built-in OpenAI-compatible server — API key field is optional.
-
-**🔐 ChatGPT Plan (Codex OAuth) — experimental:** This is separate from **OpenAI**, which uses an OpenAI Platform API key and separate usage billing. Select **ChatGPT Plan (Codex OAuth)**, then use **Sign in with browser** on desktop (localhost callback) or **Use device code** on desktop/mobile and finish authorization on OpenAI's page. The plugin synchronizes picker-visible models from the signed-in Codex account and caches only sanitized catalog metadata; use **Refresh account models** to update it. If the catalog is temporarily unavailable, the last successful cache or a minimal bundled fallback remains available. Run **Test Connection**, then save. OAuth credentials are stored only in Obsidian SecretStorage; **Sign out** clears them. Availability follows OpenAI Codex authentication, model, and allowance policies; this is third-party compatibility, not an OpenAI partnership or a general ChatGPT API.
-
-> See [Model Selection Guide](#-model-selection-guide) for details.
-
-### 🎮 Usage
-
-| Method | How |
-|--------|------|
-| **📥 Ingest single source** | `Cmd+P` → "Ingest single source" — select a note (Markdown or **PDF, v1.25.0+**) to extract entities and concepts into Wiki pages |
-| **📂 Ingest from folder** | `Cmd+P` → "Ingest from folder" — pick a folder, batch generate Wiki from all notes inside |
-| **📑 Ingest multiple files** | `Cmd+P` → "Ingest multiple files" — pick specific notes via two-pane modal (recursive folder tree + per-file checkboxes), then batch ingest the selection (with live queue + per-file cancel) |
-| **🎯 Ingest current file** | Click the `sticker` icon in the left ribbon, or `Cmd+P` → "Ingest current file" — ingest the file you're editing |
-| **🔍 Query wiki** | `Cmd+P` → "Query wiki" — conversational Q&A over your Wiki, streaming responses with `[[wiki-links]]` |
-| **🛠️ Lint wiki** | `Cmd+P` → "Lint wiki" — full health scan: duplicates, dead links, empty pages, orphans, missing aliases, contradictions. Schema suggestions surfaced inside the Lint Modal |
-| **📋 Regenerate index** | `Cmd+P` → "Regenerate index" — rebuild `wiki/index.md` with current pages and aliases |
-| **📊 View Ingestion History (v1.21.0)** | `Cmd+P` → "View Ingestion History" — browse past ingestions, lint reports, and maintenance runs in a searchable, filterable UI |
-| **⏹ Cancel current operation** | `Cmd+P` → "Cancel current ingestion" — stop an in-progress operation cleanly at the next batch boundary |
-| **🎉 Recreate Welcome Note (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — re-generate the first-run Welcome note |
-
-Re-ingesting the same source does incremental updates on entity/concept pages (new info merged in). Summary pages are regenerated.
-
-> 💡 **Smart Batch Skip:** When ingesting a folder, the plugin automatically detects already-processed files and skips them to save time and API costs. The batch report shows skipped count.
-
-![Command palette — search "karpa" to see all Karpathy LLM Wiki commands](docs/assets/command-panel.png)
-
-### ⚠️ Upgrading from an Older Version?
-
-> 🔧 **Upgrading from v1.24.x.** PDF ingest (v1.25.0) writes its cache to `.obsidian/plugins/karpathywiki/pdf-cache/` (up to 100 MB / 1000 entries / 10 MB single-entry; LRU-by-mtime eviction on startup and at each batch ingest). Your vault is **not** modified by default — turn on **Write PDF Markdown to Vault** (Settings → Wiki Configuration → Wiki Folder) only if you want a `<basename>.pdf.md` sidecar next to the source PDF. Two new settings — **Force PDF Support** (advanced, default off) and **Write PDF Markdown to Vault** (default off) — are fully backward-compatible: old `data.json` without them defaults to `false`.
-
-> 🔧 **Upgrading from v1.24.0.** The internal `<!-- reviewed: keep -->` comment marker (v1.24.0, #244) that protected only a page's *Mentions in Source* section has been removed. To keep a curated Mentions section, set `reviewed: true` in the page frontmatter — it protects the whole page (Mentions included) and, unlike the hidden comment, stays visible in the Properties panel and survives Markdown linters.
-
-**Backward compatible.** No breaking changes since v1.0.0 — your existing wiki pages, settings, and workflows are preserved without reconfiguration.
-
-**After upgrading**, run **Lint Wiki** → **Smart Fix All** for a one-click, causality-ordered repair:
-1. 🏷️ Complete Aliases (LLM batch-generates translations, acronyms, alternate names)
-2. 🔄 Merge Duplicates (cross-language, abbreviation, and high-similarity matches)
-3. 🔗 Fix Dead Links / Link Orphans / Expand Empty Pages
-
-Then **Regenerate Index** to rebuild `wiki/index.md` with alias entries for every page, enabling 
-alias-aware search (e.g., "DSA" finds "DeepSeek-Sparse-Attention").
-
-> 📖 **Detailed upgrade walkthroughs** for specific version jumps (v1.20.3 slug fingerprint, v1.16.0 double-nested links) are maintained in [GitHub Discussions / Upgrading](https://github.com/green-dalii/obsidian-llm-wiki/discussions).
-
-**Settings to review:** Force PDF Support (Settings → LLM Configuration → Advanced, off by default — only needed for non-NATIVE providers), Write PDF Markdown to Vault (Settings → Wiki Configuration → Wiki Folder, off by default), Wiki Output Language (independent from UI), Extraction Granularity (Minimal–Fine, + Custom), Page Generation Concurrency (default 3), Batch Delay (default 300ms).
-
-## ⚡ What's New in v1.25.x
-
-- **v1.25.2 (2026-07-22).** Tag vocabulary Phase 1 (dual-source eliminated), Codex OAuth (ChatGPT Plan), related-link folder-prefix fix, page-template trailing `---` fix, ESLint 0.4.1 Route A. 2515 tests.
-- **v1.25.1 (2026-07-20).** Eight silent-loss fixes (Related page, schema sections, Legacy Mentions), 3 big-file splits, DiskCache<T>, LM Studio no-key ingest, build-verification root cause. 2274 tests.
-- **v1.25.0 (2026-07-18).** Cache-only PDF Ingest (Level 1), bounded growth cache, optional vault sidecar, force-PDF universal gate, verbatim prompt, cancelable ingest, local-model guidance, i18n completeness. 2182 tests.
-
-📋 [Full version history → CHANGELOG.md](./CHANGELOG.md)
+---
 
 ## ✨ Features
 
-### 📊 Knowledge Quality
+### 📚 Knowledge quality
 
-- **🔍 Entity/Concept extraction** — LLM extracts entities (people, organizations, products, events, etc.) and concepts (theories, methods, terms, etc.) from your notes and generates standalone Wiki pages. Flexible extraction granularity (minimal ~5, coarse ~10, standard ~50, fine ~100, custom 1–500) balances analysis depth with API cost.
-- **🏷️ Mandatory page aliases** — every generated page includes at least 1 alias (translation, abbreviation, variant) for cross-language duplicate detection.
-- **🔄 Duplicate detection & merge** — semantic tiered detection catches true duplicates (cross-language translations, abbreviations, spelling variants); smart LLM fusion merges content while preserving aliases.
-- **🧩 Intelligent knowledge fusion** — multi-source updates merge new information without duplication; contradictions are preserved with source attribution; `reviewed: true` pages are protected from overwrite.
-- **📏 Content truncation guard** — 8000 max_tokens with automatic stop_reason detection and 2× token retry for API-key and local providers. The experimental ChatGPT Plan (Codex OAuth) path follows the Codex backend output policy, which does not accept a client-side max_output_tokens cap.
-- **📝 Original quote preservation** — Mentions-in-Source sections preserve quotes in their original language (optional translation) for full traceability.
-- **🎨 Customizable tag vocabulary (v1.18.0).** Settings → Wiki → Tag Vocabulary Mode → *Custom* lets you define your own entity-type and concept-type tag lists (e.g. `Medical_Arzneimittel`, `法规`). The plugin respects your vocabulary in extraction prompts and frontmatter validation; the existing Lint audit (Issue #85 v7) reports any page whose tags fall outside the active vocabulary.
+- **🔍 Entity & concept extraction** — LLM extracts entities (people, orgs, products, events) and concepts (theories, methods, terms) into standalone pages. Granularity is configurable (Minimal → Fine, plus Custom) so you trade cost vs. depth.
+- **🏷️ Mandatory aliases** — every page ships with at least one alias (translation, abbreviation, variant) so cross-language duplicate detection works.
+- **🔄 Tiered duplicate detection** — Tier 1 (direct name match: cross-language, abbreviation, high-similarity titles) is always verified; Tier 2 (shared links, medium similarity) fills remaining token budget.
+- **🧩 Smart merge & contradiction state** — duplicates merge while preserving aliases; contradictions are flagged with source attribution; `reviewed: true` pages are protected from overwrite.
+- **🎨 Custom tag vocabulary** — define your own entity-type and concept-type tag lists in Settings → Wiki → Tag Vocabulary → *Custom*; Lint reports any page whose tags fall outside the active vocabulary.
 
-![Custom tag vocabulary chip inputs](docs/assets/custom-tags.png)
+### 📄 PDF ingest (v1.25.0+)
 
-### 📄 PDF Ingest (v1.25.0)
+- **🔌 Provider gate** — Anthropic, OpenAI, and Bedrock handle PDF natively. For any other OpenAI/Anthropic-compatible endpoint, enable **Force PDF Support** in Settings → LLM Configuration → Advanced to let the plugin attempt the call. For local OCR on Apple Silicon, third-party extractors (MinerU, Docling, Mathpix, Adobe), and the full PDF ingest walkthrough, see [PDF OCR Paths](#-pdf-ocr-paths) below and [docs/PDF-OCR-GUIDE.md](./docs/PDF-OCR-GUIDE.md).
+- **🗄️ Bounded cache** — `.obsidian/plugins/karpathywiki/pdf-cache/` stores converted Markdown keyed by content hash + model + converter version. Three-defense-layer housekeeping: 100 MB total / 1000 entries / 10 MB single-entry caps with LRU-by-mtime eviction.
+- **📝 Optional vault sidecar** — Settings → Wiki Configuration → Wiki Folder → *Write PDF Markdown to Vault* writes `<basename>.pdf.md` next to the source PDF (off by default — cache-only is the default).
+- **🛡️ Verbatim transcriber prompt** — OCR-style conversion with `[illegible]` / `[figure: ...]` anti-hallucination markers; markdown-fence-wrapping from small local models is auto-cleaned before cache write.
 
-Pick a PDF from your vault — the plugin reads it through your LLM provider's native file input, converts it to Markdown, and re-enters the regular Markdown ingest pipeline. Every existing entity/concept/alias/`[[wiki-link]]` workflow applies unchanged.
+### 📄 PDF OCR Paths
 
-- **🔌 Provider gate** — Anthropic, OpenAI, Bedrock Anthropic, and Bedrock OpenAI handle PDF natively. For any other OpenAI/Anthropic-compatible endpoint, enable **Force PDF Support** in Settings → LLM Configuration → Advanced to let the plugin attempt the call (your endpoint decides; failures surface as a localized Notice guiding you to disable the toggle). See the [Local PDF OCR Path](#-local-pdf-ocr-path-v1250) below for the recommended local setup.
-- **🗄️ Content-hash cache** — identical PDF + model + converter version returns the cached Markdown with no LLM call. The cache lives in `.obsidian/plugins/karpathywiki/pdf-cache/`; cache key embeds a `converterVersion` so prompt upgrades invalidate stale entries automatically.
-- **📏 Bounded growth** — three-defense-layer cache housekeeping (100 MB total / 1000 entries / 10 MB single-entry caps) with LRU-by-mtime eviction; old entries are pruned on startup and at the start of every batch ingest. Cache only — your vault is not modified by default.
-- **📝 Optional vault sidecar** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** writes `<basename>.pdf.md` next to the source PDF after conversion. Off by default (cache-only).
-- **🛡️ Verbatim transcriber prompt** — the PDF→Markdown prompt is re-framed as OCR-style verbatim conversion with `[illegible]` / `[figure: ...]` / `[equation: ...]` anti-hallucination markers; small/local models that wrap output in ```markdown fences are auto-cleaned before cache write.
-- **⏹ Cancellable** — clicking the status bar mid-conversion aborts the in-flight LLM call through Vercel AI SDK v6.
+Three paths, pick what fits your setup:
 
-### 💬 Query & Feedback
+1. **☁️ Cloud provider with native PDF support** — Anthropic, OpenAI, or AWS Bedrock read PDFs out of the box. Just ingest; no extra setup. For any other OpenAI/Anthropic-compatible endpoint, enable **Force PDF Support** in Settings → LLM Configuration → Advanced to let the plugin attempt the call.
+2. **🖥️ Local OCR on Apple Silicon** — [oMLX](https://github.com/jundot/omlx) integrates Microsoft Markitdown as a built-in PDF→Markdown backend. Enable Markitdown in oMLX, load [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M-active, open-sourced 2026-06) as the vision model, point the plugin at oMLX as a Custom OpenAI-Compatible provider, turn on **Force PDF Support**, and pick the multimodal model oMLX is serving. The PDF never leaves your machine.
+3. **🛠️ Third-party extractor (MinerU, Docling, Mathpix, Adobe)** — run a separate extractor on your PDFs to produce `.md` files, then ingest them as regular Markdown notes via the plugin\'s standard pipeline. Most reliable for scientific papers, scanned documents, math-heavy PDFs.
 
-- **🔍 5-stage PPR seed-selection cascade (v1.24.1 PATCH).** When you ask a multi-hop question, Query Wiki composes the answer through five complementary stages before any generation runs:
-  1. **Lex fast path** — straight token-overlap against every entity/concept title and aliases (free, instant; gates the rest).
-  2. **LLM keyword generation** — the LLM proposes 8–12 cross-language keywords from your query (handles synonyms, abbreviations, token-overlap-resistant terms).
-  3. **Local substring scan** — every generated keyword is re-matched locally across page titles, aliases, and body snippets (no extra LLM call; rounds out noise-tolerant recall).
-  4. **LLM KB fallback** — when lex + keyword scan returns weak signals, the LLM re-seeds the top-N candidates against the full wiki for one semantic pass.
-  5. **PPR graph expansion** — Personalized PageRank (Haveliwala 2002) over the `[[wiki-link]]` graph starting from the candidate seed set; gives the LLM-graph-aware multi-hop context that linear search can't reach.
+📖 **Full setup walkthroughs** for all three paths (cloud providers, oMLX hardware tiers, MinerU installation, cache housekeeping) → [docs/PDF-OCR-GUIDE.md](./docs/PDF-OCR-GUIDE.md)
 
-  The cascade automatically truncates to whichever step returned enough signal — no fixed 5-step cost, no LLM calls when lex is sufficient, no lost precision when the LLM augmentation is needed. End-to-end relevance (PPR @5 = 27.1% on the project's own benchmark corpus) outperforms pure-knn baselines (24.1%) without opt-in embedding. Stage 1.5 (steps 2–3) handles the multi-hop query types that pure lex misses; Stage 1.7 (step 4) recovers when the LLM-injected keywords haven't seen enough signal yet; Stage 1.9 (step 5) guarantees that the LLM sees neighbor context, not just a flat top-N list. Replaces the older binary-tier cascade.
+### 💬 Query & maintenance
 
-- **🤖 Conversational query** — ChatGPT-style dialog with streaming Markdown output, automatic `[[wiki-links]]`, and multi-turn history.
-- **🪟 Right-docked side panel (v1.22.1, PR #196).** Query Wiki opens in a Copilot-style right sidebar leaf (reusing an existing leaf if already open) instead of a centered popup. The `message-circle` ribbon icon and `Query Wiki` command activate/reveal the panel; your notes stay visible alongside the conversation. All functionality is preserved unchanged.
+- **🧭 5-stage PPR cascade** — see [How retrieval works](#-how-retrieval-works). Personalized PageRank over `[[wiki-link]]` gives graph-aware multi-hop context.
+- **🪟 Right-docked side panel** — Query Wiki opens in a Copilot-style right sidebar leaf (v1.22.1+) instead of a centered modal.
+- **🔍 Lint health scan** — single command catches: duplicates, dead links, empty pages, orphans, missing aliases, contradictions.
+- **⚡ Smart Fix All** — one-click causal-order repair: fill aliases → merge duplicates → fix dead links → link orphans → expand empty pages, with per-phase report.
+- **📊 Operation history panel** — searchable, filterable UI for past ingestions, lint reports, and maintenance runs.
+- **🛡️ Pre-ingest gate** — empty / whitespace / frontmatter-only notes are rejected before any LLM call; content-hash dedup catches identical files across paths.
 
-![Query Wiki side panel](docs/assets/query-side-panel.png)
-- **📤 Query → Wiki feedback** — save valuable conversations back into the Wiki, with entity/concept extraction and pre-save semantic dedup.
-- **🔒 Duplicate-save guard** — hash tracking prevents unchanged conversations from re-evaluating.
+### 🔒 Privacy
 
-### 🛠️ Maintenance
+- **🚫 No backend, no tracking, no analytics.** Runs entirely inside Obsidian. Network is used only to communicate with the LLM provider you configure.
+- **📁 Source files are read-only.** The plugin never modifies your original vault notes — only creates new pages under `wiki/`.
+- **🦙 Full local mode.** Ollama, LM Studio, or any local OpenAI-compatible endpoint → your notes never leave your machine.
+- **🔐 Minimal permissions.** Vault file access for wiki management. Clipboard access only when you click the "Copy" button in the Query modal.
 
-- **🔍 Lint health scan** — single comprehensive report detects: duplicate pages, dead links, empty pages, orphans, missing aliases, contradictions.
-- **🎯 Tiered semantic duplicate detection** — Tier 1 (direct name match: cross-language, abbreviation, high-similarity titles) always verified; Tier 2 (indirect signals: shared links, medium similarity) fills token budget.
-- **⚡ One-click Smart Fix All** — batch fixes in causal order: fill aliases → merge duplicates → fix dead links → link orphans → expand empty pages, with per-phase popup report.
-- **🏷️ Alias completion** — one-click parallel batch generation of missing aliases, improving future duplicate detection.
-- **🔄 Auto-maintenance** — multi-folder watching, scheduled Lint, startup health check (all optional).
-- **⚠️ Contradiction state machine** — `detected → review-passed → resolved` (AI-fix) or `detected → unresolved` (manual).
-- **🛡️ Pre-ingest requirements gate (v1.21.0)** — every source file is validated *before* any LLM call: empty/whitespace/frontmatter-only notes are rejected, and content-hash dedup catches identical files across paths. Prevents small/local models from hallucinating entity names on blank inputs.
-- **📊 Operation History Panel (v1.21.0)** — searchable, filterable UI for past ingestions, lint reports, and maintenance runs, with insight-driven KPI cards and clickable page links.
+### 🦙 Local-first
 
-![History Panel](docs/assets/history-panel.png)
+- **🖥️ Ollama, LM Studio, OpenRouter, custom endpoint** — out-of-the-box. Local models work for query (smaller context windows); ingest on a 2,000-page vault usually needs a long-context cloud model.
+- **📄 PDF OCR path is fully local on Apple Silicon** — see [PDF OCR Paths](#-pdf-ocr-paths) below.
+- **🔐 ChatGPT Plan (Codex OAuth)** — desktop loopback callback on `127.0.0.1:1455`; mobile via device-code. Credentials live only in Obsidian SecretStorage; sign-out clears them. Third-party Codex compatibility, not an OpenAI partnership.
 
-- **🧹 Incomplete-page cleaner (v1.21.0)** — pages left in a partial state after interrupted ingests are automatically archived on startup. Recoverable from Obsidian's `.trash`.
+### 🌐 Language
 
-### 🌐 LLM & Language
-
-- **🔌 Multi-provider support** — Anthropic, Anthropic-compatible (Coding Plan), Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, custom endpoint.
-- **🔄 5xx auto-retry** — exponential backoff on HTTP 5xx / 429 / 529 across all clients (max 2 retries).
-- **📋 Dynamic model list** — fetched live from the provider API.
-- **🌐 Wiki output language** — 10 languages independent of UI (English / 简体中文 / 繁體中文 / 日本語 / 한국어 / Deutsch / Français / Español / Português / Italiano), with custom input option.
-- **🌍 Full UI internationalization** — plugin UI in 10 languages with 269+ UI fields fully translated to natural local expression.
-- **⚡ Rate-limit guardian** — automatically detects when parallel generation triggers rate limits and prompts to lower concurrency, increase batch delay, or switch provider.
-- **🦙 Web Clipper compatibility** — one-click addition of the official Obsidian Web Clipper's `Clippings/` folder to the watch list; clipped web pages auto-ingest into the Wiki.
-
-### 🏗️ Architecture & Performance
-
-- **🕸️ PPR over [[wiki-link]] graph (v1.24.0+, mature in v1.24.1 PATCH).** Personalized PageRank (Haveliwala 2002) runs over the directed graph of `[[wiki-link]]` edges between your wiki pages; the cascade seeds PPR at the cascade's top-N candidate set so multi-hop context travels through up to 3 expansion rings. This is what makes the Query Wiki answers graph-aware (a "Founders of Microsoft" question resolves via Bill Gates → Microsoft → competitors, not just literal title overlap). 2,137-page vaults typically see <100 ms warm + 3-hop expansions, regardless of vault size. Used by all 4 stages of the seed-selection cascade (Query & Feedback section above) and by lint duplicate detection when indirect links tie two candidate pages together.
-- **⚡ Parallel page generation** — configurable 1–5 concurrent pages, default 3 (parallel), 2–3× speedup on large sources; per-page error isolation.
-- **📚 Iterative batched extraction** — adaptive batch sizing eliminates the long-document max_tokens bottleneck.
-- **🏛️ Three-layer architecture** — Your vault notes (read-only) → `wiki/` (LLM-generated pages organized as `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`) → `schema/` (co-evolved configuration).
-- **🧩 Modular codebase** — 20+ focused modules in `src/`.
-
-### 🔒 Privacy & Security
-
-- **No backend, no tracking.** The plugin runs entirely inside Obsidian — no external servers, no analytics, no data collection of any kind. Unless you actively configure an LLM provider, your notes never leave your vault.
-- **Data stays local by default.** The plugin does not store, cache, or transmit your content anywhere outside of the LLM API you have chosen. Only the text you send for ingestion or query leaves your device — and only to the provider you configured.
-- **Full local mode via Ollama, LM Studio, or local providers.** For complete data sovereignty, use a locally running LLM. Your notes are processed entirely on your machine — never touching the internet.
-- **Minimal permissions.** Vault file access is used for Wiki management (reading notes, generating pages, detecting dead links). Network access is used only for communicating with your chosen LLM provider's API. Clipboard access is limited to the "Copy" button in the Query modal — used only when you click it.
+- **🌍 10 UI languages** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI and wiki-output language are independent — your wiki can be Chinese while the interface is English.
+- **📚 10 wiki-output languages** — same set; pick in Settings → Wiki Configuration. *Custom input* option for ad-hoc prompts.
+- **🈶 269+ translated UI strings** — every label, modal, and notice. Adding an 11th language is contributor-driven (PR #159 pattern).
 
 ---
 
-## 📖 Example
+## 🔍 How retrieval works
 
-**Input:** `sources/machine-learning.md`
+Most "AI search" plugins fragment your notes into chunks and embed them in a vector DB. We don't. Karpathy's argument against RAG is that chunking breaks the LLM's ability to reason across your whole knowledge graph — and that argument holds up in practice. Instead, we walk the graph you already maintain by writing `[[wiki-links]]`.
 
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
+### The 5-stage seed-selection cascade
 
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+When you ask "Who founded Microsoft?", Query Wiki runs five stages before any answer generation:
 
-**Output — Concept page:** `wiki/concepts/supervised-learning.md`
+1. **Lex fast path** — straight token-overlap against every entity/concept title and aliases. Free, instant, and the gating step for everything that follows.
+2. **LLM keyword generation** — the LLM proposes 8–12 cross-language keywords from your query (handles synonyms, abbreviations, and token-overlap-resistant terms in one LLM call).
+3. **Local substring scan** — every generated keyword is re-matched locally against page titles, aliases, and body snippets. No extra LLM call; rounds out noise-tolerant recall.
+4. **LLM KB fallback** — when lex + keyword scan returns weak signals, the LLM re-seeds the top-N candidates against the full wiki for one semantic pass.
+5. **PPR graph expansion** — Personalized PageRank (Haveliwala 2002) over the `[[wiki-link]]` graph starting from the candidate seed set. This is what gives graph-aware multi-hop context: "Bill Gates" → "Microsoft" → "competitors", not just literal title overlap.
 
-```markdown
----
-type: concept
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
+The cascade truncates at whichever step returned enough signal — no fixed 5-step cost, no LLM calls when lex is sufficient, no lost precision when LLM augmentation is needed.
 
-### Supervised Learning
+### Personalized PageRank at scale
 
-### Basic Information
-- Type: method
-- Source: [[sources/machine-learning]]
+We use Monte Carlo PPR (Fogaras 2005) — 3,000 random walks × 50 steps each — with the dead-end rule from Haveliwala 2002. Cost is **O(K × L)** independent of the number of pages, so a 2,000-page vault sees the same expansion latency as a 200-page one.
 
-### Description
-Supervised learning is a machine learning paradigm where models learn
-from labeled training data to make predictions on unseen data...
+**PPR @5 = 27.1% vs pure-kNN baseline 24.1%** on the project's own benchmark corpus (the only published retrieval benchmark in this open-source LLM-Wiki space).
 
-### Related Concepts
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
+### Why no embeddings
 
-### Related Entities
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### Mentions in Source
-- "Supervised learning uses labeled data to train predictive models..."
-```
+We deliberately rejected the embedding path in [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175). The graph signal is already there — every `[[wiki-link]]` is a hand-curated "these are related" edge, and most providers we support (Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax) don't ship a `/v1/embeddings` endpoint at all. Adding an embedding model would mean a per-page download, a per-provider adapter, and zero benefit on retrieval quality.
 
 ---
 
-## 🤖 Model Selection Guide
+## 🤖 Models
 
-This plugin follows Karpathy's philosophy: **feed the LLM full Wiki context, not chunked RAG retrieval**. Long-context models are strongly recommended — the larger your Wiki grows, the more context the LLM needs.
+**Supported providers (12+, all from models.dev cross-check 2026-07):**
 
-> 💡 **Why not RAG?** Karpathy's [original critique](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) argues that RAG fragments knowledge and breaks the LLM's ability to reason across the full knowledge graph.
+| Provider | Series | Notes |
+|----------|--------|-------|
+| **Anthropic** | Claude 5 series | Native PDF; `/v1/messages` protocol |
+| **OpenAI** | GPT-5.6 series (Sol / Terra / Luna) | Native PDF; Platform API key |
+| **Google Gemini** | Gemini 3.6 series | Native PDF (file parts since 1.5); OpenAI-compatible endpoint |
+| **DeepSeek** | DeepSeek V4 series | OpenAI-compatible; lowest cost tier |
+| **Alibaba Qwen** | Qwen3.7/3.8 series | OpenAI-compatible (DashScope) |
+| **xAI Grok** | Grok 4 series | OpenAI-compatible; long context |
+| **Moonshot Kimi** | Kimi K3 series | OpenAI-compatible; 2.8T MoE frontier |
+| **Zhipu GLM** | GLM-5 series | OpenAI-compatible; strong bilingual |
+| **MiniMax** | MiniMax M3 series | OpenAI-compatible; 1M context |
+| **Step (阶跃星辰)** | Step 3 series (Flash) | OpenAI-compatible; fast inference |
+| **Tencent Hunyuan** | Hy3 series | OpenAI-compatible; open-weight MoE |
+| **Xiaomi MiMo** | MiMo V2.5 series | MIT open-source; flat pricing |
+| **Google Gemma** | Gemma 4 series | Open-weight; 262K context |
+| **AWS Bedrock** | Anthropic + OpenAI variants | VPC / compliance path |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | Browser/device-code sign-in; SecretStorage |
+| **Local: Ollama, LM Studio, OpenRouter, Anthropic-Compatible** | Any OpenAI-/Anthropic-protocol model | Custom OpenAI-Compatible + Anthropic-Compatible (Token Plan / Coding Plan) |
 
-**💰 Value-First Strategy:** You don't need flagship models. The following **cost-effective alternatives** deliver excellent results at lower prices:
+This plugin feeds the LLM your full Wiki context per query — so **long-context models win**. The full tiered table (cloud + local) lives in [docs/MODEL-GUIDE.md](./docs/MODEL-GUIDE.md), cross-checked against [models.dev](https://models.dev/) so the picks stay current.
 
-### ☁️ Cloud Model Picks
 
-| Tier | Model | Context | Why |
-|------|-------|---------|-----|
-| **🌟 Value Pick** | **DeepSeek V4-Flash** | 1M tokens | Lowest cost ($0.14/M), 284B MoE, ideal for batch ingestion |
-| **🌟 Value Pick** | **Gemini-3.5-Flash** | 1M tokens | 4× faster output than GPT-5.5, great for agent tasks |
-| **🌟 Value Pick** | **Qwen3.6-Plus** | 1M tokens | Strong coding & agentic capabilities, competitive pricing |
-| **🌟 Value Pick** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **Balanced** | **Claude Sonnet 4.6** | 1M tokens | Great quality/cost balance, $3/$15 per million tokens |
-| **Lightweight** | **Claude Haiku 4.5** | 200K tokens | Fast and affordable for smaller wikis |
-| **Budget** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE, MIT open-source 2026-04, agent & multimodal |
-| **Flagship** | Claude Opus 4.7 | 1M tokens | Ultimate quality, higher cost — use selectively |
-| **Flagship** | GPT-5.5 | 1M tokens | Top reasoning, higher cost — use selectively |
+### What matters
 
-### 🦙 Local Model Recommendations (Ollama / LM Studio)
+- **🧠 Context window ≥ 200K tokens** for vaults over ~500 pages. Below 200K the cascade's assembled context starts getting truncated.
+- **⚖️ Instruction-following quality** matters more than raw IQ for the extraction task — pick a model that follows the schema template, not the biggest leaderboard number.
+- **🔌 Embedding endpoint is irrelevant** — we don't use embeddings. A provider that lacks `/v1/embeddings` is fine (most of our 12+ providers do).
+- **🦙 Local works for query, cloud for ingest** — ingest on a 2,000-page vault usually needs a long-context cloud model; a 262K local model covers most queries.
 
-Local inference wins on data sovereignty, offline use, and zero API cost. The trade-off is context window (most sit between 8K–128K; recent open-weight families reach 262K) and instruction following vs. flagship cloud models. **Pick by your hardware budget:** larger parameter counts buy world knowledge and instruction fidelity (better extraction quality, fewer hallucinations); smaller counts buy speed and memory headroom but pay for it in hallucinations and weaker long-context reasoning. The sweet spot on a 24 GB Apple Silicon or single consumer GPU is the 27B–35B-A3B class.
+### Anthropic vs OpenAI vs Codex OAuth — they are distinct providers
 
-| Model | Params | Context | Why |
-|-------|--------|---------|-----|
-| **Qwen3.5 27B** | 27B dense | 262K | Best quality/size trade-off for ingest; MLX 4-bit fits in 24 GB |
-| **Qwen3.5 35B-A3B** | 35B total / 3B active MoE | 262K | Faster than 27B dense at similar quality; ideal memory saver |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | Quality ceiling; needs ≥48 GB VRAM or dual GPUs |
-| **Qwen3.6 27B** | 27B dense | 256K+ | 2026-04 refresh over Qwen3.5 27B — prefer this if your hardware can take it |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Same trade-off as Qwen3.5 35B-A3B, newer weights |
-| **Gemma 4 31B IT** | 31B dense | 262K | Strong instruction following, clean Markdown output |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Lower memory than 31B dense at comparable quality |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | CPU-runnable; use only for small wikis or quick previews |
+- **Anthropic** (and its Bedrock variant) — separately billed Anthropic Platform API key.
+- **OpenAI** — separately billed OpenAI Platform API key.
+- **ChatGPT Plan (Codex OAuth)** — experimental, distinct provider that uses eligible Codex allowance after browser or device-code sign-in; availability follows OpenAI Codex authentication and allowance policies, not plan name. Third-party Codex compatibility, not an OpenAI partnership or a general ChatGPT API.
 
-**Quantization:** MLX 4-bit on Apple Silicon is typically 1.5–2× faster than GGUF Q4_K_M at the same effective bitrate. GGUF Q4_K_M is the default cross-platform choice; reach for Q5/Q8 only if you have the VRAM headroom and notice quality regression at Q4.
-
-**Context strategy:** When your Wiki grows past ~500 pages, a 262K local model still sees most of the context the Query engine assembles, but ingest on a 2000-page vault will outrun it. Common pattern: cloud for ingest + local for query. For full local setups, the 27B/35B-A3B class is the sweet spot.
-
-### 📄 Local PDF OCR Path (v1.25.0+)
-
-v1.25.0's PDF ingest works with any provider that accepts PDF as a file part. For a fully local pipeline on Apple Silicon (the only platform oMLX currently supports), the recommended setup is:
-
-1. Install [oMLX](https://github.com/jundot/omlx) and enable its built-in **Markitdown** backend (local PDF→Markdown conversion).
-2. Load **Baidu Unlimited-OCR** (open-sourced 2026-06-22, 3B total / 0.5B active, end-to-end OCR that handles long documents without the "slower the longer it generates" failure mode of older OCR models) as the vision model in oMLX.
-3. In this plugin: set provider to **Custom OpenAI-Compatible** (oMLX speaks the OpenAI-compatible protocol), point the Base URL at oMLX's local server, turn on **Force PDF Support** in Settings → LLM Configuration → Advanced, and pick the multimodal model oMLX is serving for the ingest summarization.
-
-The PDF never leaves your machine — Markitdown does the structural conversion locally, Unlimited-OCR does the visual recognition locally, and the local LLM does the summarization locally. The plugin's cache (`.obsidian/plugins/karpathywiki/pdf-cache/`) then keeps re-ingests instant.
-
-**Fallback:** if oMLX/Markitdown is unavailable (Linux/Windows or older Macs), point **Force PDF Support** directly at a local multimodal LLM that accepts PDF file parts — quality is good when the model is large enough, but VRAM demands scale steeply with page count.
-
-**🔌 Anthropic Compatible (Coding Plan):** If your provider offers an Anthropic-compatible API endpoint, select "Anthropic Compatible" and enter your provider's Base URL and API Key.
-
-> 💡 **OpenAI billing boundary:** **OpenAI** uses a separately billed Platform API key. **ChatGPT Plan (Codex OAuth)** is an experimental, distinct provider that uses eligible Codex allowance after browser or device-code sign-in; availability is not guaranteed by plan name.
-
----
-
-## 🏗️ Architecture
-
-Karpathy's three-layer separation design:
-
-```
-📄 Your vault notes (any folder)   # 📖 You pick which notes to ingest
-  ↓ ingest
-wiki/                              # 🧠 LLM-generated Wiki pages (wiki/sources/, wiki/entities/, wiki/concepts/)
-  ↓ query / maintain
-schema/                            # 📋 Wiki structure configuration (naming, templates, categories)
-```
-
-> 📖 See the full codebase structure in [CONTRIBUTING.md → Project Structure](./CONTRIBUTING.md#project-structure).
-
-**Generated pages:**
-- `wiki/sources/filename.md` — 📄 Source summary
-- `wiki/entities/entity-name.md` — 👤 Entity pages (people, orgs, projects, etc.)
-- `wiki/concepts/concept-name.md` — 💡 Concept pages (theories, methods, terms, etc.)
-- `wiki/index.md` — 📑 Auto-generated index
-- `wiki/log.md` — 📝 Operation log
-
----
+> 📖 **Full pick table** (cloud + local + PDF OCR + Codex OAuth + quantization + hardware tiers) → [docs/MODEL-GUIDE.md](./docs/MODEL-GUIDE.md)
 
 ## ❓ FAQ
 
-> **Keep your plugin updated** — new features and fixes ship frequently. Run **Settings → Community Plugins → Check for updates** regularly.
->
-> 📖 More FAQs on [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28).
+### What does the plugin actually do?
 
-**What does the plugin actually do?**
-Pick any note, folder, or selection from your vault; the LLM extracts entities and concepts and generates an interlinked wiki with `[[bidirectional links]]`. Ask questions and get conversational answers grounded in *your* notes — not internet search. Generated summaries live under `wiki/sources/`, entities under `wiki/entities/`, and concepts under `wiki/concepts/` — your original vault notes are never modified.
+Pick any note, folder, or selection; the LLM extracts entities and concepts and generates an interlinked wiki with `[[bidirectional links]]`. Ask questions and get conversational answers grounded in *your* notes, not the internet. Your original vault notes are never modified.
 
-**Is my data sent to third parties?**
-🔒 **Privacy first.** No backend, no tracking, no analytics — the plugin runs entirely inside Obsidian. Only text you explicitly send for ingestion/query leaves your device, and only to the LLM provider you configure. For complete data locality, use a local provider (Ollama or LM Studio with no API key) — your data never touches the internet.
+### How do I get started?
 
-**How is this different from RAG chatbots?**
-Unlike chunked RAG that fragments context, LLM-Wiki runs a **Personalized PageRank** engine over your existing `[[wiki-link]]` graph — finding related pages via link structure, not vector embeddings. This means zero embedding cost, no new dependencies, and full support for local and offline models.
+Install from Obsidian Community Plugins → pick a provider → **Test Connection** → run **Ingest single source** on any note. First wiki pages appear within seconds. See [Quick Start](#-quick-start).
 
-**Which LLM should I use?**
-Long-context models (≥200K tokens) work best. Budget-friendly picks: DeepSeek V4-Flash ($0.14/M), Gemini 3.5 Flash, Qwen3.6-Plus. Local models via Ollama/LM Studio work for query but have smaller context windows (8K–128K). See the [Model Selection Guide](#-model-selection-guide) for details.
+### Is my existing wiki safe?
 
-**How do I get started?**
-Install from Obsidian Community Plugins → pick an LLM provider → **Test Connection** → run **Ingest single source** (or **Ingest from folder**) on any note in your vault → your first wiki pages appear within seconds. See [Quick Start](#-quick-start) above.
+✅ Backward compatible since v1.0.0. Set `reviewed: true` on any page to protect it from overwrite. Upgrading from v1.24.x doesn't rewrite your vault; v1.25.0's PDF ingest is cache-only by default.
 
-**How can I control API costs?**
-Use Coarse or Minimal extraction granularity for batch ingestion (fewer LLM calls). Smart Batch Skip auto-detects already-ingested files. Auto-Maintenance is OFF by default (enable only if needed). Lint shows counts before running fixes — nothing is charged without your approval.
+### Is my data sent anywhere?
 
-**Is my existing wiki safe?**
-✅ Backward compatible since v1.0.0. Set `reviewed: true` on any page to protect it from overwrite. The plugin never modifies your original vault notes — only generates new pages inside the `wiki/` folder.
+🚫 No backend, no analytics — the plugin runs entirely inside Obsidian. Only text you explicitly send for ingest/query leaves your device, and only to the LLM provider you configure. For complete data locality, use Ollama or LM Studio.
 
-**Can I use the plugin in my language?**
-🌐 **10 languages** for both UI and wiki output: English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI and wiki language are independent — your wiki can be in Chinese while the interface stays in English. Adding an 11th language is contributor-driven (follow the Italian PR #159 pattern).
+### Can I use the plugin in my language?
 
-**What minimum setup is needed?**
-Obsidian v1.11.4+ (desktop or mobile). An LLM provider API key, a local Ollama/LM Studio model, or an authorized ChatGPT Plan (Codex OAuth) credential. The plugin's **llmReady guard** requires a successful connection test before core features unlock — this prevents silent failures from misconfigured providers.
+🌍 10 languages for both UI and wiki output. UI and wiki language are independent. Adding an 11th language is contributor-driven (PR #159 pattern).
 
-**How do I cancel a running operation?**
-Click the status bar text (shows "Ingesting… click to cancel") or `Cmd+P` → "Cancel current ingestion". Stops cleanly at the next batch boundary, preserving all completed work.
+### How is this different from a RAG chatbot?
 
-**Where do I get help?**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — bug reports
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — questions, feature requests, upgrade help
-- Developer Console (`Ctrl+Shift+I` / `Cmd+Option+I`) — copy logs with module-name prefixes for faster diagnosis
+🚫 No chunking. 🚫 No embeddings. 🚫 No vector DB. ✅ Personalized PageRank over your existing `[[wiki-link]]` graph — graph-aware multi-hop context, zero embedding cost, full local-model support.
 
-## 🔒 Transparency & Compliance
+### Which LLM should I use?
+
+Long-context models (≥200K tokens) work best. The [Models section](#-models) covers the principles; the full tiered table is in [docs/MODEL-GUIDE.md](./docs/MODEL-GUIDE.md).
+
+### Is there a published benchmark?
+
+Yes — PPR @5 = 27.1% vs pure-kNN baseline 24.1% on the project's own corpus. The full pipeline and benchmark script are described in [How retrieval works](#-how-retrieval-works).
+
+### How do I control API costs?
+
+Use Coarse or Minimal extraction granularity for batch ingest. Smart Batch Skip auto-detects already-ingested files. Auto-Maintenance is OFF by default. Lint shows counts before running fixes — nothing is charged without your approval.
+
+### How do I cancel a running operation?
+
+Click the status bar (shows "Ingesting… click to cancel") or `Cmd+P/Ctrl+P` → "Cancel current ingestion". Stops cleanly at the next batch boundary.
+
+### Where do I get help?
+
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) for bug reports · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) for questions and feature requests · Developer Console (`Ctrl+Shift+I` / `Cmd+Option+I`) for plugin logs.
+
+---
+
+## 🔒 Privacy
 
 This plugin is listed on the Obsidian Community Plugin Market and undergoes automated review for security and permissions.
 
-**The plugin has no backend, no server infrastructure, and no data collection of any kind.** It is purely local software running inside Obsidian. The plugin cannot and does not collect, store, or transmit your data to any server — because no such server exists.
+- **🚫 No backend, no server, no data collection.** Pure local software running inside Obsidian. The plugin cannot and does not collect, store, or transmit your data to any server — because no such server exists.
+- **🔐 Network access is opt-in.** Used only to communicate with the LLM provider you configure. You choose the provider, you enter the API key, you decide where your data goes.
+- **📁 Vault file access** is used for wiki management (reading notes, generating pages, scanning dead links, detecting duplicates). The plugin never modifies your source files.
+- **📋 Clipboard access** is used exclusively by the "Copy" button in the Query modal — and only when you click it.
 
-**Network access** is used only to communicate with the LLM provider you configure — no other network calls are made. This is entirely under your control: you choose the provider, you enter the API key, you decide where your data goes.
+For complete data locality, use Ollama or LM Studio. With a local provider, your data never leaves your machine.
 
-**File system access** (vault enumeration) is required to build and maintain the wiki: reading your source notes, generating pages, scanning for dead links, and detecting duplicate pages. The plugin never modifies your source files — only files under the wiki folder.
+---
 
-**Clipboard access** is used exclusively by the "Copy" button in the Query modal, and only when you click it.
+## 💖 Support
 
-If you prefer complete data locality, use a local LLM provider such as Ollama or LM Studio. With a local provider, your data never leaves your machine.
+If LLM-Wiki has become a meaningful part of your knowledge workflow:
 
-## 💖 Support the Project
-
-If LLM-Wiki has become a meaningful part of your knowledge workflow, you can support its ongoing development:
-
-- ☕ **[Buy me a Ko-fi](https://ko-fi.com/greenerdalii)** — one-time or monthly support via Ko-fi
-- 💳 **[Tip via PayPal](https://paypal.me/greenerdalii)** — one-time tip via PayPal
+- ☕ **[Buy me a Ko-fi](https://ko-fi.com/greenerdalii)** — one-time or monthly
+- 💳 **[Tip via PayPal](https://paypal.me/greenerdalii)** — one-time tip
 
 Sponsorship is entirely optional. The plugin stays Apache-2.0-licensed and feature-complete regardless.
 
-### Sponsors
+Thanks to [@jameses-cyber](https://github.com/jameses-cyber) and [@issaqua](https://github.com/issaqua) for supporting the project.
 
-Thanks to the following people for supporting the project:
+---
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
-
-## 📜 License
+## 📜 License & Credits
 
 Apache License, Version 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
-## 🙏 Acknowledgments
+**Built on:**
+- 💡 [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — the original concept
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) and [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — retrieval algorithms
 
-- **💡 Concept:** [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — the original vision that inspired this plugin
-- **🛠️ Platform:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 LLM transport:** [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
+**Maintainer:** [@green-dalii](https://github.com/green-dalii)
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/MODEL-GUIDE.md
+++ b/docs/MODEL-GUIDE.md
@@ -1,0 +1,133 @@
+# 🤖 Model Guide
+
+This page expands on the [README → Models](../README.md#-models) overview with a **pick-by-tier table** (cloud + local) and a **last-verified** date so the recommendations stay traceable. For live pricing and per-model capability flags (function calling, structured output, multimodal, PDF), check [models.dev](https://models.dev/) — it's the canonical open-source catalog the AI SDK and this plugin both use.
+
+**Last verified:** 2026-07-23 · **Source:** [models.dev](https://models.dev/) cross-checked with the v1.25.2 README pick tables.
+
+---
+
+## Why this page exists
+
+The plugin feeds the LLM your full Wiki context per query — so **long-context models win**. The recommendations below are tiered by *quality / cost / hardware* so you can pick by what you actually need, not by what's trending on a leaderboard. Two principles govern the picks:
+
+- **🧠 Context window ≥ 200K tokens** for vaults over ~500 pages. Below 200K the cascade's assembled context starts getting truncated.
+- **⚖️ Instruction-following quality** matters more than raw IQ for the extraction task — pick a model that follows the schema template, not the biggest leaderboard number.
+
+**Embedding endpoints are irrelevant** — we don't use embeddings. A provider that lacks `/v1/embeddings` is fine (most of our 12+ providers do).
+
+---
+
+## ☁️ Cloud Model Picks
+
+> Pricing and availability are verified against [models.dev](https://models.dev/) at the time of writing. Always re-check on the provider's pricing page before relying on the numbers.
+
+| Tier | Model | Context | Why |
+|------|-------|---------|-----|
+| **Flagship** | **Claude Fable 5** | 1M tokens | Anthropic's most capable model (2026-06-09); best instruction-following and extraction quality |
+| **Flagship** | Claude Opus 4.8 | 1M tokens | Anthropic flagship reasoning tier (2026-05-28) |
+| **Flagship** | GPT-5.6 Sol | 1.05M tokens | OpenAI deep-reasoning flagship (2026-07-09); $5/$30 per MTok |
+| **Flagship** | **Moonshot Kimi K3** | 1M tokens | 2.8T MoE open-weight frontier (2026-07); best-in-class coding benchmarks, $3/$15 per MTok |
+| **Balanced** | **Claude Sonnet 5** | 1M tokens | Latest Anthropic balanced tier (2026-06-30) |
+| **🌟 Value** | **DeepSeek V4 Flash** | 1M tokens | Lowest-cost tier — $0.14/$0.28 per MTok; ideal for batch ingestion |
+| **🌟 Value** | **Gemini 3.6 Flash** | 1M tokens | Latest Gemini flash (2026-07-21); strong speed/cost |
+| **🌟 Value** | **Qwen3.7 Plus** | 1M tokens | Alibaba DashScope API; strong agent/coding |
+| **🌟 Value** | **Grok 4.5** | 500K tokens | Latest xAI flagship (2026-07-08) |
+| **Lightweight** | **Gemini 3.5 Flash Lite** | 1M tokens | Cheapest Gemini tier; ideal for small wikis and smoke tests |
+| **Lightweight** | **laguna-s-2.1** (Poolside) | 1M tokens | 118B MoE open-weight coding model; speed champion |
+| **Lightweight** | **Gemma 4** (26B A4B / 31B) | 256K tokens | Google's open-weight series; strong instruction following |
+| **Lightweight** | **Step 3.7 Flash** (StepFun) | 256K tokens | $0.20/$1.15 per MTok; fast inference, strong agent performance |
+| **Lightweight** | **MiniMax M3** | 1M tokens | $0.30/$1.20 per MTok (3rd-party); 1M in/out context |
+| **Lightweight** | **Tencent Hy3** | 256K tokens | ¥1-2/¥4-8 per MTok; Tencent Cloud billing, open-weight |
+| **Budget** | **DeepSeek V4-Pro** | 128K tokens | $0.435/$0.87 per MTok; best quality/cost for output-heavy work |
+| **Budget** | **Xiaomi MiMo V2.5** | 1M tokens | $1/$3 per MTok, flat pricing since 2026-05; strong 1M-context option |
+| **Budget** | **Zhipu GLM-5.2** | 1M tokens | $0.90/$2.84 per MTok; latest GLM series, strong bilingual support |
+
+**Data source:** Pricing and context windows verified against [models.dev](https://models.dev/) and provider API docs (2026-07-23). DeepSeek, MiMo, Kimi, and GLM billing tiers change often; re-check before committing.
+
+The four flagships are all premium-tier models:
+
+- **Claude Fable 5** — Anthropic's best model. Best instruction-following, cleanest Markdown output, largest effective context for multi-shot schema templates.
+- **Claude Opus 4.8** — Anthropic's reasoning flagship. Strong alternative when Fable 5 is at capacity.
+- **GPT-5.6 Sol** — OpenAI's deep-reasoning flagship ($5/$30 per MTok). Best for agentic coding and multi-step tool orchestration. Terra ($2.50/$15) is the production default; Luna ($1/$6) is the budget tier.
+- **Moonshot Kimi K3** — China's best open-weight model (2.8T MoE). Top-tier coding benchmarks at a fraction of the per-token cost ($3/$15 vs ~$15/M for other flagships).
+
+For *ingest* of a 2,000-page vault where each note is 5K tokens, the cost difference between flagships is dominated by the ingest rate-limit guardian, not the per-token price.
+
+### Picking a value pick
+
+The four 🌟 value picks are interchangeable for batch ingest. Choose by:
+
+- **DeepSeek V4 Flash** — if you have DeepSeek API access and the lowest per-token cost matters (subject to DeepSeek's rate limits at peak hours).
+- **Gemini 3.6 Flash** — if you want the newest Gemini flash and Google Cloud billing (1.05M context).
+- **Qwen3.7 Plus** — if you want Alibaba Cloud billing and strong agent/coding performance.
+- **Grok 4.5** — if you want xAI billing (500K context — smaller than the rest, plan accordingly).
+
+### Budget picks
+
+For cost-sensitive workloads, three models stand out below the $1/MTok output line:
+
+- **DeepSeek V4-Pro** ($0.87/MTok output) — the best quality/cost ratio for output-heavy extraction work at 128K context.
+- **Xiaomi MiMo V2.5** ($1/$3) — flat-priced 1M-context model since 2026-05. Good balance of context and cost.
+- **Zhipu GLM-5.2** ($0.90/$2.84) — latest GLM series with 1M context; strong bilingual support.
+
+---
+
+## 🦙 Local Model Recommendations (Ollama / LM Studio)
+
+Local inference wins on data sovereignty, offline use, and zero API cost. The trade-off is context window (most sit between 8K–128K; recent open-weight families reach 262K) and instruction following vs. flagship cloud models. **Pick by your hardware budget:** larger parameter counts buy world knowledge and instruction fidelity (better extraction quality, fewer hallucinations); smaller counts buy speed and memory headroom but pay for it in hallucinations and weaker long-context reasoning. The sweet spot on a 24 GB Apple Silicon or single consumer GPU is the 26B-31B class (Gemma 4) or equivalent.
+
+| Model | Params | Context | Why |
+|-------|--------|---------|-----|
+| **Qwen3.6 (open-weight)** | multiple sizes | 128K–1M | Open-source series (Apache-2.0); available via Ollama / LM Studio / llama.cpp |
+| **Gemma 4 31B IT** | 31B dense | 262K | Strong instruction following, clean Markdown output |
+| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Lower memory than 31B dense at comparable quality |
+
+### Quantization
+
+MLX 4-bit on Apple Silicon is typically 1.5–2× faster than GGUF Q4_K_M at the same effective bitrate. GGUF Q4_K_M is the default cross-platform choice; reach for Q5/Q8 only if you have the VRAM headroom and notice quality regression at Q4.
+
+### Context strategy
+
+When your Wiki grows past ~500 pages, a 262K local model still sees most of the context the Query engine assembles, but ingest on a 2000-page vault will outrun it. Common pattern: cloud for ingest + local for query. For full local setups, the 27B/35B-A3B class is the sweet spot.
+
+### Hardware tiers
+
+| Hardware | Recommended class | Why |
+|----------|--------------------|-----|
+| 16 GB Mac (M1/M2 base) | Gemma 4 E2B / E4B IT (CPU), Qwen3.6 GGUF Q4 | E2B/E4B runs comfortably on CPU; Qwen3.6 fits with moderate quantization |
+| 24 GB Mac (M1 Pro / M2 Pro / M3 Pro) | Qwen3.6 @ MLX 4-bit or Gemma 4 31B IT @ Q4 | The sweet spot — full quality, fits in unified memory |
+| 48 GB Mac (M1/M2/M3/M4 Max) | Qwen3.6 (larger size) or Gemma 4 31B IT @ 8-bit | Quality ceiling on Apple Silicon |
+| Single 24 GB consumer GPU | Qwen3.6 @ GGUF Q4_K_M or Gemma 4 31B IT @ Q4 | Cross-platform default |
+| Dual 24 GB GPUs (NVLink not required) | Qwen3.6 (larger size) @ GGUF Q4_K_M | Splits the weights across two cards |
+
+---
+
+## 🔌 Anthropic-Compatible (Token Plan / Coding Plan)
+
+If your provider offers an Anthropic-compatible API endpoint (Anthropic's `/v1/messages` protocol), select "Anthropic Compatible" in the plugin and enter your provider's Base URL and API Key. The plugin uses the Anthropic provider adapter transparently. Common Anthropic-compatible plans:
+
+- **Token Plan** — providers that resell Anthropic API access with token-based pricing (no Claude Code subscription required).
+- **Coding Plan** — providers that bundle Anthropic API access with a coding-tool subscription (e.g. Claude Code, Cursor, Zed).
+
+No model-table pick is needed if your provider has a fixed catalog. The plugin talks the standard `/v1/messages` protocol regardless of how the provider bills.
+
+---
+
+## 💳 OpenAI vs ChatGPT Plan (Codex OAuth) — they are distinct
+
+- **OpenAI** — separately billed OpenAI Platform API key.
+- **ChatGPT Plan (Codex OAuth)** — experimental, distinct provider that uses eligible Codex allowance after browser or device-code sign-in; availability follows OpenAI Codex authentication and allowance policies, not plan name. Third-party Codex compatibility, not an OpenAI partnership or a general ChatGPT API.
+
+OAuth credentials live only in Obsidian SecretStorage. Sign-out clears the secret.
+
+---
+
+## 🔍 Verifying picks yourself
+
+For any model you're evaluating:
+
+1. **Pricing & capability flags** — [models.dev](https://models.dev/) is the canonical open-source catalog. The [JSON API](https://models.dev/api.json) returns the full database.
+2. **Multimodal / PDF support** — check the model's `modalities` and `attachment` fields on models.dev before assuming it can read a PDF file part.
+3. **Effective context vs. nominal context** — long-context models often degrade past 60-70% of nominal; a 1M-context model may be reliable only to ~700K for complex schema extraction. Run your own quick test.
+4. **Rate limits & cost** — provider pricing pages. DeepSeek and OpenRouter change tier structures often; cross-check before committing.
+**Last updated:** 2026-07-23 — verify picks at [models.dev](https://models.dev/) and provider pricing pages.

--- a/docs/PDF-OCR-GUIDE.md
+++ b/docs/PDF-OCR-GUIDE.md
@@ -1,0 +1,127 @@
+# 📄 PDF Ingest & OCR Guide
+
+**Last updated:** 2026-07-23
+
+The Karpathy LLM Wiki plugin ingests PDFs through the same path it ingests Markdown notes — the difference is **what runs the model**. The plugin sends the PDF to the configured provider's `/v1/chat/completions` (or `/v1/messages` for Anthropic) as a file part, and the provider returns Markdown. This page covers all three paths: **cloud providers with native PDF support**, **local PDF OCR on Apple Silicon**, and **third-party PDF-to-Markdown services** you can route through any OpenAI-compatible provider.
+
+> 📖 Quick cloud setup + provider gate is in the [README → PDF ingest](../README.md#-pdf-ingest-v1250) section. This page is the long form.
+
+---
+
+## ☁️ Cloud providers with native PDF support
+
+These providers accept PDF file parts directly. No conversion step, no cache orchestration — the provider does everything. Turn on **Force PDF Support** if your provider's name is hidden behind a custom base URL.
+
+| Provider | Model capability | Cost | Notes |
+|----------|------------------|------|-------|
+| **Anthropic** | Claude Opus 4.8, Sonnet 5, Fable 5 all read PDFs natively | $3-15/M output | Best multi-page table fidelity; clean Markdown output |
+| **OpenAI** | GPT-5.6 Luna / Sol / Terra read PDFs natively | $10-60/M output | Strongest on dense scientific layouts |
+| **Google Gemini** | Gemini 3.6 Flash, 3.5 Flash Lite — native PDF file parts (since 1.5) | $0.1-1.5/M output | OpenAI-compatible endpoint; 1.05M context |
+| **AWS Bedrock** (Anthropic) | Same as Anthropic, billed through AWS | Same as Anthropic | Useful for VPC / compliance |
+| **AWS Bedrock** (OpenAI) | Same as OpenAI, billed through AWS | Same as OpenAI | Useful for VPC / compliance |
+
+For other OpenAI/Anthropic-compatible endpoints (DeepSeek, Kimi, GLM, MiniMax, OpenRouter, custom), the PDF support depends on whether the endpoint accepts file parts. **Force PDF Support** in Settings → LLM Configuration → Advanced tells the plugin to attempt the call; the endpoint decides, and failures surface as a localized Notice guiding you to disable the toggle.
+
+---
+
+## 🖥️ Local PDF OCR on Apple Silicon (oMLX + Markitdown)
+
+For a fully local pipeline on Apple Silicon, the recommended setup uses [oMLX](https://github.com/jundot/omlx) — an LLM inference server with continuous batching and SSD-tiered KV caching, optimized for M-series chips. oMLX **already integrates** Microsoft [Markitdown](https://github.com/microsoft/markitdown) as a built-in PDF→Markdown backend, so no separate install of Markitdown is needed. Just enable it in oMLX.
+
+### Recommended stack
+
+| Layer | Project | Role |
+|-------|---------|------|
+| **Inference server** | [oMLX](https://github.com/jundot/omlx) | Serves an OpenAI-compatible endpoint. Apple Silicon native. |
+| **PDF → Markdown** | Markitdown (built into oMLX) | Microsoft's PDF/DOCX/PPTX → Markdown conversion. Enable in oMLX settings. |
+| **Visual recognition** | [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) | 3B total / 570M-active end-to-end OCR, open-sourced 2026-06. Handles long documents in one forward pass. Loaded as the vision model in oMLX. |
+| **Summarization** | Your local LLM (any model oMLX serves) | Does the entity/concept extraction just like a cloud provider would. |
+
+The PDF never leaves your machine. Markitdown does the structural conversion locally, Unlimited-OCR does the visual recognition locally, and the local LLM does the summarization locally. The plugin's cache (`.obsidian/plugins/karpathywiki/pdf-cache/`) then keeps re-ingests instant.
+
+### Setup (3 steps)
+
+1. **Install oMLX** and **enable its built-in Markitdown backend** (Settings → Backends → Markitdown → ON). No separate Markitdown install needed.
+2. **Load Baidu Unlimited-OCR as the vision model** — point oMLX at the model weights (Hugging Face: `baidu/Unlimited-OCR`).
+3. **Configure the plugin** — Settings → Karpathy LLM Wiki → Provider → **Custom OpenAI-Compatible**, Base URL = oMLX's local server, **Force PDF Support** ON, pick the multimodal model oMLX is serving.
+
+Click **Test Connection**, then **Save Settings**. `Cmd+P/Ctrl+P` → "Ingest single source" → pick a PDF.
+
+### Hardware expectations
+
+OCR models are all relatively lightweight — you don't need a multi-tier table. Two bands cover every scenario:
+
+| Hardware | Recommended model | Why |
+|----------|--------------------|-----|
+| 8 GB RAM (any system) | **GLM-OCR** (0.9B, MIT), **Baidu Unlimited-OCR** (3B / 570M-active), or **Qwen3-VL-2B** | The three lightweights. GLM-OCR is the OCR specialist (94.6 OmniDocBench), Unlimited-OCR is the long-document OCR (handles 50+ page docs in one forward pass), Qwen3-VL-2B is a general VLM. All three fit comfortably in 8 GB RAM. |
+| 16 GB+ RAM (any system) | **Qwen3-VL-4B/8B** @ MLX 4-bit or GGUF Q4_K_M, **DeepSeek-OCR-2** (vLLM), **Baidu Unlimited-OCR** | More memory buys larger models: Qwen3-VL-8B fits at 16 GB, Qwen3-VL-32B at 32 GB+, and DeepSeek-OCR-2 (91.09 OmniDocBench) is the dedicated OCR option. Upgrade the vision model as your hardware allows, but the three 8 GB choices already handle most real-world PDFs. |
+
+
+### Fallback: any local multimodal LLM
+
+If oMLX/Markitdown is unavailable (Linux/Windows or older Macs without M-series), point **Force PDF Support** at any local multimodal LLM that accepts PDF file parts:
+
+
+- **llama.cpp with a multimodal GGUF** (Qwen3-VL, Llama 3.2 Vision, Pixtral, Gemma 3 vision variants)
+- **Ollama with a multimodal model tag** (`ollama pull qwen3-vl:4b`, `ollama pull llama3.2-vision`)
+- **LM Studio** with a vision-capable GGUF loaded and the OpenAI-compatible server running
+- **vLLM with a dedicated OCR model** (`deepseek-ocr-2`, `glm-ocr`) — talk the standard OpenAI multimodal API
+
+Whichever you pick, set the plugin's Base URL to the server's endpoint and the model picker to the multimodal model name. The plugin's cache key includes the model, so switching models invalidates stale entries automatically.
+
+---
+
+## 🛠️ Third-party PDF-to-Markdown services (optional)
+
+If you need professional-grade PDF extraction (complex scientific layouts, scanned documents, mixed languages) without running your own OCR stack, route the converted Markdown through the plugin as a normal text source. Two services worth knowing:
+
+### [MinerU](https://mineru.net/OpenSourceTools/Extractor) — open-source PDF extractor
+
+[MinerU](https://mineru.net/OpenSourceTools/Extractor) is an open-source PDF extraction tool from Shanghai AI Lab's OpenDataLab team (17.4k GitHub stars, Apache-2.0). It handles complex multi-modal PDFs (text + images + formulas + tables), preserves structure, and converts formulas to LaTeX. Works on CPU and GPU, cross-platform (Windows/Linux/Mac).
+
+**How to use with the plugin:**
+
+1. Run MinerU on your PDFs (CLI: `magic-pdf -p input.pdf -o output/`) or via the [online playground](https://mineru.net/).
+2. Drop the resulting `.md` files into your vault under `sources/`.
+3. Run `Cmd+P/Ctrl+P` → "Ingest from folder" on that folder. The plugin sees them as regular Markdown notes — no PDF path involved.
+
+This is the **most reliable** path for scientific papers, multi-column academic PDFs, and PDFs with embedded equations. Trade-off: MinerU is a separate tool, not integrated with the plugin's cache; you re-run MinerU on PDF changes yourself.
+
+### Other options
+
+- **Adobe PDF Services API** — paid, professional-grade, preserves accessibility tags.
+- **Mathpix** — paid, best-in-class for math-heavy PDFs (arXiv papers, textbooks).
+- **Docling** (IBM) — open-source alternative to MinerU, more focused on document AI pipelines.
+
+For the plugin's purposes, all of these reduce to "convert PDF to `.md` then drop in `sources/`". Pick whichever fits your budget and accuracy bar.
+
+---
+
+## ⚙️ How the plugin's PDF cache works
+
+The plugin's PDF cache lives in `.obsidian/plugins/karpathywiki/pdf-cache/` and is keyed by **content hash + model + converter version**. Re-ingesting the same PDF with the same setup returns the cached Markdown with no LLM call. Three-defense-layer housekeeping keeps the cache bounded:
+
+- **100 MB total** — hard cap on cache size
+- **1000 entries** — hard cap on number of cached PDFs
+- **10 MB single-entry** — hard cap on per-PDF converted Markdown
+
+LRU-by-mtime eviction runs on plugin startup and at the start of every batch ingest. The cache lives in `.obsidian/` (Obsidian's plugin config dir), not in your vault — your vault is not modified by default.
+
+Turn on **Write PDF Markdown to Vault** in Settings → Wiki Configuration → Wiki Folder if you want a `<basename>.pdf.md` sidecar next to the source PDF after conversion. Off by default; cache-only is the default.
+
+---
+
+## When to use which path
+
+| Use case | Best path |
+|----------|-----------|
+| One-off research paper, no setup | Cloud (Anthropic or OpenAI) |
+| Academic PDFs with formulas / multi-column | Cloud OR MinerU → ingest `.md` |
+| Privacy-sensitive PDFs (legal, medical) | Local oMLX on Apple Silicon |
+| Scanned PDFs (image-based) | Local oMLX + Unlimited-OCR |
+| Large batch (100+ PDFs) | Cloud (cheaper at scale) OR MinerU pre-process then cloud ingest |
+| Offline / flight mode | Local oMLX on Apple Silicon |
+| Linux/Windows with consumer GPU | Local llama.cpp multimodal + Force PDF Support |
+
+The plugin handles all paths identically. The local-vs-cloud-vs-third-party decision is just which `Base URL` you point at, or which `.md` files you drop in `sources/`.
+**Last updated:** 2026-07-23 — provider PDF support and local OCR model recommendations change frequently.

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -2,11 +2,11 @@
 
 # 🧠 Karpathy LLM Wiki — Obsidian 插件
 
-> 基于 [Andrej Karpathy 的 LLM Wiki 概念](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) 实现的知识库生成系统，自动从笔记中提取实体与概念，构建互联的 Wiki 页面。
+> 一个 Obsidian 插件，把你的笔记变成互联可查的知识库——[Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) 概念，直接集成在你已有的编辑器中。
 
-> **Obsidian 官方评分 95/100 | 原生支持 10 种语言 | 零嵌入图谱检索 | 完全数据主权 | 兼容所有 LLM 提供商**
+> **零嵌入图谱检索 • 原生 10 种语言 • 兼容所有 LLM 提供商**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
@@ -14,471 +14,325 @@
 
 [官网](https://llmwiki.greenerai.top/) | [Obsidian 插件市场](https://community.obsidian.md/plugins/karpathywiki) | [博客](https://llmwiki.greenerai.top/zh/blog/) | [反馈讨论](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [快速开始](#-快速开始) | ✨ [核心特性](#-核心特性) | 🤖 [模型选择建议](#-模型选择建议) | 🔒 [透明度与合规性](#-透明度与合规性) | ❓ [常见问题 (FAQ)](#-常见问题-faq)
+📑 [目录](#-目录) • 🚀 [快速开始](#-快速开始) • ✨ [核心特性](#-核心特性) • 🔍 [检索工作原理](#-检索工作原理) • 🤖 [模型推荐](#-模型推荐) • ❓ [常见问题](#-常见问题)
 
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 如果你觉得项目帮到你，欢迎请我杯咖啡♥️或为项目点亮🌟↗
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 如果你觉得项目帮到了你，欢迎请我杯咖啡♥️或为项目点亮🌟↗
+
 
 ---
 
-> **⚡ 快速更新提醒：** 本项目迭代速度快，会经常进行 Bug 修复、性能提升或新功能、体验优化等。建议经常在 Obsidian 中更新到最新版本（**设置 → 社区插件 → 检查更新**），或开启插件的自动更新功能以确保获得最佳体验。
+> **⚡ 更新提醒：** 本项目迭代速度快，会经常进行 Bug 修复、性能提升或新功能、体验优化等。建议经常在 Obsidian 中更新到最新版本（**设置 → 社区插件 → 检查更新**），或开启插件的自动更新功能以确保获得最佳体验。
 
 ## 📑 目录
 
-- [🧠 Karpathy LLM Wiki — Obsidian 插件](#-karpathy-llm-wiki--obsidian-插件)
-  - [📑 目录](#-目录)
-  - [💡 什么是 LLM-Wiki？](#-什么是-llm-wiki)
-  - [⚡ 为什么选择 Obsidian + LLM-Wiki？](#-为什么选择-obsidian--llm-wiki)
-  - [🚀 快速开始](#-快速开始)
-    - [📦 安装](#-安装)
-    - [🔄 更新插件](#-更新插件)
-    - [🔑 配置 LLM Provider](#-配置-llm-provider)
-    - [🎮 使用方式](#-使用方式)
-    - [⚠️ 从旧版本升级？](#️-从旧版本升级)
-  - [⚡ 最新动态 v1.25.x](#-最新动态-v125x)
-  - [✨ 核心特性](#-核心特性)
-    - [📊 知识质量](#-知识质量)
-    - [📄 PDF 摄取 (v1.25.0)](#-pdf-摄取-v1250)
-    - [💬 查询与反馈](#-查询与反馈)
-    - [🛠️ 维护能力](#️-维护能力)
-    - [🌐 LLM 与语言](#-llm-与语言)
-    - [🏗️ 架构与性能](#️-架构与性能)
-    - [🔒 隐私与安全](#-隐私与安全)
-  - [📖 使用示例](#-使用示例)
-  - [🤖 模型选择建议](#-模型选择建议)
-    - [☁️ 云端模型推荐](#️-云端模型推荐)
-    - [🦙 本地模型推荐 (Ollama / LM Studio)](#-本地模型推荐-ollama--lm-studio)
-    - [📄 本地 PDF OCR 路径 (v1.25.0+)](#-本地-pdf-ocr-路径-v1250)
-  - [🏗️ 架构](#️-架构)
-  - [❓ 常见问题 (FAQ)](#-常见问题-faq)
-  - [🔒 透明度与合规性](#-透明度与合规性)
-  - [💖 支持项目](#-支持项目)
-    - [赞助者](#赞助者)
-  - [📜 许可证](#-许可证)
-  - [🙏 致谢](#-致谢)
-  - [Star History](#star-history)
----
-
-## 💡 什么是 LLM-Wiki？
-
-你写笔记，AI 来整理，你开口问。就这么简单。
-
-**🎯 痛点。** 你的笔记是个金矿——人物、概念、观点、关联。但现在它们只是文件夹里的一堆文档。找到谁跟谁有关，只能靠搜索、打标签，以及祈祷自己还记得那条线索。
-
-**✨ 思路。** [Andrej Karpathy 提出了](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)一个优雅的方案：把笔记当原材料，让 LLM 来做架构师。它读你写的东西，提取实体和概念，编织成一个结构化的 Wiki——带 `[[双向链接]]`、自动索引，还能用自然语言对你的知识库提问。
-
-**📚 你不再是图书管理员。** 不用纠结该给谁建页面，不用手工维护交叉链接，不用担心信息过时。从你的 vault 中任意选择一篇笔记（或整个文件夹、或多选文件），LLM 自动阅读、提取、撰写、链接，甚至标记矛盾——你只管继续写。
-
-**🤖 也不是另一个聊天机器人。** ChatGPT 了解互联网，LLM-Wiki 了解*你*——准确说，是你教给它的东西。每个回答都带着 `[[wiki-links]]` 回到你的知识图谱。每条回复都是一条探索路径的起点，而不是终点。
-
-**🏆 核心差异化 —— 零嵌入成本、图谱驱动的检索。** 大多数知识库插件用向量嵌入（成本高、依赖供应商、需要联网）。LLM-Wiki 在你已有的 `[[wiki-link]]` 图谱上跑 Personalized PageRank —— 零 API 调用、无新依赖、本地模型完全支持，检索质量对标嵌入级。再加上 i18n 感知的**零 LLM Tier B 章节抽取**（10 种语言），无论用什么提供商，每个用户都能用上同一个知识引擎。
+- [🤔 为什么使用此插件？](#-为什么使用此插件)
+- [🎯 适合我吗？](#-适合我吗)
+- [🚀 快速开始](#-快速开始)
+- [✨ 核心特性](#-核心特性)
+- [🔍 检索工作原理](#-检索工作原理)
+- [🤖 模型推荐](#-模型推荐)
+- [❓ 常见问题](#-常见问题)
+- [🔒 隐私](#-隐私)
+- [💖 支持项目](#-支持项目)
+- [📜 许可证与致谢](#-许可证与致谢)
 
 ---
 
-## ⚡ 为什么选择 Obsidian + LLM-Wiki？
+## 🤔 为什么使用此插件？
 
-Obsidian 是链接思考的利器。但有个问题：连线的那个人一直是你自己。
+你写笔记，它们躺在文件夹里。想找出哪些内容互相关联，只能靠回忆早已忘记的线索。
 
-LLM-Wiki 把这个关系翻转了。不是你手工构建图谱，而是 AI 随着你的笔记一起成长。你写一篇新笔记——它帮你找出你可能会错过的关联。你提一个问题——它在你自己的知识图谱里穿行，带着引用回来见你。
+**Karpathy LLM Wiki 的其他开源实现确实存在——但没有一个是开箱即用的 Obsidian 插件。** 大多数是 CLI 工具、Claude Code 技能或独立桌面应用。我们是唯一一个拥有原生 UI、库内存储和 Obsidian 内置图谱视图的插件。
 
-- **🔗 你的图谱视图活起来了。** 新笔记不再静静躺在文件夹里——它们自动生长出指向实体、概念和来源的链接。图谱有机生长，插件持续维护：检测重复、修复断链、用别名桥接不同语言。
-- **💬 你的笔记学会了对话。** 搜索变成了聊天。"我之前写过什么关于 X 的内容？"变成了对话，流式回答带着 `[[wiki-links]]` 作为路标。每个回答都是深入你自己知识的一条路径。
-- **🧠 Obsidian 成为你的思考伙伴。** 它不再只是装笔记的柜子，而是帮你*思考*的东西——浮现隐藏的关联、标记矛盾、记起你忘了自己知道的事。
+### 竞品对比
+
+| | Karpathy LLM Wiki (本插件) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **交付形态** | ✅ 一键 Obsidian 插件 | ❌ 独立 Tauri 桌面应用 | ❌ Claude Code skill | ❌ Claude Code / Codex skill | ❌ CLI + SDK + MCP 服务 |
+| **上手时间** | ✅ **5 分钟** — 社区插件市场 → 安装 → 选择 Provider → 摄入 | ❌ 30 分钟以上 — 编译/下载二进制、配置 CLI | ❌ 15 分钟 — 需要 Claude Code 订阅 + 安装技能 | ❌ 10 分钟 — 需要 Claude Code/Codex 订阅 + 配置 | ❌ 30 分钟以上 — pip install + SDK + MCP 配置 |
+| **安装路径** | ✅ Obsidian → 社区插件 → 搜索 → 安装 | ❌ 编译或下载独立二进制，再配置 CLI | ❌ 需要 Claude Code 订阅 + 安装指南 | ❌ 需要 Claude Code 或 Codex 订阅 + 配置步骤 | ❌ pip install + Python SDK + 本地服务 |
+| **架构复杂度** | ✅ **零依赖** — 无需向量数据库、无需嵌入模型、无需外部进程 | 🟡 自带 Python 运行时 + sigma.js + sqlite | 🟡 依赖 Claude Code 环境 — 非自包含 | 🟡 需要独立平台运行时 | ❌ 需要 Python、嵌入模型、向量数据库 |
+| **国际化 (界面 + Wiki 输出)** | ✅ 10 种语言（界面/Wiki 独立设置） | 🟡 2 种（英文/中文） | ❌ 仅英文 | ❌ 仅英文 | ❌ 仅英文 |
+| **LLM 提供商** | ✅ 12+（含 Codex OAuth、Bedrock、LM Studio、Ollama、Anthropic 兼容、Kimi、GLM、MiniMax、DeepSeek） | 🟡 OpenAI 兼容 | 🟡 通过 Claude Code 订阅 | 🟡 通过 Claude Code / Codex 订阅 | 🟡 OpenAI 兼容 |
+| **检索算法** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 4 信号启发式（Adamic-Adar + 2 跳衰减） | ❌ 仅 Louvain 社区检测 | ❌ 仅 Louvain + k 跳预览 | ❌ 混合：BM25 + 语义 + wiki 链接 |
+| **查询管线（5 级级联）** | ✅ Lex → LLM 关键词 → 子串扫描 → LLM KB 回退 → PPR 扩展（首个充分信号即截断） | 🟡 仅 2 跳衰减 | ❌ 仅 Louvain 聚类 | ❌ k 跳预览（无 LLM 增强） | ❌ BM25 + 语义分块（无图） |
+| **需要嵌入模型** | ✅ 不需要（零嵌入成本，有意为之） | 🟡 可选，默认关闭 | ✅ 不需要 | ✅ 不需要 | ❌ **必须 — 强制要求** |
+| **图谱可视化** | ✅ Obsidian 原生图谱视图（内建，零额外体积） | ❌ 桌面应用中自定义 sigma.js + graphology | 🟡 vis.js graph.html（独立文件） | ❌ 自定义 sigma.js 离线 HTML | ❌ 只读浏览器查看器 |
+| **Wiki 诚实度** | ✅ 当没有 Wiki 源匹配查询时显示"阶段回退"提示 | ❌ 无等效功能 | ❌ 无等效功能 | ❌ 无等效功能 | ❌ 无等效功能 |
+| **已发布检索基准** | ✅ PPR @5 = 27.1% vs 纯 knn 基线 24.1%（该领域唯一公开基准） | ❌ 58% → 71% *仅在启用嵌入时*，非同类对比 | ❌ 未公开 | ❌ 未公开 | ❌ 未公开 |
+
+### 三个有意的设计选择
+
+- **🪟 Obsidian 就是运行环境。** 不需要终端、不需要独立应用、不需要 Docker、不需要 Python。从社区插件市场安装，点击摄入，Wiki 从第一秒就存在于你的 vault 中。Obsidian 原生图谱视图渲染你的 `[[wiki-link]]` 图——内建，零额外体积。
+- **🧭 干净、自包含。** 零依赖。没有嵌入模型、没有向量数据库、没有 pip 包——一个插件读取你的笔记，与 LLM 对话，写出 Wiki 页面。一切都在 Obsidian 内部运行。
+- **🔌 任何你已付费的模型。** Anthropic、Bedrock、OpenAI、ChatGPT Plan (Codex OAuth)、DeepSeek、Kimi、GLM、MiniMax、LM Studio、Ollama、OpenRouter、Anthropic 兼容、自定义端点——十二个以上提供商，没有一个需要嵌入端点。
+
+---
+
+## 🎯 适合我吗？
+
+**✅ 适合，如果你：**
+
+- **想要 5 分钟的上手时间，而非 5 小时的项目。** 从社区插件市场安装 → 选择 Provider → 摄入一篇笔记。没有 CLI、没有 Python、没有独立运行时、没有向量数据库。几秒内就能在 `wiki/` 中看到 Wiki 页面。
+- **想要干净、自包含的解决方案。** 插件有零个外部依赖：没有嵌入模型、没有向量数据库、没有 pip 包、没有 Docker 容器。它是一个单一的 Obsidian 插件，读取你的笔记、与 LLM 对话、将 Wiki 页面写入你的 vault。一切都在 Obsidian 内部运行。
+- **想要一个基于*你的笔记*回答的可查询聊天**——而非互联网——每个答案都带有 `[[wiki-links]]` 回到你的知识图谱。
+- **关心数据主权**——使用 Ollama 或 LM Studio 完全本地运行，永不触网。
+- **使用或阅读 10 种支持语言中的任何一种**——界面和 Wiki 输出语言相互独立（你的 Wiki 可以是中文而界面是英文）。
+- **通过写 `[[wiki-links]]` 来维护图谱**——你写的每个链接已经在丰富检索；无需单独的标签/嵌入/索引步骤。
+- **想要一键维护**——Lint 健康扫描 + 一键智能修复自动处理重复、断链和孤立页，无需手动整理。
+
+**❌ 不适合，如果你：**
+
+- **想要一个通用 ChatGPT 替代品**——本插件只从*你的*知识中回答。
+- **需要对 PDF/网页/外部语料库做 RAG 管线**——我们专注于 vault 内路径（PDF 自 v1.25.0 起支持）。
+- **在寻找托管 SaaS**——没有后端、没有服务器、没有账号。
 
 ---
 
 ## 🚀 快速开始
 
-### 📦 安装
+1. **安装。** Obsidian → 设置 → 第三方插件 → 社区插件 → 浏览 → 搜索 "Karpathy LLM Wiki" → 安装 → 启用。或访问 [社区插件页面](https://community.obsidian.md/plugins/karpathywiki) 点击 **Add to Obsidian**。
+2. **配置 Provider。** 打开 设置 → Karpathy LLM Wiki → 选择 Provider（OpenAI、Anthropic、Ollama、ChatGPT Plan (Codex OAuth) 等）→ 输入 API Key（本地模型不需要）→ 点击 **测试连接** → 保存。
+3. **摄入一篇笔记。** `Cmd+P/Ctrl+P` → "摄入单个源文件" → 选择任意 Markdown（或 PDF，v1.25.0+）文件。几秒内你的首批 Wiki 页面就出现在 `wiki/sources/`、`wiki/entities/`、`wiki/concepts/` 中。
 
-**🌟 推荐 — Obsidian 社区插件市场：**
+仅此而已。插件不会修改你的原始笔记——只在 `wiki/` 下创建新页面。要与你的 Wiki 对话：`Cmd+P/Ctrl+P` → "查询 Wiki"。（`Cmd` 在 macOS 上，`Ctrl` 在 Windows/Linux 上。）
 
-1. 在 Obsidian 中打开 **设置 → 第三方插件**
-2. 点击 **浏览**，搜索 "Karpathy LLM Wiki"
-3. 点击 **安装**，然后 **启用**
+### 核心命令
 
-**🌐 或从社区插件网站安装 —** 访问 [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki)，点击 **Add to Obsidian** 即可直接安装。
-
-**⚙️ 手动安装（备用）：**
-
-1. 从 [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases) 下载 `main.js`、`manifest.json`、`styles.css`
-2. 在 Obsidian 中打开 设置 → 第三方插件，在 **已安装插件** 标签页点击文件夹图标，打开插件目录
-3. 新建一个 `karpathywiki` 文件夹，将三个文件放入其中
-4. 回到 Obsidian，点击刷新图标 — **Karpathy LLM Wiki** 会出现在已安装插件列表中
-5. 打开开关启用
-
-**🔨 开发构建：** `git clone` 后执行 `pnpm install` 和 `pnpm build`。
-
-### 🔄 更新插件
-
-本项目迭代迅速，新功能、修复和改进会频繁发布。建议保持更新：
-
-**方式一 — 手动更新（推荐）：**
-1. 打开 **设置 → 第三方插件**
-2. 点击 **检查更新**
-3. 在列表中找到 **Karpathy LLM Wiki**，点击 **更新**
-
-**方式二 — 开启自动更新：**
-1. 打开 **设置 → 第三方插件**
-2. 开启 **自动检查插件更新**
-3. 新版本会被自动检测，你可以择机手动更新
-
-> 💡 **为什么要保持更新？** 每次发布都可能包含新功能、性能优化和重要修复。我们会积极维护此插件——错过更新意味着错过更好的体验。
-
-### 🔑 配置 LLM Provider
-
-1. 打开 设置 → Karpathy LLM Wiki
-2. 从下拉菜单选择 Provider（包括 OpenAI 或 ChatGPT Plan (Codex OAuth)）
-3. API Provider 需填入 API Key（Ollama、LM Studio 和 ChatGPT Plan (Codex OAuth) 不需要）
-4. 非 Codex Provider 可点击**获取模型列表**或手动输入模型名；ChatGPT Plan (Codex OAuth) 登录后会同步账户模型目录，并提供**刷新账户模型**按钮
-5. 点击 **测试连接**，然后 **保存设置**
-
-**Ollama 本地模型（无需 API Key）：** 安装 [Ollama](https://ollama.com)，拉取模型（如 `ollama pull gemma4` 或 `ollama pull qwen3.5:27b`），在 Provider 下拉选择 "Ollama (本地)"。
-
-**LM Studio 本地模型（无需 API Key）：** 安装 [LM Studio](https://lmstudio.ai)，启动其本地服务（默认 `http://localhost:1234/v1`），在 Provider 下拉选择 "LM Studio（本地）"。LM Studio 内置 OpenAI 兼容服务，API Key 字段可选。
-
-**Anthropic 兼容（Coding Plan）：** 如果你的服务商提供 Anthropic 兼容的 API 端点（常见于 Coding Plan 订阅），选择 "Anthropic 兼容"，填入服务商提供的 Base URL 和 API Key。
-
-**ChatGPT Plan (Codex OAuth)（实验性）：** 这与使用 OpenAI Platform API Key 并单独按量计费的 **OpenAI** Provider 相互独立。选择该 Provider 后，桌面端可点击**使用浏览器登录**（localhost 回调），桌面端和移动端均可点击**使用设备代码**并在 OpenAI 页面完成授权。插件会从当前登录的 Codex 账户同步可选择模型，只缓存经过清理的模型元数据；可用**刷新账户模型**手动更新。目录暂时不可用时保留上次成功缓存或最小内置回退列表。随后测试连接并保存。OAuth 凭据只存入 Obsidian SecretStorage，**退出登录**会清除凭据。可用性取决于 OpenAI Codex 的身份验证、模型和额度政策；这属于第三方兼容功能，并非 OpenAI 合作项目或通用 ChatGPT API。
-
-### 🎮 使用方式
-
-| 方式 | 操作 |
+| 命令 | 功能 |
 |------|------|
-| **📥 摄入单个源文件** | `Cmd+P` → "摄入单个源文件" — 选择笔记（Markdown 或 **PDF，v1.25.0+**），提取实体和概念生成 Wiki 页面 |
-| **📂 从文件夹摄入** | `Cmd+P` → "从文件夹摄入" — 选择文件夹，批量处理其中所有笔记 |
-| **📑 多选文件摄入** | `Cmd+P` → "多选文件摄入" — 通过递归文件夹树 + 每文件复选框精确选择笔记，批量摄取（带实时队列 + 按文件取消）|
-| **🎯 摄入当前文件** | 点击左侧 ribbon 的 `sticker` 图标，或 `Cmd+P` → "摄入当前文件" — 直接摄入当前打开的笔记 |
-| **🔍 查询 Wiki** | `Cmd+P` → "查询 Wiki" — 对话式提问，流式回答中自带 `[[wiki-links]]` |
-| **🛠️ 维护 Wiki** | `Cmd+P` → "维护 Wiki" — 全面健康扫描：重复页、断链、空洞页、孤立页、缺失别名、矛盾。Schema 建议显示在 Lint Modal 内 |
-| **📋 重新生成索引** | `Cmd+P` → "重新生成索引" — 重建 `wiki/index.md`，包含别名信息 |
-| **📊 查看摄入历史 (v1.21.0)** | `Cmd+P` → "查看摄入历史" — 可搜索、可筛选的界面浏览历史摄入、Lint 报告和维护运行 |
-| **⏹ 取消当前操作** | `Cmd+P` → "取消当前提取" — 安全停止进行中的操作，保留已完成工作 |
-| **🎉 重建欢迎笔记 (v1.23.0)** | `Cmd+P` → "重建 Wiki 欢迎笔记" — 重新生成首次运行的欢迎笔记 |
+| **📥 摄入单个源文件** | `Cmd+P/Ctrl+P` → "摄入单个源文件" — 选择 Markdown 或 **PDF (v1.25.0+)** 文件，生成实体/概念/Wiki 页面 |
+| **📂 从文件夹摄入** | `Cmd+P/Ctrl+P` → "从文件夹摄入" — 批量处理文件夹中所有笔记，含智能批量跳过 |
+| **📑 多选文件摄入** | `Cmd+P/Ctrl+P` → "多选文件摄入" — 通过双栏文件树选择子集（带实时队列 + 按文件取消）|
+| **🔍 查询 Wiki** | `Cmd+P/Ctrl+P` → "查询 Wiki" — 在右侧停靠面板中与 Wiki 对话；答案带有 `[[wiki-links]]` |
+| **🛠️ Lint Wiki** | `Cmd+P/Ctrl+P` → "Lint Wiki" — 全面健康扫描：重复页、断链、空洞页、孤立页、缺失别名、矛盾 |
+| **⚡ 一键智能修复** | 在 Lint 弹窗内 — 按因果关系顺序修复，含各阶段执行报告 |
+| **📋 重新生成索引** | `Cmd+P/Ctrl+P` → "重新生成索引" — 用当前页面和别名重建 `wiki/index.md` |
+| **⏹ 取消** | `Cmd+P/Ctrl+P` → "取消当前摄入" 或点击状态栏 — 在下一个批次边界干净停止 |
+| **📊 摄入历史** | `Cmd+P/Ctrl+P` → "查看摄入历史" — 可搜索的 UI，浏览历史摄入、Lint 报告和维护运行 |
 
-重复摄入同一源文件时，实体/概念页以增量方式合并新信息，摘要页会重新生成。
+**从一篇笔记到互联 Wiki：**
 
-> 💡 **批量智能跳过：** 文件夹摄入时，插件自动检测已处理文件并跳过，节省时间和 API 成本。
+| 之前 | 之后 |
+|------|------|
+| `notes/machine-learning.md`（一个扁平文件） | `wiki/concepts/supervised-learning.md` 带 `[[双向链接]]`、别名、来源归属，以及 `wiki/index.md` 中的索引条目 |
 
-![命令面板 — 搜索 "karpa" 查看所有 Karpathy LLM Wiki 命令](assets/command-panel.png)
+> 💡 **保持更新。** 新功能、修复和性能改进频繁发布。设置 → 第三方插件 → 检查更新，或开启自动插件更新。
+> 📖 详细教程（安装、PDF 配置、多 Provider 说明、升级指南）见 [GitHub Discussions → 指南](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides)。
 
-### ⚠️ 从旧版本升级？
+---
 
-> 🔧 **从 v1.24.x 升级。** PDF 摄取（v1.25.0）将缓存写入 `.obsidian/plugins/karpathywiki/pdf-cache/`（上限 100 MB / 1000 条 / 单条 10 MB；启动时与每次批量摄取开始时按 LRU-by-mtime 淘汰）。你的 vault **默认不会被修改** —— 仅当在 Settings → Wiki Configuration → Wiki Folder 中开启 **Write PDF Markdown to Vault** 时，才会在源 PDF 旁写一份 `<basename>.pdf.md` sidecar。两个新设置 —— **Force PDF Support**（高级，默认关闭）与 **Write PDF Markdown to Vault**（默认关闭）—— 完全向后兼容：旧 `data.json` 不带这两个字段时会默认为 `false`。
-
-> 🔧 **从 v1.24.0 升级。** 此前用于单独保护页面*来源提及*章节的内部注释标记 `<!-- reviewed: keep -->`（v1.24.0，#244）已移除。如需保留手动整理的来源提及章节，请在页面 frontmatter 中设置 `reviewed: true`——它保护整个页面（含来源提及），且不同于隐藏的注释标记，会显示在属性面板中、也不会被 Markdown linter 破坏。
-
-**向后兼容。** 自 v1.0.0 起无破坏性变更——现有 Wiki 页面、设置和工作流全部保留，无需重新配置。
-
-**升级后**，运行 **维护 Wiki** → **一键智能修复** 按因果关系自动处理：
-1. 🏷️ 补全别名（LLM 批量生成翻译、缩写、变体名）
-2. 🔄 合并重复页面（跨语言、缩写、高相似度匹配）
-3. 🔗 修复断链 / 链接孤立页 / 扩充空洞页
-
-然后**重建索引**，为每个页面附加别名条目，启用别名感知搜索（如 "DSA" 找到 "DeepSeek-Sparse-Attention"）。
-
-> 📖 特定版本跳跃的详细升级指南（v1.20.3 指纹迁移、v1.16.0 双重嵌套链接）见 [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)。
-
-**建议检查的设置项：** Force PDF Support（Settings → LLM Configuration → Advanced，默认关闭 —— 仅对非 NATIVE provider 有意义）、Write PDF Markdown to Vault（Settings → Wiki Configuration → Wiki Folder，默认关闭）、Wiki 输出语言（独立于界面）、提取粒度（极简–精细 + 自定义）、页面生成并发度（默认 3）、批次延迟（默认 300ms）。
-
-## ⚡ 最新动态 v1.25.x
-
-- **v1.25.2 (2026-07-22).** 标签词表 Phase 1（消除双重来源）、Codex OAuth（ChatGPT Plan）、关联链接文件夹前缀修复、页面模板裸 `---` 修复、ESLint 0.4.1 路线 A。2515 个测试通过。
-- **v1.25.1 (2026-07-20).** 8 个静默丢失修复（关联页面、Schema 章节、旧版 Mentions）、3 个大文件拆分、DiskCache<T>、LM Studio 无需 API 密钥摄入、构建验证根因。2274 个测试通过。
-- **v1.25.0 (2026-07-18).** 仅缓存 PDF 摄入（Level 1）、有界缓存增长、可选的 vault sidecar、Force PDF 通用开关、逐字提示词、可取消摄入、本地模型指导、i18n 完整。2182 个测试通过。
-
-📋 [完整版本历史 → CHANGELOG.md](../CHANGELOG.md)
 ## ✨ 核心特性
 
-### 📊 知识质量
+### 📚 知识质量
 
-- **🔍 实体/概念提取** — LLM 从笔记中提取实体（人物、组织、产品、事件等）和概念（理论、方法、术语等），生成独立 Wiki 页面，支持灵活提取粒度（极简~5个、粗略~10、标准~50、精细~100、自定义1–500）平衡分析深度与 API 成本
-- **🏷️ 强制页面别名** — 每个生成的页面至少包含 1 个别名（翻译、缩写、变体名），支持跨语言重复检测
-- **🔄 重复检测与合并** — 语义分级捕获真正的重复页面（跨语言翻译、缩写、拼写变体）；智能 LLM 融合合并内容并保留别名
-- **🧩 智能知识融合** — 多源更新时智能合并新信息不重复；矛盾保留并注明归属；`reviewed: true` 页面受保护不被覆盖
-- **📏 内容截断保护** — API Key 与本地 Provider 使用 8000 max_tokens、自动检测 stop_reason 并以 2× token 重试。实验性的 ChatGPT Plan（Codex OAuth）路径遵循 Codex 后端的输出策略，不接受客户端 max_output_tokens 上限。
-- **📝 原文引用保留** — 来源提及章节保留原语言引用，可选翻译，确保可追溯性
+- **🔍 实体与概念提取** — LLM 从笔记中提取实体（人物、组织、产品、事件）和概念（理论、方法、术语），生成独立页面。提取粒度可配置（极简 → 精细，外加自定义），让你在成本与深度之间取舍。
+- **🏷️ 强制别名** — 每个页面至少包含一个别名（翻译、缩写、变体名），使跨语言重复检测得以工作。
+- **🔄 分级重复检测** — 第 1 级（直接名称匹配：跨语言、缩写、高相似度标题）全部验证；第 2 级（共享链接、中等相似度）填充剩余 token 预算。
+- **🧩 智能合并与矛盾状态** — 重复页面合并时保留别名；矛盾被标记并注明来源归属；`reviewed: true` 的页面受保护不被覆盖。
+- **🎨 自定义标签词汇表** — 在设置 → Wiki → 标签词汇表 → *自定义* 中定义自己的实体类型和概念类型标签列表；Lint 会报告任何使用活动词汇表之外标签的页面。
 
-- **🎨 自定义标签词汇表 (v1.18.0)。** 设置 → Wiki → 标签词汇表模式 → *Custom* 可定义自己的实体类型和概念类型标签列表（例如 `Medical_Arzneimittel`、`法规`）。插件在提取 prompt 和 frontmatter 校验中都会尊重你的词汇表；现有的 Lint 审计 (#85 v7) 会报告任何使用了不在活动词汇表内标签的页面。
+### 📄 PDF 摄入 (v1.25.0+)
 
-![自定义标签词汇表芯片输入](assets/custom-tags.png)
+- **🔌 Provider 准入** — Anthropic、OpenAI 和 Bedrock 原生支持 PDF。对于任何其他 OpenAI/Anthropic 兼容端点，在设置 → LLM 配置 → 高级中开启 **Force PDF Support** 让插件尝试调用。关于 Apple Silicon 上的本地 OCR、第三方提取工具（MinerU、Docling、Mathpix、Adobe）及完整 PDF 摄入教程，见下方的 [PDF OCR 路径](#-pdf-ocr-路径) 和 [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)。
+- **🗄️ 有界缓存** — `.obsidian/plugins/karpathywiki/pdf-cache/` 按内容哈希 + 模型 + 转换器版本为键存储转换后的 Markdown。三层防御治理：总计 100 MB / 1000 条 / 单条 10 MB 上限，LRU-by-mtime 淘汰。
+- **📝 可选 vault sidecar** — 设置 → Wiki 配置 → Wiki 文件夹 → *将 PDF Markdown 写入 Vault* 在源 PDF 旁写入 `<basename>.pdf.md`（默认关闭——仅缓存模式）。
+- **🛡️ 逐字转录提示** — 带 `[illegible]` / `[figure: ...]` 反幻觉标记的 OCR 风格转换；小型本地模型的 markdown 围栏包裹在写入缓存前自动清洗。
 
-### 📄 PDF 摄取 (v1.25.0)
+### 📄 PDF OCR 路径
 
-从 vault 里挑一个 PDF — 插件通过你的 LLM Provider 的原生文件输入读取它，转换成 Markdown，然后回到标准的 Markdown 摄取流程。所有既有的实体/概念/别名/`[[wiki-link]]` 工作流保持不变。
+三条路径，选择适合你配置的：
 
-- **🔌 Provider 准入** — Anthropic、OpenAI、Bedrock Anthropic 和 Bedrock OpenAI 原生支持 PDF。其他任何 OpenAI/Anthropic 兼容端点，请在 Settings → LLM Configuration → Advanced 中开启 **Force PDF Support**，让插件尝试调用（你的端点做最终判断；失败时会以本地化 Notice 提示用户关闭该开关）。本地推荐配置见 [本地 PDF OCR 路径](#-本地-pdf-ocr-路径-v1250)。
-- **🗄️ 内容哈希缓存** — 相同的 PDF + 相同的模型 + 相同的 converter version 直接返回缓存的 Markdown，无需 LLM 调用。缓存位于 `.obsidian/plugins/karpathywiki/pdf-cache/`；缓存键内嵌 `converterVersion`，prompt 升级时自动失效旧条目。
-- **📏 有界增长** — 三层防御缓存治理（总计 100 MB / 1000 条 / 单条 10 MB 上限）+ LRU-by-mtime 淘汰；启动时与每次批量摄取开始时清理旧条目。默认仅缓存 — 不会修改你的 vault。
-- **📝 可选 vault sidecar** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** 在转换完成后于源 PDF 旁写一份 `<basename>.pdf.md`。默认关闭（仅缓存）。
-- **🛡️ 逐字转录 Prompt** — PDF→Markdown prompt 重写为 OCR 风格的逐字转换，配合 `[illegible]` / `[figure: ...]` / `[equation: ...]` 反幻觉标记；小模型/本地模型把输出包裹在 ```markdown 围栏里的，会在写入缓存前自动清洗。
-- **⏹ 可取消** — 转换过程中点击状态栏可中断正在进行的 LLM 调用（经由 Vercel AI SDK v6）。
+1. **☁️ 云端 Provider 原生 PDF 支持** — Anthropic、OpenAI 或 AWS Bedrock 开箱即用。直接摄入，无需额外设置。对于任何其他 OpenAI/Anthropic 兼容端点，在设置 → LLM 配置 → 高级中开启 **Force PDF Support** 让插件尝试调用。
+2. **🖥️ Apple Silicon 本地 OCR** — [oMLX](https://github.com/jundot/omlx) 将 Microsoft Markitdown 集成为其内置的 PDF→Markdown 后端。在 oMLX 中启用 Markitdown，加载 [百度 Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR)（3B / 570M 活跃参数，2026-06 开源）作为视觉模型，将插件指向 oMLX 作为自定义 OpenAI 兼容 Provider，开启 **Force PDF Support**，选择 oMLX 服务的多模态模型。PDF 全程不离开你的机器。
+3. **🛠️ 第三方提取工具（MinerU、Docling、Mathpix、Adobe）** — 在你的 PDF 上运行独立提取工具生成 `.md` 文件，然后通过插件的标准管线将其作为普通 Markdown 笔记摄入。对于科学论文、扫描文档、数学密集型 PDF 最为可靠。
 
-### 💬 查询与反馈
+📖 **所有三条路径的完整设置教程**（云端 Provider、oMLX 硬件等级、MinerU 安装、缓存管理）→ [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-- **🔍 5 级 PPR 种子选择级联（v1.24.1 PATCH）** — 当你提出多跳问题时，Query Wiki 在任何生成启动前会通过五个互补的阶段组合答案：
-  1. **Lex 快速路径** — 直接对每个实体/概念标题与别名做 token 重叠匹配（免费、即时；为后续阶段把关）
-  2. **LLM 关键词生成** — LLM 从你的查询中提出 8–12 个跨语言关键词（处理同义词、缩写、对 token 重叠不敏感的术语）
-  3. **本地子串扫描** — 每个生成的关键词在本地对页面标题、别名与正文片段重新匹配（无额外 LLM 调用；补足噪声容忍的召回）
-  4. **LLM KB 回退** — 当 lex + 关键词扫描信号不足时，LLM 对 top-N 候选重新针对完整 wiki 做一次语义筛选
-  5. **PPR 图扩展** — 在 `[[wiki-link]]` 图上从候选种子集运行 Personalized PageRank（Haveliwala 2002）；为 LLM 提供图感知的多跳上下文，线性检索无法达到
+### 💬 查询与维护
 
-  级联会自动截断到给出足够信号的步骤 —— 没有固定的 5 步开销，lex 足够时无 LLM 调用，需要 LLM 增强时精度不丢失。端到端相关性（项目自有基准语料上 PPR @5 = 27.1%）超过纯 knn 基线（24.1%），无需嵌入。Stage 1.5（步骤 2–3）处理纯 lex 漏掉的多跳问题；Stage 1.7（步骤 4）在 LLM 注入关键词信号不足时回补；Stage 1.9（步骤 5）保证 LLM 看到的是邻居上下文而非扁平 top-N 列表。取代了旧的二分 tier 级联。
+- **🧭 5 级 PPR 级联** — 见 [检索工作原理](#-检索工作原理)。`[[wiki-link]]` 图上的 Personalized PageRank 提供图感知的多跳上下文。
+- **🪟 右侧停靠侧边栏** — 查询 Wiki 在 Copilot 风格的右侧侧边栏（v1.22.1+）中打开，而非居中弹窗。
+- **🔍 Lint 健康扫描** — 一条命令检测：重复页、断链、空洞页、孤立页、缺失别名、矛盾。
+- **⚡ 一键智能修复** — 按因果关系顺序修复：补全别名 → 合并重复 → 修复断链 → 链接孤立页 → 扩充空洞页，附带各阶段报告。
+- **📊 操作历史面板** — 可搜索、可筛选的 UI，查看历史摄入、Lint 报告和维护运行。
+- **🛡️ 摄入前置检查** — 空/空白/仅 frontmatter 的笔记在任何 LLM 调用前被拒绝；内容哈希去重捕获跨路径的相同文件。
 
-- **🤖 对话式查询** — ChatGPT 风格对话框，流式 Markdown 输出，自带 `[[wiki-links]]`，多轮历史
-- **🪟 右侧停靠侧边栏 (v1.22.1, PR #196)。** Query Wiki 在 Copilot 风格的右侧 sidebar leaf 中打开（若已存在则复用），不再以居中弹窗出现。`message-circle` ribbon 图标和 `Query Wiki` 命令激活/显示侧边栏，笔记与对话并排可见。所有功能保持不变。
-- **📤 查询到 Wiki 反馈** — 将有价值的对话保存到 Wiki，含实体/概念提取，保存前语义去重
-- **🔒 重复保存防护** — Hash 跟踪阻止未变化对话的重复评估
+### 🔒 隐私
 
-### 🛠️ 维护能力
+- **🚫 无后端、无追踪、无分析。** 完全在 Obsidian 内部运行。网络仅用于与你配置的 LLM 提供商通信。
+- **📁 源文件只读。** 插件永不修改你的原始 vault 笔记——仅在 `wiki/` 下创建新页面。
+- **🦙 完全本地模式。** Ollama、LM Studio 或任何本地 OpenAI 兼容端点——你的笔记永不离开你的机器。
+- **🔐 最小化权限。** Vault 文件访问用于 Wiki 管理。剪贴板访问仅在你在查询弹窗中点击"复制"按钮时。
 
-- **🔍 Lint 健康扫描** — 一次全面报告检测：重复页面、断链、空洞页面、孤立页面、缺失别名、矛盾
-- **🎯 语义分级重复检测** — Tier 1（直接名称匹配：跨语言、缩写、高相似度标题）全部验证；Tier 2（间接信号：共享链接、中等相似度）按 token 预算填充
-- **⚡ 一键智能修复** — 按因果关系顺序批量修复：补全别名 → 合并重复 → 修复断链 → 链接孤立页 → 扩充空洞页，完成后弹窗报告各阶段执行结果
-- **🏷️ 别名补全** — 一键并行批量生成缺失别名，提升后续重复检测准确率
-- **🔄 自动维护** — 多文件夹监听、定时 Lint、启动健康检查（均可选）
-- **⚠️ 矛盾状态机** — `检测 → 审核通过 → 已解决`（AI 修复）或 `检测 → 待修复`（手动）
-- **🛡️ 摄入前置检查（v1.21.0）** — 在任何 LLM 调用之前验证每个源文件：空文件/纯空白/仅含 frontmatter 的笔记会被直接拒绝；通过内容哈希去重识别跨路径的相同文件。防止小模型在空白输入上编造实体名。
-- **📊 操作历史面板（v1.21.0）** — 可搜索、可筛选的 UI，用于查看历史摄入、Lint 报告和维护运行记录，含洞察驱动的 KPI 卡片和可点击的页面链接。
-- **🧹 不完整页面清理（v1.21.0）** — 中途中断的摄入留下的半成品页面会在启动时自动归档至 Obsidian 的 `.trash`（可恢复）。
+### 🦙 本地优先
 
-### 🌐 LLM 与语言
+- **🖥️ Ollama、LM Studio、OpenRouter、自定义端点** — 开箱即用。本地模型可用于查询（上下文窗口较小）；2000 页 vault 的摄入通常需要长上下文云端模型。
+- **📄 Apple Silicon 上 PDF OCR 路径完全本地** — 见上方的 [PDF OCR 路径](#-pdf-ocr-路径)。
+- **🔐 ChatGPT Plan (Codex OAuth)** — 桌面端通过 `127.0.0.1:1455` 的回环回调；移动端通过设备代码。凭据仅存在于 Obsidian SecretStorage 中；退出登录清除。第三方 Codex 兼容功能，非 OpenAI 合作项目。
 
-- **🔌 多 Provider 支持** — Anthropic、Anthropic 兼容（Coding Plan）、Gemini、OpenAI、DeepSeek、Kimi、GLM、MiniMax、LM Studio、OpenRouter、Ollama、自定义接口
-- **🔄 5xx 自动重试** — 全部客户端在 HTTP 5xx/429/529 错误时指数退避重试（最多 2 次）
-- **📋 动态模型列表** — 从 Provider API 实时获取
-- **🌐 Wiki 输出语言** — 10 种语言独立于界面（英/简中/繁中/日/韩/德/法/西/葡/意），支持自定义输入。
-- **🌍 全界面国际化** — 插件 UI 支持 10 种语言（英/简中/繁中/日/韩/德/法/西/葡/意），269+ UI 字段完整翻译，自然本地表达。
-- **⚡ 速率限制守护** — 并行生成触发限流时自动检测并提示：降低并发度、增大批次延迟、切换 Provider
-- **🦙 Web Clipper 高度兼容** — 一键添加官方 Obsidian Web Clipper 的 `Clippings/` 文件夹到监听列表，网页剪藏自动摄入 Wiki
+### 🌐 语言
 
-### 🏗️ 架构与性能
-
-- **🕸️ PPR over [[wiki-link]] 图（v1.24.0+，v1.24.1 PATCH 完善）** — Personalized PageRank（Haveliwala 2002）在你 wiki 页面之间 `[[wiki-link]]` 边的有向图上运行；级联把 PPR 种子锚定在 top-N 候选集，多跳上下文最多经过 3 层扩展环。正是这个机制让 Query Wiki 答案具备图感知能力（"微软创始人"问题通过 Bill Gates → Microsoft → 竞争者 解决，而非仅靠字面标题重叠）。2,137 页的 vault 典型情况下热路径 + 3 跳扩展 < 100 ms，与 vault 规模无关。被查询与反馈区所有 4 级种子级联使用，并在 lint 重复检测（间接链接把两个候选页面关联起来时）也会用到。
-- **⚡ 并行页面生成** — 可配置 1–5 并发页面，默认 3（并行），大源文件 2–3× 加速，单页错误隔离
-- **📚 迭代批量提取** — 自适应批次大小，消除长文档的 max_tokens 瓶颈
-- **🏛️ 三层架构** — 你的 vault 笔记（只读）→ `wiki/`（LLM 生成的页面，结构化为 `wiki/sources/`、`wiki/entities/`、`wiki/concepts/`）→ `schema/`（共进化配置）
-- **🧩 模块化代码库** — 20+ 个聚焦模块，位于 `src/`
-
-### 🔒 隐私与安全
-
-- **无后端、无追踪。** 插件完全在 Obsidian 内部运行——没有外部服务器、没有数据分析、没有任何形式的数据收集。除非你主动配置 LLM 提供商，否则你的笔记永远不会离开你的 vault。
-- **数据默认保留在本地。** 插件不会存储、缓存或传输你的内容到你所选 LLM API 之外的任何地方。只有你发送用于摄入或查询的文本会离开你的设备——且仅发往你配置的提供商。
-- **通过 Ollama、LM Studio 或本地提供商实现完全本地模式。** 为了完全的数据主权，请使用本地运行的 LLM。你的笔记完全在你的机器上处理——不触碰互联网。
-- **最小化权限。** Vault 文件访问用于 Wiki 管理（阅读笔记、生成页面、检测死链）。网络访问仅用于与你所选提供商的 LLM API 通信。剪贴板访问仅限于 Query 模态框中的"复制"按钮——仅在您点击时使用。
-
----
-## 📖 使用示例
-
-**输入：** `sources/machine-learning.md`
-
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
-
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
-
-**输出 — 实体页：** `wiki/entities/supervised-learning.md`
-
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
-
-### Supervised Learning
-
-### 基本信息
-- 类型：method
-- 来源：[[sources/machine-learning]]
-
-### 描述
-监督学习是一种机器学习范式，模型从带标签的训练数据中学习，
-从而对未见数据做出预测……
-
-### 相关概念
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### 相关实体
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### 来源提及
-- "Supervised learning uses labeled data to train predictive models..."
-```
+- **🌍 10 种界面语言** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano。界面和 Wiki 输出语言相互独立——你的 Wiki 可以是中文而界面是英文。
+- **📚 10 种 Wiki 输出语言** — 同一集合；在设置 → Wiki 配置中选择。*自定义输入* 选项用于临时提示。
+- **🈶 269+ 翻译的 UI 字符串** — 每个标签、弹窗和通知。添加第 11 种语言由贡献者驱动（PR #159 模式）。
 
 ---
 
-## 🤖 模型选择建议
+## 🔍 检索工作原理
 
-本插件遵循 Karpathy 的核心理念：**将完整 Wiki 上下文直接喂给 LLM，而非切成碎片做 RAG 检索**。强烈推荐选择长上下文窗口的模型——Wiki 越大，LLM 越需要足够的上下文来保持跨页面一致性。
+大多数"AI 搜索"插件将你的笔记分块并嵌入到向量数据库中。我们不这样做。Karpathy 反对 RAG 的理由是分块破坏了 LLM 在完整知识图谱上的推理能力——这个论点在实践中成立。相反，我们遍历你通过写 `[[wiki-links]]` 已经维护的图谱。
 
-> 💡 为什么不使用 RAG？Karpathy 在[原始构想](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)中指出，RAG 将知识碎片化，破坏了 LLM 在完整知识图谱上的推理能力。
+### 5 级种子选择级联
 
-**💰 性价比优先策略：** 不必追求旗舰模型。以下**经济实惠的替代方案**能以更低成本获得出色效果：
+当你在问"谁创立了微软？"时，查询 Wiki 在任何答案生成之前运行五个阶段：
 
-### ☁️ 云端模型推荐
+1. **Lex 快速路径** — 直接对每个实体/概念的标题和别名做 token 重叠匹配。免费、即时，也是后续所有阶段的把关者。
+2. **LLM 关键词生成** — LLM 从你的查询中提出 8–12 个跨语言关键词（在一次 LLM 调用中处理同义词、缩写和 token 重叠不敏感的术语）。
+3. **本地子串扫描** — 每个生成的关键词在本地对页面标题、别名和正文片段重新匹配。无需额外 LLM 调用；补足噪声容忍的召回。
+4. **LLM KB 回退** — 当 lex + 关键词扫描返回的信号不足时，LLM 对 top-N 候选重新针对完整 Wiki 做一次语义筛选。
+5. **PPR 图扩展** — 在 `[[wiki-link]]` 图上从候选种子集运行 Personalized PageRank（Haveliwala 2002）。这是实现图感知多跳上下文的关键："比尔·盖茨" → "微软" → "竞争对手"，而不只是字面标题重叠。
 
-| 档位 | 模型 | 上下文窗口 | 推荐理由 |
-|------|------|-----------|----------|
-| **🌟 性价比首选** | **DeepSeek V4-Flash** | 1M tokens | 最低价($0.14/M)，284B MoE，批量摄入首选 |
-| **🌟 性价比首选** | **Gemini-3.5-Flash** | 1M tokens | 输出速度比 GPT-5.5 快 4 倍，智能体任务出色 |
-| **🌟 性价比首选** | **Qwen3.6-Plus** | 1M tokens | 编码和智能体能力强劲，价格有竞争力 |
-| **🌟 性价比首选** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **均衡型** | **Claude Sonnet 4.6** | 1M tokens | 质量与成本平衡佳，$3/$15 每百万 token |
-| **轻量型** | **Claude Haiku 4.5** | 200K tokens | 快速经济，适合小型 Wiki |
-| **经济型** | **Xiaomi MiMo-V2.5** | 1M tokens | 小米 310B/15B MoE，2026-04 MIT 开源，Agent 与多模态 |
-| **旗舰型** | Claude Opus 4.7 | 1M tokens | 极致质量，成本较高 — 选择性使用 |
-| **旗舰型** | GPT-5.5 | 1M tokens | 顶级推理，成本较高 — 选择性使用 |
+级联在任一阶段返回足够信号时截断——没有固定的 5 步开销，lex 足够时无需 LLM 调用，LLM 增强时不损失精度。
 
-### 🦙 本地模型推荐 (Ollama / LM Studio)
+### 规模化的 Personalized PageRank
 
-本地推理的最大优势是数据主权、离线可用、零 API 费用；代价是上下文窗口较小（多为 8K–128K，近期开源权重可达 262K）以及指令跟随能力不及旗舰云端模型。**按硬件预算选型：** 参数越大，世界知识和指令遵循越强（抽取质量越高、幻觉越少）；参数越小，速度和显存越省，但幻觉和长上下文推理能力会明显下降。24 GB Apple Silicon 或单张消费级 GPU 上的甜点是 27B–35B-A3B 级别。
+我们使用 Monte Carlo PPR（Fogaras 2005）——3,000 次随机游走 × 每次 50 步——配合 Haveliwala 2002 的死端规则。开销为 **O(K × L)**，与页面数量无关，因此 2000 页 vault 的扩展延迟与 200 页 vault 相同。
 
-| 模型 | 参数量 | 上下文 | 推荐理由 |
-|------|--------|--------|----------|
-| **Qwen3.5 27B** | 27B dense | 262K | 摄入场景下质量与体积的最佳平衡；MLX 4-bit 可装进 24 GB |
-| **Qwen3.5 35B-A3B** | 35B 总 / 3B 激活 MoE | 262K | 速度优于 27B dense，质量相当；理想的显存节省方案 |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | 质量上限；需要 ≥48 GB 显存或双卡 |
-| **Qwen3.6 27B** | 27B dense | 256K+ | 2026-04 在 Qwen3.5 27B 之上的更新版，硬件能扛得住时优先选这个 |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | 与 Qwen3.5 35B-A3B 同样的取舍，权重更新 |
-| **Gemma 4 31B IT** | 31B dense | 262K | 指令跟随强，Markdown 输出干净 |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | 比 31B dense 更省显存，质量相当 |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | 可纯 CPU 运行；仅适合小型 Wiki 或快速预览 |
+**PPR @5 = 27.1% vs 纯 knn 基线 24.1%** —— 基于项目自有基准语料（该开源 LLM-Wiki 领域唯一已发布的检索基准）。
 
-**量化建议：** Apple Silicon 上 MLX 4-bit 通常比同等有效比特率的 GGUF Q4_K_M 快 1.5–2×。GGUF Q4_K_M 是跨平台的默认选择；只有当显存有富余且发现 Q4 质量有可见回归时再考虑 Q5/Q8。
+### 为什么不需要嵌入
 
-**上下文策略：** Wiki 超过 ~500 页时，262K 本地模型仍能覆盖 Query 引擎组装的大多数上下文，但 2000 页 vault 的摄入会超出其能力。常见组合：云端摄入 + 本地查询。如果坚持全程本地，27B/35B-A3B 级别是甜点。
-
-### 📄 本地 PDF OCR 路径 (v1.25.0+)
-
-v1.25.0 的 PDF 摄取支持任何接受 PDF 作为文件部分的 Provider。要在 Apple Silicon（oMLX 目前唯一支持的平台）上搭建完全本地的管线，推荐配置如下：
-
-1. 安装 [oMLX](https://github.com/jundot/omlx)，启用其内置的 **Markitdown** 后端（本地 PDF→Markdown 转换）。
-2. 加载 **百度 Unlimited-OCR**（2026-06-22 开源，3B 总参 / 0.5B 激活，端到端 OCR，攻克长文档"越生成越慢"的旧模型通病）作为 oMLX 的视觉模型。
-3. 在本插件中：Provider 选择 **Custom OpenAI-Compatible**（oMLX 走 OpenAI 兼容协议），把 Base URL 指向 oMLX 的本地服务地址，Settings → LLM Configuration → Advanced 中开启 **Force PDF Support**，摄入总结时选用 oMLX 提供的多模态模型。
-
-PDF 全程不离开你的机器 — Markitdown 做结构化转换，Unlimited-OCR 做视觉识别，本地 LLM 做摘要。本插件的缓存（`.obsidian/plugins/karpathywiki/pdf-cache/`）让重复摄取保持即时。
-
-**回退方案：** 如果 oMLX/Markitdown 不可用（Linux/Windows 或较旧的 Mac），把 **Force PDF Support** 直接指向接受 PDF 文件部分的本地多模态 LLM — 模型足够大时质量不错，但显存需求随页数急剧上升。
-
-**🔌 Anthropic Compatible (Coding Plan):** 如果你的 Provider 提供 Anthropic 兼容 API 端点，选择 "Anthropic Compatible" 并输入 Provider 的 Base URL 和 API Key。
-
-> 💡 **OpenAI 计费边界：** **OpenAI** 使用单独计费的 Platform API Key；**ChatGPT Plan (Codex OAuth)** 是独立的实验性 Provider，通过浏览器或设备代码登录后使用符合条件的 Codex 套餐额度，不能仅凭套餐名称保证可用。
+我们在 [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175) 中有意拒绝了嵌入路径。图谱信号已经在那里——每个 `[[wiki-link]]` 都是一条手动 curated 的"这些内容相关"边，而我们支持的大多数 Provider（Ollama、LM Studio、Anthropic、Bedrock、Kimi、GLM、MiniMax）根本没有 `/v1/embeddings` 端点。添加嵌入模型意味着每个页面一次下载、每个 Provider 一个适配器，而对检索质量没有任何提升。
 
 ---
 
-## 🏗️ 架构
+## 🤖 模型推荐
 
-基于 Karpathy 的三层分离设计：
+**支持的 Provider（12+，基于 2026-07 来自 models.dev 的交叉核对）：**
 
-```
-📄 你的 vault 笔记（任意文件夹）   # 📖 你选择哪些笔记进行摄入
-  ↓ ingest
-wiki/                              # 🧠 LLM 生成的 Wiki 页面（wiki/sources/、wiki/entities/、wiki/concepts/）
-  ↓ query / maintain
-schema/                            # 📋 Wiki 结构配置（命名规范、页面模板、分类规则）
-```
+| Provider | 系列 | 备注 |
+|----------|------|------|
+| **Anthropic** | Claude 5 系列 | 原生 PDF；`/v1/messages` 协议 |
+| **OpenAI** | GPT-5.6 系列（Sol / Terra / Luna） | 原生 PDF；Platform API Key |
+| **Google Gemini** | Gemini 3.6 系列 | 原生 PDF（自 1.5 开始支持文件部分）；OpenAI 兼容端点 |
+| **DeepSeek** | DeepSeek V4 系列 | OpenAI 兼容；最低成本档 |
+| **Alibaba Qwen** | Qwen3.7/3.8 系列 | OpenAI 兼容（DashScope）|
+| **xAI Grok** | Grok 4 系列 | OpenAI 兼容；长上下文 |
+| **Moonshot Kimi** | Kimi K3 系列 | OpenAI 兼容；2.8T MoE 前沿 |
+| **Zhipu GLM** | GLM-5 系列 | OpenAI 兼容；双语言能力强 |
+| **MiniMax** | MiniMax M3 系列 | OpenAI 兼容；1M 上下文 |
+| **Step（阶跃星辰）** | Step 3 系列（Flash） | OpenAI 兼容；快速推理 |
+| **Tencent Hunyuan** | Hy3 系列 | OpenAI 兼容；开放权重 MoE |
+| **Xiaomi MiMo** | MiMo V2.5 系列 | MIT 开源；统一低价 |
+| **Google Gemma** | Gemma 4 系列 | 开放权重；262K 上下文 |
+| **AWS Bedrock** | Anthropic + OpenAI 变种 | VPC / 合规路径 |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | 浏览器/设备代码登录；SecretStorage |
+| **本地：Ollama, LM Studio, OpenRouter, Anthropic 兼容** | 任何 OpenAI/Anthropic 协议模型 | 自定义 OpenAI 兼容 + Anthropic 兼容（Token Plan / Coding Plan）|
 
-> 📖 完整代码结构见 [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure)。
+本插件每次查询向 LLM 提供完整的 Wiki 上下文——因此 **长上下文模型胜出**。完整的分级表格（云端 + 本地）见 [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)，来自 [models.dev](https://models.dev/) 交叉核对以确保推荐持续有效。
 
-**生成的页面结构：**
-- `wiki/sources/文件名.md` — 📄 源文件摘要
-- `wiki/entities/实体名.md` — 👤 实体页（人物、组织、项目等）
-- `wiki/concepts/概念名.md` — 💡 概念页（理论、方法、术语等）
-- `wiki/index.md` — 📑 自动生成的索引
-- `wiki/log.md` — 📝 操作日志
+### 什么更重要
+
+- **🧠 上下文窗口 ≥ 200K tokens**，对于超过 ~500 页的 vault。低于 200K 时，级联组装的上下文会开始被截断。
+- **⚖️ 指令遵循质量** 对提取任务比原始 IQ 更重要——选择一个能遵循 Schema 模板的模型，而非排行榜上最大的数字。
+- **🔌 嵌入端点无关紧要**——我们不使用嵌入。缺乏 `/v1/embeddings` 的 Provider 完全没问题（我们 12+ 个 Provider 中大部分都没有）。
+- **🦙 本地用于查询，云端用于摄入**——2000 页 vault 的摄入通常需要长上下文云端模型；262K 的本地模型覆盖大部分查询。
+
+### Anthropic vs OpenAI vs Codex OAuth —— 它们是不同的 Provider
+
+- **Anthropic**（及其 Bedrock 变种）—— 单独计费的 Anthropic Platform API Key。
+- **OpenAI** —— 单独计费的 OpenAI Platform API Key。
+- **ChatGPT Plan (Codex OAuth)** —— 实验性、独立的 Provider，在浏览器或设备代码登录后使用符合条件的 Codex 额度；可用性遵循 OpenAI Codex 身份验证和额度政策，而非计划名称。第三方 Codex 兼容功能，非 OpenAI 合作项目或通用 ChatGPT API。
+
+> 📖 **完整选择表格**（云端 + 本地 + PDF OCR + Codex OAuth + 量化 + 硬件等级）→ [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
 ---
 
-## ❓ 常见问题 (FAQ)
+## ❓ 常见问题
 
-> **请保持插件更新** — 新功能和修复频繁推出。在 Obsidian 中定期前往 **设置 → 第三方插件 → 检查更新**。
->
-> 📖 更多问答见 [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28)。
+### 这个插件到底能做什么？
 
-**这个插件到底能做什么？**
-从你的 vault 中任意选择一篇笔记、一个文件夹或一组文件，LLM 自动提取实体与概念，生成带 `[[双向链接]]` 的互联 Wiki。提问时获得基于*你的*笔记的对话式回答——而非互联网搜索。生成的摘要放在 `wiki/sources/`，实体放在 `wiki/entities/`，概念放在 `wiki/concepts/`，而你原始的 vault 笔记不会被任何修改。
+选择任意笔记、文件夹或文件组；LLM 提取实体和概念，生成带有 `[[双向链接]]` 的互联 Wiki。提问时获得基于*你的*笔记的对话式回答，而非互联网。你的原始 vault 笔记永不修改。
 
-**我的数据会被发送给第三方吗？**
-🔒 **隐私优先。** 无后端、无追踪、无分析——插件完全在 Obsidian 内部运行。只有你主动发送用于摄入/查询的文本才会离开你的设备，且仅发往你配置的 LLM 提供商。如需完全数据本地化，使用本地 Provider（Ollama 或 LM Studio，无需 API key）——你的数据永不触网。
+### 如何开始使用？
 
-**这和 RAG 聊天机器人有何不同？**
-不同于碎片化上下文的 RAG，LLM-Wiki 运行**个性化 PageRank** 引擎，基于你现有的 `[[wiki-link]]` 图结构查找相关页面——而非向量 embedding。这意味着零 embedding 成本、无新依赖、完全支持本地和离线模型。
+从 Obsidian 社区插件市场安装 → 选择 Provider → **测试连接** → 在任意笔记上运行 **摄入单个源文件**。首条 Wiki 页面在几秒内出现。见 [快速开始](#-快速开始)。
 
-**该选哪个 LLM？**
-推荐长上下文模型（≥200K tokens）。性价比首选：DeepSeek V4-Flash ($0.14/M)、Gemini 3.5 Flash、Qwen3.6-Plus。本地模型（Ollama/LM Studio）可用于查询，但上下文窗口较小（8K–128K）。详见[模型选择建议](#-模型选择建议)。
+### 我现有的 Wiki 安全吗？
 
-**如何开始使用？**
-从 Obsidian 社区插件市场安装 → 选择 LLM Provider → **测试连接** → 在 vault 中任意笔记上运行 **摄入单个源文件**（或 **从文件夹摄入**）→ 数秒内即可生成首批 Wiki 页面。详见[快速开始](#-快速开始)。
+✅ 自 v1.0.0 向后兼容。在任何页面设置 `reviewed: true` 以保护不被覆盖。从 v1.24.x 升级不会重写你的 vault；v1.25.0 的 PDF 摄入默认仅缓存。
 
-**如何控制 API 成本？**
-使用粗略或极简提取粒度进行批量摄入（更少 LLM 调用）。智能批量跳过自动检测已处理文件。自动维护默认关闭（按需开启）。Lint 在运行修复前显示计数——不经你确认不会产生费用。
+### 我的数据会被发送给第三方吗？
 
-**我的现有 Wiki 安全吗？**
-✅ 自 v1.0.0 向后兼容。在任何页面设置 `reviewed: true` 以保护不被覆盖。插件从不修改你的原始 vault 笔记——只会在 `wiki/` 文件夹内生成新页面。
+🚫 无后端、无分析——插件完全在 Obsidian 内部运行。只有你明确发送用于摄入/查询的文本离开你的设备，且仅发往你配置的 LLM 提供商。如需完全数据本地化，使用 Ollama 或 LM Studio。
 
-**可以用我的语言使用吗？**
-🌐 **10 种语言** 支持界面和 Wiki 输出：English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano。界面语言和 Wiki 语言互相独立。
+### 能用我的语言使用吗？
 
-**最低配置要求？**
-Obsidian v1.11.4+（桌面端或移动端）。需要 LLM Provider API Key、Ollama/LM Studio 本地模型，或已授权的 ChatGPT Plan (Codex OAuth) 凭据。插件的 **llmReady 守卫** 要求先通过连接测试才能使用核心功能——防止因配置错误导致的静默失败。
+🌍 界面和 Wiki 输出均为 10 种语言。界面语言和 Wiki 语言相互独立。添加第 11 种语言由贡献者驱动（PR #159 模式）。
 
-**如何取消正在运行的操作？**
-点击状态栏文字（显示"摄入中… 点击取消"），或 `Cmd+P` → "取消当前提取"。安全停止于下一批次边界，保留已完成的工作。
+### 这和 RAG 聊天机器人有何不同？
 
-**如何获得帮助？**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — 提交 Bug
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — 提问与反馈
-- 开发者工具（`Ctrl+Shift+I` / `Cmd+Option+I`）— 复制日志，加速问题排查
+🚫 无分块。🚫 无嵌入。🚫 无向量数据库。✅ 在你现有的 `[[wiki-link]]` 图上运行 Personalized PageRank——图感知的多跳上下文、零嵌入成本、完全本地模型支持。
 
-## 🔒 透明度与合规性
+### 该选哪个 LLM？
 
-本插件已上架 Obsidian 社区插件市场，并接受安全与权限的自动化审查。
+长上下文模型（≥200K tokens）效果最佳。[模型推荐](#-模型推荐) 一节涵盖了原则；完整分级表格见 [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)。
 
-**本插件没有后端、没有服务器基础设施、不进行任何形式的数据收集。** 它是纯粹运行在 Obsidian 内部的本地软件。插件不能也不会有任何方式收集、存储或传输你的数据到任何服务器——因为这样的服务器根本不存在。
+### 有公开的基准测试吗？
 
-**网络访问**仅用于与你配置的 LLM 提供商通信——不会进行其他网络调用。这完全由你掌控：你选择提供商、你输入 API 密钥、你决定数据发往何处。
+有——PPR @5 = 27.1% vs 纯 knn 基线 24.1%，基于项目自有语料。完整的管线及基准脚本在 [检索工作原理](#-检索工作原理) 中描述。
 
-**文件系统访问**（vault 枚举）用于构建和维护 Wiki：阅读你的源笔记、生成页面、扫描死链、检测重复页面。插件从不修改你的源文件——仅修改 wiki 文件夹下的文件。
+### 如何控制 API 成本？
 
-**剪贴板访问**仅用于 Query 模态框中的"复制"按钮，且仅在你点击时使用。
+使用粗略或极简提取粒度进行批量摄入。智能批量跳过自动检测已处理文件。自动维护默认关闭。Lint 在运行修复前显示计数——不经你确认不产生费用。
 
-如果你希望数据完全保留在本地，请使用 Ollama 或 LM Studio 等本地 LLM 提供商。使用本地提供商时，你的数据永远不会离开你的机器。
+### 如何取消正在运行的操作？
+
+点击状态栏（显示"摄入中… 点击取消"）或 `Cmd+P/Ctrl+P` → "取消当前摄入"。在下一个批次边界干净停止。
+
+### 哪里可以获得帮助？
+
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) 提交 Bug · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) 提问与反馈 · 开发者控制台（`Ctrl+Shift+I` / `Cmd+Option+I`）查看插件日志。
+
+---
+
+## 🔒 隐私
+
+本插件已上架 Obsidian 社区插件市场，并接受安全与权限的自动化审核。
+
+- **🚫 无后端、无服务器、无数据收集。** 纯本地软件，运行于 Obsidian 内部。插件不能也不会以任何方式收集、存储或传输你的数据到任何服务器——因为这样的服务器根本不存在。
+- **🔐 网络访问是自愿的。** 仅用于与你配置的 LLM 提供商通信。你选择提供商、你输入 API Key、你决定数据去向。
+- **📁 Vault 文件访问** 用于 Wiki 管理（阅读笔记、生成页面、扫描死链、检测重复）。插件永不修改你的源文件。
+- **📋 剪贴板访问** 仅用于查询弹窗中的"复制"按钮——且仅在你点击时使用。
+
+如需完全数据本地化，使用 Ollama 或 LM Studio。使用本地 Provider 时，你的数据永不离开你的机器。
+
+---
 
 ## 💖 支持项目
 
 如果 LLM-Wiki 已成为你知识工作流中重要的一部分，你可以通过以下方式支持其持续开发：
 
-- ☕ **[在 Ko-fi 上请我喝杯咖啡](https://ko-fi.com/greenerdalii)** — 通过 Ko-fi 提供一次性或月度支持
-- 💳 **[通过 PayPal 打赏](https://paypal.me/greenerdalii)** — 通过 PayPal 一次性打赏
+- ☕ **[在 Ko-fi 上请我喝杯咖啡](https://ko-fi.com/greenerdalii)** — 一次性或月度支持
+- 💳 **[通过 PayPal 打赏](https://paypal.me/greenerdalii)** — 一次性打赏
 
-赞助完全自愿。无论是否赞助，插件始终保持 Apache-2.0 许可且功能完整。
+赞助完全自愿。插件始终保留 Apache-2.0 许可且功能完整。
 
-### 赞助者
+感谢 [@jameses-cyber](https://github.com/jameses-cyber) 和 [@issaqua](https://github.com/issaqua) 对项目的支持。
 
-感谢以下支持项目的人：
+---
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
+## 📜 许可证与致谢
 
-## 📜 许可证
+Apache License, Version 2.0 — 详见 [LICENSE](../LICENSE) 和 [NOTICE](../NOTICE)。
 
-Apache License 2.0 — 详见 [LICENSE](LICENSE) 和 [NOTICE](NOTICE)。
+**构建于：**
+- 💡 [Andrej Karpathy 的 LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 原始概念
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/)（`@ai-sdk/openai`、`@ai-sdk/anthropic`、`@ai-sdk/openai-compatible`）通过 Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) 和 [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — 检索算法
 
-## 🙏 致谢
+**维护者：** [@green-dalii](https://github.com/green-dalii)
 
-- **💡 概念来源：** [Andrej Karpathy 的 LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 本插件的原始构想
-- **🛠️ 开发平台：** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 LLM 传输层：** [Vercel AI SDK v6](https://ai-sdk.dev/)（`@ai-sdk/openai`、`@ai-sdk/anthropic`、`@ai-sdk/openai-compatible`）via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -6,487 +6,330 @@
 
 > **Obsidian-offizielle Bewertung 95/100 | Native Unterstützung für 10 Sprachen | Null-Embedding-Graph-Suche | Volle Datensouveränität | Kompatibel mit jedem LLM-Anbieter**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | **Deutsch** | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md) | [Italiano](README_IT.md)
 
-[Offizielle Website](https://llmwiki.greenerai.top/) | [Obsidian-Marktplatz](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback & Diskussion](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[Offizielle Website](https://llmwiki.greenerai.top/) | [Obsidian-Marktplatz](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Diskussionen](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [Schnellstart](#-schnellstart) | ✨ [Funktionen](#-funktionen) | 🤖 [Modellempfehlungen](#-modellempfehlungen) | 🔒 [Transparenz & Compliance](#-transparenz--compliance) | ❓ [FAQ](#-faq)
+📑 [Inhalt](#-inhalt) • 🚀 [Schnellstart](#-schnellstart) • ✨ [Funktionen](#-funktionen) • 🔍 [Wie die Suche funktioniert](#-wie-die-suche-funktioniert) • 🤖 [Modelle](#-modelle) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Wenn dir dieses Plugin geholfen hat, lad mich gerne auf einen Kaffee♥️ ein oder vergib einen Stern🌟↗
 
 ---
 
-> **⚡ Schnellupdate-Hinweis：** Dieses Projekt entwickelt sich rasant weiter – Fehlerbehebungen, Leistungsverbesserungen, neue Funktionen und UX-Optimierungen werden häufig veröffentlicht. Wir empfehlen, in Obsidian regelmäßig zu aktualisieren (**Einstellungen → Community-Plugins → Nach Updates suchen**) oder die automatische Plugin-Aktualisierung zu aktivieren.
+> **⚡ Schnellupdate-Hinweis:** Dieses Projekt entwickelt sich rasant weiter – Fehlerbehebungen, Leistungsverbesserungen, neue Funktionen und UX-Optimierungen werden häufig veröffentlicht. Wir empfehlen, in Obsidian regelmäßig zu aktualisieren (**Einstellungen → Community-Plugins → Nach Updates suchen**) oder die automatische Plugin-Aktualisierung zu aktivieren.
 
-## 📑 Contents
+## 📑 Inhalt
 
-- [🧠 Karpathy LLM Wiki Plugin für Obsidian](#-karpathy-llm-wiki-plugin-für-obsidian)
-  - [📑 Contents](#-contents)
-  - [💡 Über LLM Wiki](#-über-llm-wiki)
-  - [⚡ Warum Obsidian + LLM-Wiki?](#-warum-obsidian--llm-wiki)
-  - [🚀 Schnellstart](#-schnellstart)
-    - [📦 Installation](#-installation)
-    - [🔄 Aktualisierung](#-aktualisierung)
-    - [🔑 LLM-Provider konfigurieren](#-llm-provider-konfigurieren)
-    - [🎮 Verwendung](#-verwendung)
-    - [⚠️ Upgrade von einer älteren Version?](#️-upgrade-von-einer-älteren-version)
-  - [⚡ Neuerungen in v1.25.x](#-neuerungen-in-v125x)
-  - [✨ Funktionen](#-funktionen)
-    - [📊 Knowledge Quality](#-knowledge-quality)
-    - [📄 PDF Ingest (v1.25.0)](#-pdf-ingest-v1250)
-    - [💬 Query \& Feedback](#-query--feedback)
-    - [🛠️ Maintenance](#️-maintenance)
-    - [🌐 LLM \& Language](#-llm--language)
-    - [🏗️ Architecture \& Performance](#️-architecture--performance)
-    - [🔒 Datenschutz \& Sicherheit](#-datenschutz--sicherheit)
-  - [📖 Beispiel](#-beispiel)
-  - [🤖 Modellempfehlungen](#-modellempfehlungen)
-    - [☁️ Cloud-Modell-Empfehlungen](#️-cloud-modell-empfehlungen)
-    - [🦙 Lokale Modell-Empfehlungen (Ollama / LM Studio)](#-lokale-modell-empfehlungen-ollama--lm-studio)
-    - [📄 Lokaler PDF-OCR-Pfad (v1.25.0+)](#-lokaler-pdf-ocr-pfad-v1250)
-  - [🏗️ Architektur](#️-architektur)
-  - [❓ FAQ](#-faq)
-  - [🔒 Transparenz \& Compliance](#-transparenz--compliance)
-  - [💖 Projekt unterstützen](#-projekt-unterstützen)
-    - [Sponsoren](#sponsoren)
-  - [📜 License](#-license)
-  - [🙏 Danksagungen](#-danksagungen)
-  - [Star History](#star-history)
-
-## 💡 Über LLM Wiki
-
-Notizen schreiben. KI organisiert. Fragen stellen. Das ist alles.
-
-**🎯 Das Problem.** Notizen enthalten wertvolle Informationen — Personen, Konzepte, Ideen, Verbindungen. Aktuell liegen sie jedoch als einzelne Dateien in Ordnern. Um Verknüpfungen zu finden, müssen Sie suchen, kennzeichnen und sich an Zusammenhänge erinnern.
-
-**✨ Die Lösung.** [Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) hat einen eleganten Ansatz vorgeschlagen: Notizen als Rohmaterial behandeln und den LLM die Architekturarbeit überlassen. Der LLM liest die Notizen, extrahiert Entities und Concepts und verknüpft sie zu einem strukturierten Wiki — mit `[[bidirektionalen Links]]`, automatisch generiertem Index und Chat-Interface für Anfragen an die eigene Wissensbasis.
-
-**📚 Keine Bibliotheksarbeit mehr.** Keine Bewertung des Seitenwerts. Keine Pflege von Querverweisen. Keine Angst vor veraltetem Content. Wähle eine beliebige Notiz (oder einen Ordner, oder eine Mehrfachauswahl) aus deinem Vault — der LLM liest, extrahiert, schreibt, verlinkt und markiert Widersprüche, während Sie im Flow bleiben.
-
-**🤖 Kein weiterer Chatbot.** ChatGPT kennt das Internet. LLM Wiki kennt *Sie* — genauer: das, was Sie ihm beigebracht haben. Jede Antwort enthält `[[wiki-links]]` zurück in den Knowledge Graph. Jede Antwort ist ein Wegweiser, kein Dead End.
+- [🤔 Warum dieses Plugin?](#-warum-dieses-plugin)
+- [🎯 Ist es etwas für mich?](#-ist-es-etwas-für-mich)
+- [🚀 Schnellstart](#-schnellstart)
+- [✨ Funktionen](#-funktionen)
+- [🔍 Wie die Suche funktioniert](#-wie-die-suche-funktioniert)
+- [🤖 Modelle](#-modelle)
+- [❓ FAQ](#-faq)
+- [🔒 Privatsphäre](#-privatsphäre)
+- [💖 Unterstützung](#-unterstützung)
+- [📜 Lizenz & Danksagungen](#-lizenz--danksagungen)
 
 ---
 
-## ⚡ Warum Obsidian + LLM-Wiki?
+## 🤔 Warum dieses Plugin?
 
-Obsidian ist brillant im vernetzten Denken. Aber das Problem: Sie selbst müssen alle Verbindungen herstellen.
+Du schreibst Notizen. Sie liegen in Ordnern. Zusammenhänge zu finden bedeutet, sich an Fäden zu erinnern, die du vor Monaten verloren hast.
 
-LLM-Wiki dreht das um. Statt dass Sie den Graphen von Hand aufbauen, wächst die KI ihn mit Ihnen. Fügen Sie eine Notiz über ein neues Konzept hinzu — sie findet Zusammenhänge, die Sie übersehen hätten. Stellen Sie eine Frage — sie durchsucht Ihren eigenen Wissensgraphen und liefert Antworten mit Quellenbelegen.
+**Andere Open-Source-Neuimplementierungen von Karpathys LLM-Wiki-Idee existieren — aber keine davon ist ein One-Click-Obsidian-Plugin.** Die meisten sind CLI-Tools, Claude-Code-Skills oder separate Desktop-Apps. Wir sind das einzige Plugin mit nativer UI, In-Vault-Speicher und Obsidians eigenem Graph View.
 
-- **🔗 Ihr Graph View wird lebendig.** Neue Notizen stehen nicht einfach nur da — sie sprießen Verbindungen zu Entities, Konzepten und Quellen. Der Graph wächst organisch, und das Plugin pflegt ihn: erkennt Duplikate, repariert tote Links, überbrückt Sprachen mit Aliases.
-- **💬 Ihre Notizen lernen, mit Ihnen zu sprechen.** Suche wird zum Gespräch. „Was habe ich über X geschrieben?" wird zum Dialog mit Streaming-Antworten und `[[wiki-links]]` als Wegmarken. Jede Antwort ist ein Pfad tiefer in Ihr eigenes Wissen.
-- **🧠 Obsidian wird zum Denkpartner.** Es hört auf, eine Ablage für Notizen zu sein, und wird zu etwas, das Ihnen beim *Denken* hilft — verborgene Zusammenhänge aufdeckt, Widersprüche markiert, sich an das erinnert, was Sie vergessen hatten.
+### Wie wir abschneiden
+
+|  | Karpathy LLM Wiki (dieses Plugin) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **Lieferform** | ✅ One-Click-Obsidian-Plugin | ❌ Separate Tauri-Desktop-App | ❌ Claude-Code-Skill | ❌ Claude-Code-/Codex-Skill | ❌ CLI + SDK + MCP-Server |
+| **Einrichtungsaufwand** | ✅ **5 Minuten** — Community Plugins → Installieren → Provider wählen → Ingest | ❌ 30 Min.+ — Binary kompilieren/herunterladen, CLI konfigurieren | ❌ 15 Min. — benötigt Claude-Code-Abo + Skill-Installation | ❌ 10 Min. — benötigt Claude-Code-/Codex-Abo + Skill-Einrichtung | ❌ 30 Min.+ — pip install + SDK + MCP-Konfiguration |
+| **Installationsweg** | ✅ Obsidian → Community Plugins → Suchen → Installieren | ❌ Separates Binary kompilieren oder herunterladen, dann CLI konfigurieren | ❌ Benötigt Claude-Code-Abo + Installationsanleitung | ❌ Benötigt Claude-Code- oder Codex-Abo + Einrichtungsschritte | ❌ pip install + Python SDK + lokaler Server |
+| **Architekturkomplexität** | ✅ **Keine Abhängigkeiten** — keine Vektor-DB, kein Embedding-Modell, keine externen Prozesse | 🟡 Eigenes Python-Runtime + sigma.js + sqlite | 🟡 Nutzt Claude-Code-Umgebung — nicht eigenständig | 🟡 Erfordert separate Plattform-Laufzeitumgebung | ❌ Erfordert Python, Embedding-Modell, Vektor-DB |
+| **i18n (UI + Wiki-Ausgabe)** | ✅ 10 Sprachen (unabhängige UI/Ausgabe) | 🟡 2 (EN / 中文) | ❌ Nur Englisch | ❌ Nur Englisch | ❌ Nur Englisch |
+| **LLM-Anbieter** | ✅ 12+ (inkl. Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-kompatibel, Kimi, GLM, MiniMax, DeepSeek) | 🟡 OpenAI-kompatibel | 🟡 Abo über Claude Code | 🟡 Abo über Claude Code / Codex | 🟡 OpenAI-kompatibel |
+| **Suchalgorithmus** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 4-Signal-Heuristik (Adamic-Adar + 2-Hop-Decay) | ❌ Nur Louvain-Community-Erkennung | ❌ Louvain + k-Hop-Vorschauen | ❌ Hybrid: BM25 + semantisch + Wikilink |
+| **Query-Pipeline (5-Stufen-Kaskade)** | ✅ Lex → LLM-Keywords → Substring-Scan → LLM-KB-Fallback → PPR-Expansion (bricht bei erstem ausreichendem Signal ab) | 🟡 Nur 2-Hop-Decay | ❌ Nur Louvain-Clustering | ❌ k-Hop-Vorschauen (keine LLM-Erweiterung) | ❌ BM25 + semantisch über Chunks (kein Graph) |
+| **Embeddings erforderlich** | ✅ Nein (null Embedding-Kosten, bewusst so gewählt) | 🟡 Optional, standardmäßig aus | ✅ Nein | ✅ Nein | ❌ **Ja — zwingend erforderlich** |
+| **Graph-Visualisierung** | ✅ Obsidians nativer Graph View (integriert, null zusätzliche Größe) | ❌ Benutzerdefiniertes sigma.js + graphology in Desktop-App | 🟡 vis.js graph.html (separate Datei) | ❌ Benutzerdefiniertes sigma.js offline HTML | ❌ Read-only-Browser-Viewer |
+| **Wiki-Ehrlichkeit** | ✅ „Stage FALLBACK"-Banner, wenn keine Wiki-Quelle zur Abfrage passt | ❌ Kein Äquivalent | ❌ Kein Äquivalent | ❌ Kein Äquivalent | ❌ Kein Äquivalent |
+| **Veröffentlichter Such-Benchmark** | ✅ PPR @5 = 27,1 % vs. reine-kNN 24,1 % (einzige veröffentlichte Zahl in diesem Bereich) | ❌ 58 % → 71 % *nur mit aktivierten Embeddings*, nicht in unserem Apples-to-Apples-Format | ❌ Nicht veröffentlicht | ❌ Nicht veröffentlicht | ❌ Nicht veröffentlicht |
+
+### Drei Dinge, die wir bewusst gewählt haben
+
+- **🪟 Obsidian ist die Laufzeitumgebung.** Kein Terminal, keine separate App, kein Docker, kein Python. Aus Community-Plugins installieren, auf Ingest klicken, das Wiki lebt von der ersten Sekunde an in deinem Vault. Obsidians nativer Graph View rendert deinen `[[wiki-link]]`-Graphen — integriert, null zusätzliche Bundle-Größe.
+- **🧭 Sauber und autark.** Keine Abhängigkeiten. Kein Embedding-Modell, keine Vektor-Datenbank, kein pip-Paket — ein einziges Plugin, das deine Notizen liest, mit einem LLM spricht und Wiki-Seiten schreibt. Alles lebt innerhalb von Obsidian.
+- **🔌 Jedes Modell, für das du bereits bezahlst.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-kompatibel, eigener Endpunkt — zwölf-plus Anbieter, keiner davon benötigt einen Embedding-Endpunkt.
+
+---
+
+## 🎯 Ist es etwas für mich?
+
+**✅ Ja, wenn du:**
+
+- **Eine 5-Minuten-Einrichtung willst, kein 5-Stunden-Projekt.** Aus Community-Plugins installieren → Provider wählen → eine Notiz ingestieren. Kein CLI, kein Python, keine separate Laufzeitumgebung, keine Vektor-DB. Du siehst Wiki-Seiten in `wiki/` innerhalb von Sekunden.
+- **Etwas Sauberes und Autarkes möchtest.** Das Plugin hat genau null externe Abhängigkeiten: kein Embedding-Modell, keine Vektor-Datenbank, kein pip-Paket, kein Docker-Container. Es ist ein einziges Obsidian-Plugin, das deine Notizen liest, mit einem LLM spricht und Wiki-Seiten in deinen Vault schreibt. Alles lebt innerhalb von Obsidian.
+- **Einen befragbaren Chat möchtest, der aus *deinen* Notizen antwortet** — nicht aus dem Internet — wobei jede Antwort `[[wiki-links]]` zurück in deinen Wissensgraphen trägt.
+- **Wert auf Datensouveränität legst** — läuft vollständig lokal mit Ollama oder LM Studio, ohne jemals das Internet zu berühren.
+- **In einer von 10 unterstützten Sprachen schreibst oder liest** — UI und Wiki-Ausgabe sind unabhängig (dein Wiki kann auf Chinesisch sein, während die Oberfläche auf Englisch ist).
+- **Den Graphen durch Schreiben von `[[wiki-links]]` pflegst** — jeder Link, den du setzt, bereichert bereits die Suche; kein separater Tagging-/Embedding-/Indexing-Schritt.
+- **One-Click-Wartung möchtest** — Lint-Gesundheitsscan + Smart Fix All halten Duplikate, tote Links und verwaiste Seiten in Schach, ohne dass du von Hand kuratieren musst.
+
+**❌ Nein, wenn du:**
+
+- **Einen allgemeinen ChatGPT-Ersatz suchst** — dieses Plugin antwortet nur aus *deinem* Wissen.
+- **Eine RAG-Pipeline für PDFs/Webseiten/externe Korpora brauchst** — wir konzentrieren uns auf den In-Vault-Pfad (PDFs werden seit v1.25.0 unterstützt).
+- **Nach einem gehosteten SaaS suchst** — es gibt kein Backend, keinen Server, keinen Account.
 
 ---
 
 ## 🚀 Schnellstart
 
-### 📦 Installation
+1. **Installieren.** Obsidian → Einstellungen → Community-Plugins → Durchsuchen → „Karpathy LLM Wiki" suchen → Installieren → Aktivieren. Oder besuche die [Community-Plugin-Seite](https://community.obsidian.md/plugins/karpathywiki) und klicke auf **Zu Obsidian hinzufügen**.
+2. **Provider konfigurieren.** Einstellungen → Karpathy LLM Wiki → Provider wählen (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth) usw.) → API-Key eingeben (nicht nötig bei lokalen Anbietern) → **Test Connection** klicken → Speichern.
+3. **Eine Notiz ingestieren.** `Cmd+P/Ctrl+P` → „Ingest single source" → eine beliebige Markdown- (oder PDF-, v1.25.0+) Datei wählen. Deine ersten Wiki-Seiten erscheinen innerhalb von Sekunden in `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`.
 
-**🌟 Empfohlen — Obsidian Community Plugin Market:**
+Das war's. Das Plugin ändert nichts an deinen ursprünglichen Notizen — es erstellt nur neue Seiten unter `wiki/`. Um mit deinem Wiki zu chatten: `Cmd+P/Ctrl+P` → „Query wiki". (`Cmd` auf macOS, `Ctrl` auf Windows/Linux.)
 
-1. Gehe in Obsidian zu **Einstellungen → Community-Plugins**
-2. Klicke auf **Durchsuchen** und suche nach "Karpathy LLM Wiki"
-3. Klicke auf **Installieren**, dann **Aktivieren**
+### Kernbefehle
 
-**🌐 Oder über die Community Plugin Website —** besuche [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) und klicke auf **Zu Obsidian hinzufügen**, um direkt zu installieren.
+| Befehl | Beschreibung |
+|---------|--------------|
+| **📥 Einzelne Quelle aufnehmen** | `Cmd+P/Ctrl+P` → „Ingest single source" — wähle eine Markdown- oder **PDF (v1.25.0+)**-Datei, erhalte Entity-/Concept-/Wiki-Seiten |
+| **📂 Aus Ordner aufnehmen** | `Cmd+P/Ctrl+P` → „Ingest from folder" — Batch-Aufnahme aller Notizen in einem Ordner, mit intelligentem Batch-Überspringen |
+| **📑 Mehrere Dateien aufnehmen** | `Cmd+P/Ctrl+P` → „Ingest multiple files" — wähle eine Teilmenge über eine zweigeteilte Dateibaumansicht (mit Live-Queue + pro-Datei-Abbruch) |
+| **🔍 Wiki abfragen** | `Cmd+P/Ctrl+P` → „Query wiki" — chatte mit deinem Wiki in einem rechts angedockten Seitenpanel; Antworten enthalten `[[wiki-links]]` |
+| **🛠️ Wiki linten** | `Cmd+P/Ctrl+P` → „Lint wiki" — vollständiger Gesundheitsscan: Duplikate, tote Links, leere Seiten, verwaiste Seiten, fehlende Aliase, Widersprüche |
+| **⚡ Smart Fix All** | innerhalb des Lint-Modals — One-Click-Reparatur in kausaler Reihenfolge mit Phasenbericht |
+| **📋 Index neu generieren** | `Cmd+P/Ctrl+P` → „Regenerate index" — baue `wiki/index.md` mit aktuellen Seiten und Aliasen neu auf |
+| **⏹ Abbrechen** | `Cmd+P/Ctrl+P` → „Cancel current ingestion" oder auf die Statusleiste klicken — stoppt sauber an der nächsten Batch-Grenze |
+| **📊 Aufnahmeverlauf** | `Cmd+P/Ctrl+P` → „View Ingestion History" — durchsuchbare UI für vergangene Aufnahmen, Lint-Berichte und Wartungsläufe |
 
-**⚙️ Manuell (Alternative):**
+| Vorher | Nachher |
+|--------|-------|
+| `notes/machine-learning.md` (eine flache Datei) | `wiki/concepts/supervised-learning.md` mit `[[bidirektionalen Links]]`, Aliasen, Quellenangabe und einem Eintrag in `wiki/index.md` |
 
-1. Lade `main.js`, `manifest.json`, `styles.css` von [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases) herunter
-2. Gehe in Obsidian zu Einstellungen → Community-Plugins. Auf dem Tab **Installierte Plugins** klicke auf das Ordnersymbol, um das Plugin-Verzeichnis zu öffnen
-3. Erstelle einen Ordner namens `karpathywiki` und lege die drei Dateien hinein
-4. Zurück in Obsidian klicke auf das Aktualisierungssymbol — **Karpathy LLM Wiki** erscheint unter Installierte Plugins
-5. Schalte es ein, um es zu aktivieren
+> 💡 **Bleib auf dem neuesten Stand.** Neue Funktionen, Fehlerbehebungen und Leistungsverbesserungen erscheinen häufig. Einstellungen → Community-Plugins → Nach Updates suchen, oder aktiviere automatische Plugin-Updates.
+> 📖 Ausführliche Anleitungen (Installation, PDF-Einrichtung, Multi-Provider-Hinweise, Upgrades) werden in [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides) gepflegt.
 
-**🔨 Entwicklung:** `git clone`, `pnpm install`, `pnpm build`
+---
 
-### 🔄 Aktualisierung
-
-Dieses Projekt entwickelt sich rasch — neue Funktionen, Fehlerbehebungen und Verbesserungen werden häufig veröffentlicht. Wir empfehlen, auf dem aktuellen Stand zu bleiben:
-
-**Option A — Manuelle Aktualisierung (empfohlen):**
-1. Gehe zu **Einstellungen → Community-Plugins**
-2. Klicke auf **Nach Updates suchen**
-3. Finde **Karpathy LLM Wiki** in der Liste und klicke auf **Aktualisieren**
-
-**Option B — Automatische Aktualisierung aktivieren:**
-1. Gehe zu **Einstellungen → Community-Plugins**
-2. Schalte **Automatisch nach Plugin-Updates suchen** ein
-3. Neue Versionen werden automatisch erkannt; aktualisieren Sie nach Bedarf manuell
-
-> 💡 **Warum aktualisieren?** Jedes Release kann neue Funktionen, Leistungsverbesserungen und wichtige Fehlerbehebungen enthalten.
-
-### 🔑 LLM-Provider konfigurieren
-
-1. Öffne Einstellungen → Karpathy LLM Wiki
-2. Wähle einen Provider aus dem Dropdown (einschließlich OpenAI oder ChatGPT Plan (Codex OAuth))
-3. Gib bei API-Providern den API-Key ein (nicht für Ollama, LM Studio oder ChatGPT Plan (Codex OAuth))
-4. Verwende bei Nicht-Codex-Providern **Fetch Models** oder gib ein Modell manuell ein; ChatGPT Plan (Codex OAuth) befüllt seine kuratierte Modellliste automatisch
-5. Klicke auf **Test Connection**, dann **Save Settings**
-
-**🦙 Ollama (lokal, kein API-Key):** Installiere [Ollama](https://ollama.com), pulle ein Modell (`ollama pull gemma4` oder `ollama pull qwen3.5:27b`), wähle "Ollama (Local)" im Provider-Dropdown.
-
-**🎛️ LM Studio (lokal, kein API-Key):** Installiere [LM Studio](https://lmstudio.ai), starte den lokalen Server (Standard `http://localhost:1234/v1`), wähle "LM Studio (Local)" im Provider-Dropdown.
-
-**🔐 ChatGPT Plan (Codex OAuth) — experimentell:** Dieser Provider ist unabhängig von **OpenAI**, das einen separat abgerechneten OpenAI-Platform-API-Key nutzt. Wähle ihn aus und verwende auf dem Desktop **Im Browser anmelden** (localhost-Callback) oder auf Desktop/Mobilgeräten **Gerätecode verwenden**, um die Autorisierung auf der OpenAI-Seite abzuschließen. Das Plugin synchronisiert die auswählbaren Modelle des angemeldeten Codex-Kontos und speichert nur bereinigte Katalogmetadaten; **Kontomodelle aktualisieren** lädt sie neu. Bei einem vorübergehenden Fehler bleibt der letzte Cache oder eine minimale Rückfallliste verfügbar. Teste danach die Verbindung und speichere. OAuth-Zugangsdaten liegen ausschließlich in Obsidian SecretStorage; **Abmelden** löscht sie. Die Verfügbarkeit folgt den Authentifizierungs-, Modell- und Kontingentrichtlinien von OpenAI Codex. Dies ist Drittanbieter-Kompatibilität, keine OpenAI-Partnerschaft und keine allgemeine ChatGPT-API.
-
-### 🎮 Verwendung
-
-| Methode | Anleitung |
-|---------|-----------|
-| **📥 Einzelne Quelle aufnehmen** | `Cmd+P` → "Ingest single source" — wähle eine Note (Markdown oder **PDF, v1.25.0+**), um Wiki-Seiten mit Entitäten/Konzepten zu generieren |
-| **📂 Aus Ordner aufnehmen** | `Cmd+P` → "Ingest from folder" — wähle einen Ordner, um Wiki aus allen Notizen im Batch zu generieren |
-| **📑 Mehrere Dateien aufnehmen** | `Cmd+P` → "Ingest multiple files" — wähle Notizen über rekursiven Ordnerbaum + Kontrollkästchen, dann Batch-Aufnahme (mit Live-Queue + pro-Datei-Abbruch) |
-| **🎯 Aktuelle Datei aufnehmen** | Klicke auf das `sticker`-Symbol in der linken Ribbon, oder `Cmd+P` → "Ingest current file" |
-| **🔍 Wiki abfragen** | `Cmd+P` → "Query wiki" — konversationelle Q&A mit Streaming und `[[wiki-links]]` |
-| **🛠️ Wiki linten** | `Cmd+P` → "Lint wiki" — vollständiger Health-Check: Duplikate, tote Links, leere Seiten, Orphans, fehlende Aliase, Widersprüche |
-| **📋 Index neu generieren** | `Cmd+P` → "Regenerate index" — baue `wiki/index.md` mit Alias-Einträgen neu auf |
-| **📊 Aufnahmeverlauf (v1.21.0)** | `Cmd+P` → "View Ingestion History" — durchsuche vergangene Aufnahmen, Lint-Berichte und Wartungsläufe |
-| **⏹ Vorgang abbrechen** | `Cmd+P` → "Cancel current ingestion" — stoppe sicher am nächsten Batch-Grenzwert |
-| **🎉 Willkommensnotiz (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — generiere die Willkommensnotiz neu |
-
-Die erneute Aufnahme derselben Quelle führt zu inkrementellen Aktualisierungen (neue Informationen werden eingefügt). Zusammenfassungen werden neu generiert.
-
-> 💡 **Smart Batch Skip:** Bei der Ordner-Aufnahme erkennt das Plugin bereits verarbeitete Dateien und überspringt sie — spart Zeit und API-Kosten.
-
-![Befehlspalette — "karpa" suchen, um alle Karpathy LLM Wiki-Befehle zu sehen](assets/command-panel.png)
-
-
-### ⚠️ Upgrade von einer älteren Version?
-
-> 🔧 **Upgrade von v1.24.x.** Der PDF-Ingest (v1.25.0) schreibt seinen Cache nach `.obsidian/plugins/karpathywiki/pdf-cache/` (bis zu 100 MB / 1000 Einträge / 10 MB Einzel-Limit; LRU-by-mtime-Eviction beim Start und zu Beginn jedes Batch-Ingests). Ihr Vault wird **standardmäßig nicht verändert** — aktivieren Sie **Write PDF Markdown to Vault** (Settings → Wiki Configuration → Wiki Folder) nur, wenn Sie einen `<basename>.pdf.md`-Sidecar neben die Quell-PDF möchten. Zwei neue Einstellungen — **Force PDF Support** (Erweitert, Standard aus) und **Write PDF Markdown to Vault** (Standard aus) — sind vollständig rückwärtskompatibel: Alte `data.json` ohne diese Felder fallen auf `false` zurück.
-
-> 🔧 **Upgrade von v1.24.0.** Der interne Kommentar-Marker `<!-- reviewed: keep -->` (v1.24.0, #244), der nur den *Mentions-in-Source*-Abschnitt einer Seite schützte, wurde entfernt. Um einen kuratierten Mentions-Abschnitt zu erhalten, setze `reviewed: true` im Frontmatter der Seite — das schützt die gesamte Seite samt Mentions und bleibt, anders als der versteckte Kommentar, im Properties-Panel sichtbar und übersteht Markdown-Linter.
-
-**Rückwärtskompatibel.** Seit v1.0.0 keine Breaking Changes — bestehende Wiki-Seiten, Einstellungen und Workflows bleiben ohne Neukonfiguration erhalten.
-
-**Nach dem Upgrade** führe **Lint Wiki** → **Smart Fix All** für eine automatische Reparatur in kausaler Reihenfolge aus:
-1. 🏷️ Aliase vervollständigen (LLM generiert Übersetzungen, Abkürzungen, Alternativnamen)
-2. 🔄 Duplikate zusammenführen (sprachübergreifend, Abkürzungen, hohe Ähnlichkeit)
-3. 🔗 Tote Links reparieren / Orphans verknüpfen / Leere Seiten erweitern
-
-Dann **Index neu generieren**, um `wiki/index.md` mit Alias-Einträgen neu aufzubauen und alias-bewusste Suche zu aktivieren.
-
-> 📖 Detaillierte Upgrade-Anleitungen für spezifische Versionssprünge (v1.20.3 Slug-Fingerprint, v1.16.0 Doppel-Nesting) in [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions).
-
-**Zu prüfende Einstellungen:** Force PDF Support (Settings → LLM Configuration → Advanced, Standard aus — nur für Nicht-NATIVE-Provider nötig), Write PDF Markdown to Vault (Settings → Wiki Configuration → Wiki Folder, Standard aus), Wiki-Ausgabesprache (unabhängig von UI), Extraktionsgranularität (Minimal–Fein + Benutzerdefiniert), Seiten-Generierungs-Parallelität (Standard 3), Batch-Verzögerung (Standard 300ms).
-
-## ⚡ Neuerungen in v1.25.x
-
-- **v1.25.2 (2026-07-22).** Tag-Vokabular Phase 1（doppelte Quelle entfernt）、Codex OAuth（ChatGPT Plan）、Ordner-Präfix-Korrektur für Related Links、Seitenvorlage `---`-Abschluss behoben、ESLint 0.4.1 Route A。2515 Tests bestanden.
-- **v1.25.1 (2026-07-20).** Acht Silent-Loss-Korrekturen（Related-Seite、Schema-Bereiche、Legacy Mentions）、3 große Dateiaufteilungen、DiskCache<T>、LM Studio ohne API-Schlüssel、Build-Überprüfung。2274 Tests bestanden.
-- **v1.25.0 (2026-07-18).** Cache-only PDF-Ingest（Level 1）、beschränktes Cache-Wachstum、optionaler Vault-Sidecar、Force PDF Universal-Gate、wörtliches Transkriptions-Prompt、abbrechbarer Ingest、lokale Modell-Empfehlungen、i18n Vollständigkeit。2182 Tests bestanden.
-
-📋 [Vollständiger Versionsverlauf → CHANGELOG.md](../CHANGELOG.md)
 ## ✨ Funktionen
 
-### 📊 Knowledge Quality
+### 📚 Wissensqualität
 
-- **🔍 Entity/Concept Extraction** — LLM extrahiert Entities (Personen, Orgs, Produkte, Events) und Concepts (Theorien, Methoden, Terme) aus Notizen mit flexibler Extraktionsgranularität (Minimal~5 Einträge, Groß~10, Standard~50, Fein~100, Benutzerdefiniert 1–500) für Balance zwischen Analyse-Tiefe und API-Kosten
-- **🏷️ Mandatory Page Aliases** — Jede generierte Page enthält mindestens einen Alias (Übersetzung, Akronym, alternativer Name); ermöglicht Cross-Language Duplikat-Detection
-- **🔄 Duplicate Detection & Merge** — Semantic Tiering erfasst echte Duplikate (Cross-Language-Übersetzungen, Abkürzungen, Schreibvarianten); intelligentes LLM Merge fusioniert Content und bewahrt Aliases
-- **🧩 Smart Knowledge Fusion** — Multi-Source Updates mergen neue Info ohne Redundanz, Widersprüche werden mit Attribution bewahrt, `reviewed: true` Pages sind vor Überschreibung geschützt
-- **📏 Schutz vor Inhaltskürzung** — API-Key- und lokale Provider verwenden 8000 max_tokens mit automatischer stop_reason-Erkennung und einem Wiederholungsversuch mit 2× Tokens. Der experimentelle ChatGPT-Plan-Pfad (Codex OAuth) folgt der Ausgaberichtlinie des Codex-Backends, das kein clientseitiges max_output_tokens-Limit akzeptiert.
-- **📝 Verbatim Source Mentions** — Original-Language-Quotes mit optionaler Übersetzung für Nachvollziehbarkeit bewahren
+- **🔍 Entity- & Concept-Extraktion** — LLM extrahiert Entitäten (Personen, Organisationen, Produkte, Ereignisse) und Konzepte (Theorien, Methoden, Begriffe) in eigenständige Seiten. Die Granularität ist konfigurierbar (Minimal → Fein, plus Benutzerdefiniert), sodass du Kosten gegen Tiefe abwägen kannst.
+- **🏷️ Obligatorische Aliase** — jede Seite wird mit mindestens einem Alias (Übersetzung, Abkürzung, Variante) ausgeliefert, damit sprachübergreifende Duplikaterkennung funktioniert.
+- **🔄 Abgestufte Duplikaterkennung** — Stufe 1 (direkter Namensmatch: sprachübergreifend, Abkürzung, hohe Titelähnlichkeit) wird immer verifiziert; Stufe 2 (gemeinsame Links, mittlere Ähnlichkeit) füllt das verbleibende Token-Budget.
+- **🧩 Intelligentes Zusammenführen & Widerspruchsstatus** — Duplikate werden unter Erhalt der Aliase zusammengeführt; Widersprüche werden mit Quellenangabe markiert; `reviewed: true`-Seiten sind vor Überschreibung geschützt.
+- **🎨 Anpassbares Tag-Vokabular** — definiere eigene Entity-Typ- und Concept-Typ-Tag-Listen in Einstellungen → Wiki → Tag-Vokabular → *Custom*; Lint meldet jede Seite, deren Tags außerhalb des aktiven Vokabulars liegen.
 
-- **🎨 Anpassbares Tag-Vokabular (v1.18.0).** Einstellungen → Wiki → Tag-Vokabular-Modus → *Custom* erlaubt es, eigene Entity- und Concept-Tag-Listen zu definieren (z. B. `Medical_Arzneimittel`, `法规`). Das Plugin respektiert dein Vokabular in Extraction-Prompts und Frontmatter-Validierung; die bestehende Lint-Audit (Issue #85 v7) meldet jede Seite, deren Tags außerhalb des aktiven Vokabulars liegen.
+### 📄 PDF-Ingest (v1.25.0+)
 
-### 📄 PDF Ingest (v1.25.0)
+- **🔌 Provider-Gate** — Anthropic, OpenAI und Bedrock verarbeiten PDF nativ. Für jeden anderen OpenAI/Anthropic-kompatiblen Endpunkt aktiviere **Force PDF Support** in Einstellungen → LLM Configuration → Advanced, damit das Plugin den Aufruf versucht. Für lokale OCR auf Apple Silicon, Drittanbieter-Extraktoren (MinerU, Docling, Mathpix, Adobe) und die vollständige PDF-Ingest-Anleitung siehe [PDF-OCR-Pfade](#-pdf-ocr-pfade) unten und [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md).
+- **🗄️ Begrenzter Cache** — `.obsidian/plugins/karpathywiki/pdf-cache/` speichert konvertiertes Markdown, keyed by Content-Hash + Modell + Converter-Version. Drei-Schichten-Housekeeping: 100 MB gesamt / 1000 Einträge / 10 MB Einzel-Limit mit LRU-by-mtime-Eviction.
+- **📝 Optionaler Vault-Sidecar** — Einstellungen → Wiki Configuration → Wiki Folder → *Write PDF Markdown to Vault* schreibt `<basename>.pdf.md` neben die Quell-PDF (standardmäßig aus — Nur-Cache ist der Standard).
+- **🛡️ Verbatim-Transcriber-Prompt** — OCR-artige Konvertierung mit `[illegible]` / `[figure: ...]`-Anti-Halluzinations-Markern; Markdown-Fence-Einschluss von kleinen lokalen Modellen wird vor dem Cache-Schreiben automatisch bereinigt.
 
-Wähle eine PDF aus deinem Vault — das Plugin liest sie über den nativen Datei-Input deines LLM-Providers, konvertiert sie zu Markdown und tritt wieder in die reguläre Markdown-Ingest-Pipeline ein. Alle bestehenden Entity/Concept/Alias/`[[wiki-link]]`-Workflows gelten unverändert.
+### 📄 PDF-OCR-Pfade
 
-- **🔌 Provider-Gate** — Anthropic, OpenAI, Bedrock Anthropic und Bedrock OpenAI verarbeiten PDF nativ. Für jeden anderen OpenAI/Anthropic-kompatiblen Endpunkt aktiviere **Force PDF Support** unter Settings → LLM Configuration → Advanced, damit das Plugin den Aufruf versucht (dein Endpunkt entscheidet; bei Fehlern erscheint eine lokalisierte Notice mit Anleitung zum Deaktivieren). Die empfohlene lokale Konfiguration findest du unter [Lokaler PDF-OCR-Pfad](#-lokaler-pdf-ocr-pfad-v1250).
-- **🗄️ Content-Hash-Cache** — identische PDF + Modell + Converter-Version liefert das gecachte Markdown ohne LLM-Aufruf. Der Cache liegt in `.obsidian/plugins/karpathywiki/pdf-cache/`; der Cache-Schlüssel enthält `converterVersion`, sodass Prompt-Upgrades alte Einträge automatisch ungültig machen.
-- **📏 Begrenztes Wachstum** — Drei-Schichten-Verteidigung mit Cache-Housekeeping (100 MB gesamt / 1000 Einträge / 10 MB Einzel-Limit) plus LRU-by-mtime-Eviction; alte Einträge werden beim Start und zu Beginn jedes Batch-Ingests aufgeräumt. Nur Cache — dein Vault wird standardmäßig nicht verändert.
-- **📝 Optionaler Vault-Sidecar** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** schreibt nach der Konvertierung eine `<basename>.pdf.md` neben die Quell-PDF. Standard aus (nur Cache).
-- **🛡️ Verbatim-Transcriber-Prompt** — der PDF→Markdown-Prompt ist als OCR-artige Verbatim-Konvertierung umformuliert und enthält `[illegible]` / `[figure: ...]` / `[equation: ...]` Anti-Halluzinations-Marker; kleine/lokale Modelle, die ihre Ausgabe in ```markdown-Fences einschließen, werden vor dem Cache-Schreiben automatisch bereinigt.
-- **⏹ Abbrechbar** — Klick auf die Statusleiste während der Konvertierung bricht den laufenden LLM-Aufruf ab (über Vercel AI SDK v6).
+Drei Pfade — wähle, was zu deinem Setup passt:
 
-### 💬 Query & Feedback
+1. **☁️ Cloud-Provider mit nativer PDF-Unterstützung** — Anthropic, OpenAI oder AWS Bedrock lesen PDFs out of the box. Einfach ingestieren; keine zusätzliche Einrichtung. Für jeden anderen OpenAI/Anthropic-kompatiblen Endpunkt aktiviere **Force PDF Support** in Einstellungen → LLM Configuration → Advanced, damit das Plugin den Aufruf versucht.
+2. **🖥️ Lokale OCR auf Apple Silicon** — [oMLX](https://github.com/jundot/omlx) integriert Microsoft Markitdown als eingebautes PDF→Markdown-Backend. Aktiviere Markitdown in oMLX, lade [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M-aktiv, Open-Source seit 2026-06) als Vision-Modell, richte das Plugin auf oMLX als benutzerdefinierten OpenAI-kompatiblen Provider aus, aktiviere **Force PDF Support** und wähle das multimodale Modell, das oMLX bereitstellt. Die PDF verlässt niemals deinen Rechner.
+3. **🛠️ Drittanbieter-Extraktor (MinerU, Docling, Mathpix, Adobe)** — führe einen separaten Extraktor auf deinen PDFs aus, um `.md`-Dateien zu erzeugen, und ingestiere sie dann als reguläre Markdown-Notizen über die Standard-Pipeline des Plugins. Am zuverlässigsten für wissenschaftliche Arbeiten, gescannte Dokumente und mathematiklastige PDFs.
 
-- **🔍 5-Stufige PPR-Seed-Selektions-Kaskade (v1.24.1 PATCH).** Bei einer Multi-Hop-Frage baut Query Wiki die Antwort aus fünf komplementären Stufen zusammen, bevor irgendeine Generierung startet:
-  1. **Lex-Schnellpfad** — direkter Token-Überlappungs-Check gegen jeden Entity/Concept-Titel und Alias (kostenlos, sofort; gate't die nachfolgenden Stufen)
-  2. **LLM-Keyword-Generierung** — das LLM schlägt 8–12 sprachübergreifende Keywords aus deiner Anfrage vor (absorbiert Synonyme, Akronyme, token-resistente Begriffe)
-  3. **Lokaler Substring-Scan** — jedes generierte Keyword wird lokal erneut gegen Seitentitel, Aliase und Body-Snippets gematcht (kein zusätzlicher LLM-Aufruf; rundet die rauschtolerante Recall ab)
-  4. **LLM-KB-Fallback** — wenn lex + Keyword-Scan schwache Signale liefern, re-seed't das LLM die Top-N-Kandidaten mit einem semantischen Pass gegen die gesamte Wiki
-  5. **PPR-Graph-Expansion** — Personalized PageRank (Haveliwala 2002) startet auf dem `[[wiki-link]]`-Graph aus dem Kandidaten-Seed-Set; liefert dem LLM graph-bewussten Multi-Hop-Kontext, den lineare Suche nicht erreicht
+📖 **Vollständige Einrichtungsanleitungen** für alle drei Pfade (Cloud-Provider, oMLX-Hardware-Stufen, MinerU-Installation, Cache-Housekeeping) → [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-  Die Kaskade bricht automatisch ab, sobald genug Signal zurückkommt — keine fixen 5-Schritt-Kosten, keine LLM-Aufrufe wenn Lex ausreicht, kein Präzisionsverlust wenn LLM-Augmentation nötig ist. End-to-End-Relevanz (PPR @5 = 27,1% auf dem projekt-eigenen Benchmark-Korpus) übertrifft reine knn-Baselines (24,1%) ohne Embedding-Opt-in. Stage 1.5 (Schritte 2–3) übernimmt Multi-Hop-Fragetypen, die reines Lex verfehlt; Stage 1.7 (Schritt 4) rettet schwache LLM-injizierte Keyword-Signale; Stage 1.9 (Schritt 5) garantiert, dass das LLM Nachbarschaftskontext statt einer flachen Top-N-Liste sieht. Ersetzt die ältere binäre Tier-Kaskade.
+### 💬 Abfrage & Wartung
 
-- **🤖 Conversational Query** — ChatGPT-Style-Dialog, Streaming Markdown Output, `[[wiki-links]]`, Multi-Turn History
-- **🪟 Rechts angedocktes Seitenpanel (v1.22.1, PR #196).** Query Wiki öffnet sich in einem Copilot-artigen rechten Sidebar-Leaf (existierendes Leaf wird wiederverwendet) statt eines zentrierten Popups. Das `message-circle` Ribbon-Icon und der `Query Wiki`-Befehl aktivieren/zeigen das Panel; deine Notizen bleiben neben der Konversation sichtbar. Alle Funktionen bleiben unverändert.
-- **📤 Query-to-Wiki Feedback** — Wertvolle Conversations ins Wiki speichern, Entity/Concept Extraction, Semantic Dedup vor dem Speichern
-- **🔒 Duplicate Save Prevention** — Hash Tracking verhindert Re-Evaluation unveränderter Conversations
+- **🧭 5-Stufen-PPR-Kaskade** — siehe [Wie die Suche funktioniert](#-wie-die-suche-funktioniert). Personalized PageRank über `[[wiki-link]]` liefert graph-bewussten Multi-Hop-Kontext.
+- **🪟 Rechts angedocktes Seitenpanel** — Query Wiki öffnet sich in einem Copilot-artigen rechten Sidebar-Blatt (v1.22.1+) statt einem zentrierten Modal.
+- **🔍 Lint-Gesundheitsscan** — ein einziger Befehl erfasst: Duplikate, tote Links, leere Seiten, verwaiste Seiten, fehlende Aliase, Widersprüche.
+- **⚡ Smart Fix All** — One-Click-Reparatur in kausaler Reihenfolge: Aliase ergänzen → Duplikate zusammenführen → tote Links reparieren → verwaiste Seiten verlinken → leere Seiten erweitern, mit Phasenbericht.
+- **📊 Betriebsverlaufs-Panel** — durchsuchbare, filterbare UI für vergangene Aufnahmen, Lint-Berichte und Wartungsläufe.
+- **🛡️ Pre-Ingest-Gate** — leere/Whitespace-/Nur-Frontmatter-Notizen werden vor jedem LLM-Aufruf abgelehnt; Content-Hash-Dedup erkennt identische Dateien über Pfade hinweg.
 
-### 🛠️ Maintenance
+### 🔒 Privatsphäre
 
-- **🔍 Lint Health Scan** — Duplikate, tote Links, leere Pages, Orphans, fehlende Aliases und Widersprüche in einem umfassenden Report erkennen
-- **🎯 Semantic-Tier Duplicate Detection** — Tier 1 (direkte Name-Matches: Cross-Language, Abkürzungen, hochähnliche Titel) immer verifiziert; Tier 2 (indirekte Signale: gemeinsame Links, moderate Ähnlichkeit) füllt Token-Budget
-- **⚡ Smart Fix All** — Kausal geordneter Batch-Fix: Aliase vervollständigen → Duplikate mergen → tote Links auflösen → Orphans verlinken → leere Pages erweitern
-- **🏷️ Alias Completion** — One-Click parallele Batch-Generierung fehlender Aliases zur Verbesserung zukünftiger Duplikat-Detection
-- **🔄 Auto-Maintenance** — Multi-Folder File Watcher, periodischer Lint, Startup Health Check (Startup Quick Fixes standardmäßig AN, File Watcher und Periodic Lint standardmäßig AUS)
-- **⚠️ Contradiction State Machine** — `detected → review_ok → resolved` (AI Fix) oder `detected → pending_fix` (manuell)
-- **🛡️ Pre-Ingest Requirements Gate (v1.21.0)** — Jede Quelldatei wird *vor* jedem LLM-Aufruf validiert: leere/Whitelist-/nur-Frontmatter-Notizen werden abgelehnt; Content-Hash-Dedup erkennt identische Dateien über Pfade hinweg. Verhindert Halluzinationen lokaler Modelle bei leeren Eingaben.
-- **📊 Operation History Panel (v1.21.0)** — Durchsuchbare, filterbare UI für vergangene Ingests, Lint-Berichte und Wartungsläufe, mit Insight-getriebenen KPI-Karten und klickbaren Seitenlinks.
-- **🧹 Incomplete-Page Cleaner (v1.21.0)** — Durch unterbrochene Ingests unvollständig gebliebene Seiten werden beim Start automatisch archiviert (aus Obsidians `.trash` wiederherstellbar).
+- **🚫 Kein Backend, kein Tracking, keine Analysen.** Läuft vollständig innerhalb von Obsidian. Netzwerk wird nur für die Kommunikation mit dem von dir konfigurierten LLM-Anbieter genutzt.
+- **📁 Quelldateien sind schreibgeschützt.** Das Plugin ändert niemals deine ursprünglichen Vault-Notizen — es erstellt nur neue Seiten unter `wiki/`.
+- **🦙 Vollständiger lokaler Modus.** Ollama, LM Studio oder ein beliebiger lokaler OpenAI-kompatibler Endpunkt → deine Notizen verlassen niemals deinen Rechner.
+- **🔐 Minimale Berechtigungen.** Vault-Dateizugriff für die Wiki-Verwaltung. Zwischenablage-Zugriff nur, wenn du auf die Schaltfläche „Kopieren" im Abfrage-Modal klickst.
 
-### 🌐 LLM & Language
+### 🦙 Lokal-first
 
-- **🔌 Multi-Provider Support** — Anthropic, Anthropic Compatible, Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, Custom Endpoint
-- **🔄 5xx Auto Retry** — Alle Clients wiederholen bei HTTP 5xx/429/529-Fehlern mit Exponential Backoff (max. 2)
-- **📋 Dynamic Model List** — Echtzeit-Fetch von Provider-API
-- **🌐 Wiki Output Language** — Interface-unabhängige 10 Sprachen (Englisch/Simpl. Chinesisch/Trad. Chinesisch/Japanisch/Koreanisch/Deutsch/Französisch/Spanisch/Portugiesisch/Italienisch), Custom Input supported.
-- **🌍 Full UI Internationalization** — Plugin UI unterstützt 10 Sprachen (EN/Simpl. ZH/Trad. ZH/JA/KO/DE/FR/ES/PT/IT), 269+ UI-Felder vollständig übersetzt, natürliche lokale Ausdrücke.
-- **⚡ Rate Limit Guardian** — Wenn parallele Generierung Rate Limits auslöst, automatische Erkennung und Empfehlung: Parallelität reduzieren, Batch-Delay erhöhen, Provider wechseln
-- **🦙 Web Clipper Compatible** — Obsidian Web Clipper's `Clippings/`-Ordner mit einem Klick zur Watchlist hinzufügen, Web-Clips automatisch in Wiki übernehmen
+- **🖥️ Ollama, LM Studio, OpenRouter, eigener Endpunkt** — sofort einsatzbereit. Lokale Modelle funktionieren für Abfragen (kleinere Kontextfenster); Ingest in einem 2.000-Seiten-Vault benötigt normalerweise ein Cloud-Modell mit langem Kontext.
+- **📄 PDF-OCR-Pfad ist auf Apple Silicon vollständig lokal** — siehe [PDF-OCR-Pfade](#-pdf-ocr-pfade) unten.
+- **🔐 ChatGPT Plan (Codex OAuth)** — Desktop-Loopback-Callback auf `127.0.0.1:1455`; Mobil über Gerätecode. Anmeldeinformationen leben nur in Obsidian SecretStorage; Abmelden löscht sie. Drittanbieter-Codex-Kompatibilität, keine OpenAI-Partnerschaft.
 
-### 🏗️ Architecture & Performance
+### 🌐 Sprache
 
-- **🕸️ PPR über [[wiki-link]]-Graph (v1.24.0+, ausgereift in v1.24.1 PATCH).** Personalized PageRank (Haveliwala 2002) läuft über den gerichteten Graph der `[[wiki-link]]`-Kanten zwischen deinen Wiki-Seiten; die Kaskade verankert PPR-Seeds auf der Top-N-Kandidatenmenge, sodass Multi-Hop-Kontext durch bis zu 3 Expansionsringe wandert. Das ist es, was Query-Wiki-Antworten graph-bewusst macht (eine „Gründer von Microsoft"-Frage löst sich über Bill Gates → Microsoft → Wettbewerber — nicht nur über wörtliche Titel-Überlappung). 2.137-Seiten-Vaults sehen typischerweise <100 ms für warm + 3-Hop-Expansion, unabhängig von der Vault-Größe. Wird von allen 4 Stufen der Seed-Selektions-Kaskade (Query & Feedback oben) verwendet und von der Lint-Duplikat-Detection, wenn indirekte Links zwei Kandidatenseiten verbinden.
-- **⚡ Parallel Page Generation** — Konfigurierbare 1–5 parallele Pages, Standard 3 (parallel), 2–3× Speedup bei großen Sources, per-Page Error Isolation
-- **📚 Iterative Batch Extraction** — Adaptive Batch-Sizing, eliminiert max_tokens-Bottleneck bei langen Dokumenten
-- **🏛️ Three-Layer Architecture** — Deine Vault-Notizen (read-only) → `wiki/` (LLM-generierte Seiten, organisiert als `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`) → `schema/` (co-evolved Config)
-- **🧩 Modular Codebase** — 20+ fokussierte Module in `src/`
-
-### 🔒 Datenschutz & Sicherheit
-
-- **Kein Backend, keine Telemetrie.** Das Plugin läuft vollständig innerhalb von Obsidian — es gibt keinen externen Server, keine Analyse und keine Datenerfassung jeglicher Art. Ihre Notizen verlassen niemals Ihren Vault, es sei denn, Sie konfigurieren ausdrücklich einen LLM-Anbieter.
-- **Ihre Daten bleiben standardmäßig lokal.** Das Plugin speichert, zwischenspeichert oder überträgt Ihre Inhalte nirgendwo außerhalb der von Ihnen gewählten LLM-API. Nur der Text, den Sie zur Aufnahme oder Abfrage senden, verlässt Ihr Gerät — und nur an den von Ihnen konfigurierten Anbieter.
-- **Vollständiger lokaler Modus mit Ollama, LM Studio oder lokalen Anbietern.** Für vollständige Datensouveränität verwenden Sie ein lokal laufendes LLM. Ihre Notizen werden vollständig auf Ihrem Rechner verarbeitet — nichts berührt das Internet.
-- **Minimale Berechtigungen.** Vault-Dateizugriff ist für die Wiki-Verwaltung erforderlich (Lesen von Notizen, Generieren von Seiten, Erkennen toter Links). Netzwerkzugriff wird ausschließlich für LLM-API-Aufrufe an Ihren gewählten Anbieter verwendet. Zwischenablagezugriff ist auf die Schaltfläche „Kopieren" im Abfrage-Modal beschränkt — nur wenn Sie darauf klicken.
+- **🌍 10 UI-Sprachen** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI und Wiki-Ausgabesprache sind unabhängig — dein Wiki kann auf Chinesisch sein, während die Oberfläche auf Englisch ist.
+- **📚 10 Wiki-Ausgabesprachen** — dieselbe Auswahl; wähle in Einstellungen → Wiki Configuration. *Custom Input*-Option für Ad-hoc-Prompts.
+- **🈶 269+ übersetzte UI-Strings** — jedes Label, Modal und jeder Hinweis. Eine 11. Sprache hinzuzufügen ist beitragsgesteuert (PR #159-Muster).
 
 ---
 
+## 🔍 Wie die Suche funktioniert
+
+Die meisten „KI-Suche"-Plugins fragmentieren deine Notizen in Chunks und betten sie in eine Vektor-DB ein. Wir nicht. Karpathys Argument gegen RAG ist, dass Chunking die Fähigkeit des LLM bricht, über deinen gesamten Wissensgraphen hinweg zu reasoning — und dieses Argument bestätigt sich in der Praxis. Stattdessen durchlaufen wir den Graphen, den du bereits pflegst, indem du `[[wiki-links]]` schreibst.
+
+### Die 5-Stufen-Seed-Selektions-Kaskade
+
+Wenn du fragst „Wer hat Microsoft gegründet?", durchläuft Query Wiki fünf Stufen, bevor eine Antwort generiert wird:
+
+1. **Lex-Schnellpfad** — direkter Token-Überlappungs-Check gegen jeden Entity-/Concept-Titel und alle Aliase. Kostenlos, sofort und das Tor für alles, was danach kommt.
+2. **LLM-Keyword-Generierung** — das LLM schlägt 8–12 sprachübergreifende Keywords aus deiner Abfrage vor (behandelt Synonyme, Abkürzungen und token-resistente Begriffe in einem LLM-Aufruf).
+3. **Lokaler Substring-Scan** — jedes generierte Keyword wird lokal erneut gegen Seitentitel, Aliase und Body-Ausschnitte gematcht. Kein zusätzlicher LLM-Aufruf; rundet die rauschtolerante Trefferquote ab.
+4. **LLM-KB-Fallback** — wenn Lex + Keyword-Scan schwache Signale liefern, führt das LLM einen semantischen Durchlauf gegen das gesamte Wiki durch, um die Top-N-Kandidaten neu zu seeden.
+5. **PPR-Graph-Expansion** — Personalized PageRank (Haveliwala 2002) über dem `[[wiki-link]]`-Graphen, startend von der Kandidaten-Seed-Menge. Dies liefert graph-bewussten Multi-Hop-Kontext: „Bill Gates" → „Microsoft" → „Wettbewerber", nicht nur wörtliche Titelüberlappung.
+
+Die Kaskade bricht ab, sobald der erreichte Schritt genug Signal geliefert hat — keine fixen 5-Stufen-Kosten, keine LLM-Aufrufe wenn Lex ausreicht, kein Präzisionsverlust wenn LLM-Erweiterung nötig ist.
+
+### Personalized PageRank in großem Maßstab
+
+Wir verwenden Monte-Carlo-PPR (Fogaras 2005) — 3.000 zufällige Walks × 50 Schritte — mit der Dead-End-Regel von Haveliwala 2002. Die Kosten sind **O(K × L)** unabhängig von der Seitenzahl, sodass ein 2.000-Seiten-Vault die gleiche Expansionslatenz wie ein 200-Seiten-Vault hat.
+
+**PPR @5 = 27,1 % vs. reine-kNN-Baseline 24,1 %** auf dem projekteigenen Benchmark-Korpus (dem einzigen veröffentlichten Such-Benchmark in diesem Open-Source-LLM-Wiki-Bereich).
+
+### Warum keine Embeddings
+
+Wir haben den Embedding-Pfad in [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175) bewusst abgelehnt. Das Graph-Signal ist bereits vorhanden — jeder `[[wiki-link]]` ist eine handkuratierte „diese sind verwandt"-Kante, und die meisten unserer unterstützten Anbieter (Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax) haben gar keinen `/v1/embeddings`-Endpunkt. Das Hinzufügen eines Embedding-Modells würde einen Download pro Seite, einen Adapter pro Anbieter und null Nutzen für die Suchqualität bedeuten.
 
 ---
 
-## 📖 Beispiel
+## 🤖 Modelle
 
-**Input:** `sources/machine-learning.md`
+**Unterstützte Anbieter (12+, alle geprüft gegen models.dev 2026-07):**
 
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
+| Anbieter | Serie | Hinweise |
+|----------|-------|----------|
+| **Anthropic** | Claude 5-Serie | Nativer PDF-Support; `/v1/messages`-Protokoll |
+| **OpenAI** | GPT-5.6-Serie (Sol / Terra / Luna) | Nativer PDF-Support; Platform-API-Key |
+| **Google Gemini** | Gemini 3.6-Serie | Nativer PDF-Support (Datei-Parts seit 1.5); OpenAI-kompatibler Endpunkt |
+| **DeepSeek** | DeepSeek V4-Serie | OpenAI-kompatibel; günstigste Kostenstufe |
+| **Alibaba Qwen** | Qwen3.7/3.8-Serie | OpenAI-kompatibel (DashScope) |
+| **xAI Grok** | Grok 4-Serie | OpenAI-kompatibel; langer Kontext |
+| **Moonshot Kimi** | Kimi K3-Serie | OpenAI-kompatibel; 2,8T MoE Frontier |
+| **Zhipu GLM** | GLM-5-Serie | OpenAI-kompatibel; stark zweisprachig |
+| **MiniMax** | MiniMax M3-Serie | OpenAI-kompatibel; 1M Kontext |
+| **Step (阶跃星辰)** | Step 3-Serie (Flash) | OpenAI-kompatibel; schnelle Inferenz |
+| **Tencent Hunyuan** | Hy3-Serie | OpenAI-kompatibel; Open-Weight MoE |
+| **Xiaomi MiMo** | MiMo V2.5-Serie | MIT Open-Source; Flat-Pricing |
+| **Google Gemma** | Gemma 4-Serie | Open-Weight; 262K Kontext |
+| **AWS Bedrock** | Anthropic + OpenAI-Varianten | VPC/Compliance-Pfad |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | Browser-/Gerätecode-Anmeldung; SecretStorage |
+| **Lokal: Ollama, LM Studio, OpenRouter, Anthropic-Compatible** | Jedes OpenAI-/Anthropic-Protokoll-Modell | Custom OpenAI-Compatible + Anthropic-Compatible (Token Plan / Coding Plan) |
 
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+Dieses Plugin füttert dem LLM pro Abfrage den gesamten Wiki-Kontext — daher gewinnen **Modelle mit langem Kontextfenster**. Die vollständige Tabelle (Cloud + Lokal) befindet sich in [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md), geprüft gegen [models.dev](https://models.dev/), damit die Empfehlungen aktuell bleiben.
 
-**Output — Entity-Page:** `wiki/entities/supervised-learning.md`
+### Was zählt
 
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
+- **🧠 Kontextfenster ≥ 200K Tokens** für Vaults über ~500 Seiten. Unter 200K wird der von der Kaskade zusammengestellte Kontext zu stark gekürzt.
+- **⚖️ Instruction-Following-Qualität** ist für die Extraktionsaufgabe wichtiger als roher IQ — wähle ein Modell, das der Schema-Vorlage folgt, nicht die größte Leaderboard-Zahl.
+- **🔌 Embedding-Endpunkt ist irrelevant** — wir verwenden keine Embeddings. Ein Anbieter ohne `/v1/embeddings` ist in Ordnung (die meisten unserer 12+ Anbieter haben keinen).
+- **🦙 Lokal für Abfragen, Cloud für Ingest** — Ingest in einem 2.000-Seiten-Vault benötigt normalerweise ein Cloud-Modell mit langem Kontext; ein 262K-lokales Modell deckt die meisten Abfragen ab.
 
-### Supervised Learning
+### Anthropic vs. OpenAI vs. Codex OAuth — es sind unterschiedliche Anbieter
 
-### Basisinformationen
-- Typ: method
-- Quelle: [[sources/machine-learning]]
+- **Anthropic** (und seine Bedrock-Variante) — separat abgerechneter Anthropic-Platform-API-Key.
+- **OpenAI** — separat abgerechneter OpenAI-Platform-API-Key.
+- **ChatGPT Plan (Codex OAuth)** — experimenteller, eigenständiger Anbieter, der nach Browser- oder Gerätecode-Anmeldung berechtigtes Codex-Kontingent nutzt; die Verfügbarkeit folgt den OpenAI-Codex-Authentifizierungs- und Kontingentrichtlinien, nicht dem Plannamen. Drittanbieter-Codex-Kompatibilität, keine OpenAI-Partnerschaft oder allgemeine ChatGPT-API.
 
-### Beschreibung
-Supervised Learning (überwachtes Lernen) ist ein Machine-Learning-Paradigma,
-bei dem Modelle aus gelabelten Trainingsdaten lernen, um Vorhersagen für
-neue Daten zu treffen...
-
-### Verwandte Konzepte
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### Verwandte Entities
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### Erwähnungen in der Quelle
-- "Supervised learning uses labeled data to train predictive models..."
-```
-
----
-
-## 🤖 Modellempfehlungen
-
-Dieses Plugin folgt Karpathys Kernphilosophie: **den vollen Wiki-Context direkt an den LLM übergeben, statt ihn in RAG Retrieval Shards zu fragmentieren**. Modelle mit langem Context Window werden dringend empfohlen — je größer das Wiki, desto mehr Context benötigt der LLM zur Aufrechterhaltung der Cross-Page Consistency.
-
-> 💡 **Warum kein RAG?** Karpathy hat im [Original-Konzept](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) darauf hingewiesen, dass RAG Knowledge fragmentiert und die Reasoning Ability des LLM über den gesamten Knowledge Graph untergräbt.
-
-**💰 Preis-Leistung-Strategie:** Sie benötigen keine Flagship-Modelle. Die folgenden **kostengünstigen Alternativen** liefern hervorragende Ergebnisse zu niedrigeren Kosten:
-
-### ☁️ Cloud-Modell-Empfehlungen
-
-| Stufe | Modell | Context Window | Begründung |
-|-------|--------|--------------|------------|
-| **🌟 Preis-Leistung** | **DeepSeek V4-Flash** | 1M tokens | Günstigster Preis ($0.14/M), 284B MoE, ideal für Batch-Ingestion |
-| **🌟 Preis-Leistung** | **Gemini-3.5-Flash** | 1M tokens | 4× schneller als GPT-5.5, exzellent für Agent-Aufgaben |
-| **🌟 Preis-Leistung** | **Qwen3.6-Plus** | 1M tokens | Starke Coding- & Agent-Fähigkeiten, wettbewerbsfähiger Preis |
-| **🌟 Preis-Leistung** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **Ausgewogen** | **Claude Sonnet 4.6** | 1M tokens | Gute Balance aus Qualität und Kosten, $3/$15 pro Million Tokens |
-| **Leichtgewicht** | **Claude Haiku 4.5** | 200K tokens | Schnell und wirtschaftlich, für kleinere Wikis |
-| **Wirtschaftlich** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE, MIT Open-Source 2026-04, Agent & Multimodal |
-| **Flagship** | Claude Opus 4.7 | 1M tokens | Höchste Qualität, höhere Kosten — selektiv einsetzen |
-| **Flagship** | GPT-5.5 | 1M tokens | Top-Reasoning, höhere Kosten — selektiv einsetzen |
-
-### 🦙 Lokale Modell-Empfehlungen (Ollama / LM Studio)
-
-Lokale Inferenz gewinnt bei Datensouveränität, Offline-Nutzung und ohne API-Kosten. Der Preis ist ein kleineres Context-Fenster (meist 8K–128K, neuere Open-Weight-Familien erreichen 262K) und schwächere Instruction-Following-Fähigkeit im Vergleich zu Flagship-Cloud-Modellen. **Wähle nach Hardware-Budget:** Mehr Parameter bedeuten stärkeres Weltwissen und bessere Instruction-Fidelity (höhere Extraktionsqualität, weniger Halluzinationen); weniger Parameter bedeuten mehr Tempo und Speicher-Headroom, dafür mehr Halluzinationen und schwächeres Long-Context-Reasoning. Der Sweet Spot auf 24 GB Apple Silicon oder einer einzelnen Consumer-GPU ist die 27B–35B-A3B-Klasse.
-
-| Modell | Parameter | Context | Begründung |
-|-------|-----------|---------|------------|
-| **Qwen3.5 27B** | 27B dense | 262K | Beste Qualität/Größe-Balance für Ingest; MLX 4-bit passt in 24 GB |
-| **Qwen3.5 35B-A3B** | 35B total / 3B aktiv MoE | 262K | Schneller als 27B dense bei ähnlicher Qualität; idealer Memory-Saver |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | Qualitäts-Ceiling; benötigt ≥48 GB VRAM oder Dual-GPU |
-| **Qwen3.6 27B** | 27B dense | 256K+ | 2026-04 Refresh gegenüber Qwen3.5 27B — bevorzuge diesen, wenn die Hardware es trägt |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Gleiche Trade-offs wie Qwen3.5 35B-A3B, neuere Weights |
-| **Gemma 4 31B IT** | 31B dense | 262K | Starkes Instruction-Following, saubere Markdown-Ausgabe |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Weniger Speicher als 31B dense bei vergleichbarer Qualität |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | CPU-lauffähig; nur für kleine Wikis oder schnelle Vorschauen |
-
-**Quantisierung:** MLX 4-bit auf Apple Silicon ist typischerweise 1,5–2× schneller als GGUF Q4_K_M bei gleicher effektiver Bitrate. GGUF Q4_K_M ist die plattformübergreifende Default-Wahl; Q5/Q8 nur, wenn du VRAM-Headroom hast und Qualitätsverlust bei Q4 bemerkst.
-
-**Context-Strategie:** Wenn dein Wiki über ~500 Seiten wächst, sieht ein 262K-Lokalmodell noch den Großteil des vom Query-Engine assemblierten Kontexts, aber Ingest auf einem 2000-Seiten-Vault übersteigt seine Kapazität. Häufiges Muster: Cloud für Ingest + lokal für Query. Für volle lokale Setups ist die 27B/35B-A3B-Klasse der Sweet Spot.
-
-### 📄 Lokaler PDF-OCR-Pfad (v1.25.0+)
-
-Der PDF-Ingest von v1.25.0 funktioniert mit jedem Provider, der PDF als File-Part akzeptiert. Für eine vollständig lokale Pipeline auf Apple Silicon (die einzige Plattform, die oMLX derzeit unterstützt), ist dies die empfohlene Konfiguration:
-
-1. Installiere [oMLX](https://github.com/jundot/omlx) und aktiviere das eingebaute **Markitdown**-Backend (lokale PDF→Markdown-Konvertierung).
-2. Lade **Baidu Unlimited-OCR** (am 22.06.2026 Open-Source gestellt, 3B total / 0,5B aktiv, End-to-End-OCR, das das "mit zunehmender Generierung langsamer werden"-Problem älterer OCR-Modelle bei langen Dokumenten löst) als Vision-Modell in oMLX.
-3. In diesem Plugin: Wähle den Provider **Custom OpenAI-Compatible** (oMLX spricht das OpenAI-kompatible Protokoll), zeige die Base URL auf den lokalen oMLX-Server, aktiviere **Force PDF Support** unter Settings → LLM Configuration → Advanced, und wähle das von oMLX bereitgestellte multimodale Modell für die Ingest-Zusammenfassung.
-
-Die PDF verlässt deine Maschine nicht — Markitdown übernimmt die strukturelle Konvertierung lokal, Unlimited-OCR die visuelle Erkennung lokal, und das lokale LLM die Zusammenfassung lokal. Der Plugin-Cache (`.obsidian/plugins/karpathywiki/pdf-cache/`) hält Re-Ingest dann sofort.
-
-**Fallback:** Wenn oMLX/Markitdown nicht verfügbar ist (Linux/Windows oder ältere Macs), richte **Force PDF Support** direkt auf ein lokales multimodales LLM aus, das PDF-File-Parts akzeptiert — die Qualität ist gut, wenn das Modell groß genug ist, aber die VRAM-Anforderungen steigen mit der Seitenzahl steil an.
-
-**🔌 Anthropic Compatible (Coding Plan):** Wenn Ihr Provider einen Anthropic-kompatiblen API-Endpunkt bietet, wählen Sie "Anthropic Compatible" und geben Sie die Base URL und den API Key Ihres Providers ein.
-
-**🦙 Ollama (lokal, kein API-Key):** [Ollama](https://ollama.com) installieren, ein Modell pullen (`ollama pull gemma4` oder `ollama pull qwen3.5:27b`), im Provider-Dropdown "Ollama (Local)" auswählen.
-
-**🎛️ LM Studio (lokal, kein API-Key):** [LM Studio](https://lmstudio.ai) installieren, den lokalen Server starten (Standard `http://localhost:1234/v1`), im Provider-Dropdown "LM Studio (Local)" auswählen. LM Studio betreibt einen eingebauten OpenAI-kompatiblen Server — API-Key-Feld ist optional.
-
-> 💡 **OpenAI-Abrechnungsgrenze:** **OpenAI** nutzt einen separat abgerechneten Platform-API-Key. **ChatGPT Plan (Codex OAuth)** ist ein unabhängiger experimenteller Provider, der nach Browser- oder Gerätecode-Anmeldung ein berechtigtes Codex-Kontingent nutzt; der Planname allein garantiert keine Verfügbarkeit.
-
----
-
-## 🏗️ Architektur
-
-Basierend auf Karpathys Drei-Schichten-Design:
-
-```
-📄 Deine Vault-Notizen (beliebiger Ordner)   # 📖 Du wählst, welche Notizen ingestiert werden
-  ↓ ingest
-wiki/                                          # 🧠 LLM-generierte Wiki-Seiten (wiki/sources/, wiki/entities/, wiki/concepts/)
-  ↓ query / maintain
-schema/                                        # 📋 Wiki-Strukturkonfiguration (Benennung, Vorlagen, Kategorien)
-```
-
-> 📖 Die vollständige Code-Struktur findest du in [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure).
-
-**Generierte Seiten:**
-- `wiki/sources/dateiname.md` — 📄 Quellen-Zusammenfassung
-- `wiki/entities/entitätsname.md` — 👤 Entitätsseiten (Personen, Organisationen, Projekte etc.)
-- `wiki/concepts/konzeptname.md` — 💡 Konzeptseiten (Theorien, Methoden, Begriffe etc.)
-- `wiki/index.md` — 📑 Automatisch generierter Index
-- `wiki/log.md` — 📝 Betriebsprotokoll
-
+> 📖 **Vollständige Auswahltabelle** (Cloud + Lokal + PDF-OCR + Codex OAuth + Quantisierung + Hardware-Stufen) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
 ---
 
 ## ❓ FAQ
 
-> **Plugin aktuell halten.** Neue Funktionen und Fixes erscheinen häufig. **Einstellungen → Community-Plugins → Nach Updates suchen** regelmäßig ausführen.
->
-> 📖 Weitere FAQs in [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28).
+### Was macht das Plugin genau?
 
-**Was macht das Plugin genau?**
-Wähle eine beliebige Notiz, einen Ordner oder eine Mehrfachauswahl aus deinem Vault; der LLM extrahiert Entitäten und Konzepte und generiert ein vernetztes Wiki mit `[[bidirektionalen Links]]`. Stelle Fragen und erhalte Antworten aus *deinen* Notizen — keine Internetsuche. Generierte Zusammenfassungen liegen unter `wiki/sources/`, Entitäten unter `wiki/entities/`, Konzepte unter `wiki/concepts/` — deine ursprünglichen Vault-Notizen werden nie verändert.
+Wähle eine beliebige Notiz, einen Ordner oder eine Auswahl; der LLM extrahiert Entitäten und Konzepte und generiert ein vernetztes Wiki mit `[[bidirektionalen Links]]`. Stelle Fragen und erhalte Antworten aus *deinen* Notizen — nicht aus dem Internet. Deine ursprünglichen Vault-Notizen werden nie verändert.
 
-**Werden meine Daten an Dritte gesendet?**
-🔒 **Datenschutz zuerst.** Kein Backend, kein Tracking, keine Analysen — das Plugin läuft vollständig in Obsidian. Nur Text, den du explizit sendest, verlässt dein Gerät. Für vollständige Datenlokalität verwende einen lokalen Anbieter (Ollama oder LM Studio ohne API-Key) — deine Daten verlassen nie das Internet.
+### Wie fange ich an?
 
-**Worin unterscheidet sich das von RAG-Chatbots?**
-Anders als RAG, das den Kontext fragmentiert, verwendet LLM-Wiki eine **Personalized PageRank**-Engine über deinen `[[wiki-link]]`-Graphen — verwandte Seiten werden über Linkstrukturen gefunden, nicht über Vektor-Embeddings. Null Embedding-Kosten, keine neuen Abhängigkeiten.
+Aus Obsidian Community-Plugins installieren → Provider wählen → **Test Connection** → **Ingest single source** auf einer beliebigen Notiz ausführen. Erste Wiki-Seiten erscheinen innerhalb von Sekunden. Siehe [Schnellstart](#-schnellstart).
 
-**Welchen LLM soll ich wählen?**
-Langkontext-Modelle (≥200K Tokens) funktionieren am besten. Preiswerte Optionen: DeepSeek V4-Flash ($0.14/M), Gemini 3.5 Flash, Qwen3.6-Plus. Lokale Modelle (Ollama/LM Studio) für Abfragen nutzbar, aber mit kleineren Kontextfenstern (8K–128K).
+### Ist mein bestehendes Wiki sicher?
 
-**Wie fange ich an?**
-Aus Obsidian Community Plugins installieren → LLM-Anbieter wählen → **Test Connection** → **Ingest single source** (oder **Ingest from folder**) auf einer beliebigen Notiz in deinem Vault ausführen → Deine ersten Wiki-Seiten erscheinen in Sekunden. Siehe [Quick Start](#-quick-start) oben.
+✅ Rückwärtskompatibel seit v1.0.0. Setze `reviewed: true` auf einer Seite, um sie vor Überschreiben zu schützen. Das Upgrade von v1.24.x überschreibt deinen Vault nicht; der PDF-Ingest von v1.25.0 ist standardmäßig Nur-Cache.
 
-**Wie kontrolliere ich API-Kosten?**
-Nutze Grobe oder Minimale Extraktionsgranularität für Batch-Aufnahme (weniger LLM-Aufrufe). Smart Batch Skip erkennt bereits verarbeitete Dateien automatisch. Auto-Maintenance ist standardmäßig AUS.
+### Werden meine Daten an Dritte gesendet?
 
-**Ist mein bestehendes Wiki sicher?**
-✅ Rückwärtskompatibel seit v1.0.0. Setze `reviewed: true` auf einer Seite, um sie vor Überschreiben zu schützen. Das Plugin ändert nie deine ursprünglichen Vault-Notizen — es erzeugt nur neue Seiten im `wiki/`-Ordner.
+🚫 Kein Backend, keine Analysen — das Plugin läuft vollständig in Obsidian. Nur Text, den du explizit zum Aufnehmen/Abfragen sendest, verlässt dein Gerät, und nur an den von dir konfigurierten LLM-Anbieter. Für vollständige Datenlokalität verwende Ollama oder LM Studio.
 
-**Kann ich das Plugin in meiner Sprache nutzen?**
-🌐 **10 Sprachen** für UI und Wiki-Ausgabe: English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI- und Wiki-Sprache sind unabhängig voneinander.
+### Kann ich das Plugin in meiner Sprache nutzen?
 
-**Mindestanforderungen?**
-Obsidian v1.11.4+ (Desktop oder Mobilgerät). Erforderlich ist ein LLM-API-Key, ein lokales Ollama/LM-Studio-Modell oder autorisierte ChatGPT Plan (Codex OAuth)-Zugangsdaten. Die **llmReady-Sperre** erfordert einen erfolgreichen Verbindungstest vor Freischaltung der Kernfunktionen.
+🌍 10 Sprachen für sowohl UI als auch Wiki-Ausgabe. UI- und Wiki-Sprache sind unabhängig voneinander. Das Hinzufügen einer 11. Sprache ist beitragsgesteuert (PR #159-Muster).
 
-**Wie breche ich einen laufenden Vorgang ab?**
-Klicke den Statustext oder `Cmd+P` → "Cancel current ingestion". Stoppt sicher am nächsten Batch-Grenzwert.
+### Worin unterscheidet sich das von einem RAG-Chatbot?
 
-**Wo bekomme ich Hilfe?**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — Fehler melden
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — Fragen & Feedback
-- Entwicklerkonsole (`Ctrl+Shift+I`) — Logs kopieren für schnellere Diagnose
+🚫 Kein Chunking. 🚫 Keine Embeddings. 🚫 Keine Vektor-DB. ✅ Personalized PageRank über deinen bestehenden `[[wiki-link]]`-Graphen — graph-bewusster Multi-Hop-Kontext, null Embedding-Kosten, vollständige Unterstützung lokaler Modelle.
 
-## 🔒 Transparenz & Compliance
+### Welchen LLM soll ich wählen?
 
-Dieses Plugin ist im Obsidian Community Plugin Market gelistet und wird einer automatisierten Überprüfung auf Sicherheit und Berechtigungen unterzogen.
+Modelle mit langem Kontext (≥200K Tokens) funktionieren am besten. Der Abschnitt [Modelle](#-modelle) erklärt die Prinzipien; die vollständige Tabelle befindet sich in [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md).
 
-**Das Plugin hat kein Backend, keine Server-Infrastruktur und keinerlei Datenerfassung.** Es ist reine lokale Software, die innerhalb von Obsidian ausgeführt wird. Das Plugin kann und wird Ihre Daten auf keine Weise sammeln, speichern oder an irgendeinen Server übertragen — weil ein solcher Server nicht existiert.
+### Gibt es einen veröffentlichten Benchmark?
 
-**Netzwerkzugriff** wird nur zur Kommunikation mit dem von Ihnen konfigurierten LLM-Anbieter verwendet — es werden keine anderen Netzwerkaufrufe getätigt. Dies liegt vollständig in Ihrer Kontrolle: Sie wählen den Anbieter, Sie geben den API-Schlüssel ein, Sie entscheiden, wohin Ihre Daten gehen.
+Ja — PPR @5 = 27,1 % vs. reine-kNN-Baseline 24,1 % auf dem projekteigenen Korpus. Die vollständige Pipeline und das Benchmark-Skript sind beschrieben unter [Wie die Suche funktioniert](#-wie-die-suche-funktioniert).
 
-**Dateisystemzugriff** (Vault-Auflistung) ist für den Aufbau und die Pflege des Wikis erforderlich: Lesen Ihrer Quellnotizen, Generieren von Seiten, Scannen auf tote Links und Erkennen doppelter Seiten. Das Plugin verändert niemals Ihre Quelldateien — nur Dateien im Wiki-Ordner.
+### Wie kontrolliere ich API-Kosten?
 
-**Zwischenablagezugriff** wird ausschließlich von der Schaltfläche „Kopieren" im Abfrage-Modal verwendet, und nur, wenn Sie darauf klicken.
+Verwende Grobe oder Minimale Extraktionsgranularität für Batch-Aufnahme. Smart Batch Skip erkennt bereits verarbeitete Dateien automatisch. Auto-Maintenance ist standardmäßig AUS. Lint zeigt Anzahl an, bevor Reparaturen ausgeführt werden — nichts wird ohne deine Zustimmung berechnet.
 
-Wenn Sie vollständige Datenlokalität bevorzugen, verwenden Sie einen lokalen LLM-Anbieter wie Ollama oder LM Studio. Mit einem lokalen Anbieter verlassen Ihre Daten niemals Ihren Rechner.
+### Wie breche ich einen laufenden Vorgang ab?
 
-## 💖 Projekt unterstützen
+Klicke auf die Statusleiste (zeigt „Ingesting… click to cancel") oder `Cmd+P/Ctrl+P` → „Cancel current ingestion". Stoppt sauber an der nächsten Batch-Grenze.
 
-Wenn LLM-Wiki zu einem wichtigen Teil Ihres Wissens-Workflows geworden ist, können Sie die laufende Entwicklung unterstützen:
+### Wo bekomme ich Hilfe?
 
-- ☕ **[Kaufen Sie mir einen Kaffee auf Ko-fi](https://ko-fi.com/greenerdalii)** — einmalige oder monatliche Unterstützung über Ko-fi
-- 💳 **[Trinkgeld über PayPal](https://paypal.me/greenerdalii)** — einmaliges Trinkgeld über PayPal
-
-Sponsoring ist völlig freiwillig. Das Plugin bleibt Apache-2.0-lizenziert und vollständig funktionsfähig.
-
-### Sponsoren
-
-Dank an die folgenden Personen für die Unterstützung des Projekts:
-
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
-
-## 📜 License
-
-Apache License 2.0 — siehe [LICENSE](LICENSE) und [NOTICE](NOTICE).
-
-## 🙏 Danksagungen
-
-- **💡 Konzept:** [Andrej Karpathys LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — die ursprüngliche Vision, die dieses Plugin inspiriert hat
-- **🛠️ Plattform:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 LLM-Transport:** [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) für Fehlermeldungen · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) für Fragen und Funktionswünsche · Entwicklerkonsole (`Ctrl+Shift+I` / `Cmd+Option+I`) für Plugin-Logs.
 
 ---
 
-**Official Site:** [llmwiki.greenerai.top](https://llmwiki.greenerai.top/)
+## 🔒 Privatsphäre
+
+Dieses Plugin ist im Obsidian Community Plugin Market gelistet und wird einer automatisierten Überprüfung auf Sicherheit und Berechtigungen unterzogen.
+
+- **🚫 Kein Backend, kein Server, keine Datenerfassung.** Reine lokale Software, die innerhalb von Obsidian läuft. Das Plugin kann und wird deine Daten auf keine Weise sammeln, speichern oder an irgendeinen Server übertragen — weil ein solcher Server nicht existiert.
+- **🔐 Netzwerkzugriff ist optional.** Wird nur für die Kommunikation mit dem von dir konfigurierten LLM-Anbieter verwendet. Du wählst den Anbieter, du gibst den API-Key ein, du entscheidest, wohin deine Daten gehen.
+- **📁 Vault-Dateizugriff** wird für die Wiki-Verwaltung verwendet (Lesen von Notizen, Generieren von Seiten, Scannen auf tote Links, Erkennen von Duplikaten). Das Plugin ändert niemals deine Quelldateien.
+- **📋 Zwischenablage-Zugriff** wird ausschließlich von der Schaltfläche „Kopieren" im Abfrage-Modal verwendet — und nur, wenn du darauf klickst.
+
+Für vollständige Datenlokalität verwende Ollama oder LM Studio. Mit einem lokalen Anbieter verlassen deine Daten niemals deinen Rechner.
+
+---
+
+## 💖 Unterstützung
+
+Wenn LLM-Wiki zu einem wichtigen Teil deines Wissens-Workflows geworden ist:
+
+- ☕ **[Kauf mir einen Kaffee auf Ko-fi](https://ko-fi.com/greenerdalii)** — einmalig oder monatlich
+- 💳 **[Trinkgeld via PayPal](https://paypal.me/greenerdalii)** — einmaliges Trinkgeld
+
+Sponsoring ist völlig freiwillig. Das Plugin bleibt Apache-2.0-lizenziert und voll funktionsfähig.
+
+Dank an [@jameses-cyber](https://github.com/jameses-cyber) und [@issaqua](https://github.com/issaqua) für die Unterstützung des Projekts.
+
+---
+
+## 📜 Lizenz & Danksagungen
+
+Apache License, Version 2.0 — siehe [LICENSE](../LICENSE) und [NOTICE](../NOTICE).
+
+**Basiert auf:**
+- 💡 [Andrej Karpathys LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — das ursprüngliche Konzept
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) und [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — Suchalgorithmen
+
+**Betreuer:** [@green-dalii](https://github.com/green-dalii)
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -2,484 +2,333 @@
 
 # 🧠 Karpathy LLM Wiki Plugin para Obsidian
 
-> Base de conocimiento estructurada impulsada por IA que ingiere tus notas y genera un Wiki conectado — basado en el concepto de [LLM Wiki de Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+> Un plugin de Obsidian que convierte tus notas en una base de conocimiento conectada y consultable: la idea del [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f), integrada en el editor donde ya escribes.
 
-> **Puntuación oficial Obsidian 95/100 | Soporte nativo de 10 idiomas | Búsqueda por grafo sin embeddings | Plena soberanía de datos | Compatible con cualquier proveedor de LLM**
+> **Recuperación por grafo sin embeddings • 10 idiomas nativos • Funciona con cualquier proveedor**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | **Español** | [Português](README_PT.md) | [Italiano](README_IT.md)
 
-[Sitio oficial](https://llmwiki.greenerai.top/) | [Mercado de Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Comentarios y debate](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[Sitio oficial](https://llmwiki.greenerai.top/) | [Mercado de Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Debate](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [Inicio rápido](#-inicio-rápido) | ✨ [Características](#-características) | 🤖 [Guía de Selección de Models](#-guía-de-selección-de-models) | 🔒 [Transparencia y cumplimiento](#-transparencia-y-cumplimiento) | ❓ [FAQ](#-faq)
+📑 [Contenido](#-contenido) • 🚀 [Inicio rápido](#-inicio-rápido) • ✨ [Características](#-características) • 🔍 [Cómo funciona la recuperación](#-cómo-funciona-la-recuperación) • 🤖 [Modelos](#-modelos) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Si este plugin te ha sido útil, invítame a un café♥️ o deja una estrella🌟↗
 
 ---
 
-## 📑 Contents
+## 📑 Contenido
 
-- [🧠 Karpathy LLM Wiki Plugin para Obsidian](#-karpathy-llm-wiki-plugin-para-obsidian)
-  - [📑 Contents](#-contents)
-  - [💡 ¿Qué es LLM-Wiki?](#-qué-es-llm-wiki)
-  - [⚡ ¿Por qué Obsidian + LLM-Wiki?](#-por-qué-obsidian--llm-wiki)
-  - [🚀 Inicio rápido](#-inicio-rápido)
-    - [📦 Instalación](#-instalación)
-    - [🔄 Actualización](#-actualización)
-    - [🔑 Configurar un proveedor LLM](#-configurar-un-proveedor-llm)
-    - [🎮 Uso](#-uso)
-    - [⚠️ ¿Actualizar desde una versión anterior?](#️-actualizar-desde-una-versión-anterior)
-  - [⚡ Novedades en v1.25.x](#-novedades-en-v125x)
-  - [✨ Características](#-características)
-    - [📊 Calidad del Conocimiento](#-calidad-del-conocimiento)
-    - [📄 Ingesta de PDF (v1.25.0)](#-ingesta-de-pdf-v1250)
-    - [💬 Query \& Feedback](#-query--feedback)
-    - [🛠️ Mantenimiento](#️-mantenimiento)
-    - [🌐 LLM \& Idioma](#-llm--idioma)
-    - [🏗️ Arquitectura \& Rendimiento](#️-arquitectura--rendimiento)
-    - [🔒 Privacidad y seguridad](#-privacidad-y-seguridad)
-  - [📖 Ejemplo](#-ejemplo)
-  - [🤖 Guía de Selección de Models](#-guía-de-selección-de-models)
-    - [☁️ Modelos en la nube](#️-modelos-en-la-nube)
-    - [🦙 Modelos locales (Ollama / LM Studio)](#-modelos-locales-ollama--lm-studio)
-    - [📄 Ruta OCR PDF local (v1.25.0+)](#-ruta-ocr-pdf-local-v1250)
-  - [🏗️ Arquitectura](#️-arquitectura)
-  - [❓ FAQ](#-faq)
-  - [🔒 Transparencia y cumplimiento](#-transparencia-y-cumplimiento)
-  - [💖 Apoyar el proyecto](#-apoyar-el-proyecto)
-    - [Patrocinadores](#patrocinadores)
-  - [📜 Licencia](#-licencia)
-  - [🙏 Agradecimientos](#-agradecimientos)
-  - [Star History](#star-history)
-
-## 💡 ¿Qué es LLM-Wiki?
-
-Escribe. La IA organiza. Pregunta. Así de simple.
-
-**🎯 El problema.** Tus notas son una mina de oro: personas, conceptos, ideas, conexiones. Pero ahora mismo son solo archivos en carpetas. Buscar relaciones requiere etiquetado manual y memoria.
-
-**✨ La solución.** [Andrej Karpathy propuso](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) un enfoque elegante: trata tus notas como materia prima y deja que un LLM desempeñe el papel de arquitecto. Lee lo que escribes, extrae entities y concepts, y los teje en un Wiki estructurado — con `[[wiki-links]]` bidireccionales, índice generado automáticamente e interfaz de chat que responde desde *tu* conocimiento.
-
-**📚 No necesitas ser el bibliotecario.** No decidir qué merece página. No mantener enlaces cruzados. No verificar si algo está desactualizado. Elige cualquier nota (o carpeta, o selección múltiple) de tu vault — el LLM lee, extrae, escribe, enlaza y señala contradicciones — mientras tú mantienes el flujo.
-
-**🤖 No es un chatbot más.** ChatGPT conoce internet. LLM-Wiki te conoce *a ti* — o más bien, lo que le has enseñado. Cada respuesta incluye `[[wiki-links]]` de regreso a tu grafo de conocimiento. Cada respuesta es un punto de partida, no un callejón sin salida.
+- [🤔 Por qué este plugin?](#-por-qué-este-plugin)
+- [🎯 Es para mí?](#-es-para-mí)
+- [🚀 Inicio rápido](#-inicio-rápido)
+- [✨ Características](#-características)
+- [🔍 Cómo funciona la recuperación](#-cómo-funciona-la-recuperación)
+- [🤖 Modelos](#-modelos)
+- [❓ FAQ](#-faq)
+- [🔒 Privacidad](#-privacidad)
+- [💖 Apoyar el proyecto](#-apoyar-el-proyecto)
+- [📜 Licencia y créditos](#-licencia-y-créditos)
 
 ---
 
-## ⚡ ¿Por qué Obsidian + LLM-Wiki?
+## 🤔 Por qué este plugin?
 
-Obsidian es brillante en el pensamiento conectado. Pero hay un inconveniente: eres tú quien hace todas las conexiones.
+Escribes notas. Se quedan en carpetas. Encontrar relaciones significa recordar hilos que olvidaste hace meses.
 
-LLM-Wiki invierte eso. En lugar de que construyas el grafo a mano, la IA lo cultiva contigo. Agrega una nota sobre un nuevo concepto — encuentra las conexiones que habrías pasado por alto. Haz una pregunta — recorre tu propio grafo de conocimiento y trae respuestas con citas.
+**Existen otras reimplementaciones open-source de la idea de Karpathy, pero ninguna llega como un plugin de Obsidian listo para usar.** La mayoría son herramientas CLI, skills de Claude Code o aplicaciones de escritorio separadas. Somos el único con UI nativa, almacenamiento dentro del vault y el Graph View de Obsidian integrado.
 
-- **🔗 Tu Graph View cobra vida.** Las nuevas notas no simplemente están ahí — brotan enlaces a entidades, conceptos y fuentes. El grafo crece orgánicamente, y el plugin lo mantiene: detectando duplicados, corrigiendo enlaces rotos, poniendo puentes entre idiomas mediante aliases.
-- **💬 Tus notas aprenden a responderte.** La búsqueda se convierte en conversación. "¿Qué escribí sobre X?" se transforma en un diálogo, con respuestas en streaming y `[[wiki-links]]` como migas de pan. Cada respuesta es un camino más profundo en tu propio conocimiento.
-- **🧠 Obsidian se convierte en un compañero de pensamiento.** Deja de ser un archivador de notas y pasa a ser algo que te ayuda a *pensar* — revelando conexiones ocultas, señalando contradicciones, recordando lo que habías olvidado que sabías.
+### Cómo nos comparamos
+
+|  | Karpathy LLM Wiki (este plugin) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **Forma de entrega** | ✅ Plugin de Obsidian listo para usar | ❌ App de escritorio Tauri separada | ❌ Skill de Claude Code | ❌ Skill de Claude Code / Codex | ❌ CLI + SDK + servidor MCP |
+| **Esfuerzo de configuración** | ✅ **5 minutos** — Plugins comunitarios → Instalar → elegir proveedor → Ingestar | ❌ 30 min+ — compilar/descargar binario, configurar CLI | ❌ 15 min — requiere suscripción Claude Code + instalar skill | ❌ 10 min — requiere suscripción Claude Code/Codex + configurar skill | ❌ 30 min+ — pip install + SDK + configuración MCP |
+| **Instalación** | ✅ Obsidian → Plugins comunitarios → buscar → Instalar | ❌ Compilar o descargar binario, luego configurar CLI | ❌ Requiere suscripción Claude Code + guía de instalación | ❌ Requiere suscripción Claude Code o Codex + pasos de configuración | ❌ pip install + Python SDK + servidor local |
+| **Complejidad arquitectónica** | ✅ **Cero dependencias** — sin base de datos vectorial, sin modelo de embeddings, sin procesos externos | 🟡 Incluye su propio runtime Python + sigma.js + sqlite | 🟡 Usa el entorno de Claude Code — no es autónomo | 🟡 Requiere plataforma de ejecución separada | ❌ Requiere Python, modelo de embeddings, BD vectorial |
+| **i18n (UI + salida wiki)** | ✅ 10 idiomas (UI / salida independientes) | 🟡 2 (EN / 中文) | ❌ Solo inglés | ❌ Solo inglés | ❌ Solo inglés |
+| **Proveedores LLM** | ✅ 12+ (incluye Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-compatible, Kimi, GLM, MiniMax, DeepSeek) | 🟡 Compatible con OpenAI | 🟡 Suscripción vía Claude Code | 🟡 Suscripción vía Claude Code / Codex | 🟡 Compatible con OpenAI |
+| **Algoritmo de recuperación** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 Heurística de 4 señales (Adamic-Adar + decaimiento de 2 saltos) | ❌ Solo detección de comunidades Louvain | ❌ Louvain + previsualizaciones k-hop | ❌ Híbrido: BM25 + semántico + wikilink |
+| **Pipeline de consulta (cascada de 5 etapas)** | ✅ Lex → palabras clave LLM → escaneo de subcadenas → fallback LLM KB → expansión PPR (se trunca al llegar a suficiente señal) | 🟡 Solo decaimiento de 2 saltos | ❌ Solo clustering Louvain | ❌ Previsualizaciones k-hop (sin aumento LLM) | ❌ BM25 + semántico sobre fragmentos (sin grafo) |
+| **Embeddings necesarios** | ✅ No (cero costo de embeddings, por diseño) | 🟡 Opcional, desactivado por defecto | ✅ No | ✅ No | ❌ **Sí — obligatorio** |
+| **Visualización de grafo** | ✅ Graph View nativo de Obsidian (integrado, cero tamaño extra) | ❌ sigma.js personalizado + graphology en app de escritorio | 🟡 graph.html vis.js (archivo separado) | ❌ sigma.js HTML offline personalizado | ❌ Visor de solo lectura en navegador |
+| **Honestidad del Wiki** | ✅ Cartel "Stage FALLBACK" cuando ninguna fuente del wiki coincide con tu consulta | ❌ Sin equivalente | ❌ Sin equivalente | ❌ Sin equivalente | ❌ Sin equivalente |
+| **Benchmark de recuperación publicado** | ✅ PPR @5 = 27.1% vs knn puro 24.1% (único número publicado en este espacio) | ❌ 58% → 71% *solo con embeddings activados*, no en nuestro formato comparable | ❌ No publicado | ❌ No publicado | ❌ No publicado |
+
+### Tres cosas que elegimos a propósito, no por accidente
+
+- **🪟 Obsidian es el runtime.** Sin terminal, sin aplicación separada, sin Docker, sin Python. Instálalo desde Plugins Comunitarios, haz clic en Ingestar, el wiki vive en tu vault desde el primer segundo. El Graph View nativo de Obsidian renderiza tu grafo `[[wiki-link]]` — integrado, cero tamaño extra.
+- **🧑‍🍳 Limpio y autocontenido.** Cero dependencias. Sin modelo de embeddings, sin base de datos vectorial, sin paquete pip — un solo plugin que lee tus notas, habla con un LLM y escribe páginas wiki. Todo vive dentro de Obsidian.
+- **🔌 Cualquier modelo por el que ya pagas.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-compatible, endpoint personalizado — más de doce proveedores, ninguno requiere tener un endpoint de embeddings.
+
+---
+
+## 🎯 Es para mí?
+
+**✅ Sí, si:**
+
+- **Quieres una configuración de 5 minutos, no un proyecto de 5 horas.** Instala desde Plugins Comunitarios → elige un proveedor → ingesta una nota. Sin CLI, sin Python, sin runtime separado, sin BD vectorial. Ves páginas wiki en `wiki/` en segundos.
+- **Quieres algo limpio y autocontenido.** El plugin tiene exactamente cero dependencias externas: sin modelo de embeddings, sin base de datos vectorial, sin paquete pip, sin contenedor Docker. Es un solo plugin de Obsidian que lee tus notas, habla con un LLM y escribe páginas wiki en tu vault. Todo vive dentro de Obsidian.
+- **Quieres un chat consultable que responda desde *tus* notas** — no desde internet — con cada respuesta llevando `[[wiki-links]]` de vuelta a tu grafo de conocimiento.
+- **Te importa la soberanía de datos** — funciona completamente en local con Ollama o LM Studio, sin tocar internet.
+- **Escribes o lees en cualquiera de los 10 idiomas compatibles** — la UI y el idioma de salida del wiki son independientes (tu wiki puede estar en chino mientras la interfaz está en inglés).
+- **Mantienes el grafo escribiendo `[[wiki-links]]`** — cada enlace que escribes ya enriquece la recuperación; sin paso separado de etiquetado/embedding/indexación.
+- **Quieres mantenimiento con un clic** — Escaneo de salud Lint + Smart Fix All mantienen a raya duplicados, enlaces rotos y páginas huérfanas sin que tengas que curar manualmente.
+
+**❌ No, si:**
+
+- **Quieres un reemplazo de ChatGPT de uso general** — este plugin responde solo desde *tu* conocimiento.
+- **Necesitas un pipeline RAG sobre PDFs / páginas web / corpus externos** — nos enfocamos en la ruta dentro del vault (los PDFs son compatibles desde v1.25.0).
+- **Buscas un SaaS alojado** — no hay backend, ni servidor, ni cuenta.
 
 ---
 
 ## 🚀 Inicio rápido
 
-### 📦 Instalación
+1. **Instala.** Obsidian → Configuración → Plugins comunitarios → Examinar → busca "Karpathy LLM Wiki" → Instalar → Habilitar. O visita la [página del Plugin Comunitario](https://community.obsidian.md/plugins/karpathywiki) y haz clic en **Add to Obsidian**.
+2. **Configura un proveedor.** Abre Configuración → Karpathy LLM Wiki → elige un proveedor (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth), etc.) → introduce la clave API (no necesaria para local) → haz clic en **Test Connection** → Guardar.
+3. **Ingesta una nota.** `Cmd+P/Ctrl+P` → "Ingest single source" → elige cualquier archivo Markdown (o **PDF**, v1.25.0+). Tus primeras páginas wiki aparecen en `wiki/sources/`, `wiki/entities/`, `wiki/concepts/` en segundos.
 
-**🌟 Recomendado — Mercado de plugins comunitarios de Obsidian:**
-1. En Obsidian, ve a **Configuración → Plugins comunitarios**
-2. Haz clic en **Examinar** y busca "Karpathy LLM Wiki"
-3. Haz clic en **Instalar**, luego **Habilitar**
+Eso es todo. El plugin no modifica nada en tus notas originales — solo crea páginas nuevas dentro de `wiki/`. Para chatear con tu wiki: `Cmd+P/Ctrl+P` → "Query wiki". (`Cmd` en macOS, `Ctrl` en Windows/Linux.)
 
-**🌐 O desde el sitio web de plugins comunitarios —** visita [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) y haz clic en **Add to Obsidian**.
+### Comandos principales
 
-**⚙️ Manual (alternativa):**
-1. Descarga `main.js`, `manifest.json`, `styles.css` desde [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
-2. En Obsidian, ve a Configuración → Plugins comunitarios. Haz clic en el icono de carpeta para abrir el directorio de plugins
-3. Crea una carpeta llamada `karpathywiki`, coloca los tres archivos dentro
-4. De vuelta en Obsidian, haz clic en el icono de refrescar — **Karpathy LLM Wiki** aparecerá
-5. Actívalo para habilitarlo
+| Comando | Qué hace |
+|---------|----------|
+| **📥 Ingest single source** | `Cmd+P/Ctrl+P` → "Ingest single source" — elige un archivo Markdown o **PDF (v1.25.0+)**, obtén páginas de entidades/conceptos/wiki |
+| **📂 Ingest from folder** | `Cmd+P/Ctrl+P` → "Ingest from folder" — ingesta por lotes cada nota de una carpeta, con salto inteligente de lotes |
+| **📑 Ingest multiple files** | `Cmd+P/Ctrl+P` → "Ingest multiple files" — selecciona un subconjunto mediante un árbol de carpetas de dos paneles (con cola en vivo + cancelación por archivo) |
+| **🔍 Query wiki** | `Cmd+P/Ctrl+P` → "Query wiki" — chatea con tu wiki en un panel lateral derecho; las respuestas llevan `[[wiki-links]]` |
+| **🛠️ Lint wiki** | `Cmd+P/Ctrl+P` → "Lint wiki" — escaneo de salud completo: duplicados, enlaces rotos, páginas vacías, huérfanas, alias faltantes, contradicciones |
+| **⚡ Smart Fix All** | dentro del Modal Lint — reparación en orden causal con un clic e informe por fase |
+| **📋 Regenerate index** | `Cmd+P/Ctrl+P` → "Regenerate index" — reconstruye `wiki/index.md` con páginas y alias actuales |
+| **⏹ Cancelar** | `Cmd+P/Ctrl+P` → "Cancel current ingestion" o haz clic en la barra de estado — se detiene limpiamente en el próximo límite de lote |
+| **📊 Ingestion history** | `Cmd+P/Ctrl+P` → "View Ingestion History" — interfaz buscable para ingestiones pasadas, informes Lint y ejecuciones de mantenimiento |
 
-**🔨 Desarrollo:** `git clone`, `pnpm install`, `pnpm build`.
+| Antes | Después |
+|-------|---------|
+| `notes/machine-learning.md` (un archivo plano) | `wiki/concepts/supervised-learning.md` con `[[enlaces bidireccionales]]`, alias, atribución de fuente y una entrada en `wiki/index.md` |
 
-### 🔄 Actualización
+> 💡 **Mantenerse actualizado.** Las nuevas funciones, correcciones y mejoras de rendimiento se publican con frecuencia. Configuración → Plugins comunitarios → Buscar actualizaciones, o activa las actualizaciones automáticas de plugins.
+> 📖 Guías detalladas (instalación, configuración PDF, notas multi-proveedor, actualizaciones) se mantienen en [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides).
 
-Este proyecto evoluciona rápidamente. Recomendamos mantenerse actualizado:
+---
 
-**Opción A — Actualización manual (recomendada):**
-1. Ve a **Configuración → Plugins comunitarios**
-2. Haz clic en **Buscar actualizaciones**
-3. Encuentra **Karpathy LLM Wiki** y haz clic en **Actualizar**
-
-**Opción B — Habilitar actualización automática:**
-1. Ve a **Configuración → Plugins comunitarios**
-2. Activa **Comprobar automáticamente actualizaciones de plugins**
-
-> 💡 **¿Por qué mantenerse actualizado?** Cada versión puede incluir nuevas funciones, mejoras de rendimiento y correcciones de errores importantes.
-
-### 🔑 Configurar un proveedor LLM
-
-1. Abre Configuración → Karpathy LLM Wiki
-2. Elige un proveedor del menú desplegable, incluidos OpenAI o ChatGPT Plan (Codex OAuth)
-3. Para proveedores API, introduce su clave (no se necesita para Ollama, LM Studio ni ChatGPT Plan (Codex OAuth))
-4. Para proveedores que no sean Codex, usa **Fetch Models** o introduce un modelo; ChatGPT Plan (Codex OAuth) rellena automáticamente su lista de modelos seleccionados
-5. Haz clic en **Test Connection**, luego **Guardar configuración**
-
-**🦙 Ollama (local):** Instala [Ollama](https://ollama.com), descarga un modelo, selecciona "Ollama (Local)".
-
-**🎛️ LM Studio (local):** Instala [LM Studio](https://lmstudio.ai), inicia el servidor local, selecciona "LM Studio (Local)".
-
-**🔐 ChatGPT Plan (Codex OAuth) — experimental:** Es independiente de **OpenAI**, que usa una clave de OpenAI Platform con facturación por separado. Selecciónalo y usa **Iniciar sesión con el navegador** en escritorio (callback localhost), o **Usar código de dispositivo** en escritorio/móvil y termina la autorización en la página de OpenAI. El plugin sincroniza los modelos seleccionables de la cuenta Codex conectada y solo almacena metadatos de catálogo depurados; **Actualizar modelos de cuenta** permite renovarlos. Si el catálogo falla temporalmente, conserva la última caché o una lista mínima de respaldo. Después prueba la conexión y guarda. Las credenciales OAuth solo se almacenan en Obsidian SecretStorage; **Cerrar sesión** las borra. La disponibilidad sigue las políticas de autenticación, modelos y asignación de OpenAI Codex. Es compatibilidad de terceros, no una asociación con OpenAI ni una API general de ChatGPT.
-
-### 🎮 Uso
-
-| Método | Cómo |
-|--------|------|
-| **📥 Ingestar fuente individual** | `Cmd+P` → "Ingest single source" — selecciona una nota (Markdown o **PDF, v1.25.0+**) para generar páginas Wiki con entidades y conceptos |
-| **📂 Ingestar desde carpeta** | `Cmd+P` → "Ingest from folder" — selecciona una carpeta para generar Wiki en lote |
-| **📑 Ingerir varios archivos** | `Cmd+P` → "Ingest multiple files" — elige notas mediante árbol de carpetas + casillas, ingesta en lote (con cola en vivo + cancelación por archivo) |
-| **🎯 Ingestar archivo actual** | Haz clic en el icono `sticker` de la cinta izquierda, o `Cmd+P` → "Ingest current file" |
-| **🔍 Consultar wiki** | `Cmd+P` → "Query wiki" — Q&A conversacional con streaming y `[[wiki-links]]` |
-| **🛠️ Verificar wiki** | `Cmd+P` → "Lint wiki" — análisis completo: duplicados, enlaces rotos, páginas vacías, huérfanas, alias faltantes, contradicciones |
-| **📋 Regenerar índice** | `Cmd+P` → "Regenerate index" — reconstruye `wiki/index.md` con entradas de alias |
-| **📊 Historial de ingesta (v1.21.0)** | `Cmd+P` → "View Ingestion History" — explora ingestiones, informes Lint y ejecuciones de mantenimiento |
-| **⏹ Cancelar operación** | `Cmd+P` → "Cancel current ingestion" — se detiene de forma segura en el próximo límite de lote |
-| **🎉 Recrear nota de bienvenida (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — regenera la nota de bienvenida |
-
-La re-ingesta de la misma fuente fusiona nueva información de forma incremental. Los resúmenes se regeneran.
-
-> 💡 **Smart Batch Skip:** Al ingestar una carpeta, el plugin detecta y salta automáticamente los archivos ya procesados — ahorra tiempo y costes de API.
-
-![Paleta de comandos — busca "karpa" para ver todos los comandos](assets/command-panel.png)
-
-### ⚠️ ¿Actualizar desde una versión anterior?
-
-> 🔧 **Actualizar desde v1.24.x.** La ingesta de PDF (v1.25.0) escribe su caché en `.obsidian/plugins/karpathywiki/pdf-cache/` (hasta 100 MB / 1000 entradas / 10 MB por entrada individual; evicción LRU-by-mtime al iniciar y al comienzo de cada ingesta por lotes). Tu vault **no se modifica por defecto** — activa **Write PDF Markdown to Vault** (Settings → Wiki Configuration → Wiki Folder) sólo si quieres un sidecar `<basename>.pdf.md` junto al PDF fuente. Dos ajustes nuevos — **Force PDF Support** (avanzado, desactivado por defecto) y **Write PDF Markdown to Vault** (desactivado por defecto) — son totalmente retrocompatibles: un `data.json` antiguo sin estos campos volverá a `false`.
-
-> 🔧 **Actualizar desde v1.24.0.** Se ha eliminado el marcador de comentario interno `<!-- reviewed: keep -->` (v1.24.0, #244) que protegía únicamente la sección *Menciones en Source* de una página. Para conservar una sección de Menciones curada, establece `reviewed: true` en el frontmatter de la página: protege toda la página (Menciones incluidas) y, a diferencia del comentario oculto, permanece visible en el panel de Propiedades y resiste los linters de Markdown.
-
-**Retrocompatible.** Sin cambios incompatibles desde v1.0.0 — tus páginas Wiki, configuración y flujos de trabajo existentes se conservan sin reconfiguración.
-
-**Después de actualizar**, ejecuta **Lint Wiki** → **Smart Fix All** para una reparación automática en orden causal:
-1. 🏷️ Completar alias (LLM genera traducciones, abreviaturas, nombres alternativos)
-2. 🔄 Fusionar duplicados (multilingüe, abreviaturas, alta similitud)
-3. 🔗 Reparar enlaces rotos / vincular huérfanos / expandir páginas vacías
-
-Luego **Regenerar índice** para reconstruir `wiki/index.md` con entradas de alias.
-
-> 📖 Guías detalladas para saltos de versión específicos en [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions).
-
-**Ajustes a revisar:** Force PDF Support (Settings → LLM Configuration → Advanced, desactivado por defecto — sólo relevante para proveedores no NATIVE), Write PDF Markdown to Vault (Settings → Wiki Configuration → Wiki Folder, desactivado por defecto), Idioma de salida del Wiki (independiente de la UI), Granularidad de extracción, Concurrencia (predet. 3), Retraso de lote (predet. 300ms).
-
-## ⚡ Novedades en v1.25.x
-
-- **v1.25.2 (2026-07-22).** Vocabulario de etiquetas Fase 1（fuente doble eliminada）、Codex OAuth（ChatGPT Plan）、corrección de prefijo de carpeta en enlaces relacionados、plantilla de página `---` final corregida、ESLint 0.4.1 Route A. 2515 pruebas superadas.
-- **v1.25.1 (2026-07-20).** Ocho correcciones de pérdida silenciosa（página relacionada、secciones de esquema、Menciones heredadas）、3 divisiones de archivos grandes、DiskCache<T>、LM Studio sin clave API、causa raíz de verificación de compilación. 2274 pruebas superadas.
-- **v1.25.0 (2026-07-18).** Ingesta PDF solo en caché（Nivel 1）、crecimiento de caché limitado、sidecar de bóveda opcional、puerta universal Force PDF、mensaje de transcripción textual、ingesta cancelable、guía de modelos locales、integridad i18n. 2182 pruebas superadas.
-
-📋 [Historial completo de versiones → CHANGELOG.md](../CHANGELOG.md)
 ## ✨ Características
 
-### 📊 Calidad del Conocimiento
+### 📚 Calidad del conocimiento
 
-- **🔍 Entity/Concept Extraction** — El LLM extrae entities (personas, organizaciones, productos, eventos) y concepts (teorías, métodos, términos) de tus notas con granularidad de extracción flexible (Mínima~5 elementos, Gruesa~10, Estándar~50, Fina~100, Personalizada 1–500) para balancear profundidad de análisis y costos de API
-- **🏷️ Mandatory Page Aliases** — Cada página generada incluye al menos 1 alias (traducción, acrónimo, nombre alternativo), habilitando detección de duplicados cross-language
-- **🔄 Duplicate Detection & Merge** — El semantic tiering detecta duplicados verdaderos (traducciones cross-language, abreviaturas, variantes de ortografía); el merge inteligente de LLM fusiona contenido y preserva aliases
-- **🧩 Smart Knowledge Fusion** — Las actualizaciones multi-source fusionan información nueva sin redundancia; las contradicciones se preservan con atribución; las páginas `reviewed: true` se protegen de sobrescritura
-- **📏 Protección contra el truncamiento** — Los proveedores con clave API y locales usan 8000 max_tokens, detectan stop_reason automáticamente y reintentan con 2× tokens. La ruta experimental de ChatGPT Plan (Codex OAuth) sigue la política de salida del backend Codex, que no acepta un límite max_output_tokens del cliente.
-- **📝 Verbatim Source Mentions** — Las citas en idioma original se preservan con traducción opcional para trazabilidad
+- **🔍 Extracción de entidades y conceptos** — El LLM extrae entidades (personas, organizaciones, productos, eventos) y conceptos (teorías, métodos, términos) en páginas independientes. La granularidad es configurable (Mínima → Fina, más Personalizada) para que puedas equilibrar costo vs. profundidad.
+- **🏷️ Alias obligatorios** — cada página incluye al menos un alias (traducción, abreviatura, variante) para que la detección de duplicados entre idiomas funcione.
+- **🔄 Detección de duplicados por niveles** — Nivel 1 (coincidencia directa de nombre: entre idiomas, abreviatura, títulos de alta similitud) siempre se verifica; Nivel 2 (enlaces compartidos, similitud media) llena el presupuesto de tokens restante.
+- **🧩 Fusión inteligente y máquina de estados de contradicción** — los duplicados se fusionan preservando alias; las contradicciones se marcan con atribución de fuente; las páginas con `reviewed: true` están protegidas contra sobrescritura.
+- **🎨 Vocabulario de etiquetas personalizable** — define tus propias listas de etiquetas de tipo de entidad y concepto en Configuración → Wiki → Tag Vocabulary → *Custom*; Lint informa de cualquier página cuyas etiquetas estén fuera del vocabulario activo.
 
-- **🎨 Vocabulario de etiquetas personalizable (v1.18.0).** Ajustes → Wiki → Modo de vocabulario de etiquetas → *Personalizado* te permite definir tus propias listas de etiquetas de tipo de entidad y concepto (por ejemplo, `Medical_Arzneimittel`, `法规`). El plugin respeta tu vocabulario en los prompts de extracción y en la validación de frontmatter; la auditoría de Lint (Issue #85 v7) reporta cualquier página cuyas etiquetas estén fuera del vocabulario activo.
+### 📄 Ingesta de PDF (v1.25.0+)
 
-### 📄 Ingesta de PDF (v1.25.0)
+- **🔌 Puerta de proveedor** — Anthropic, OpenAI y Bedrock manejan PDF de forma nativa. Para cualquier otro endpoint compatible con OpenAI/Anthropic, activa **Force PDF Support** en Configuración → LLM Configuration → Advanced para que el plugin intente la llamada. Para OCR local en Apple Silicon, extractores de terceros (MinerU, Docling, Mathpix, Adobe) y la guía completa de ingesta PDF, consulta [Rutas de OCR PDF](#-rutas-de-ocr-pdf) más abajo y [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md).
+- **🗄️ Caché acotada** — `.obsidian/plugins/karpathywiki/pdf-cache/` almacena el Markdown convertido, indexado por hash de contenido + modelo + versión del convertidor. Mantenimiento de tres capas de defensa: 100 MB total / 1000 entradas / 10 MB por entrada individual con evicción LRU por mtime.
+- **📝 Sidecar opcional en el vault** — Configuración → Wiki Configuration → Wiki Folder → *Write PDF Markdown to Vault* escribe `<basename>.pdf.md` junto al PDF fuente (desactivado por defecto — solo caché es el valor predeterminado).
+- **🛡️ Prompt de transcripción literal** — conversión estilo OCR con marcadores anti-alucinación `[illegible]` / `[figure: ...]`; el envoltorio de fences markdown de modelos locales pequeños se limpia automáticamente antes de escribir en caché.
 
-Elige un PDF de tu vault — el plugin lo lee a través de la entrada nativa de archivo de tu proveedor LLM, lo convierte a Markdown y vuelve a entrar en el pipeline estándar de ingesta Markdown. Todos los flujos existentes de entidad/concepto/alias/`[[wiki-link]]` se aplican sin cambios.
+### 📄 Rutas de OCR PDF
 
-- **🔌 Puerta de proveedor** — Anthropic, OpenAI, Bedrock Anthropic y Bedrock OpenAI manejan PDF de forma nativa. Para cualquier otro endpoint compatible con OpenAI/Anthropic, activa **Force PDF Support** en Settings → LLM Configuration → Advanced para que el plugin intente la llamada (tu endpoint decide; los fallos se muestran como un Notice localizado guiándote a desactivar el toggle). La configuración local recomendada está en [Ruta OCR PDF local](#-ruta-ocr-pdf-local-v1250).
-- **🗄️ Caché por hash de contenido** — un mismo PDF + mismo modelo + misma versión de convertidor devuelve el Markdown en caché sin llamar al LLM. La caché vive en `.obsidian/plugins/karpathywiki/pdf-cache/`; la clave lleva `converterVersion` para invalidar automáticamente las entradas obsoletas cuando se actualice el prompt.
-- **📏 Crecimiento acotado** — limpieza de caché en tres capas de defensa (100 MB total / 1000 entradas / 10 MB por entrada individual) con evicción LRU-by-mtime; las entradas antiguas se purgan al iniciar y al comenzar cada ingesta por lotes. Solo caché — tu vault no se modifica por defecto.
-- **📝 Sidecar opcional en el vault** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** escribe un `<basename>.pdf.md` junto al PDF fuente tras la conversión. Desactivado por defecto (solo caché).
-- **🛡️ Prompt transcripción literal** — el prompt de PDF→Markdown se reformula como conversión literal estilo OCR con marcadores anti-alucinación `[illegible]` / `[figure: ...]` / `[equation: ...]`; los modelos pequeños/locales que envuelven su salida en fences ```markdown se limpian automáticamente antes de escribir en caché.
-- **⏹ Cancelable** — al hacer clic en la barra de estado durante la conversión se interrumpe la llamada LLM en curso (vía Vercel AI SDK v6).
+Tres rutas, elige la que se ajuste a tu configuración:
 
-### 💬 Query & Feedback
+1. **☁️ Proveedor cloud con soporte PDF nativo** — Anthropic, OpenAI o AWS Bedrock leen PDFs sin configuración adicional. Solo ingesta; no se necesita configuración extra. Para cualquier otro endpoint compatible con OpenAI/Anthropic, activa **Force PDF Support** en Configuración → LLM Configuration → Advanced para que el plugin intente la llamada.
+2. **🖥️ OCR local en Apple Silicon** — [oMLX](https://github.com/jundot/omlx) integra Microsoft Markitdown como backend PDF→Markdown incorporado. Activa Markitdown en oMLX, carga [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M activos, open-source 2026-06) como modelo de visión, apunta el plugin a oMLX como proveedor Custom OpenAI-Compatible, activa **Force PDF Support** y elige el modelo multimodal que oMLX está sirviendo. El PDF nunca sale de tu máquina.
+3. **🛠️ Extractor de terceros (MinerU, Docling, Mathpix, Adobe)** — ejecuta un extractor separado en tus PDFs para producir archivos `.md`, luego ingéstalos como notas Markdown regulares a través del pipeline estándar del plugin. La opción más fiable para artículos científicos, documentos escaneados y PDFs con muchas matemáticas.
 
-- **🔍 Cascada de selección de semillas PPR en 5 etapas (v1.24.1 PATCH).** Cuando formulas una pregunta multi-hop, Query Wiki compone la respuesta a través de cinco etapas complementarias antes de que arranque cualquier generación:
-  1. **Camino rápido Lex** — comprobación directa de solapamiento de tokens contra cada título/alias de entity/concept (gratis, instantánea; controla las etapas siguientes)
-  2. **Generación de palabras clave LLM** — el LLM propone 8–12 palabras clave inter-idiomas desde tu consulta (absorbe sinónimos, acrónimos, términos resistentes al solapamiento de tokens)
-  3. **Escaneo local de subcadenas** — cada palabra clave generada se re-matchea localmente contra títulos de página, aliases y fragmentos de cuerpo (sin llamada LLM adicional; completa el recall tolerante al ruido)
-  4. **Fallback LLM KB** — cuando lex + escaneo de palabras clave devuelven señales débiles, el LLM re-siembra los top-N candidatos con una pasada semántica sobre el wiki completo
-  5. **Expansión de grafo PPR** — Personalized PageRank (Haveliwala 2002) ejecutado sobre el grafo `[[wiki-link]]` desde el conjunto de semillas candidatas; aporta al LLM el contexto multi-hop consciente del grafo que la búsqueda lineal no alcanza
+📖 **Guías de configuración completas** para las tres rutas (proveedores cloud, niveles de hardware oMLX, instalación de MinerU, mantenimiento de caché) → [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-  La cascada se trunca automáticamente en la etapa que devuelva suficiente señal — sin coste fijo de 5 etapas, sin llamadas LLM cuando Lex basta, sin pérdida de precisión cuando se necesita la augmentación LLM. La relevancia end-to-end (PPR @5 = 27,1% sobre el corpus de benchmark interno del proyecto) supera a las líneas base knn puras (24,1%) sin opt-in de embedding. Stage 1.5 (pasos 2–3) absorbe los tipos de pregunta multi-hop que el Lex puro pierde; Stage 1.7 (paso 4) recupera señales débiles de palabras clave inyectadas por LLM; Stage 1.9 (paso 5) garantiza que el LLM vea contexto de vecinos en vez de un top-N plano. Reemplaza la antigua cascada binaria por tiers.
+### 💬 Consulta y mantenimiento
 
-- **🤖 Conversational Query** — Diálogo estilo ChatGPT con Markdown en streaming e `[[wiki-links]]`, historial multi-turn
-- **🪟 Panel lateral acoplado a la derecha (v1.22.1, PR #196).** Query Wiki se abre en un leaf del sidebar derecho estilo Copilot (reutilizando un leaf existente) en lugar de un popup centrado. El icono ribbon `message-circle` y el comando `Query Wiki` activan/muestran el panel; tus notas quedan visibles junto a la conversación. Toda la funcionalidad se conserva sin cambios.
-- **📤 Query-to-Wiki Feedback** — Guarda conversaciones valiosas al Wiki con entity/concept extraction, semantic dedup antes de guardar
-- **🔒 Duplicate Save Prevention** — El hash tracking previene re-evaluación de conversaciones sin cambios
+- **🧭 Cascada PPR de 5 etapas** — consulta [Cómo funciona la recuperación](#-cómo-funciona-la-recuperación). Personalized PageRank sobre `[[wiki-link]]` proporciona contexto multi-hop consciente del grafo.
+- **🪟 Panel lateral acoplado a la derecha** — Query Wiki se abre en un panel lateral derecho estilo Copilot (v1.22.1+) en lugar de un modal centrado.
+- **🔍 Escaneo de salud Lint** — un solo comando detecta: duplicados, enlaces rotos, páginas vacías, huérfanas, alias faltantes, contradicciones.
+- **⚡ Smart Fix All** — reparación en orden causal con un clic: completar alias → fusionar duplicados → arreglar enlaces rotos → enlazar huérfanas → expandir páginas vacías, con informe por fase.
+- **📊 Panel de historial de operaciones** — interfaz buscable y filtrable para ingestiones pasadas, informes Lint y ejecuciones de mantenimiento.
+- **🛡️ Portal de pre-ingestión** — las notas vacías / solo espacios / solo frontmatter se rechazan antes de cualquier llamada LLM; el dedup por hash de contenido detecta archivos idénticos en distintas rutas.
 
-### 🛠️ Mantenimiento
+### 🔒 Privacidad
 
-- **🔍 Lint Health Scan** — Detecta duplicados, dead links, empty pages, orphans, aliases faltantes y contradicciones en informe integral
-- **🎯 Semantic-Tier Duplicate Detection** — Tier 1 (coincidencias directas de nombre: cross-language, abreviaturas, títulos de alta similitud) siempre verificadas; Tier 2 (señales indirectas: enlaces compartidos, similitud moderada) llena el presupuesto de tokens
-- **⚡ Smart Fix All** — Batch fix ordenado por causalidad: aliases completados → duplicados fusionados → dead links resueltos → orphans enlazados → empty pages expandidas
-- **🏷️ Alias Completion** — Generación paralela de batch de aliases faltantes en un clic, mejorando detección futura de duplicados
-- **🔄 Auto-Maintenance** — File watcher multi-carpeta, lint periódico, health check al inicio (Startup Quick Fixes activado por defecto, File Watcher y Periodic Lint desactivados por defecto)
-- **⚠️ Contradiction State Machine** — `detected → review_ok → resolved` (AI fix) o `detected → pending_fix` (manual)
-- **🛡️ Portal de pre-ingestión (v1.21.0)** — Cada archivo fuente se valida *antes* de cualquier llamada LLM: las notas vacías/en blanco/solo frontmatter son rechazadas; el dedup por hash de contenido detecta archivos idénticos a través de rutas. Previene que los modelos locales alucinen nombres de entidades en entradas vacías.
-- **📊 Panel de historial de operaciones (v1.21.0)** — UI buscable y filtrable para ingestiones pasadas, informes de lint y ejecuciones de mantenimiento, con tarjetas KPI impulsadas por insights y enlaces clickeables a páginas.
-- **🧹 Limpiador de páginas incompletas (v1.21.0)** — Las páginas que quedaron en un estado parcial tras ingestiones interrumpidas se archivan automáticamente al inicio (recuperables desde la `.trash` de Obsidian).
+- **🚫 Sin backend, sin seguimiento, sin análisis.** Se ejecuta completamente dentro de Obsidian. La red se usa solo para comunicarse con el proveedor LLM que configures.
+- **📁 Los archivos fuente son de solo lectura.** El plugin nunca modifica tus notas originales del vault — solo crea páginas nuevas dentro de `wiki/`.
+- **🦙 Modo local completo.** Ollama, LM Studio o cualquier endpoint local compatible con OpenAI → tus notas nunca salen de tu máquina.
+- **🔐 Permisos mínimos.** Acceso a archivos del vault para la gestión del wiki. Acceso al portapapeles solo cuando haces clic en el botón "Copiar" en el modal de Consulta.
 
-### 🌐 LLM & Idioma
+### 🦙 Local-first
 
-- **🔌 Multi-Provider** — Anthropic, Anthropic Compatible (Coding Plan), Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, custom endpoints
-- **🔄 5xx Retry** — Reintento automático de backoff exponencial (máx 2) en errores HTTP 5xx/429/529 en todos los clientes
-- **📋 Dynamic Model List** — Fetching en tiempo real desde APIs de provider
-- **🌐 Idioma de salida Wiki** — 10 idiomas independientes de la UI (EN/ZH simplif/ZH trad/JA/KO/DE/FR/ES/PT/IT), con input personalizado.
-- **🌍 Internacionalización completa de UI** — Interfaz del plugin en 10 idiomas (EN/ZH simplif/ZH trad/JA/KO/DE/FR/ES/PT/IT), 269+ campos UI totalmente traducidos, expresiones locales naturales.
-- **⚡ Rate Limit Guardian** — Cuando la generación paralela activa rate limits, auto-detección y sugerencias: reducir concurrencia, aumentar delay batch, cambiar provider
-- **🦙 Web Clipper Compatible** — Agregar con un clic el folder `Clippings/` de Obsidian Web Clipper a la watchlist, clips web auto-ingestados en Wiki
+- **🖥️ Ollama, LM Studio, OpenRouter, endpoint personalizado** — listos para usar. Los modelos locales funcionan para consulta (ventanas de contexto más pequeñas); la ingesta en un vault de 2000 páginas normalmente necesita un modelo cloud de contexto largo.
+- **📄 La ruta de OCR PDF es completamente local en Apple Silicon** — consulta [Rutas de OCR PDF](#-rutas-de-ocr-pdf) más abajo.
+- **🔐 ChatGPT Plan (Codex OAuth)** — callback loopback de escritorio en `127.0.0.1:1455`; móvil mediante código de dispositivo. Las credenciales viven solo en Obsidian SecretStorage; cerrar sesión las borra. Compatibilidad de terceros con Codex, no una asociación con OpenAI.
 
-### 🏗️ Arquitectura & Rendimiento
+### 🌐 Idioma
 
-- **🕸️ PPR sobre el grafo [[wiki-link]] (v1.24.0+, madurado en v1.24.1 PATCH).** Personalized PageRank (Haveliwala 2002) se ejecuta sobre el grafo dirigido de aristas `[[wiki-link]]` entre tus páginas wiki; la cascada ancla las semillas PPR en el conjunto de candidatos top-N, y el contexto multi-hop viaja hasta 3 anillos de expansión. Esto es lo que hace que las respuestas de Query Wiki tengan conciencia del grafo (una pregunta «fundadores de Microsoft» se resuelve vía Bill Gates → Microsoft → competidores, no sólo por solapamiento literal de títulos). Vaults de 2.137 páginas suelen ver <100 ms para warm + expansión de 3 saltos, independientemente del tamaño del vault. Es usado por las 4 etapas de la cascada de selección de semillas (sección Query & Feedback arriba) y por la detección de duplicados de Lint cuando enlaces indirectos conectan dos páginas candidatas.
-- **⚡ Parallel Page Generation** — 1–5 páginas concurrentes configurables, por defecto 3 (paralelo), 2–3× más rápido para sources grandes, aislamiento de errores por página
-- **📚 Iterative Batch Extraction** — El tamaño de batch adaptativo elimina el cuello de botella de max_tokens para documentos largos
-- **🏛️ Three-Layer Architecture** — Tus notas del vault (solo lectura) → `wiki/` (páginas generadas por el LLM, organizadas como `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`) → `schema/` (config co-evolucionada)
-- **🧩 Modular Codebase** — 20+ módulos enfocados en `src/`
-
-### 🔒 Privacidad y seguridad
-
-- **Sin backend, sin telemetría.** El plugin se ejecuta completamente dentro de Obsidian — no hay servidor externo, ni análisis, ni recopilación de datos de ningún tipo. Tus notas nunca salen de tu bóveda a menos que configures explícitamente un proveedor LLM.
-- **Tus datos permanecen locales por defecto.** El plugin no almacena, almacena en caché ni transmite tu contenido a ningún lugar más allá de la API LLM que elijas. Solo el texto que envías para ingesta o consulta sale de tu dispositivo — y solo al proveedor que configuraste.
-- **Modo completamente local con Ollama, LM Studio o proveedores locales.** Para una soberanía total de datos, utiliza un LLM de ejecución local. Tus notas se procesan completamente en tu máquina — nada toca Internet.
-- **Permisos mínimos.** El acceso a archivos de la bóveda es necesario para la gestión del wiki (leer notas, generar páginas, detectar enlaces rotos). El acceso a la red se usa exclusivamente para llamadas a la API LLM de tu proveedor elegido. El acceso al portapapeles se limita al botón "Copiar" en el modal de Consulta — solo cuando haces clic en él.
+- **🌍 10 idiomas de UI** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. La UI y el idioma de salida del wiki son independientes — tu wiki puede estar en chino mientras la interfaz está en inglés.
+- **📚 10 idiomas de salida del wiki** — el mismo conjunto; elige en Configuración → Wiki Configuration. Opción *Custom input* para prompts ad-hoc.
+- **🈶 269+ cadenas de UI traducidas** — cada etiqueta, modal y aviso. Añadir un 11.º idioma es impulsado por contribuciones (patrón PR #159).
 
 ---
 
+## 🔍 Cómo funciona la recuperación
+
+La mayoría de los plugins de "búsqueda AI" fragmentan tus notas en trozos y los incrustan en una base de datos vectorial. Nosotros no. El argumento de Karpathy contra RAG es que la fragmentación rompe la capacidad del LLM para razonar a través de todo tu grafo de conocimiento — y ese argumento se sostiene en la práctica. En su lugar, recorremos el grafo que ya mantienes al escribir `[[wiki-links]]`.
+
+### La cascada de selección de semillas de 5 etapas
+
+Cuando preguntas "Quién fundó Microsoft?", Query Wiki ejecuta cinco etapas antes de comenzar a generar cualquier respuesta:
+
+1. **Ruta rápida Lex** — superposición directa de tokens contra cada título de entidad/concepto y sus alias. Gratis, instantánea, y es el paso de control para todo lo que sigue.
+2. **Generación de palabras clave LLM** — el LLM propone de 8 a 12 palabras clave inter-idiomas a partir de tu consulta (maneja sinónimos, abreviaturas y términos resistentes a la superposición de tokens en una sola llamada LLM).
+3. **Escaneo local de subcadenas** — cada palabra clave generada se vuelve a cotejar localmente contra títulos de página, alias y fragmentos del cuerpo. Sin llamada LLM adicional; completa el recall tolerante al ruido.
+4. **Fallback LLM KB** — cuando lex + escaneo de palabras clave devuelven señales débiles, el LLM resiembra los N mejores candidatos contra el wiki completo en una pasada semántica.
+5. **Expansión de grafo PPR** — Personalized PageRank (Haveliwala 2002) sobre el grafo `[[wiki-link]]` partiendo del conjunto de semillas candidatas. Esto es lo que proporciona contexto multi-hop consciente del grafo: "Bill Gates" → "Microsoft" → "competidores", no solo superposición literal de títulos.
+
+La cascada se trunca en el paso que devuelva suficiente señal — sin costo fijo de 5 etapas, sin llamadas LLM cuando lex es suficiente, sin pérdida de precisión cuando se necesita aumento LLM.
+
+### Personalized PageRank a escala
+
+Usamos Monte Carlo PPR (Fogaras 2005) — 3000 caminatas aleatorias × 50 pasos cada una — con la regla de dead-end de Haveliwala 2002. El costo es **O(K × L)** independiente del número de páginas, por lo que un vault de 2000 páginas ve la misma latencia de expansión que uno de 200 páginas.
+
+**PPR @5 = 27.1% vs línea base knn puro 24.1%** en el corpus de benchmark del proyecto (el único benchmark de recuperación publicado en este espacio open-source de LLM-Wiki).
+
+### Por qué no embeddings
+
+Rechazamos deliberadamente la ruta de embeddings en [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175). La señal del grafo ya está ahí — cada `[[wiki-link]]` es una arista "estos están relacionados" curada a mano, y la mayoría de los proveedores que soportamos (Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax) no tienen ningún endpoint `/v1/embeddings`. Añadir un modelo de embeddings significaría una descarga por página, un adaptador por proveedor y cero beneficio en la calidad de recuperación.
 
 ---
 
----
+## 🤖 Modelos
 
-## 📖 Ejemplo
+**Proveedores compatibles (12+, cotejados con models.dev en 2026-07):**
 
-**Entrada:** `sources/machine-learning.md`
+| Proveedor | Series | Notas |
+|-----------|--------|-------|
+| **Anthropic** | Claude 5 series | PDF nativo; protocolo `/v1/messages` |
+| **OpenAI** | GPT-5.6 series (Sol / Terra / Luna) | PDF nativo; clave API Platform |
+| **Google Gemini** | Gemini 3.6 series | PDF nativo (file parts desde 1.5); endpoint compatible con OpenAI |
+| **DeepSeek** | DeepSeek V4 series | Compatible con OpenAI; nivel de costo más bajo |
+| **Alibaba Qwen** | Qwen3.7/3.8 series | Compatible con OpenAI (DashScope) |
+| **xAI Grok** | Grok 4 series | Compatible con OpenAI; contexto largo |
+| **Moonshot Kimi** | Kimi K3 series | Compatible con OpenAI; 2.8T MoE frontier |
+| **Zhipu GLM** | GLM-5 series | Compatible con OpenAI; bilingüe fuerte |
+| **MiniMax** | MiniMax M3 series | Compatible con OpenAI; contexto de 1M |
+| **Step (阶跃星辰)** | Step 3 series (Flash) | Compatible con OpenAI; inferencia rápida |
+| **Tencent Hunyuan** | Hy3 series | Compatible con OpenAI; MoE de peso abierto |
+| **Xiaomi MiMo** | MiMo V2.5 series | MIT open-source; precio plano |
+| **Google Gemma** | Gemma 4 series | Peso abierto; contexto 262K |
+| **AWS Bedrock** | Variantes Anthropic + OpenAI | Ruta VPC / cumplimiento normativo |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | Inicio de sesión por navegador/código de dispositivo; SecretStorage |
+| **Local: Ollama, LM Studio, OpenRouter, Anthropic-Compatible** | Cualquier modelo de protocolo OpenAI-/Anthropic- | Custom OpenAI-Compatible + Anthropic-Compatible (Token Plan / Coding Plan) |
 
-```markdown
-### Machine Learning
-Machine learning usa algoritmos para aprender de datos.
+Este plugin alimenta al LLM con el contexto completo de tu Wiki por consulta — por lo que **los modelos de contexto largo ganan**. La tabla completa por niveles (cloud + local) vive en [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md), cotejada con [models.dev](https://models.dev/) para que las recomendaciones se mantengan actualizadas.
 
-### Tipos
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+### Qué importa
 
-**Salida — Entity page:** `wiki/entities/supervised-learning.md`
+- **🧠 Ventana de contexto ≥ 200K tokens** para vaults de más de ~500 páginas. Por debajo de 200K, el contexto ensamblado de la cascada empieza a truncarse.
+- **⚖️ La calidad de seguimiento de instrucciones importa más que el IQ bruto** para la tarea de extracción — elige un modelo que siga la plantilla del esquema, no el número más grande en el leaderboard.
+- **🔌 El endpoint de embeddings es irrelevante** — no usamos embeddings. Un proveedor que carezca de `/v1/embeddings` funciona bien (la mayoría de nuestros 12+ proveedores lo son).
+- **🦙 Local funciona para consulta, cloud para ingesta** — la ingesta en un vault de 2000 páginas normalmente necesita un modelo cloud de contexto largo; un modelo local de 262K cubre la mayoría de las consultas.
 
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["Supervisado", "Supervised Learning"]
----
+### Anthropic vs OpenAI vs Codex OAuth — son proveedores distintos
 
-### Supervised Learning
+- **Anthropic** (y su variante Bedrock) — clave API de Anthropic Platform facturada por separado.
+- **OpenAI** — clave API de OpenAI Platform facturada por separado.
+- **ChatGPT Plan (Codex OAuth)** — experimental, proveedor distinto que usa la asignación Codex elegible después de iniciar sesión por navegador o código de dispositivo; la disponibilidad sigue las políticas de autenticación y asignación de OpenAI Codex, no el nombre del plan. Compatibilidad de terceros con Codex, no una asociación con OpenAI ni una API general de ChatGPT.
 
-### Información Básica
-- Type: method
-- Source: [[sources/machine-learning]]
-
-### Descripción
-Supervised learning es un paradigma de machine learning donde los modelos aprenden
-de datos de entrenamiento etiquetados para hacer predicciones sobre datos no vistos...
-
-### Conceptos Relacionados
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### Entities Relacionados
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### Menciones en Source
-- "Supervised learning usa datos etiquetados para entrenar modelos predictivos..."
-```
+> 📖 **Tabla completa de selección** (cloud + local + OCR PDF + Codex OAuth + cuantización + niveles de hardware) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
 ---
-
-## 🤖 Guía de Selección de Models
-
-Este plugin sigue la filosofía de Karpathy: **alimentar al LLM con el contexto completo del Wiki, no con recuperación RAG fragmentada**. Se recomiendan fuertemente los models de long-context: cuanto más crece tu Wiki, más contexto necesita el LLM.
-
-> 💡 **¿Por qué no RAG?** La [crítica original de Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) argumenta que RAG fragmenta el conocimiento y rompe la capacidad del LLM para razonar a través del grafo de conocimiento completo.
-
-**🌟 Recomendaciones principales:**
-
-### ☁️ Modelos en la nube
-
-| Tier | Model | Context Window | Por qué |
-|------|-------|---------------|---------|
-| **🌟 Valor** | **DeepSeek V4-Flash** | 1M tokens | Precio más bajo ($0.14/M), 284B MoE, ideal para ingestión batch |
-| **🌟 Valor** | **Gemini-3.5-Flash** | 1M tokens | 4× más rápido que GPT-5.5, excelente para tareas agent |
-| **🌟 Valor** | **Qwen3.6-Plus** | 1M tokens | Fuerte capacidad coding & agent, precio competitivo |
-| **🌟 Valor** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **Balanceado** | **Claude Sonnet 4.6** | 1M tokens | Buen equilibrio calidad/costo, $3/$15 por millón de tokens |
-| **Ligero** | **Claude Haiku 4.5** | 200K tokens | Rápido y económico, para wikis pequeños |
-| **Económico** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE, open-source MIT 2026-04, agente y multimodal |
-| **Flagship** | Claude Opus 4.7 | 1M tokens | Calidad máxima, costo alto — usar selectivamente |
-| **Flagship** | GPT-5.5 | 1M tokens | Razonamiento top, costo alto — usar selectivamente |
-
-### 🦙 Modelos locales (Ollama / LM Studio)
-
-La inferencia local gana en soberanía de datos, uso sin conexión y cero coste de API. La contraprestación es una ventana de contexto menor (suelen estar entre 8K–128K; las familias open-weight recientes llegan a 262K) y un seguimiento de instrucciones más débil frente a los modelos cloud flagship. **Elige según tu presupuesto de hardware:** más parámetros = más conocimiento del mundo y mejor fidelidad a las instrucciones (mayor calidad de extracción, menos alucinaciones); menos parámetros = más velocidad y holgura de memoria, a costa de más alucinaciones y razonamiento de contexto largo más débil. El sweet spot en 24 GB Apple Silicon o una GPU de consumo única es la clase 27B–35B-A3B.
-
-| Model | Parámetros | Contexto | Por qué |
-|-------|------------|----------|---------|
-| **Qwen3.5 27B** | 27B dense | 262K | Mejor equilibrio calidad/tamaño para ingestión; MLX 4-bit cabe en 24 GB |
-| **Qwen3.5 35B-A3B** | 35B total / 3B activos MoE | 262K | Más rápido que 27B dense con calidad similar; ahorrador ideal de memoria |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | Techo de calidad; requiere ≥48 GB VRAM o doble GPU |
-| **Qwen3.6 27B** | 27B dense | 256K+ | Refresh 2026-04 sobre Qwen3.5 27B — preferido si tu hardware lo soporta |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Misma disyuntiva que Qwen3.5 35B-A3B, con pesos más nuevos |
-| **Gemma 4 31B IT** | 31B dense | 262K | Fuerte seguimiento de instrucciones, salida Markdown limpia |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Menos memoria que 31B dense con calidad comparable |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | Ejecutable en CPU pura; solo para wikis pequeños o vistas previas rápidas |
-
-**Cuantización:** MLX 4-bit en Apple Silicon suele ser 1,5–2× más rápido que GGUF Q4_K_M a la misma tasa de bits efectiva. GGUF Q4_K_M es la opción por defecto multiplataforma; pasa a Q5/Q8 solo si tienes holgura de VRAM y notas regresión de calidad en Q4.
-
-**Estrategia de contexto:** Cuando tu Wiki crece por encima de ~500 páginas, un modelo local de 262K aún cubre la mayor parte del contexto que ensambla el motor de Query, pero la ingestión de un vault de 2000 páginas lo sobrepasará. Patrón habitual: cloud para ingestión + local para query. Para setups totalmente locales, la clase 27B/35B-A3B es el sweet spot.
-
-### 📄 Ruta OCR PDF local (v1.25.0+)
-
-La ingesta de PDF de v1.25.0 funciona con cualquier proveedor que acepte PDF como parte de archivo. Para un pipeline totalmente local en Apple Silicon (la única plataforma que oMLX soporta actualmente), esta es la configuración recomendada:
-
-1. Instala [oMLX](https://github.com/jundot/omlx) y activa su backend integrado **Markitdown** (conversión local PDF→Markdown).
-2. Carga **Baidu Unlimited-OCR** (open-source el 22/06/2026, 3B total / 0,5B activos, OCR de extremo a extremo que maneja documentos largos sin el modo de fallo "cuanto más genera, más lento va" de los modelos OCR antiguos) como modelo de visión en oMLX.
-3. En este plugin: elige el proveedor **Custom OpenAI-Compatible** (oMLX habla el protocolo compatible con OpenAI), apunta la Base URL al servidor local de oMLX, activa **Force PDF Support** en Settings → LLM Configuration → Advanced, y elige el modelo multimodal que sirve oMLX para el resumen de la ingestión.
-
-El PDF nunca sale de tu máquina — Markitdown hace la conversión estructural en local, Unlimited-OCR el reconocimiento visual en local, y el LLM local el resumen en local. La caché del plugin (`.obsidian/plugins/karpathywiki/pdf-cache/`) mantiene las re-ingestiones instantáneas.
-
-**Fallback:** si oMLX/Markitdown no está disponible (Linux/Windows o Macs antiguos), apunta **Force PDF Support** directamente a un LLM multimodal local que acepte partes de archivo PDF — la calidad es buena cuando el modelo es suficientemente grande, pero los requisitos de VRAM crecen de forma pronunciada con el número de páginas.
-
-**🔌 Anthropic Compatible (Coding Plan):** Si tu provider ofrece un endpoint de API compatible con Anthropic, selecciona "Anthropic Compatible" e ingresa el Base URL y API Key de tu provider.
-
-**🦙 Ollama (local, sin clave API):** Instala [Ollama](https://ollama.com), descarga un modelo (`ollama pull gemma4` o `ollama pull qwen3.5:27b`), selecciona "Ollama (Local)" en el desplegable de provider.
-
-**🎛️ LM Studio (local, sin clave API):** Instala [LM Studio](https://lmstudio.ai), inicia su servidor local (por defecto `http://localhost:1234/v1`), selecciona "LM Studio (Local)" en el desplegable de provider. LM Studio ejecuta un servidor compatible con OpenAI integrado — el campo de clave API es opcional.
-
-> 💡 **Límite de facturación de OpenAI:** **OpenAI** usa una clave de Platform facturada por separado. **ChatGPT Plan (Codex OAuth)** es un proveedor experimental independiente que usa una asignación Codex elegible tras iniciar sesión por navegador o código de dispositivo; el nombre del plan no garantiza disponibilidad.
-
----
-
-## 🏗️ Arquitectura
-
-Diseño de tres capas de Karpathy:
-
-```
-📄 Tus notas del vault (cualquier carpeta)   # 📖 Tú eliges qué notas ingestar
-  ↓ ingest
-wiki/                                         # 🧠 Páginas Wiki generadas por el LLM (wiki/sources/, wiki/entities/, wiki/concepts/)
-  ↓ query / maintain
-schema/                                       # 📋 Configuración de estructura Wiki
-```
-
-> 📖 Ver la estructura completa del código en [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure).
-
-**Páginas generadas:**
-- wiki/sources/filename.md — 📄 Resumen de la fuente
-- wiki/entities/entity-name.md — 👤 Páginas de entidades
-- wiki/concepts/concept-name.md — 💡 Páginas de conceptos
-- wiki/index.md — 📑 Índice generado automáticamente
-- wiki/log.md — 📝 Registro de operaciones
-
----
-
----
-
 
 ## ❓ FAQ
 
-> **Mantén tu plugin actualizado.** Ejecuta **Configuración → Plugins comunitarios → Buscar actualizaciones** regularmente.
->
-> 📖 Más FAQ en [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28).
+### Qué hace exactamente el plugin?
 
-**¿Qué hace exactamente este plugin?**
-Elige cualquier nota, carpeta o selección múltiple de tu vault; el LLM extrae entidades y conceptos y genera un Wiki interconectado con `[[wiki-links]]`. Obtén respuestas basadas en *tus* notas — no búsqueda en Internet. Los resúmenes generados viven bajo `wiki/sources/`, las entidades bajo `wiki/entities/`, los conceptos bajo `wiki/concepts/` — tus notas originales del vault nunca se modifican.
+Elige cualquier nota, carpeta o selección; el LLM extrae entidades y conceptos y genera un wiki interconectado con `[[enlaces bidireccionales]]`. Haz preguntas y recibe respuestas conversacionales basadas en *tus* notas, no en internet. Tus notas originales del vault nunca se modifican.
 
-**¿Mis datos se envían a terceros?**
-🔒 **Privacidad primero.** Sin backend, sin seguimiento, sin análisis — el plugin funciona completamente dentro de Obsidian. Solo el texto que envías explícitamente sale de tu dispositivo.
+### Cómo empiezo?
 
-**¿En qué se diferencia de los chatbots RAG?**
-LLM-Wiki ejecuta un motor **Personalized PageRank** sobre tu grafo `[[wiki-link]]` — encontrando páginas mediante estructura de enlaces, no embeddings. Costo cero, sin nuevas dependencias.
+Instala desde Plugins Comunitarios de Obsidian → elige un proveedor → **Test Connection** → ejecuta **Ingest single source** en cualquier nota. Las primeras páginas wiki aparecen en segundos. Consulta [Inicio rápido](#-inicio-rápido).
 
-**¿Qué LLM debería usar?**
-Modelos de contexto largo (≥200K tokens). Opciones económicas: DeepSeek V4-Flash ($0.14/M), Gemini 3.5 Flash, Qwen3.6-Plus.
+### Mi wiki existente está segura?
 
-**¿Cómo empiezo?**
-Instala → elige proveedor LLM → **Test Connection** → ejecuta **Ingest single source** (o **Ingest from folder**) sobre cualquier nota de tu vault → tus primeras páginas Wiki aparecen en segundos. Ver [Inicio rápido](#-inicio-rápido) arriba.
+✅ Retrocompatible desde v1.0.0. Establece `reviewed: true` en cualquier página para protegerla contra sobrescritura. Actualizar desde v1.24.x no reescribe tu vault; la ingesta de PDF de v1.25.0 es solo caché por defecto.
 
-**¿Cómo controlo costos de API?**
-Granularidad Gruesa o Mínima para lotes. Smart Batch Skip salta archivos ya procesados. Mantenimiento automático DESACTIVADO por defecto.
+### Mis datos se envían a algún sitio?
 
-**¿Mi wiki está segura?**
-✅ Retrocompatible desde v1.0.0. `reviewed: true` protege páginas de sobrescritura. El plugin nunca modifica tus notas originales del vault — solo genera nuevas páginas dentro de la carpeta `wiki/`.
+🚫 Sin backend, sin análisis — el plugin se ejecuta completamente dentro de Obsidian. Solo el texto que envías explícitamente para ingesta/consulta sale de tu dispositivo, y solo al proveedor LLM que configures. Para localidad completa de datos, usa Ollama o LM Studio.
 
-**¿Puedo usar el plugin en mi idioma?**
-🌐 **10 idiomas** para UI y salida Wiki: English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano.
+### Puedo usar el plugin en mi idioma?
 
-**¿Requisitos mínimos?**
-Obsidian v1.11.4+ (escritorio o móvil). Se requiere una clave API LLM, Ollama/LM Studio local o credenciales autorizadas de ChatGPT Plan (Codex OAuth). El **guardián llmReady** requiere Test Connection.
+🌍 10 idiomas tanto para la UI como para la salida del wiki. La UI y el idioma del wiki son independientes. Añadir un 11.º idioma es impulsado por contribuciones (patrón PR #159).
 
-**¿Cómo cancelar una operación?**
-Barra de estado o `Cmd+P` → "Cancel current ingestion".
+### En qué se diferencia de un chatbot RAG?
 
-**¿Dónde obtener ayuda?**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — reportar errores
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — preguntas
-- Consola (`Ctrl+Shift+I`) — copia logs
+🚫 Sin fragmentación. 🚫 Sin embeddings. 🚫 Sin BD vectorial. ✅ Personalized PageRank sobre tu grafo `[[wiki-link]]` existente — contexto multi-hop consciente del grafo, cero costo de embeddings, soporte completo de modelos locales.
 
-## 🔒 Transparencia y cumplimiento
+### Qué LLM debería usar?
+
+Los modelos de contexto largo (≥200K tokens) funcionan mejor. La [sección Modelos](#-modelos) cubre los principios; la tabla completa por niveles está en [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md).
+
+### Hay un benchmark publicado?
+
+Sí — PPR @5 = 27.1% vs línea base knn puro 24.1% en el corpus del proyecto. El pipeline completo y el script de benchmark se describen en [Cómo funciona la recuperación](#-cómo-funciona-la-recuperación).
+
+### Cómo controlo los costos de API?
+
+Usa granularidad Gruesa o Mínima para ingesta por lotes. Smart Batch Skip detecta automáticamente archivos ya procesados. El Mantenimiento Automático está DESACTIVADO por defecto. Lint muestra recuentos antes de ejecutar correcciones — no se cobra nada sin tu aprobación.
+
+### Cómo cancelo una operación en curso?
+
+Haz clic en la barra de estado (muestra "Ingesting… click to cancel") o `Cmd+P/Ctrl+P` → "Cancel current ingestion". Se detiene limpiamente en el próximo límite de lote.
+
+### Dónde obtengo ayuda?
+
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) para informes de errores · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) para preguntas y solicitudes de funciones · Consola del desarrollador (`Ctrl+Shift+I` / `Cmd+Option+I`) para los registros del plugin.
+
+---
+
+## 🔒 Privacidad
 
 Este plugin está listado en el Mercado de Plugins Comunitarios de Obsidian y se somete a revisión automatizada de seguridad y permisos.
 
-**El plugin no tiene backend, ni infraestructura de servidor, ni recopilación de datos de ningún tipo.** Es software puramente local que se ejecuta dentro de Obsidian. El plugin no puede ni recopila, almacena o transmite tus datos a ningún servidor — porque dicho servidor no existe.
+- **🚫 Sin backend, sin servidor, sin recopilación de datos.** Software puramente local que se ejecuta dentro de Obsidian. El plugin no puede ni recopila, almacena ni transmite tus datos a ningún servidor — porque dicho servidor no existe.
+- **🔐 El acceso a la red es opt-in.** Se usa únicamente para comunicarse con el proveedor LLM que configures. Tú eliges el proveedor, tú introduces la clave API, tú decides a dónde van tus datos.
+- **📁 El acceso a los archivos del vault** se usa para la gestión del wiki (leer notas, generar páginas, escanear enlaces rotos, detectar duplicados). El plugin nunca modifica tus archivos fuente.
+- **📋 El acceso al portapapeles** se usa exclusivamente por el botón "Copiar" en el modal de Consulta, y solo cuando haces clic en él.
 
-**El acceso a la red** se utiliza solo para comunicarse con el proveedor LLM que configures — no se realizan otras llamadas de red. Esto está completamente bajo tu control: tú eliges el proveedor, tú introduces la clave API, tú decides a dónde van tus datos.
+Para una localidad completa de datos, utiliza Ollama o LM Studio. Con un proveedor local, tus datos nunca salen de tu máquina.
 
-**El acceso al sistema de archivos** (enumeración de la bóveda) es necesario para construir y mantener el wiki: leer tus notas fuente, generar páginas, escanear enlaces rotos y detectar páginas duplicadas. El plugin nunca modifica tus archivos fuente — solo los archivos dentro de la carpeta wiki.
-
-**El acceso al portapapeles** se usa exclusivamente por el botón "Copiar" en el modal de Consulta, y solo cuando haces clic en él.
-
-Si prefieres una localidad completa de datos, utiliza un proveedor LLM local como Ollama o LM Studio. Con un proveedor local, tus datos nunca salen de tu máquina.
+---
 
 ## 💖 Apoyar el proyecto
 
-Si LLM-Wiki se ha convertido en una parte importante de tu flujo de trabajo de conocimiento, puedes apoyar su desarrollo continuo:
+Si LLM-Wiki se ha convertido en una parte importante de tu flujo de trabajo de conocimiento:
 
-- ☕ **[Invítame a un café en Ko-fi](https://ko-fi.com/greenerdalii)** — apoyo único o mensual vía Ko-fi
-- 💳 **[Propina vía PayPal](https://paypal.me/greenerdalii)** — propina única vía PayPal
+- ☕ **[Invítame a un café en Ko-fi](https://ko-fi.com/greenerdalii)** — apoyo único o mensual
+- 💳 **[Propina vía PayPal](https://paypal.me/greenerdalii)** — propina única
 
 El patrocinio es totalmente opcional. El plugin sigue siendo Apache-2.0 y completo en funciones.
 
-### Patrocinadores
+Gracias a [@jameses-cyber](https://github.com/jameses-cyber) y [@issaqua](https://github.com/issaqua) por apoyar el proyecto.
 
-Gracias a las siguientes personas por apoyar el proyecto:
+---
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
+## 📜 Licencia y créditos
 
-## 📜 Licencia
+Apache License, Versión 2.0 — consulta [LICENSE](../LICENSE) y [NOTICE](../NOTICE).
 
-Apache License 2.0 — consulta [LICENSE](LICENSE) y [NOTICE](NOTICE).
+**Construido sobre:**
+- 💡 [LLM Wiki de Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — el concepto original
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) y [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — algoritmos de recuperación
 
-## 🙏 Agradecimientos
+**Mantenedor:** [@green-dalii](https://github.com/green-dalii)
 
-- **💡 Concepto:** [LLM Wiki de Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — la visión original que inspiró este plugin
-- **🛠️ Plataforma:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 Transporte LLM:** [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -2,485 +2,330 @@
 
 # 🧠 Karpathy LLM Wiki — Plugin Obsidian
 
-> Base de connaissances structurée alimentée par IA. Ingestion automatique des notes et génération d'un Wiki interconnecté — inspiré du concept de [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) d'Andrej Karpathy.
+> Plugin Obsidian qui transforme vos notes en une base de connaissances interconnectee et questionnable — l'idee de [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) d'Andrej Karpathy, integree dans l'editeur ou vous ecrivez deja.
 
-> **Note officielle Obsidian 95/100 | Support natif de 10 langues | Recherche par graphe sans embedding | Souveraineté totale des données | Compatible avec tout fournisseur LLM**
+> **Recherche par graphe sans embedding • 10 langues natives • Fonctionne avec tous les fournisseurs**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | **Français** | [Español](README_ES.md) | [Português](README_PT.md) | [Italiano](README_IT.md)
 
-[Site officiel](https://llmwiki.greenerai.top/) | [Marketplace Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Retour d'expérience](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[Site officiel](https://llmwiki.greenerai.top/) | [Marketplace Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [Démarrage rapide](#-démarrage-rapide) | ✨ [Fonctionnalités](#-fonctionnalités) | 🤖 [Guide de sélection de modèle](#-guide-de-sélection-de-modèle) | 🔒 [Transparence et conformité](#-transparence-et-conformité) | ❓ [FAQ](#-faq)
+📑 [Sommaire](#-sommaire) • 🚀 [Démarrage rapide](#-démarrage-rapide) • ✨ [Fonctionnalités](#-fonctionnalités) • 🔍 [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche) • 🤖 [Modèles](#-modèles) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Si ce plugin t'a aidé, offre-moi un café♥️ ou dépose une étoile🌟↗
 
 ---
 
-> **⚡ Avis de mise à jour rapide：** Ce projet évolue rapidement – corrections de bugs, améliorations de performances, nouvelles fonctionnalités et optimisations UX sont fréquentes. Nous vous recommandons de mettre à jour régulièrement dans Obsidian (**Paramètres → Plugins communautaires → Vérifier les mises à jour**) ou d'activer la mise à jour automatique des plugins.
+## 📑 Sommaire
 
-## 📑 Contents
-
-- [🧠 Karpathy LLM Wiki — Plugin Obsidian](#-karpathy-llm-wiki--plugin-obsidian)
-  - [📑 Contents](#-contents)
-  - [💡 Présentation](#-présentation)
-  - [⚡ Pourquoi Obsidian + LLM-Wiki ?](#-pourquoi-obsidian--llm-wiki-)
-  - [🚀 Démarrage rapide](#-démarrage-rapide)
-    - [📦 Installation](#-installation)
-    - [🔄 Mise à jour](#-mise-à-jour)
-    - [🔑 Configurer un fournisseur LLM](#-configurer-un-fournisseur-llm)
-    - [🎮 Utilisation](#-utilisation)
-    - [⚠️ Mise à niveau depuis une ancienne version ?](#️-mise-à-niveau-depuis-une-ancienne-version-)
-  - [⚡ Nouveautés v1.25.x](#-nouveautés-v125x)
-  - [✨ Fonctionnalités](#-fonctionnalités)
-    - [📊 Qualité des connaissances](#-qualité-des-connaissances)
-    - [📄 Ingestion PDF (v1.25.0)](#-ingestion-pdf-v1250)
-    - [💬 Query et feedback](#-query-et-feedback)
-    - [🛠️ Maintenance](#️-maintenance)
-    - [🌐 LLM et langue](#-llm-et-langue)
-    - [🏗️ Architecture et performance](#️-architecture-et-performance)
-    - [🔒 Confidentialité et sécurité](#-confidentialité-et-sécurité)
-  - [📖 Exemple](#-exemple)
-  - [🤖 Guide de sélection de modèle](#-guide-de-sélection-de-modèle)
-    - [☁️ Recommandations cloud](#️-recommandations-cloud)
-    - [🦙 Recommandations locales (Ollama / LM Studio)](#-recommandations-locales-ollama--lm-studio)
-    - [📄 Voie OCR PDF locale (v1.25.0+)](#-voie-ocr-pdf-locale-v1250)
-  - [🏗️ Architecture](#️-architecture)
-  - [❓ FAQ](#-faq)
-  - [🔒 Transparence et conformité](#-transparence-et-conformité)
-  - [💖 Soutenir le projet](#-soutenir-le-projet)
-    - [Sponsors](#sponsors)
-  - [📜 Licence](#-licence)
-  - [🙏 Remerciements](#-remerciements)
-  - [Star History](#star-history)
-
-## 💡 Présentation
-
-Vous écrivez. L'IA organise. Vous interrogez. Rien de plus.
-
-**🎯 Le problème.** Vos notes constituent une mine d'informations — personnes, concepts, idées, connexions. Pourtant, elles ne sont que des fichiers dans des dossiers. Identifier les liens entre elles nécessite de chercher, taguer et espérer retrouver le fil.
-
-**✨ La solution.** [Andrej Karpathy a proposé](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) une approche élégante : traiter vos notes comme des matières premières et confier à un LLM le rôle d'architecte. Il analyse vos écrits, extrait les Entity et Concept, puis les intègre dans un Wiki structuré — doté de `[[Wiki-links]]` bidirectionnels, d'un index auto-généré et d'une interface conversationnelle répondant aux questions à partir de *vos* connaissances.
-
-**📚 Libérez-vous du rôle de bibliothécaire.** Plus besoin de décider ce qui mérite une page. Plus besoin de maintenir les liens croisés. Plus besoin de vérifier l'obsolescence. Choisissez n'importe quelle note (ou dossier, ou sélection multiple) de votre vault — le LLM lit, extrait, rédige, relie et signale les contradictions — pendant que vous restez concentré sur l'essentiel.
-
-**🤖 Ce n'est pas un chatbot de plus.** ChatGPT connaît Internet. LLM-Wiki connaît *vous* — ou plutôt, ce que vous lui avez enseigné. Chaque réponse intègre des `[[Wiki-links]]` vers votre graphe de connaissances. Chaque réponse est un point de départ, jamais une impasse.
+- [Pourquoi ce plugin ?](#-pourquoi-ce-plugin-)
+- [Est-ce pour moi ?](#-est-ce-pour-moi-)
+- [Démarrage rapide](#-démarrage-rapide)
+- [Fonctionnalités](#-fonctionnalités)
+- [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche)
+- [Modèles](#-modèles)
+- [FAQ](#-faq)
+- [Confidentialité](#-confidentialité)
+- [Soutien](#-soutien)
+- [Licence et crédits](#-licence-et-crédits)
 
 ---
 
-## ⚡ Pourquoi Obsidian + LLM-Wiki ?
+## 🤔 Pourquoi ce plugin ?
 
-Obsidian excelle dans la pensee liee. Mais il y a un hic : c'est vous qui faites tous les liens.
+Vous prenez des notes. Elles restent dans des dossiers. Retrouver ce qui se relie à quoi signifie se souvenir de fils que vous avez perdus de vue il y a des mois.
 
-LLM-Wiki inverse la donne. Au lieu de construire le graphe a la main, l'IA le developpe avec vous. Ajoutez une note sur un nouveau concept — elle trouve les connexions que vous auriez manquees. Posez une question — elle parcourt votre propre graphe de connaissances et revient avec des reponses citees.
+**D'autres réimplémentations open-source de l'idée LLM Wiki de Karpathy existent — mais aucune ne se livre comme un plugin Obsidian en un clic.** La plupart sont des outils CLI, des skills Claude Code ou des applications de bureau séparées. Nous sommes le seul à proposer une UI native, un stockage dans le coffre et le Graph View natif d'Obsidian.
 
-- **🔗 Votre Graph View prend vie.** Les nouvelles notes ne restent pas inertes — elles germent des liens vers des entites, des concepts et des sources. Le graphe grandit de maniere organique, et le plugin l'entretient : detection des doublons, correction des liens morts, ponts entre langues via les aliases.
-- **💬 Vos notes apprennent a vous repondre.** La recherche devient conversation. « Qu'ai-je ecrit sur X ? » devient un dialogue, avec des reponses en streaming et des `[[wiki-links]]` comme fil d'Ariane. Chaque reponse est un chemin plus profond dans vos propres connaissances.
-- **🧠 Obsidian devient un partenaire de reflexion.** Il cesse d'etre un simple classeur a notes et devient un outil qui vous aide a *penser* — revelant des connexions cachees, signalant les contradictions, se rappelant ce que vous aviez oublie.
+### Comparaison
+
+| | Karpathy LLM Wiki (ce plugin) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **Format de livraison** | ✅ Plugin Obsidian en un clic | ❌ Application Tauri séparée | ❌ Skill Claude Code | ❌ Skill Claude Code / Codex | ❌ CLI + SDK + serveur MCP |
+| **Effort d'installation** | ✅ **5 minutes** — Plugins communautaires → Installer → choisir un fournisseur → Ingester | ❌ 30 min+ — compiler/télécharger un binaire, configurer CLI | ❌ 15 min — nécessite abonnement Claude Code + installation skill | ❌ 10 min — nécessite abonnement Claude Code/Codex + configuration | ❌ 30 min+ — pip install + SDK + config MCP |
+| **Chemin d'installation** | ✅ Obsidian → Plugins communautaires → rechercher → Installer | ❌ Compiler ou télécharger un binaire séparé, puis configurer CLI | ❌ Nécessite abonnement Claude Code + guide d'installation | ❌ Nécessite abonnement Claude Code ou Codex + étapes de configuration | ❌ pip install + Python SDK + serveur local |
+| **Complexité architecturale** | ✅ **Zéro dépendance** — pas de BD vectorielle, pas de modèle d'embedding, pas de processus externe | 🟡 Embarque son propre runtime Python + sigma.js + sqlite | 🟡 Utilise l'environnement Claude Code — pas autonome | 🟡 Nécessite une plateforme d'exécution séparée | ❌ Nécessite Python, modèle d'embedding, BD vectorielle |
+| **i18n (UI + sortie Wiki)** | ✅ 10 langues (UI / sortie indépendantes) | 🟡 2 (EN / 中文) | ❌ Anglais uniquement | ❌ Anglais uniquement | ❌ Anglais uniquement |
+| **Fournisseurs LLM** | ✅ 12+ (dont Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-compatible, Kimi, GLM, MiniMax, DeepSeek) | 🟡 Compatible OpenAI | 🟡 Abonnement via Claude Code | 🟡 Abonnement via Claude Code / Codex | 🟡 Compatible OpenAI |
+| **Algorithme de recherche** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 Heuristique 4 signaux (Adamic-Adar + décroissance 2-sauts) | ❌ Détection de communautés Louvain uniquement | ❌ Louvain + aperçus k-hop | ❌ Hybride : BM25 + sémantique + wikilink |
+| **Pipeline de requête (cascade 5 étapes)** | ✅ Lex → mots-clés LLM → scan sous-chaîne → fallback LLM KB → expansion PPR (troncature dès signal suffisant) | 🟡 Décroissance 2-sauts uniquement | ❌ Clustering Louvain uniquement | ❌ Aperçus k-hop (sans augmentation LLM) | ❌ BM25 + sémantique sur chunks (sans graphe) |
+| **Embeddings requis** | ✅ Non (zéro coût d'embedding, par conception) | 🟡 Optionnel, désactivé par défaut | ✅ Non | ✅ Non | ❌ **Oui — obligatoire** |
+| **Visualisation du graphe** | ✅ Graph View natif d'Obsidian (intégré, zéro taille supplémentaire) | ❌ sigma.js + graphology personnalisés dans l'appli bureau | 🟡 graph.html vis.js (fichier séparé) | ❌ sigma.js HTML hors ligne personnalisé | ❌ Visualiseur navigateur lecture seule |
+| **Honnêteté Wiki** | ✅ Bannière « Stage FALLBACK » quand aucune source wiki ne correspond à votre requête | ❌ Pas d'équivalent | ❌ Pas d'équivalent | ❌ Pas d'équivalent | ❌ Pas d'équivalent |
+| **Benchmark de recherche publié** | ✅ PPR @5 = 27,1 % vs kNN pur 24,1 % (seul chiffre publié dans cet espace) | ❌ 58 % → 71 % *uniquement avec embeddings*, pas dans notre format comparable | ❌ Non publié | ❌ Non publié | ❌ Non publié |
+
+### Trois choix délibérés, pas accidentels
+
+- **🪟 Obsidian est l'environnement d'exécution.** Pas de terminal, pas d'application séparée, pas de Docker, pas de Python. Installez depuis les Plugins communautaires, cliquez sur Ingester, le wiki vit dans votre coffre dès la première seconde. Le Graph View natif d'Obsidian rend votre graphe de `[[wiki-links]]` — intégré, zéro taille de bundle supplémentaire.
+- **🧭 Propre et autonome.** Zéro dépendance. Pas de modèle d'embedding, pas de base de données vectorielle, pas de package pip — un seul plugin qui lit vos notes, dialogue avec un LLM et écrit des pages wiki. Tout vit dans Obsidian.
+- **🔌 N'importe quel modèle que vous payez déjà.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-compatible, endpoint personnalisé — douze fournisseurs et plus, aucun n'a besoin d'un endpoint d'embedding.
+
+---
+
+## 🎯 Est-ce pour moi ?
+
+**✅ Oui, si vous :**
+
+- **Voulez une installation en 5 minutes, pas un projet de 5 heures.** Installez depuis les Plugins communautaires → choisissez un fournisseur → Ingérez une note. Pas de CLI, pas de Python, pas d'environnement d'exécution séparé, pas de BD vectorielle. Vous voyez des pages wiki dans `wiki/` en quelques secondes.
+- **Voulez quelque chose de propre et autonome.** Le plugin a exactement zéro dépendance externe : pas de modèle d'embedding, pas de base de données vectorielle, pas de package pip, pas de conteneur Docker. C'est un seul plugin Obsidian qui lit vos notes, dialogue avec un LLM et écrit des pages wiki dans votre coffre. Tout vit dans Obsidian.
+- **Voulez un chat questionnable qui répond à partir de *vos* notes** — pas d'Internet — chaque réponse étant accompagnée de `[[wiki-links]]` vers votre graphe de connaissances.
+- **Tenez à la souveraineté des données** — fonctionne entièrement en local avec Ollama ou LM Studio, sans jamais toucher à Internet.
+- **Écrivez ou lisez dans l'une des 10 langues prises en charge** — la langue de l'UI et celle du wiki sont indépendantes (votre wiki peut être en chinois pendant que l'interface est en anglais).
+- **Maintenez le graphe en écrivant des `[[wiki-links]]`** — chaque lien que vous écrivez enrichit déjà la recherche ; aucune étape séparée de tagging/embedding/indexation.
+- **Voulez une maintenance en un clic** — Lint (analyse de santé) + Smart Fix All maintiennent doublons, liens morts et pages orphelines sous contrôle sans curation manuelle.
+
+**❌ Non, si vous :**
+
+- **Voulez un remplacement généraliste de ChatGPT** — ce plugin répond uniquement à partir de *vos* connaissances.
+- **Avez besoin d'un pipeline RAG sur des PDF / pages web / corpus externes** — nous nous concentrons sur le chemin dans le coffre (les PDF sont pris en charge depuis la v1.25.0).
+- **Cherchez un SaaS hébergé** — il n'y a pas de backend, pas de serveur, pas de compte.
 
 ---
 
 ## 🚀 Démarrage rapide
 
-### 📦 Installation
+1. **Installez.** Obsidian → Paramètres → Plugins communautaires → Parcourir → recherchez « Karpathy LLM Wiki » → Installer → Activer. Ou visitez la [page du plugin communautaire](https://community.obsidian.md/plugins/karpathywiki) et cliquez sur **Ajouter à Obsidian**.
+2. **Configurez un fournisseur.** Ouvrez Paramètres → Karpathy LLM Wiki → choisissez un fournisseur (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth), etc.) → entrez la clé API (pas nécessaire pour le local) → cliquez sur **Test Connection** → Enregistrez.
+3. **Ingérez une note.** `Cmd+P/Ctrl+P` → « Ingest single source » → choisissez n'importe quel fichier Markdown (ou PDF, v1.25.0+). Vos premières pages wiki apparaissent dans `wiki/sources/`, `wiki/entities/`, `wiki/concepts/` en quelques secondes.
 
-**🌟 Recommandé — Marché des plugins communautaires Obsidian :**
-1. Dans Obsidian, allez dans **Paramètres → Plugins communautaires**
-2. Cliquez sur **Parcourir** et recherchez « Karpathy LLM Wiki »
-3. Cliquez sur **Installer**, puis **Activer**
+C'est tout. Le plugin ne modifie rien dans vos notes originales — il crée uniquement de nouvelles pages dans `wiki/`. Pour discuter avec votre wiki : `Cmd+P/Ctrl+P` → « Query wiki ». (`Cmd` sur macOS, `Ctrl` sur Windows/Linux.)
 
-**🌐 Ou depuis le site des plugins communautaires —** visitez [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) et cliquez sur **Add to Obsidian**.
+### Commandes principales
 
-**⚙️ Manuel (alternative) :**
-1. Téléchargez `main.js`, `manifest.json`, `styles.css` depuis les [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
-2. Dans Obsidian, allez dans Paramètres → Plugins communautaires. Cliquez sur l'icône de dossier pour ouvrir le répertoire des plugins
-3. Créez un dossier nommé `karpathywiki`, déposez les trois fichiers à l'intérieur
-4. De retour dans Obsidian, cliquez sur l'icône de rafraîchissement — **Karpathy LLM Wiki** apparaîtra
-5. Activez-le pour l'activer
+| Commande | Action |
+|----------|--------|
+| **📥 Ingest single source** | `Cmd+P/Ctrl+P` → « Ingest single source » — choisissez un fichier Markdown ou **PDF (v1.25.0+)** pour obtenir des pages entité/concept/wiki |
+| **📂 Ingest from folder** | `Cmd+P/Ctrl+P` → « Ingest from folder » — ingestion par lot de toutes les notes d'un dossier, avec saut intelligent de lot |
+| **📑 Ingest multiple files** | `Cmd+P/Ctrl+P` → « Ingest multiple files » — sélectionnez un sous-ensemble via une arborescence à deux volets (file d'attente en direct + annulation par fichier) |
+| **🔍 Query wiki** | `Cmd+P/Ctrl+P` → « Query wiki » — discutez avec votre wiki dans un panneau latéral droit ; les réponses sont accompagnées de `[[wiki-links]]` |
+| **🛠️ Lint wiki** | `Cmd+P/Ctrl+P` → « Lint wiki » — analyse complète de santé : doublons, liens morts, pages vides, orphelines, alias manquants, contradictions |
+| **⚡ Smart Fix All** | dans le modal Lint — réparation en un clic par ordre causal avec rapport par phase |
+| **📋 Regenerate index** | `Cmd+P/Ctrl+P` → « Regenerate index » — reconstruit `wiki/index.md` avec les pages et alias actuels |
+| **⏹ Cancel** | `Cmd+P/Ctrl+P` → « Cancel current ingestion » ou cliquez sur la barre d'état — s'arrête proprement à la prochaine limite de lot |
+| **📊 Ingestion history** | `Cmd+P/Ctrl+P` → « View Ingestion History » — UI consultable pour les ingestions passées, rapports Lint et maintenances |
 
-**🔨 Développement :** `git clone`, `pnpm install`, `pnpm build`.
+| Avant | Après |
+|-------|-------|
+| `notes/machine-learning.md` (un fichier plat) | `wiki/concepts/supervised-learning.md` avec `[[liens bidirectionnels]]`, alias, attribution de source et une entrée dans `wiki/index.md` |
 
-### 🔄 Mise à jour
-
-Ce projet évolue rapidement. Nous vous recommandons de rester à jour :
-
-**Option A — Mise à jour manuelle (recommandée) :**
-1. Allez dans **Paramètres → Plugins communautaires**
-2. Cliquez sur **Vérifier les mises à jour**
-3. Trouvez **Karpathy LLM Wiki** et cliquez sur **Mettre à jour**
-
-**Option B — Activer la mise à jour automatique :**
-1. Allez dans **Paramètres → Plugins communautaires**
-2. Activez **Vérifier automatiquement les mises à jour des plugins**
-
-> 💡 **Pourquoi rester à jour ?** Chaque version peut inclure de nouvelles fonctionnalités, des améliorations de performance et des corrections de bugs importantes.
-
-### 🔑 Configurer un fournisseur LLM
-
-1. Ouvrez Paramètres → Karpathy LLM Wiki
-2. Choisissez un fournisseur dans le menu déroulant, notamment OpenAI ou ChatGPT Plan (Codex OAuth)
-3. Pour un fournisseur API, entrez sa clé (inutile pour Ollama, LM Studio ou ChatGPT Plan (Codex OAuth))
-4. Pour les fournisseurs autres que Codex, utilisez **Fetch Models** ou saisissez un modèle ; ChatGPT Plan (Codex OAuth) remplit automatiquement sa liste de modèles sélectionnés
-5. Cliquez sur **Test Connection**, puis **Enregistrer les paramètres**
-
-**🦙 Ollama (local) :** Installez [Ollama](https://ollama.com), téléchargez un modèle, sélectionnez « Ollama (Local) ».
-
-**🎛️ LM Studio (local) :** Installez [LM Studio](https://lmstudio.ai), démarrez le serveur local, sélectionnez « LM Studio (Local) ».
-
-**🔐 ChatGPT Plan (Codex OAuth) — expérimental :** Ce fournisseur est distinct d'**OpenAI**, qui utilise une clé API OpenAI Platform facturée séparément. Sélectionnez-le, puis utilisez **Se connecter avec le navigateur** sur ordinateur (rappel localhost) ou **Utiliser un code d’appareil** sur ordinateur/mobile et terminez l'autorisation sur la page OpenAI. Le plugin synchronise les modèles sélectionnables du compte Codex connecté et ne met en cache que des métadonnées nettoyées ; **Actualiser les modèles du compte** permet de les mettre à jour. En cas d'indisponibilité temporaire, le dernier cache ou une liste de secours minimale reste disponible. Testez ensuite la connexion et enregistrez. Les identifiants OAuth sont stockés uniquement dans Obsidian SecretStorage ; **Se déconnecter** les efface. La disponibilité suit les politiques d'authentification, de modèles et de quota d'OpenAI Codex. Il s'agit d'une compatibilité tierce, pas d'un partenariat OpenAI ni d'une API ChatGPT générale.
-
-### 🎮 Utilisation
-
-| Méthode | Comment |
-|---------|---------|
-| **📥 Ingestion d'une source unique** | `Cmd+P` → « Ingest single source » — sélectionnez une note (Markdown ou **PDF, v1.25.0+**) pour générer des pages Wiki avec entités et concepts |
-| **📂 Ingestion depuis un dossier** | `Cmd+P` → « Ingest from folder » — sélectionnez un dossier pour générer le Wiki en lot depuis toutes les notes |
-| **📑 Importer plusieurs fichiers** | `Cmd+P` → « Ingest multiple files » — choisissez des fichiers via l'arborescence + cases à cocher, puis ingestion (avec file d'attente + annulation par fichier) |
-| **🎯 Ingestion du fichier actuel** | Cliquez sur l'icône `sticker` dans le ruban gauche, ou `Cmd+P` → « Ingest current file » |
-| **🔍 Interroger le wiki** | `Cmd+P` → « Query wiki » — Q&R conversationnelle avec streaming et `[[wiki-links]]` |
-| **🛠️ Vérifier le wiki** | `Cmd+P` → « Lint wiki » — bilan complet : doublons, liens morts, pages vides, orphelines, alias manquants, contradictions |
-| **📋 Régénérer l'index** | `Cmd+P` → « Regenerate index » — reconstruit `wiki/index.md` avec les alias |
-| **📊 Historique d'ingestion (v1.21.0)** | `Cmd+P` → « View Ingestion History » — parcourez les ingestions, rapports Lint et maintenances passés |
-| **⏹ Annuler l'opération** | `Cmd+P` → « Cancel current ingestion » — arrêt propre à la prochaine limite de lot |
-| **🎉 Recréer la note de bienvenue (v1.23.0)** | `Cmd+P` → « Recreate Wiki Welcome Note » — regénère la note de bienvenue |
-
-La ré-ingestion d'une même source fusionne les nouvelles informations de manière incrémentielle. Les résumés sont regénérés.
-
-> 💡 **Smart Batch Skip :** Lors de l'ingestion d'un dossier, le plugin détecte et ignore automatiquement les fichiers déjà traités — économise du temps et des coûts d'API.
-
-![Palette de commandes — recherchez "karpa" pour voir toutes les commandes](assets/command-panel.png)
-
-### ⚠️ Mise à niveau depuis une ancienne version ?
-
-> 🔧 **Mise à niveau depuis v1.24.x.** L'ingestion PDF (v1.25.0) écrit son cache dans `.obsidian/plugins/karpathywiki/pdf-cache/` (jusqu'à 100 Mo / 1000 entrées / 10 Mo par entrée individuelle ; éviction LRU-by-mtime au démarrage et au début de chaque ingestion batch). Votre vault n'est **pas modifié par défaut** — n'activez **Write PDF Markdown to Vault** (Settings → Wiki Configuration → Wiki Folder) que si vous souhaitez un sidecar `<basename>.pdf.md` à côté du PDF source. Deux nouveaux paramètres — **Force PDF Support** (avancé, désactivé par défaut) et **Write PDF Markdown to Vault** (désactivé par défaut) — sont entièrement rétrocompatibles : un ancien `data.json` sans ces champs retombera sur `false`.
-
-> 🔧 **Mise à niveau depuis v1.24.0.** Le marqueur de commentaire interne `<!-- reviewed: keep -->` (v1.24.0, #244), qui protégeait uniquement la section *Mentions in Source* d'une page, a été supprimé. Pour conserver une section Mentions organisée manuellement, définissez `reviewed: true` dans le frontmatter de la page : elle protège toute la page (Mentions comprises) et, contrairement au commentaire masqué, reste visible dans le panneau Propriétés et résiste aux linters Markdown.
-
-**Rétrocompatible.** Aucun changement cassant depuis la v1.0.0 — vos pages Wiki, paramètres et flux de travail existants sont préservés sans reconfiguration.
-
-**Après la mise à niveau**, exécutez **Lint Wiki** → **Smart Fix All** pour une réparation automatique en ordre causal :
-1. 🏷️ Compléter les aliases (l'LLM génère traductions, acronymes, noms alternatifs)
-2. 🔄 Fusionner les doublons (multilingue, abréviations, haute similarité)
-3. 🔗 Réparer les liens morts / relier les orphelins / compléter les pages vides
-
-Puis **Régénérer l'index** pour reconstruire `wiki/index.md` avec les entrées d'alias et activer la recherche sensible aux alias (par exemple, "DSA" trouve "DeepSeek-Sparse-Attention").
-
-> 📖 Les guides de mise à niveau détaillés pour des sauts de version spécifiques (v1.20.3 empreinte de slug, v1.16.0 liens doublement imbriqués) sont maintenus dans [GitHub Discussions / Upgrading](https://github.com/green-dalii/obsidian-llm-wiki/discussions).
-
-**Paramètres à vérifier :** Force PDF Support (Settings → LLM Configuration → Advanced, désactivé par défaut — uniquement pertinent pour les providers non-NATIVE), Write PDF Markdown to Vault (Settings → Wiki Configuration → Wiki Folder, désactivé par défaut), Langue de sortie du Wiki (indépendante de l'UI), Granularité d'extraction (Minimal–Fin + Personnalisé), Concurrence de génération de pages (défaut 3), Délai de batch (défaut 300ms).
+> 💡 **Restez à jour.** Nouvelles fonctionnalités, correctifs et améliorations de performances sont fréquents. Paramètres → Plugins communautaires → Vérifier les mises à jour, ou activez les mises à jour automatiques des plugins.
+> 📖 Les guides détaillés (installation, configuration PDF, notes multi-fournisseurs, mises à niveau) sont maintenus dans [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides).
 
 ---
-## ⚡ Nouveautés v1.25.x
 
-- **v1.25.2 (2026-07-22).** Vocabulaire des tags Phase 1（source double éliminée）、Codex OAuth（ChatGPT Plan）、correction de préfixe de dossier pour les liens associés、modèle de page `---` terminal corrigé、ESLint 0.4.1 Route A. 2515 tests réussis.
-- **v1.25.1 (2026-07-20).** Huit corrections de pertes silencieuses（page liée、sections de schéma、Mentions héritées）、3 fractionnements de fichiers volumineux、DiskCache<T>、LM Studio sans clé API、cause racine de vérification de build. 2274 tests réussis.
-- **v1.25.0 (2026-07-18).** Ingestion PDF en cache uniquement（Niveau 1）、croissance de cache limitée、sidecar de coffre optionnel、portail universel Force PDF、invite de transcription textuelle、ingestion annulable、guide des modèles locaux、exhaustivité i18n. 2182 tests réussis.
-
-📋 [Historique complet des versions → CHANGELOG.md](../CHANGELOG.md)
 ## ✨ Fonctionnalités
 
-### 📊 Qualité des connaissances
+### 📚 Qualité des connaissances
 
-- **🔍 Extraction Entity/Concept** — Le LLM extrait les Entity (personnes, organisations, produits, événements) et les Concept (théories, méthodes, termes) de vos notes avec granularité d'extraction flexible (Minimale~5 éléments, Grossière~10, Standard~50, Fine~100, Personnalisée 1–500) pour équilibrer profondeur d'analyse et coûts API
-- **🏷️ Mandatory Page Aliases** — Chaque page générée inclut au moins un alias (traduction, acronyme, nom alternatif), permettant la détection de doublons inter-langues
-- **🔄 Détection et fusion de doublons** — Le Semantic Tiering identifie les vrais doublons (traductions inter-langues, abréviations, variantes orthographiques) ; la fusion intelligente par LLM consolide le contenu et préserve les alias
-- **🧩 Smart Knowledge Fusion** — Les mises à jour multi-sources fusionnent les nouvelles informations sans redondance, préservent les contradictions avec attribution, et protègent les pages `reviewed: true` de l'écrasement
-- **📏 Protection contre la troncature** — Les fournisseurs avec clé API et locaux utilisent 8000 max_tokens, détectent automatiquement stop_reason et réessaient avec 2× tokens. Le chemin expérimental ChatGPT Plan (Codex OAuth) suit la politique de sortie du backend Codex, qui n'accepte pas de limite max_output_tokens côté client.
-- **📝 Verbatim Source Mentions** — Préservation des citations en langue originale avec traduction optionnelle pour traçabilité
+- **🔍 Extraction d'entités et de concepts** — Le LLM extrait les entités (personnes, organisations, produits, événements) et les concepts (théories, méthodes, termes) dans des pages autonomes. La granularité est configurable (Minimale → Fine, plus Personnalisée) pour équilibrer coût et profondeur.
+- **🏷️ Alias obligatoires** — chaque page est livrée avec au moins un alias (traduction, abréviation, variante) pour que la détection de doublons inter-langues fonctionne.
+- **🔄 Détection de doublons à plusieurs niveaux** — Niveau 1 (correspondance directe de nom : inter-langues, abréviations, titres de haute similarité) toujours vérifié ; Niveau 2 (liens partagés, similarité moyenne) remplit le budget de tokens restant.
+- **🧩 Fusion intelligente et état des contradictions** — les doublons sont fusionnés en préservant les alias ; les contradictions sont signalées avec attribution de source ; les pages `reviewed: true` sont protégées contre l'écrasement.
+- **🎨 Vocabulaire de tags personnalisable** — définissez vos propres listes de tags de type entité et concept dans Paramètres → Wiki → Vocabulaire de tags → *Personnalisé* ; Lint signale toute page dont les tags sortent du vocabulaire actif.
 
-- **🎨 Vocabulaire de tags personnalisable (v1.18.0).** Paramètres → Wiki → Mode de vocabulaire de tags → *Personnalisé* vous permet de définir vos propres listes de tags de type entité et concept (par ex. `Medical_Arzneimittel`, `法规`). Le plugin respecte votre vocabulaire dans les prompts d'extraction et la validation du frontmatter ; l'audit Lint (Issue #85 v7) signale toute page dont les tags sortent du vocabulaire actif.
+### 📄 Ingestion PDF (v1.25.0+)
 
-### 📄 Ingestion PDF (v1.25.0)
+- **🔌 Porte fournisseur** — Anthropic, OpenAI et Bedrock gèrent le PDF nativement. Pour tout autre endpoint compatible OpenAI/Anthropic, activez **Force PDF Support** dans Paramètres → Configuration LLM → Avancé pour que le plugin tente l'appel. Pour l'OCR local sur Apple Silicon, les extracteurs tiers (MinerU, Docling, Mathpix, Adobe) et le guide complet d'ingestion PDF, voir [Voies OCR PDF](#-voies-ocr-pdf) ci-dessous et [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md).
+- **🗄️ Cache à croissance bornée** — `.obsidian/plugins/karpathywiki/pdf-cache/` stocke le Markdown converti, indexé par hash de contenu + modèle + version du convertisseur. Ménage à trois niveaux de défense : 100 Mo total / 1000 entrées / 10 Mo par entrée avec éviction LRU-by-mtime.
+- **📝 Sidecar coffre optionnel** — Paramètres → Configuration Wiki → Dossier Wiki → *Write PDF Markdown to Vault* écrit `<basename>.pdf.md` à côté du PDF source (désactivé par défaut — cache uniquement).
+- **🛡️ Invite de transcription textuelle** — Conversion style OCR avec marqueurs anti-hallucination `[illegible]` / `[figure: ...]` ; le wrapping dans des fences ```markdown par les petits modèles locaux est automatiquement nettoyé avant l'écriture en cache.
 
-Choisissez un PDF dans votre vault — le plugin le lit via l'entrée fichier native de votre provider LLM, le convertit en Markdown, puis réintègre le pipeline d'ingestion Markdown standard. Tous les workflows existants entité/concept/alias/`[[wiki-link]]` s'appliquent inchangés.
+### 📄 Voies OCR PDF
 
-- **🔌 Porte provider** — Anthropic, OpenAI, Bedrock Anthropic et Bedrock OpenAI gèrent le PDF nativement. Pour tout autre endpoint compatible OpenAI/Anthropic, activez **Force PDF Support** dans Settings → LLM Configuration → Advanced pour laisser le plugin tenter l'appel (votre endpoint décide ; en cas d'échec, une Notice localisée vous guide pour désactiver le toggle). La configuration locale recommandée est dans [Voie OCR PDF locale](#-voie-ocr-pdf-locale-v1250).
-- **🗄️ Cache par hash de contenu** — PDF + modèle + version de convertisseur identiques renvoient le Markdown caché sans appel LLM. Le cache vit dans `.obsidian/plugins/karpathywiki/pdf-cache/` ; la clé embarque `converterVersion` pour invalider automatiquement les entrées obsolètes lors d'une mise à jour de prompt.
-- **📏 Croissance bornée** — ménage de cache à trois niveaux de défense (100 Mo total / 1000 entrées / 10 Mo par entrée) avec éviction LRU-by-mtime ; les anciennes entrées sont purgées au démarrage et au début de chaque ingestion batch. Cache uniquement — votre vault n'est pas modifié par défaut.
-- **📝 Sidecar Vault optionnel** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** écrit un `<basename>.pdf.md` à côté du PDF source après conversion. Désactivé par défaut (cache uniquement).
-- **🛡️ Prompt transcripteur verbatim** — le prompt PDF→Markdown est reformulé en conversion verbatim de style OCR avec des marqueurs anti-hallucination `[illegible]` / `[figure: ...]` / `[equation: ...]` ; les petits modèles / modèles locaux qui enveloppent leur sortie dans des fences ```markdown sont nettoyés automatiquement avant l'écriture en cache.
-- **⏹ Annulable** — un clic sur la barre de statut pendant la conversion interrompt l'appel LLM en cours (via Vercel AI SDK v6).
+Trois chemins, choisissez celui qui correspond à votre configuration :
 
-### 💬 Query et feedback
+1. **☁️ Fournisseur cloud avec support PDF natif** — Anthropic, OpenAI ou AWS Bedrock lisent les PDF directement. Il suffit d'ingérer ; aucune configuration supplémentaire. Pour tout autre endpoint compatible OpenAI/Anthropic, activez **Force PDF Support** dans Paramètres → Configuration LLM → Avancé pour que le plugin tente l'appel.
+2. **🖥️ OCR local sur Apple Silicon** — [oMLX](https://github.com/jundot/omlx) intègre Microsoft Markitdown comme backend PDF→Markdown intégré. Activez Markitdown dans oMLX, chargez [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M actifs, open-source 2026-06) comme modèle de vision, pointez le plugin vers oMLX comme fournisseur personnalisé compatible OpenAI, activez **Force PDF Support** et choisissez le modèle multimodal servi par oMLX. Le PDF ne quitte jamais votre machine.
+3. **🛠️ Extracteur tiers (MinerU, Docling, Mathpix, Adobe)** — exécutez un extracteur séparé sur vos PDF pour produire des fichiers `.md`, puis ingérez-les comme des notes Markdown standard via le pipeline normal du plugin. Plus fiable pour les articles scientifiques, documents scannés, PDF riches en mathématiques.
 
-- **🔍 Cascade de sélection de graines PPR en 5 étapes (v1.24.1 PATCH).** Sur une question multi-hop, Query Wiki compose la réponse à travers cinq étapes complémentaires avant qu'aucune génération ne démarre :
-  1. **Chemin rapide Lex** — vérification directe de chevauchement de tokens contre chaque titre/alias d'Entity/Concept (gratuit, instantané ; gate les étapes suivantes)
-  2. **Génération de mots-clés LLM** — le LLM propose 8 à 12 mots-clés inter-langues à partir de votre requête (absorbe synonymes, acronymes, termes résistants au chevauchement de tokens)
-  3. **Scan local de sous-chaînes** — chaque mot-clé généré est re-matché localement contre titres de pages, alias et extraits de corps (aucun appel LLM supplémentaire ; complète le rappel tolérant au bruit)
-  4. **Fallback LLM KB** — quand lex + scan de mots-clés renvoie des signaux faibles, le LLM re-seed les top-N candidats avec une passe sémantique sur l'ensemble du wiki
-  5. **Expansion de graphe PPR** — Personalized PageRank (Haveliwala 2002) exécuté sur le graphe `[[wiki-link]]` à partir de l'ensemble de graines candidats ; apporte au LLM le contexte multi-hop conscient du graphe que la recherche linéaire n'atteint pas
+📖 **Guides d'installation complets** pour les trois chemins (fournisseurs cloud, niveaux matériels oMLX, installation MinerU, ménage du cache) → [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-  La cascade se tronque automatiquement à l'étape qui renvoie assez de signal — pas de coût fixe de 5 étapes, pas d'appels LLM quand Lex suffit, pas de perte de précision quand l'augmentation LLM est nécessaire. La pertinence end-to-end (PPR @5 = 27,1 % sur le corpus de benchmark interne du projet) surpasse les baselines knn pures (24,1 %) sans opt-in d'embedding. Stage 1.5 (étapes 2–3) prend en charge les questions multi-hop que le Lex pur manque ; Stage 1.7 (étape 4) récupère les signaux faibles des mots-clés injectés par LLM ; Stage 1.9 (étape 5) garantit que le LLM voit du contexte voisin plutôt qu'une plate top-N. Remplace l'ancienne cascade binaire à deux niveaux.
+### 💬 Requête et maintenance
 
-- **🤖 Conversational Query** — Dialogue style ChatGPT avec Markdown streaming et `[[Wiki-links]]`, historique multi-tours
-- **🪟 Panneau latéral ancré à droite (v1.22.1, PR #196).** Query Wiki s'ouvre dans un panneau latéral droit de style Copilot (en réutilisant un panneau existant) au lieu d'une popup centrée. L'icône ribbon `message-circle` et la commande `Query Wiki` activent/affichent le panneau ; vos notes restent visibles à côté de la conversation. Toutes les fonctionnalités sont conservées sans changement.
-- **📤 Query-to-Wiki Feedback** — Sauvegarde des conversations pertinentes dans le Wiki avec extraction Entity/Concept et déduplication sémantique préalable
-- **🔒 Duplicate Save Prevention** — Le suivi par hash empêche la ré-évaluation des conversations inchangées
+- **🧭 Cascade PPR en 5 étapes** — voir [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche). Personalized PageRank sur le graphe `[[wiki-link]]` pour un contexte multi-hop conscient du graphe.
+- **🪟 Panneau latéral ancré à droite** — Query Wiki s'ouvre dans un panneau latéral droit style Copilot (v1.22.1+) au lieu d'un modal centré.
+- **🔍 Lint — analyse de santé** — une seule commande détecte : doublons, liens morts, pages vides, orphelines, alias manquants, contradictions.
+- **⚡ Smart Fix All** — réparation en un clic par ordre causal : remplir les alias → fusionner les doublons → corriger les liens morts → relier les orphelines → développer les pages vides, avec rapport par phase.
+- **📊 Panneau d'historique des opérations** — UI consultable et filtrable pour les ingestions passées, rapports Lint et maintenances.
+- **🛡️ Portail de pré-ingestion** — les notes vides / blancs / uniquement du frontmatter sont rejetées avant tout appel LLM ; la déduplication par hash de contenu détecte les fichiers identiques à travers les chemins.
 
-### 🛠️ Maintenance
+### 🔒 Confidentialité
 
-- **🔍 Lint Health Scan** — Détection des doublons, liens morts, pages vides, pages orphelines, alias manquants et contradictions dans un rapport complet
-- **🎯 Semantic-Tier Duplicate Detection** — Tier 1 (correspondances directes de noms : inter-langues, abréviations, titres de haute similarité) toujours vérifié ; Tier 2 (signaux indirects : liens partagés, similarité modérée) selon le budget de tokens
-- **⚡ Smart Fix All** — Correction par batch ordonnée par causalité : alias complétés → doublons fusionnés → liens morts résolus → orphelins reliés → pages vides complétées
-- **🏷️ Alias Completion** — Génération parallèle par batch des alias manquants en un clic, améliorant la détection future de doublons
-- **🔄 Auto-Maintenance** — Surveillance de dossiers multiples, Lint périodique, vérification de santé au démarrage (Startup Quick Fixes activé par défaut, File Watcher et Periodic Lint désactivés par défaut)
-- **⚠️ Contradiction State Machine** — `detected → review_ok → resolved` (correction IA) ou `detected → pending_fix` (manuel)
-- **🛡️ Portail de pré-ingestion (v1.21.0)** — Chaque fichier source est validé *avant* tout appel LLM : les notes vides/blanches/avec uniquement du frontmatter sont rejetées ; le déduplication par hash de contenu détecte les fichiers identiques à travers les chemins. Empêche les modèles locaux d'halluciner des noms d'entités sur des entrées vides.
-- **📊 Panneau d'historique des opérations (v1.21.0)** — UI consultable et filtrable pour les ingestions passées, rapports de lint et exécutions de maintenance, avec cartes KPI pilotées par l'insight et liens cliquables vers les pages.
-- **🧹 Nettoyeur de pages incomplètes (v1.21.0)** — Les pages laissées dans un état partiel après des ingestions interrompues sont automatiquement archivées au démarrage (récupérables depuis la `.trash` d'Obsidian).
+- **🚫 Pas de backend, pas de suivi, pas d'analyse.** Fonctionne entièrement dans Obsidian. Le réseau est utilisé uniquement pour communiquer avec le fournisseur LLM que vous configurez.
+- **📁 Les fichiers sources sont en lecture seule.** Le plugin ne modifie jamais vos notes originales du coffre — il crée uniquement de nouvelles pages dans `wiki/`.
+- **🦙 Mode entièrement local.** Ollama, LM Studio ou tout endpoint local compatible OpenAI → vos notes ne quittent jamais votre machine.
+- **🔐 Permissions minimales.** Accès aux fichiers du coffre pour la gestion du wiki. Accès au presse-papiers uniquement lorsque vous cliquez sur le bouton « Copier » dans le modal de requête.
 
-### 🌐 LLM et langue
+### 🦙 Priorité au local
 
-- **🔌 Multi-Provider** — Anthropic, Anthropic Compatible (Coding Plan), Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, endpoints personnalisés
-- **🔄 5xx Retry** — Retry automatique avec backoff exponentiel (max 2) sur les erreurs HTTP 5xx/429/529 pour tous les clients
-- **📋 Dynamic Model List** — Récupération en temps réel depuis les APIs des providers
-- **🌐 Langue de sortie du Wiki** — 10 langues indépendantes de l'UI (EN/ZH simplifié/ZH traditionnel/JA/KO/DE/FR/ES/PT/IT), avec entrée personnalisée.
-- **🌍 Internationalisation complète de l'UI** — Interface du plugin en 10 langues (EN/ZH simplifié/ZH traditionnel/JA/KO/DE/FR/ES/PT/IT), 269+ champs UI entièrement traduits, expressions locales naturelles.
-- **⚡ Rate Limit Guardian** — Quand la génération parallèle déclenche des rate limits, auto-détection et suggestions : réduire la concurrence, augmenter le délai batch, changer de provider
-- **🦙 Web Clipper Compatible** — Ajout en un clic du dossier `Clippings/` d'Obsidian Web Clipper à la watchlist, clips web auto-ingérés dans le Wiki
+- **🖥️ Ollama, LM Studio, OpenRouter, endpoint personnalisé** — prêts à l'emploi. Les modèles locaux fonctionnent pour les requêtes (fenêtres de contexte plus petites) ; l'ingestion d'un coffre de 2000 pages nécessite généralement un modèle cloud à long contexte.
+- **📄 La voie OCR PDF est entièrement locale sur Apple Silicon** — voir [Voies OCR PDF](#-voies-ocr-pdf) ci-dessous.
+- **🔐 ChatGPT Plan (Codex OAuth)** — rappel localhost sur `127.0.0.1:1455` sur ordinateur ; mobile via code d'appareil. Les identifiants vivent uniquement dans Obsidian SecretStorage ; la déconnexion les efface. Compatibilité tierce Codex, pas un partenariat OpenAI.
 
-### 🏗️ Architecture et performance
+### 🌐 Langue
 
-- **🕸️ PPR sur le graphe [[wiki-link]] (v1.24.0+, muri dans v1.24.1 PATCH).** Personalized PageRank (Haveliwala 2002) s'exécute sur le graphe orienté d'arêtes `[[wiki-link]]` entre vos pages wiki ; la cascade ancre les graines PPR sur l'ensemble de candidats top-N, et le contexte multi-hop voyage jusqu'à 3 anneaux d'expansion. C'est ce qui rend les réponses de Query Wiki conscientes du graphe (une question « fondateurs de Microsoft » se résout via Bill Gates → Microsoft → concurrents, pas seulement par chevauchement littéral de titres). Les vaults de 2 137 pages observent typiquement <100 ms pour warm + expansion 3-hop, indépendamment de la taille du vault. Utilisé par les 4 étapes de la cascade de sélection de graines (section Query et feedback ci-dessus) et par la détection de doublons Lint quand des liens indirects relient deux pages candidates.
-- **⚡ Parallel Page Generation** — 1–5 pages concurrentes configurables, défaut 3 (parallèle), 2–3× plus rapide pour les grandes sources, isolation des erreurs par page
-- **📚 Iterative Batch Extraction** — Taille de batch adaptative élimine le goulot d'étranglement max_tokens pour les documents longs
-- **🏛️ Three-Layer Architecture** — Vos notes du vault (lecture seule) → `wiki/` (pages générées par le LLM, organisées en `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`) → `schema/` (config co-évoluée)
-- **🧩 Modular Codebase** — 20+ modules focalisés dans `src/`
-
-### 🔒 Confidentialité et sécurité
-
-- **Pas de backend, pas de télémétrie.** Le plugin fonctionne entièrement dans Obsidian — aucun serveur externe, aucune analyse, aucune collecte de données d'aucune sorte. Vos notes ne quittent jamais votre coffre-fort, sauf si vous configurez explicitement un fournisseur LLM.
-- **Vos données restent locales par défaut.** Le plugin ne stocke, ne met en cache ni ne transmet votre contenu ailleurs que vers l'API LLM que vous avez choisie. Seul le texte que vous envoyez pour ingestion ou requête quitte votre appareil — et uniquement vers le fournisseur que vous avez configuré.
-- **Mode entièrement local avec Ollama, LM Studio ou fournisseurs locaux.** Pour une souveraineté totale des données, utilisez un LLM exécuté localement. Vos notes sont traitées entièrement sur votre machine — rien ne touche Internet.
-- **Permissions minimales.** L'accès aux fichiers du coffre est requis pour la gestion du wiki (lecture des notes, génération de pages, détection de liens morts). L'accès réseau est utilisé exclusivement pour les appels API LLM vers le fournisseur que vous avez choisi. L'accès au presse-papiers se limite au bouton « Copier » dans la fenêtre modale de requête — uniquement lorsque vous cliquez dessus.
+- **🌍 10 langues d'interface** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. La langue de l'UI et celle du wiki sont indépendantes — votre wiki peut être en chinois pendant que l'interface est en anglais.
+- **📚 10 langues de sortie wiki** — même ensemble ; choisissez dans Paramètres → Configuration Wiki. Option *Custom input* pour les invites ad-hoc.
+- **🈶 269+ chaînes UI traduites** — chaque label, modal et notice. L'ajout d'une 11e langue est piloté par les contributeurs (modèle PR #159).
 
 ---
 
+## 🔍 Fonctionnement de la recherche
+
+La plupart des plugins de « recherche IA » fragmentent vos notes en morceaux et les intègrent dans une base de données vectorielle. Pas nous. L'argument de Karpathy contre le RAG est que le découpage brise la capacité du LLM à raisonner sur l'ensemble de votre graphe de connaissances — et cet argument se vérifie en pratique. Au lieu de cela, nous parcourons le graphe que vous maintenez déjà en écrivant des `[[wiki-links]]`.
+
+### La cascade de sélection de graines en 5 étapes
+
+Quand vous demandez « Qui a fondé Microsoft ? », Query Wiki exécute cinq étapes avant toute génération de réponse :
+
+1. **Chemin rapide Lex** — chevauchement direct de tokens contre chaque titre d'entité/concept et alias. Gratuit, instantané, et l'étape de filtrage pour tout ce qui suit.
+2. **Génération de mots-clés LLM** — le LLM propose 8 à 12 mots-clés inter-langues à partir de votre requête (gère les synonymes, abréviations et termes résistants au chevauchement de tokens en un seul appel LLM).
+3. **Scan local de sous-chaînes** — chaque mot-clé généré est re-matché localement contre les titres de pages, alias et extraits de corps. Aucun appel LLM supplémentaire ; complète le rappel tolérant au bruit.
+4. **Fallback LLM KB** — quand lex + scan de mots-clés renvoient des signaux faibles, le LLM ré-ensemence les N meilleurs candidats avec une passe sémantique sur l'ensemble du wiki.
+5. **Expansion de graphe PPR** — Personalized PageRank (Haveliwala 2002) sur le graphe `[[wiki-link]]` à partir de l'ensemble de graines candidates. C'est ce qui donne le contexte multi-hop conscient du graphe : « Bill Gates » → « Microsoft » → « concurrents », pas seulement un chevauchement littéral de titres.
+
+La cascade se tronque à l'étape qui a renvoyé suffisamment de signal — pas de coût fixe de 5 étapes, pas d'appels LLM quand lex est suffisant, pas de perte de précision quand l'augmentation LLM est nécessaire.
+
+### Personalized PageRank à l'échelle
+
+Nous utilisons Monte Carlo PPR (Fogaras 2005) — 3000 marches aléatoires × 50 pas chacune — avec la règle de cul-de-sac de Haveliwala 2002. Le coût est **O(K × L)** indépendant du nombre de pages, donc un coffre de 2000 pages a la même latence d'expansion qu'un coffre de 200 pages.
+
+**PPR @5 = 27,1 % vs baseline kNN pur 24,1 %** sur le corpus de benchmark du projet (le seul benchmark de recherche publié dans cet espace open-source LLM-Wiki).
+
+### Pourquoi pas d'embeddings
+
+Nous avons délibérément rejeté la voie des embeddings dans [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175). Le signal du graphe est déjà là — chaque `[[wiki-link]]` est une arête « ces pages sont liées » curated manuellement, et la plupart des fournisseurs que nous supportons (Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax) n'ont pas du tout d'endpoint `/v1/embeddings`. Ajouter un modèle d'embedding signifierait un téléchargement par page, un adaptateur par fournisseur et zéro bénéfice sur la qualité de recherche.
 
 ---
 
----
+## 🤖 Modèles
 
-## 📖 Exemple
+**Fournisseurs pris en charge (12+, vérifiés cross-check models.dev 2026-07) :**
 
-**Entrée :** `sources/machine-learning.md`
+| Fournisseur | Séries | Notes |
+|------------|--------|-------|
+| **Anthropic** | Claude 5 series | PDF natif ; protocole `/v1/messages` |
+| **OpenAI** | GPT-5.6 series (Sol / Terra / Luna) | PDF natif ; clé API Platform |
+| **Google Gemini** | Gemini 3.6 series | PDF natif (file parts depuis 1.5) ; endpoint compatible OpenAI |
+| **DeepSeek** | DeepSeek V4 series | Compatible OpenAI ; niveau de coût le plus bas |
+| **Alibaba Qwen** | Qwen3.7/3.8 series | Compatible OpenAI (DashScope) |
+| **xAI Grok** | Grok 4 series | Compatible OpenAI ; long contexte |
+| **Moonshot Kimi** | Kimi K3 series | Compatible OpenAI ; 2,8T MoE frontière |
+| **Zhipu GLM** | GLM-5 series | Compatible OpenAI ; fort bilingue |
+| **MiniMax** | MiniMax M3 series | Compatible OpenAI ; 1M contexte |
+| **Step (阶跃星辰)** | Step 3 series (Flash) | Compatible OpenAI ; inférence rapide |
+| **Tencent Hunyuan** | Hy3 series | Compatible OpenAI ; MoE open-weight |
+| **Xiaomi MiMo** | MiMo V2.5 series | Open-source MIT ; tarification plate |
+| **Google Gemma** | Gemma 4 series | Open-weight ; contexte 262K |
+| **AWS Bedrock** | Variantes Anthropic + OpenAI | VPC / conformité |
+| **ChatGPT Plan (Codex OAuth)** | API Codex Responses | Connexion navigateur/code d'appareil ; SecretStorage |
+| **Local : Ollama, LM Studio, OpenRouter, Anthropic-Compatible** | Tout modèle protocole OpenAI/Anthropic | Custom OpenAI-Compatible + Anthropic-Compatible (Token Plan / Coding Plan) |
 
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
+Ce plugin alimente le LLM avec le contexte complet de votre Wiki par requête — donc **les modèles à long contexte gagnent**. Le tableau complet des niveaux (cloud + local) se trouve dans [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md), vérifié par recoupement avec [models.dev](https://models.dev/) pour que les choix restent à jour.
 
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+### Ce qui compte
 
-**Sortie — Page Entity :** `wiki/entities/supervised-learning.md`
+- **🧠 Fenêtre de contexte ≥ 200K tokens** pour les coffres de plus de ~500 pages. En dessous de 200K, le contexte assemblé par la cascade commence à être tronqué.
+- **⚖️ La qualité de suivi des instructions** importe plus que le QI brut pour la tâche d'extraction — choisissez un modèle qui suit le modèle de schéma, pas le plus grand numéro du classement.
+- **🔌 L'endpoint d'embedding n'a pas d'importance** — nous n'utilisons pas d'embeddings. Un fournisseur sans `/v1/embeddings` est parfait (c'est le cas de la plupart de nos 12+ fournisseurs).
+- **🦙 Local pour les requêtes, cloud pour l'ingestion** — l'ingestion sur un coffre de 2000 pages nécessite généralement un modèle cloud à long contexte ; un modèle local 262K couvre la plupart des requêtes.
 
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
+### Anthropic vs OpenAI vs Codex OAuth — ce sont des fournisseurs distincts
 
-### Supervised Learning
+- **Anthropic** (et sa variante Bedrock) — clé API Anthropic Platform facturée séparément.
+- **OpenAI** — clé API OpenAI Platform facturée séparément.
+- **ChatGPT Plan (Codex OAuth)** — fournisseur expérimental distinct qui utilise une allocation Codex éligible après connexion par navigateur ou code d'appareil ; la disponibilité suit les politiques d'authentification et d'allocation OpenAI Codex, pas le nom du forfait. Compatibilité tierce Codex, pas un partenariat OpenAI ou une API ChatGPT générale.
 
-### Basic Information
-- Type: method
-- Source: [[sources/machine-learning]]
-
-### Description
-Supervised learning is a machine learning paradigm where models learn
-from labeled training data to make predictions on unseen data...
-
-### Related Concepts
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### Related Entities
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### Mentions in Source
-- "Supervised learning uses labeled data to train predictive models..."
-```
-
----
-
-## 🤖 Guide de sélection de modèle
-
-Ce plugin suit la philosophie de Karpathy : **donner au LLM le contexte Wiki complet, pas une récupération RAG fragmentée**. Les modèles à long contexte sont fortement recommandés — plus votre Wiki s'étend, plus le LLM a besoin de contexte.
-
-> 💡 **Pourquoi pas RAG ?** La [critique originale de Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) soutient que RAG fragmente les connaissances et altère la capacité du LLM à raisonner sur le graphe de connaissances complet.
-
-**💰 Stratégie rapport qualité-prix :** Vous n'avez pas besoin de modèles phares. Les **alternatives économiques** suivantes offrent d'excellents résultats à des coûts plus bas :
-
-### ☁️ Recommandations cloud
-
-| Niveau | Modèle | Fenêtre de contexte | Motivation |
-|--------|--------|---------------------|------------|
-| **🌟 Rapport Q/P** | **DeepSeek V4-Flash** | 1M tokens | Prix le plus bas ($0.14/M), 284B MoE, idéal pour l'ingestion batch |
-| **🌟 Rapport Q/P** | **Gemini-3.5-Flash** | 1M tokens | 4× plus rapide que GPT-5.5, excellent pour les tâches agentiques |
-| **🌟 Rapport Q/P** | **Qwen3.6-Plus** | 1M tokens | Capacités coding & agent fortes, prix compétitif |
-| **🌟 Rapport Q/P** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **Équilibré** | **Claude Sonnet 4.6** | 1M tokens | Bon équilibre qualité/coût, $3/$15 par million de tokens |
-| **Léger** | **Claude Haiku 4.5** | 200K tokens | Rapide et économique, pour wikis plus petits |
-| **Économique** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE, open-source MIT 2026-04, agent & multimodal |
-| **Phare** | Claude Opus 4.7 | 1M tokens | Qualité ultime, coût élevé — utiliser sélectivement |
-| **Phare** | GPT-5.5 | 1M tokens | Raisonnement top niveau, coût élevé — utiliser sélectivement |
-
-### 🦙 Recommandations locales (Ollama / LM Studio)
-
-L'inférence locale brille par la souveraineté des données, l'usage hors ligne et l'absence de coût API. Le compromis : une fenêtre de contexte plus petite (souvent 8K–128K, les familles open-weight récentes atteignent 262K) et un suivi des instructions moins bon que les modèles phares cloud. **Choisissez selon votre budget matériel :** plus de paramètres = meilleures connaissances et fidélité aux instructions (extraction de meilleure qualité, moins d'hallucinations) ; moins de paramètres = plus de vitesse et de mémoire disponible, au prix de plus d'hallucinations et d'un raisonnement long contexte plus faible. Le sweet spot sur 24 Go Apple Silicon ou un GPU grand public unique est la classe 27B–35B-A3B.
-
-| Modèle | Paramètres | Contexte | Motivation |
-|--------|------------|----------|------------|
-| **Qwen3.5 27B** | 27B dense | 262K | Meilleur rapport qualité/taille pour l'ingestion ; MLX 4-bit tient dans 24 Go |
-| **Qwen3.5 35B-A3B** | 35B total / 3B actifs MoE | 262K | Plus rapide que 27B dense à qualité équivalente ; économie de mémoire idéale |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | Plafond de qualité ; nécessite ≥48 Go de VRAM ou deux GPU |
-| **Qwen3.6 27B** | 27B dense | 256K+ | Refresh 2026-04 du Qwen3.5 27B — à privilégier si votre hardware le permet |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Même compromis que Qwen3.5 35B-A3B, poids plus récents |
-| **Gemma 4 31B IT** | 31B dense | 262K | Suivi des instructions fort, sortie Markdown propre |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Moins de mémoire que 31B dense à qualité comparable |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | Fonctionne en CPU pur ; pour petits wikis ou aperçus rapides uniquement |
-
-**Quantification :** MLX 4-bit sur Apple Silicon est généralement 1,5 à 2× plus rapide que GGUF Q4_K_M à débit binaire effectif équivalent. GGUF Q4_K_M est le choix par défaut multi-plateforme ; ne passez à Q5/Q8 que si vous avez de la VRAM en réserve et que vous constatez une régression à Q4.
-
-**Stratégie de contexte :** Quand votre Wiki dépasse ~500 pages, un modèle local à 262K couvre encore la majorité du contexte assemblé par le moteur de Query, mais l'ingestion d'un vault de 2000 pages le dépassera. Schéma courant : cloud pour l'ingestion + local pour le Query. Pour une installation entièrement locale, la classe 27B/35B-A3B est le sweet spot.
-
-### 📄 Voie OCR PDF locale (v1.25.0+)
-
-L'ingestion PDF de v1.25.0 fonctionne avec tout provider qui accepte les PDF comme partie de fichier. Pour une pipeline entièrement locale sur Apple Silicon (la seule plateforme actuellement supportée par oMLX), voici la configuration recommandée :
-
-1. Installer [oMLX](https://github.com/jundot/omlx) et activer le backend **Markitdown** intégré (conversion PDF→Markdown locale).
-2. Charger **Baidu Unlimited-OCR** (open-source le 22/06/2026, 3B total / 0,5B actifs, OCR de bout en bout qui traite les documents longs sans le mode d'échec « plus ça génère, plus c'est lent » des anciens modèles OCR) comme modèle vision dans oMLX.
-3. Dans ce plugin : choisir le provider **Custom OpenAI-Compatible** (oMLX parle le protocole compatible OpenAI), pointer la Base URL vers le serveur local oMLX, activer **Force PDF Support** dans Settings → LLM Configuration → Advanced, et choisir le modèle multimodal servi par oMLX pour la synthèse d'ingestion.
-
-Le PDF ne quitte jamais votre machine — Markitdown fait la conversion structurelle en local, Unlimited-OCR la reconnaissance visuelle en local, et le LLM local le résumé en local. Le cache du plugin (`.obsidian/plugins/karpathywiki/pdf-cache/`) garde alors les ré-ingestions instantanées.
-
-**Fallback :** si oMLX/Markitdown n'est pas disponible (Linux/Windows ou Mac anciens), pointer **Force PDF Support** directement vers un LLM multimodal local qui accepte les PDF comme partie de fichier — la qualité est bonne quand le modèle est assez grand, mais les besoins en VRAM croissent fortement avec le nombre de pages.
-
-**🔌 Anthropic Compatible (Coding Plan) :** Si votre provider offre un endpoint API compatible Anthropic, sélectionnez « Anthropic Compatible » et saisissez votre Base URL et API Key du provider.
-
-**🦙 Ollama (local, sans clé API) :** Installer [Ollama](https://ollama.com), tirer un modèle (`ollama pull gemma4` ou `ollama pull qwen3.5:27b`), sélectionner « Ollama (Local) » dans le menu déroulant des providers.
-
-**🎛️ LM Studio (local, sans clé API) :** Installer [LM Studio](https://lmstudio.ai), démarrer son serveur local (par défaut `http://localhost:1234/v1`), sélectionner « LM Studio (Local) » dans le menu déroulant des providers. LM Studio exécute un serveur compatible OpenAI intégré — le champ de clé API est facultatif.
-
-> 💡 **Séparation de facturation OpenAI :** **OpenAI** utilise une clé Platform facturée séparément. **ChatGPT Plan (Codex OAuth)** est un fournisseur expérimental distinct qui utilise un quota Codex éligible après connexion par navigateur ou code d'appareil ; le nom du forfait ne garantit pas sa disponibilité.
-
----
-
-## 🏗️ Architecture
-
-Le design à trois couches de Karpathy :
-
-```
-📄 Vos notes du vault (dossier quelconque)   # 📖 Vous choisissez quelles notes ingérer
-  ↓ ingest
-wiki/                                          # 🧠 Pages Wiki générées par le LLM (wiki/sources/, wiki/entities/, wiki/concepts/)
-  ↓ query / maintain
-schema/                                        # 📋 Configuration de la structure du Wiki
-```
-
-> 📖 Voir la structure complète du code dans [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure).
-
-**Pages générées :**
-- `wiki/sources/fichier.md` — 📄 Résumé de la source
-- `wiki/entities/nom-entite.md` — 👤 Pages d'entités (personnes, organisations, projets, etc.)
-- `wiki/concepts/nom-concept.md` — 💡 Pages de concepts (théories, méthodes, termes, etc.)
-- `wiki/index.md` — 📑 Index auto-généré
-- `wiki/log.md` — 📝 Journal d'opérations
-
-
----
+> 📖 **Tableau de sélection complet** (cloud + local + PDF OCR + Codex OAuth + quantification + niveaux matériels) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
 ## ❓ FAQ
 
-> **Gardez votre plugin à jour.** Exécutez **Paramètres → Plugins communautaires → Vérifier les mises à jour** régulièrement.
->
-> 📖 Plus de FAQ sur [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28).
+### Que fait exactement le plugin ?
 
-**Que fait exactement ce plugin ?**
-Choisissez n'importe quelle note, dossier ou sélection multiple de votre vault ; le LLM extrait les entités et concepts et génère un Wiki interconnecté avec `[[liens wiki]]`. Obtenez des réponses conversationnelles depuis *vos* notes — pas de recherche Internet. Les résumés générés vivent sous `wiki/sources/`, les entités sous `wiki/entities/`, les concepts sous `wiki/concepts/` — vos notes originales du vault ne sont jamais modifiées.
+Choisissez n'importe quelle note, dossier ou sélection ; le LLM extrait les entités et concepts et génère un wiki interconnecté avec des `[[liens bidirectionnels]]`. Posez des questions et obtenez des réponses conversationnelles fondées sur *vos* notes, pas sur Internet. Vos notes originales du coffre ne sont jamais modifiées.
 
-**Mes données sont-elles envoyées à des tiers ?**
-🔒 **Confidentialité d'abord.** Pas de backend, pas de suivi, pas d'analyse — le plugin tourne entièrement dans Obsidian. Seul le texte que vous envoyez explicitement quitte votre appareil. Pour une localité complète des données, utilisez un fournisseur local (Ollama ou LM Studio sans clé API).
+### Comment commencer ?
 
-**En quoi est-ce différent des chatbots RAG ?**
-Contrairement au RAG qui fragmente le contexte, LLM-Wiki utilise un moteur **Personalized PageRank** sur votre graphe de `[[wiki-link]]`s existant — trouvant les pages connexes via la structure de liens, pas des embeddings vectoriels. Zéro coût d'embedding, aucune nouvelle dépendance.
+Installez depuis les Plugins communautaires Obsidian → choisissez un fournisseur → **Test Connection** → exécutez **Ingest single source** sur n'importe quelle note. Les premières pages wiki apparaissent en quelques secondes. Voir [Démarrage rapide](#-démarrage-rapide).
 
-**Quel LLM choisir ?**
-Les modèles à long contexte (≥200K tokens) fonctionnent le mieux. Options économiques : DeepSeek V4-Flash ($0.14/M), Gemini 3.5 Flash, Qwen3.6-Plus. Les modèles locaux (Ollama/LM Studio) fonctionnent pour les requêtes mais ont des fenêtres de contexte plus petites (8K–128K).
+### Mon wiki existant est-il sûr ?
 
-**Comment commencer ?**
-Installez depuis les plugins communautaires Obsidian → choisissez un fournisseur LLM → **Test Connection** → exécutez **Ingest single source** (ou **Ingest from folder**) sur n'importe quelle note de votre vault → vos premières pages Wiki apparaissent en secondes. Voir [Démarrage rapide](#-démarrage-rapide) ci-dessus.
+✅ Rétrocompatible depuis la v1.0.0. Définissez `reviewed: true` sur n'importe quelle page pour la protéger contre l'écrasement. La mise à niveau depuis v1.24.x ne réécrit pas votre coffre ; l'ingestion PDF v1.25.0 est en cache uniquement par défaut.
 
-**Comment contrôler les coûts d'API ?**
-Utilisez la granularité Grossière ou Minimale pour l'ingestion par lots (moins d'appels LLM). Smart Batch Skip détecte automatiquement les fichiers déjà traités. La maintenance automatique est désactivée par défaut.
+### Mes données sont-elles envoyées quelque part ?
 
-**Mon Wiki existant est-il sûr ?**
-✅ Rétrocompatible depuis v1.0.0. Définissez `reviewed: true` sur une page pour la protéger contre l'écrasement. Le plugin ne modifie jamais vos notes originales du vault — il génère uniquement de nouvelles pages dans le dossier `wiki/`.
+🚫 Pas de backend, pas d'analyse — le plugin fonctionne entièrement dans Obsidian. Seul le texte que vous envoyez explicitement pour ingestion/requête quitte votre appareil, et uniquement vers le fournisseur LLM que vous configurez. Pour une localité complète des données, utilisez Ollama ou LM Studio.
 
-**Puis-je utiliser le plugin dans ma langue ?**
-🌐 **10 langues** pour l'interface et la sortie Wiki : English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. La langue de l'interface et celle du Wiki sont indépendantes.
+### Puis-je utiliser le plugin dans ma langue ?
 
-**Configuration minimale ?**
-Obsidian v1.11.4+ (ordinateur ou mobile). Une clé API LLM, un modèle Ollama/LM Studio local ou des identifiants ChatGPT Plan (Codex OAuth) autorisés sont requis. Le verrou **llmReady** nécessite un test de connexion avant de débloquer les fonctionnalités principales.
+🌍 10 langues pour l'interface et la sortie wiki. La langue de l'UI et celle du wiki sont indépendantes. L'ajout d'une 11e langue est piloté par les contributeurs (modèle PR #159).
 
-**Comment annuler une opération en cours ?**
-Cliquez sur le texte de la barre d'état ou `Cmd+P` → « Cancel current ingestion ». Arrêt propre à la prochaine limite de lot.
+### En quoi est-ce différent d'un chatbot RAG ?
 
-**Où obtenir de l'aide ?**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — signaler un bug
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — questions et retours
-- Console développeur (`Ctrl+Shift+I`) — copier les logs pour un diagnostic plus rapide
+🚫 Pas de découpage. 🚫 Pas d'embeddings. 🚫 Pas de BD vectorielle. ✅ Personalized PageRank sur votre graphe `[[wiki-link]]` existant — contexte multi-hop conscient du graphe, zéro coût d'embedding, support complet des modèles locaux.
 
-## 🔒 Transparence et conformité
+### Quel LLM dois-je utiliser ?
+
+Les modèles à long contexte (≥200K tokens) fonctionnent le mieux. La [section Modèles](#-modèles) couvre les principes ; le tableau complet des niveaux se trouve dans [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md).
+
+### Existe-t-il un benchmark publié ?
+
+Oui — PPR @5 = 27,1 % vs baseline kNN pur 24,1 % sur le corpus du projet. Le pipeline complet et le script de benchmark sont décrits dans [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche).
+
+### Comment contrôler les coûts d'API ?
+
+Utilisez la granularité d'extraction Grossière ou Minimale pour l'ingestion par lots. Smart Batch Skip détecte automatiquement les fichiers déjà ingérés. La maintenance automatique est DÉSACTIVÉE par défaut. Lint montre les compteurs avant d'exécuter les corrections — rien n'est facturé sans votre approbation.
+
+### Comment annuler une opération en cours ?
+
+Cliquez sur la barre d'état (affiche « Ingestion… cliquer pour annuler ») ou `Cmd+P/Ctrl+P` → « Cancel current ingestion ». S'arrête proprement à la prochaine limite de lot.
+
+### Où obtenir de l'aide ?
+
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) pour les signalements de bugs · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) pour les questions et demandes de fonctionnalités · Console développeur (`Ctrl+Shift+I` / `Cmd+Option+I`) pour les logs du plugin.
+
+---
+
+## 🔒 Confidentialité
 
 Ce plugin est répertorié sur le marché des plugins communautaires Obsidian et fait l'objet d'une vérification automatisée de la sécurité et des autorisations.
 
-**Le plugin n'a pas de backend, pas d'infrastructure serveur et aucune collecte de données d'aucune sorte.** C'est un logiciel purement local qui s'exécute dans Obsidian. Le plugin ne peut pas et ne collecte, stocke ou transmet vos données à aucun serveur — parce qu'un tel serveur n'existe pas.
+- **🚫 Pas de backend, pas de serveur, pas de collecte de données.** Logiciel purement local fonctionnant dans Obsidian. Le plugin ne peut pas et ne collecte, stocke ou transmet vos données à aucun serveur — parce qu'un tel serveur n'existe pas.
+- **🔐 L'accès réseau est sur option.** Utilisé uniquement pour communiquer avec le fournisseur LLM que vous configurez. Vous choisissez le fournisseur, vous entrez la clé API, vous décidez où vont vos données.
+- **📁 L'accès aux fichiers du coffre** est utilisé pour la gestion du wiki (lecture des notes, génération de pages, analyse des liens morts, détection des doublons). Le plugin ne modifie jamais vos fichiers sources.
+- **📋 L'accès au presse-papiers** est utilisé exclusivement par le bouton « Copier » dans le modal de requête — et uniquement lorsque vous cliquez dessus.
 
-**L'accès réseau** est utilisé uniquement pour communiquer avec le fournisseur LLM que vous configurez — aucun autre appel réseau n'est effectué. Cela est entièrement sous votre contrôle : vous choisissez le fournisseur, vous entrez la clé API, vous décidez où vont vos données.
+Pour une localité complète des données, utilisez Ollama ou LM Studio. Avec un fournisseur local, vos données ne quittent jamais votre machine.
 
-**L'accès au système de fichiers** (énumération du coffre) est requis pour construire et maintenir le wiki : lire vos notes sources, générer des pages, analyser les liens morts et détecter les pages en double. Le plugin ne modifie jamais vos fichiers sources — uniquement les fichiers du dossier wiki.
+---
 
-**L'accès au presse-papiers** est utilisé exclusivement par le bouton « Copier » dans la fenêtre modale de requête, et uniquement lorsque vous cliquez dessus.
+## 💖 Soutien
 
-Si vous préférez une localité complète des données, utilisez un fournisseur LLM local tel qu'Ollama ou LM Studio. Avec un fournisseur local, vos données ne quittent jamais votre machine.
+Si LLM-Wiki est devenu une partie importante de votre flux de travail de connaissances :
 
-## 💖 Soutenir le projet
+- ☕ **[Offrez-moi un café sur Ko-fi](https://ko-fi.com/greenerdalii)** — ponctuel ou mensuel
+- 💳 **[Pourboire via PayPal](https://paypal.me/greenerdalii)** — pourboire ponctuel
 
-Si LLM-Wiki est devenu une partie importante de votre flux de travail de connaissances, vous pouvez soutenir son développement continu :
+Le sponsoring est entièrement facultatif. Le plugin reste sous licence Apache-2.0 et complet en fonctionnalités.
 
-- ☕ **[Offrez-moi un café sur Ko-fi](https://ko-fi.com/greenerdalii)** — soutien ponctuel ou mensuel via Ko-fi
-- 💳 **[Pourboire via PayPal](https://paypal.me/greenerdalii)** — pourboire ponctuel via PayPal
+Merci à [@jameses-cyber](https://github.com/jameses-cyber) et [@issaqua](https://github.com/issaqua) pour leur soutien au projet.
 
-Le sponsoring est entièrement facultatif. Le plugin reste sous licence Apache-2.0 et complet en termes de fonctionnalités.
+---
 
-### Sponsors
+## 📜 Licence et crédits
 
-Merci aux personnes suivantes pour leur soutien au projet :
+Apache License, Version 2.0 — voir [LICENSE](LICENSE) et [NOTICE](NOTICE).
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
+**Construit avec :**
+- 💡 [LLM Wiki d'Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — le concept original
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) et [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — algorithmes de recherche
 
-## 📜 Licence
+**Mainteneur :** [@green-dalii](https://github.com/green-dalii)
 
-Apache License 2.0 — voir [LICENSE](LICENSE) et [NOTICE](NOTICE).
-
-## 🙏 Remerciements
-
-- **💡 Concept :** [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) d'Andrej Karpathy — la vision originale ayant inspiré ce plugin
-- **🛠️ Plateforme :** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 Transport LLM :** [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_IT.md
+++ b/docs/README_IT.md
@@ -2,509 +2,332 @@
 
 # 🧠 Karpathy LLM Wiki Plugin per Obsidian
 
-> Base di conoscenza strutturata e potenziata dall'IA che acquisisce le tue note e genera un Wiki interconnesso — basato sul [concetto di LLM Wiki di Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+> Un plugin Obsidian che trasforma le tue note in una base di conoscenza connessa e interrogabile — il concetto di [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f), integrato nell'editor dove già scrivi.
 
-> **Punteggio ufficiale Obsidian 95/100 | Supporto nativo per 10 lingue | Ricerca su grafo senza embedding | Piena sovranità dei dati | Compatibile con qualsiasi provider LLM**
+> **Recupero su grafo senza embedding • 10 lingue native • Funziona con qualsiasi provider**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md) | **Italiano**
 
-[Sito ufficiale](https://llmwiki.greenerai.top/) | [Marketplace Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback e discussioni](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[Sito ufficiale](https://llmwiki.greenerai.top/) | [Marketplace Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussioni](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [Avvio rapido](#-avvio-rapido) | ✨ [Funzionalità](#-funzionalità) | 🤖 [Guida alla scelta del modello](#-guida-alla-scelta-del-modello) | 🔒 [Trasparenza e conformità](#-trasparenza-e-conformità) | ❓ [FAQ](#-faq)
+📑 [Indice](#-indice) • 🚀 [Avvio rapido](#-avvio-rapido) • ✨ [Funzionalità](#-funzionalità) • 🔍 [Come funziona il recupero](#-come-funziona-il-recupero) • 🤖 [Modelli](#-modelli) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Se questo plugin ti è stato utile, offrimi un caffè♥️ o lascia una stella🌟↗
 
 ---
 
-> **⚡ Promemoria sugli aggiornamenti rapidi:** questo progetto evolve rapidamente con frequenti correzioni di bug, miglioramenti delle prestazioni, nuove funzionalità e ottimizzazioni dell'esperienza utente. Ti consigliamo di aggiornare regolarmente all'ultima versione in Obsidian (**Impostazioni → Plugin della community → Verifica aggiornamenti**) oppure di abilitare l'aggiornamento automatico dei plugin per garantire la migliore esperienza.
-
 ## 📑 Indice
 
-- [🧠 Karpathy LLM Wiki Plugin per Obsidian](#-karpathy-llm-wiki-plugin-per-obsidian)
-  - [📑 Indice](#-indice)
-  - [💡 Cos'è LLM-Wiki?](#-cosè-llm-wiki)
-  - [⚡ Perché Obsidian + LLM-Wiki?](#-perché-obsidian--llm-wiki)
-  - [🚀 Avvio rapido](#-avvio-rapido)
-    - [📦 Installazione](#-installazione)
-    - [🔄 Aggiornamento](#-aggiornamento)
-    - [🔑 Configurare un provider LLM](#-configurare-un-provider-llm)
-    - [🎮 Utilizzo](#-utilizzo)
-    - [⚠️ Aggiornamento da una versione precedente?](#️-aggiornamento-da-una-versione-precedente)
-  - [⚡ Novità in v1.25.x](#-novità-in-v125x)
-  - [✨ Funzionalità](#-funzionalità)
-    - [📊 Qualità della conoscenza](#-qualità-della-conoscenza)
-    - [📄 Ingestione PDF (v1.25.0)](#-ingestione-pdf-v1250)
-    - [💬 Query e feedback](#-query-e-feedback)
-    - [🛠️ Manutenzione](#️-manutenzione)
-    - [🌐 LLM e lingua](#-llm-e-lingua)
-    - [🏗️ Architettura e prestazioni](#️-architettura-e-prestazioni)
-    - [🔒 Privacy e sicurezza](#-privacy-e-sicurezza)
-  - [📖 Esempio](#-esempio)
-  - [🤖 Guida alla scelta del modello](#-guida-alla-scelta-del-modello)
-    - [☁️ Modelli cloud](#️-modelli-cloud)
-    - [🦙 Modelli locali (Ollama / LM Studio)](#-modelli-locali-ollama--lm-studio)
-    - [📄 Percorso OCR PDF locale (v1.25.0+)](#-percorso-ocr-pdf-locale-v1250)
-  - [🏗️ Architettura](#️-architettura)
-  - [❓ FAQ](#-faq)
-  - [🔒 Trasparenza e conformità](#-trasparenza-e-conformità)
-  - [💖 Sostenere il progetto](#-sostenere-il-progetto)
-    - [Sponsor](#sponsor)
-  - [📜 Licenza](#-licenza)
-  - [🙏 Ringraziamenti](#-ringraziamenti)
-  - [Star History](#star-history)
----
-
-## 💡 Cos'è LLM-Wiki?
-
-Tu scrivi. L'IA organizza. Tu chiedi. Tutto qui.
-
-**🎯 Il problema.** Le tue note sono una miniera d'oro — persone, concetti, idee, connessioni. Ma per ora sono solo file in cartelle. Trovare cosa è collegato a cosa significa cercare, applicare tag e sperare di ricordare il filo conduttore.
-
-**✨ La soluzione.** [Andrej Karpathy ha proposto](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) qualcosa di elegante: trattare le tue note come materia prima e lasciare che sia un LLM a svolgere il lavoro di architetto. Legge ciò che scrivi, estrae entità e concetti e li intreccia in un Wiki strutturato — completo di `[[collegamenti bidirezionali]]`, un indice generato automaticamente e un'interfaccia di chat che risponde alle domande a partire dalla *tua* conoscenza.
-
-**📚 Così non devi più fare il bibliotecario.** Niente più decisioni su cosa merita una pagina. Nessun collegamento incrociato da mantenere. Nessun dubbio sull'obsolescenza dei contenuti. Scegli una qualsiasi nota (o cartella, o selezione multipla) dal tuo vault — l'LLM legge, estrae, scrive, collega e segnala perfino le contraddizioni — mentre tu resti concentrato.
-
-**🤖 E non è l'ennesimo chatbot.** ChatGPT conosce internet. LLM-Wiki conosce *te* — o meglio, ciò che gli hai insegnato. Ogni risposta riporta `[[wiki-link]]` verso il tuo grafo della conoscenza. Ogni risposta è un punto di partenza, non un vicolo cieco.
+- [🤔 Perché questo plugin?](#-perché-questo-plugin)
+- [🎯 Fa per me?](#-fa-per-me)
+- [🚀 Avvio rapido](#-avvio-rapido)
+- [✨ Funzionalità](#-funzionalità)
+- [🔍 Come funziona il recupero](#-come-funziona-il-recupero)
+- [🤖 Modelli](#-modelli)
+- [❓ FAQ](#-faq)
+- [🔒 Privacy](#-privacy)
+- [💖 Supporto](#-supporto)
+- [📜 Licenza e crediti](#-licenza-e-crediti)
 
 ---
 
-## ⚡ Perché Obsidian + LLM-Wiki?
+## 🤔 Perché questo plugin?
 
-Obsidian è eccezionale nel pensiero connesso. Ma c'è un trucco: sei tu a fare tutti i collegamenti.
+Prendi appunti. Loro restano in cartelle. Trovare cosa è collegato a cosa significa ricordare fili che hai dimenticato mesi fa.
 
-LLM-Wiki ribalta la situazione. Invece di costruire il grafo a mano, è l'IA a farlo crescere insieme a te. Aggiungi una nota su un nuovo concetto — l'IA trova le connessioni che ti sfuggirebbero. Poni una domanda — l'IA attraversa il tuo grafo della conoscenza e riporta risposte con citazioni.
+**Esistono altre reimplementazioni open-source dell'idea di LLM Wiki di Karpathy — ma nessuna è un plugin Obsidian installabile con un clic.** La maggior parte sono strumenti da riga di comando, skill per Claude Code o app desktop separate. Noi siamo l'unico con interfaccia nativa, archiviazione nel vault e la Graph View integrata di Obsidian.
 
-- **🔗 La tua Graph View prende vita.** Le nuove note non restano lì inerti — generano collegamenti verso entità, concetti e sorgenti. Il grafo cresce in modo organico e il plugin lo mantiene: rilevando duplicati, correggendo collegamenti interrotti, creando ponti tra lingue tramite gli alias.
-- **💬 Le tue note imparano a risponderti.** La ricerca diventa conversazione. "Cosa ho scritto su X?" diventa un dialogo, con risposte in streaming e `[[wiki-link]]` come tracce da seguire. Ogni risposta è un percorso più in profondità nella tua conoscenza.
-- **🧠 Obsidian diventa un partner di pensiero.** Smette di essere uno schedario per le note e inizia a essere qualcosa che ti aiuta a *pensare* — facendo emergere connessioni nascoste, segnalando contraddizioni, ricordando ciò che avevi dimenticato di sapere.
+### Confronto
+
+| | Karpathy LLM Wiki (questo plugin) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **Forma di distribuzione** | ✅ Plugin Obsidian con un clic | ❌ App desktop Tauri separata | ❌ Skill Claude Code | ❌ Skill Claude Code / Codex | ❌ CLI + SDK + server MCP |
+| **Sforzo di configurazione** | ✅ **5 minuti** — Community Plugins → Installa → scegli provider → Ingest | ❌ 30 min+ — compila/scarica binario, configura CLI | ❌ 15 min — richiede abbonamento Claude Code + installazione skill | ❌ 10 min — richiede abbonamento Claude Code / Codex + configurazione skill | ❌ 30 min+ — pip install + SDK + configurazione MCP |
+| **Percorso di installazione** | ✅ Obsidian → Community Plugins → cerca → Installa | ❌ Compila o scarica un binario separato, poi configura CLI | ❌ Richiede abbonamento Claude Code + guida all'installazione | ❌ Richiede abbonamento Claude Code o Codex + passaggi di configurazione | ❌ pip install + Python SDK + server locale |
+| **Complessità architetturale** | ✅ **Zero dipendenze** — niente DB vettoriale, niente modello di embedding, niente processi esterni | 🟡 Incorpora il proprio runtime Python + sigma.js + sqlite | 🟡 Usa l'ambiente di Claude Code — non autonomo | 🟡 Richiede piattaforma runtime separata | ❌ Richiede Python, modello di embedding, DB vettoriale |
+| **i18n (interfaccia + output wiki)** | ✅ 10 lingue (interfaccia / output indipendenti) | 🟡 2 (EN / 中文) | ❌ Solo inglese | ❌ Solo inglese | ❌ Solo inglese |
+| **Provider LLM** | ✅ 12+ (incl. Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-compatibile, Kimi, GLM, MiniMax, DeepSeek) | 🟡 Compatibile OpenAI | 🟡 Abbonamento via Claude Code | 🟡 Abbonamento via Claude Code / Codex | 🟡 Compatibile OpenAI |
+| **Algoritmo di recupero** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 Euristica a 4 segnali (Adamic-Adar + decadimento 2-hop) | ❌ Solo rilevamento comunità Louvain | ❌ Solo Louvain + anteprime k-hop | ❌ Ibrido: BM25 + semantico + wikilink |
+| **Pipeline di interrogazione (cascata a 5 stadi)** | ✅ Lex → keyword LLM → scansione sottostringhe → fallback KB LLM → espansione PPR (si interrompe al primo segnale sufficiente) | 🟡 Solo decadimento 2-hop | ❌ Solo clustering Louvain | ❌ Anteprime k-hop (senza augment LLM) | ❌ BM25 + semantico su chunk (senza grafo) |
+| **Richiede embedding** | ✅ No (costo embedding zero, per progettazione) | 🟡 Opzionale, disattivato per default | ✅ No | ✅ No | ❌ **Sì — obbligatorio** |
+| **Visualizzazione grafo** | ✅ Graph View nativa di Obsidian (integrata, dimensione zero aggiuntiva) | ❌ sigma.js + graphology personalizzati in app desktop | 🟡 vis.js graph.html (file separato) | ❌ sigma.js offline HTML personalizzato | ❌ Visualizzatore browser sola lettura |
+| **Onestà del wiki** | ✅ Banner "STADIO FALLBACK" quando nessuna fonte wiki corrisponde alla tua domanda | ❌ Nessun equivalente | ❌ Nessun equivalente | ❌ Nessun equivalente | ❌ Nessun equivalente |
+| **Benchmark di recupero pubblicato** | ✅ PPR @5 = 27,1% vs pura kNN 24,1% (unico numero pubblicato in questo spazio) | ❌ 58% → 71% *solo con embedding attivati*, non nel nostro formato mela-mela | ❌ Non pubblicato | ❌ Non pubblicato | ❌ Non pubblicato |
+
+### Tre scelte deliberate, non casuali
+
+- **🪟 Obsidian è il runtime.** Niente terminale, niente app separata, niente Docker, niente Python. Installa da Community Plugins, clicca Ingest, il wiki vive nel tuo vault dal primo secondo. La Graph View nativa di Obsidian renderizza il tuo grafo `[[wiki-link]]` — integrata, dimensione zero aggiuntiva nel bundle.
+- **🧭 Pulito e autonomo.** Zero dipendenze. Niente modello di embedding, niente database vettoriale, niente pacchetto pip — un singolo plugin che legge le tue note, parla con un LLM e scrive pagine wiki. Tutto vive dentro Obsidian.
+- **🔌 Qualsiasi modello per cui già paghi.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-compatibile, endpoint personalizzato — dodici e più provider, nessuno dei quali deve avere un endpoint per embedding.
+
+---
+
+## 🎯 Fa per me?
+
+**✅ Sì, se:**
+
+- **Vuoi una configurazione da 5 minuti, non un progetto da 5 ore.** Installa da Community Plugins → scegli un provider → Ingest una nota. Niente CLI, niente Python, niente runtime separato, niente DB vettoriale. Vedi le pagine wiki in `wiki/` in pochi secondi.
+- **Vuoi qualcosa di pulito e autonomo.** Il plugin ha esattamente zero dipendenze esterne: niente modello di embedding, niente database vettoriale, niente pacchetto pip, niente container Docker. È un singolo plugin Obsidian che legge le tue note, parla con un LLM e scrive pagine wiki nel tuo vault. Tutto vive dentro Obsidian.
+- **Vuoi una chat interrogabile che risponda dalle *tue* note** — non da internet — con ogni risposta che porta `[[wiki-link]]` di ritorno nel tuo grafo della conoscenza.
+- **Ti importa della sovranità dei dati** — funziona completamente in locale con Ollama o LM Studio, senza mai toccare internet.
+- **Scrivi o leggi in una qualsiasi delle 10 lingue supportate** — l'interfaccia e la lingua di output del wiki sono indipendenti (il tuo wiki può essere in cinese mentre l'interfaccia è in inglese).
+- **Mantieni il grafo scrivendo `[[wiki-link]]`** — ogni link che scrivi arricchisce già il recupero; nessun passaggio separato di tagging/embedding/indicizzazione.
+- **Vuoi manutenzione con un clic** — scansione salute Lint + Smart Fix All tengono sotto controllo duplicati, link morti e pagine orfane senza che tu debba curare a mano.
+
+**❌ No, se:**
+
+- **Vuoi un sostituto generico di ChatGPT** — questo plugin risponde solo dalla *tua* conoscenza.
+- **Hai bisogno di una pipeline RAG su PDF / pagine web / corpora esterni** — ci concentriamo sul percorso in-vault (i PDF sono supportati dalla v1.25.0).
+- **Cerchi un SaaS ospitato** — non c'è backend, niente server, nessun account.
 
 ---
 
 ## 🚀 Avvio rapido
 
-### 📦 Installazione
+1. **Installa.** Obsidian → Impostazioni → Plugin della community → Sfoglia → cerca "Karpathy LLM Wiki" → Installa → Abilita. Oppure visita la [pagina del plugin della community](https://community.obsidian.md/plugins/karpathywiki) e clicca su **Add to Obsidian**.
+2. **Configura un provider.** Apri Impostazioni → Karpathy LLM Wiki → scegli un provider (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth), ecc.) → inserisci la chiave API (non necessaria per provider locali) → clicca su **Test Connection** → Salva.
+3. **Ingerisci una nota.** `Cmd+P/Ctrl+P` → "Ingest single source" → scegli un file Markdown (o PDF, v1.25.0+). Le tue prime pagine wiki appaiono in `wiki/sources/`, `wiki/entities/`, `wiki/concepts/` in pochi secondi.
 
-**🌟 Consigliato — Marketplace dei plugin della community di Obsidian:**
+Questo è tutto. Il plugin non modifica nulla nelle tue note originali — crea solo nuove pagine in `wiki/`. Per chattare con il tuo wiki: `Cmd+P/Ctrl+P` → "Query wiki". (`Cmd` su macOS, `Ctrl` su Windows/Linux.)
 
-1. In Obsidian, vai su **Impostazioni → Plugin della community**
-2. Clicca su **Sfoglia** e cerca "Karpathy LLM Wiki"
-3. Clicca su **Installa**, poi su **Abilita**
+### Comandi principali
 
-**🌐 Oppure dal sito dei plugin della community —** visita [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) e clicca su **Add to Obsidian** per installarlo direttamente.
+| Comando | Cosa fa |
+|---------|---------|
+| **📥 Ingest singola fonte** | `Cmd+P/Ctrl+P` → "Ingest single source" — scegli un file Markdown o **PDF (v1.25.0+)** , ottieni pagine entità/concetto/wiki |
+| **📂 Ingest da cartella** | `Cmd+P/Ctrl+P` → "Ingest from folder" — ingest in batch di ogni nota in una cartella, con salto intelligente dei già elaborati |
+| **📑 Ingest file multipli** | `Cmd+P/Ctrl+P` → "Ingest multiple files" — seleziona un sottoinsieme tramite albero cartelle a due pannelli (con coda live + annullamento per file) |
+| **🔍 Query wiki** | `Cmd+P/Ctrl+P` → "Query wiki" — chatta con il tuo wiki in un pannello laterale ancorato a destra; le risposte portano `[[wiki-link]]` |
+| **🛠️ Lint wiki** | `Cmd+P/Ctrl+P` → "Lint wiki" — scansione salute completa: duplicati, link morti, pagine vuote, orfani, alias mancanti, contraddizioni |
+| **⚡ Smart Fix All** | dentro il modale Lint — riparazione in ordine causale con un clic e report per fase |
+| **📋 Rigenera indice** | `Cmd+P/Ctrl+P` → "Regenerate index" — ricostruisce `wiki/index.md` con pagine e alias correnti |
+| **⏹ Annulla** | `Cmd+P/Ctrl+P` → "Cancel current ingestion" o clicca sulla barra di stato — si ferma pulitamente al prossimo limite di lotto |
+| **📊 Cronologia ingestioni** | `Cmd+P/Ctrl+P` → "View Ingestion History" — interfaccia ricercabile per ingestioni passate, report lint ed esecuzioni di manutenzione |
 
-**⚙️ Manuale (alternativa):**
+| Prima | Dopo |
+|-------|------|
+| `notes/machine-learning.md` (un file piatto) | `wiki/concepts/supervised-learning.md` con `[[collegamenti bidirezionali]]`, alias, attribuzione della fonte e una voce in `wiki/index.md` |
 
-1. Scarica `main.js`, `manifest.json`, `styles.css` dalle [Release](https://github.com/green-dalii/obsidian-llm-wiki/releases)
-2. In Obsidian, vai su Impostazioni → Plugin della community. Nella scheda **Plugin installati**, clicca sull'icona della cartella per aprire la directory dei plugin
-3. Crea una cartella chiamata `karpathywiki` e inserisci i tre file al suo interno
-4. Tornato in Obsidian, clicca sull'icona di aggiornamento — **Karpathy LLM Wiki** comparirà tra i plugin installati
-5. Attivalo per abilitarlo
-
-**🔨 Sviluppo:** `git clone`, `pnpm install`, `pnpm build`.
-
-### 🔄 Aggiornamento
-
-Questo progetto evolve rapidamente — nuove funzionalità, correzioni di bug e miglioramenti vengono rilasciati con frequenza. Ti consigliamo di restare aggiornato:
-
-**Opzione A — Aggiornamento manuale (consigliato):**
-1. Vai su **Impostazioni → Plugin della community**
-2. Clicca su **Verifica aggiornamenti**
-3. Trova **Karpathy LLM Wiki** nell'elenco e clicca su **Aggiorna**
-
-**Opzione B — Abilita l'aggiornamento automatico:**
-1. Vai su **Impostazioni → Plugin della community**
-2. Attiva **Verifica automaticamente gli aggiornamenti dei plugin**
-3. Le nuove versioni verranno rilevate automaticamente; aggiorna manualmente quando preferisci
-
-> 💡 **Perché restare aggiornato?** Ogni release può includere nuove funzionalità, miglioramenti delle prestazioni e correzioni di bug importanti. Manteniamo attivamente questo plugin — saltare gli aggiornamenti significa perdere un'esperienza migliore.
-
-### 🔑 Configurare un provider LLM
-
-1. Apri Impostazioni → Karpathy LLM Wiki
-2. Scegli un provider dal menu a discesa (inclusi OpenAI o ChatGPT Plan (Codex OAuth))
-3. Per i provider API inserisci la chiave (non necessaria per Ollama, LM Studio o ChatGPT Plan (Codex OAuth))
-4. Per i provider diversi da Codex usa **Fetch Models** o inserisci un modello; ChatGPT Plan (Codex OAuth) popola automaticamente l'elenco dei modelli selezionati
-5. Clicca su **Test Connection**, poi su **Save Settings**
-
-**🦙 Ollama (locale, nessuna chiave API):** installa [Ollama](https://ollama.com), scarica un modello (`ollama pull gemma4` o `ollama pull qwen3.5:27b`), seleziona "Ollama (Local)" nel menu dei provider.
-
-**🎛️ LM Studio (locale, nessuna chiave API):** installa [LM Studio](https://lmstudio.ai), avvia il suo server locale (predefinito `http://localhost:1234/v1`), seleziona "LM Studio (Local)" nel menu dei provider. LM Studio esegue un server integrato compatibile con OpenAI — il campo della chiave API è facoltativo.
-
-**🔐 ChatGPT Plan (Codex OAuth) — sperimentale:** è separato da **OpenAI**, che usa una chiave OpenAI Platform fatturata a parte. Selezionalo e usa **Accedi con il browser** su desktop (callback localhost), oppure **Usa codice dispositivo** su desktop/mobile e completa l'autorizzazione nella pagina OpenAI. Il plugin sincronizza i modelli selezionabili dell'account Codex connesso e memorizza solo metadati ripuliti; **Aggiorna modelli account** li aggiorna manualmente. Se il catalogo è temporaneamente indisponibile, resta disponibile l'ultima cache o un elenco minimo di riserva. Poi verifica la connessione e salva. Le credenziali OAuth sono archiviate solo in Obsidian SecretStorage; **Esci** le cancella. La disponibilità segue le politiche di autenticazione, modelli e disponibilità di OpenAI Codex. È compatibilità di terze parti, non una partnership OpenAI né un'API ChatGPT generale.
-
-> Vedi la [Guida alla scelta del modello](#-guida-alla-scelta-del-modello) per i dettagli.
-
-### 🎮 Utilizzo
-
-| Metodo | Come |
-|--------|------|
-| **📥 Acquisisci singola fonte** | `Cmd+P` → "Ingest single source" — seleziona una nota (Markdown o **PDF, v1.25.0+**) per generare pagine Wiki con entità e concetti |
-| **📂 Acquisisci da cartella** | `Cmd+P` → "Ingest from folder" — seleziona una cartella per generare Wiki in lote |
-| **📑 Acquisisci più file** | `Cmd+P` → "Ingest multiple files" — scegli note tramite albero cartelle + checkbox, acquisizione in lote (con coda live + annullamento per file) |
-| **🎯 Acquisisci file corrente** | Clicca l'icona `sticker` nella barra sinistra, o `Cmd+P` → "Ingest current file" |
-| **🔍 Interroga il wiki** | `Cmd+P` → "Query wiki" — Q&A conversazionale con streaming e `[[wiki-link]]` |
-| **🛠️ Verifica il wiki** | `Cmd+P` → "Lint wiki" — controllo completo: duplicati, link morti, pagine vuote, orfane, alias mancanti, contraddizioni |
-| **📋 Rigenera indice** | `Cmd+P` → "Regenerate index" — ricostruisce `wiki/index.md` con voci alias |
-| **📊 Cronologia acquisizioni (v1.21.0)** | `Cmd+P` → "View Ingestion History" — esplora acquisizioni, rapporti Lint e manutenzioni passate |
-| **⏹ Annulla operazione** | `Cmd+P` → "Cancel current ingestion" — si ferma in sicurezza al prossimo limite di lotto |
-| **🎉 Ricrea nota di benvenuto (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — rigenera la nota di benvenuto |
-
-La ri-acquisizione della stessa fonte fonde nuove informazioni in modo incrementale. I riepiloghi vengono rigenerati.
-
-> 💡 **Smart Batch Skip:** Durante l'acquisizione di una cartella, il plugin rileva e salta automaticamente i file già elaborati — risparmia tempo e costi API.
-
-![Command palette — cerca "karpa" per visualizzare tutti i comandi](assets/command-panel.png)
-
-### ⚠️ Aggiornamento da una versione precedente?
-
-> 🔧 **Aggiornamento da v1.24.x.** L'ingestione PDF (v1.25.0) scrive la sua cache in `.obsidian/plugins/karpathywiki/pdf-cache/` (fino a 100 MB / 1000 voci / 10 MB per singola voce; eviction LRU-by-mtime all'avvio e all'inizio di ogni ingestione in batch). Il tuo vault **non viene modificato per default** — attiva **Write PDF Markdown to Vault** (Settings → Wiki Configuration → Wiki Folder) solo se vuoi un sidecar `<basename>.pdf.md` accanto al PDF sorgente. Due nuove impostazioni — **Force PDF Support** (avanzato, disattivato per default) e **Write PDF Markdown to Vault** (disattivato per default) — sono completamente retrocompatibili: un vecchio `data.json` senza questi campi ripiegherà su `false`.
-
-> 🔧 **Aggiornamento da v1.24.0.** Il marcatore di commento interno `<!-- reviewed: keep -->` (v1.24.0, #244), che proteggeva solo la sezione *Mentions in Source* di una pagina, è stato rimosso. Per conservare una sezione Mentions curata manualmente, imposta `reviewed: true` nel frontmatter della pagina: protegge l'intera pagina (Mentions incluse) e, a differenza del commento nascosto, resta visibile nel pannello Proprietà e resiste ai linter Markdown.
-
-**Retrocompatibile.** Nessuna modifica che comprometta la compatibilità dalla v1.0.0 — le tue pagine Wiki, impostazioni e flussi di lavoro esistenti vengono preservati senza riconfigurazione.
-
-**Dopo l'aggiornamento**, esegui **Lint Wiki** → **Smart Fix All** per riparazione automatica:
-1. 🏷️ Completare alias (LLM genera traduzioni, abbreviazioni, nomi alternativi)
-2. 🔄 Unire duplicati (multilingua, abbreviazioni, alta similarità)
-3. 🔗 Riparare link morti / collegare orfani / espandere pagine vuote
-
-Poi **Rigenera indice** per ricostruire `wiki/index.md` con voci alias.
-
-> 📖 Guide dettagliate per salti di versione specifici in [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions).
-
-**Impostazioni da verificare:** Force PDF Support (Settings → LLM Configuration → Advanced, disattivato per default — necessario solo per provider non NATIVE), Write PDF Markdown to Vault (Settings → Wiki Configuration → Wiki Folder, disattivato per default), Lingua di output Wiki, Granularità di estrazione, Concorrenza (predefinito 3), Ritardo lotto (predefinito 300ms).
-- **🏷️ Alias mancanti**: pagine senza alias (di qualsiasi versione, se non hai mai eseguito "Complete Aliases"). Clicca su **"Complete Aliases"** — l'LLM genera in blocco traduzioni, acronimi e nomi alternativi. Questo è fondamentale per il rilevamento dei duplicati.
-- **🔄 Pagine duplicate**: pagine con contenuti sovrapposti (es. "CoT" vs "思维链" create da versioni precedenti prive di deduplicazione consapevole degli alias). Clicca su **"Merge Duplicates"** per fonderle e preservare tutti gli alias.
-- **💀 Collegamenti interrotti / Pagine vuote / Pagine orfane**: problemi standard di manutenzione del wiki.
-
-**3️⃣ Usa Smart Fix All**
-Clicca su **"Smart Fix All"** nel report di Lint per una riparazione con un clic, ordinata per causalità: alias completati → duplicati uniti → collegamenti interrotti corretti → orfane collegate → pagine vuote espanse. È il modo più rapido per ripulire un wiki costruito attraverso molte versioni.
-
-**4️⃣ Abilita la generazione parallela delle pagine**
-Impostazioni → **LLM Configuration**:
-- **⚡ Page Generation Concurrency**: imposta a 3 per la maggior parte dei provider. Velocizza l'acquisizione di 2–3× su sorgenti con oltre 10 entità.
-- **⏱️ Batch Delay**: parti da 300 ms. Aumenta a 500–800 ms se incontri limiti di frequenza.
-
-**5️⃣ Rivedi le impostazioni attuali:**
-- **🌐 Wiki Output Language**: indipendente dalla lingua dell'interfaccia — il tuo Wiki può essere in cinese mentre l'interfaccia del plugin resta in inglese, o viceversa.
-- **📊 Granularità di estrazione**: cinque opzioni controllano quanto in profondità l'LLM estrae le entità dalle sorgenti:
-  - **Fine** (~100 elementi) — Analisi approfondita, incluse le menzioni dei casi limite. Costo elevato in token, ideale per le sorgenti chiave.
-  - **Standard** (~50 elementi) — Estrazione bilanciata. Buon valore predefinito per le note quotidiane.
-  - **Grossolana** (~10 elementi) — Panoramica rapida, solo entità principali. Costo basso, acquisizione veloce.
-  - **Minima** (~5 elementi) — Solo elementi essenziali. Ideale per l'elaborazione in batch di oltre 100 file o per testare nuove sorgenti.
-  - **Personalizzata** (1–500 elementi) — Limiti di entità/concetti definiti dall'utente per flussi di lavoro specializzati.
-  > 💡 **Consiglio**: usa Minima o Grossolana per le cartelle di grandi dimensioni per risparmiare tempo e costi API. Usa Fine in modo selettivo sui documenti chiave che meritano un'analisi approfondita.
-- **🔄 Auto-Maintenance**: Startup Quick Fixes è attivo per impostazione predefinita (controllo di salute una tantum all'avvio); File Watcher e Periodic Lint sono disattivati per impostazione predefinita — abilitali solo se desideri l'elaborazione automatica in background.
-
-> **🛡️ Sicurezza**: la generazione parallela usa `Promise.allSettled` — se una pagina fallisce, le altre proseguono. Le pagine fallite vengono ritentate individualmente con backoff esponenziale. Smart Batch Skip rileva automaticamente i file già acquisiti per risparmiare tempo e costi API.
+> 💡 **Resta aggiornato.** Nuove funzionalità, correzioni e miglioramenti delle prestazioni vengono rilasciati frequentemente. Impostazioni → Plugin della community → Verifica aggiornamenti, o abilita l'aggiornamento automatico dei plugin.
+> 📖 Guide dettagliate (installazione, configurazione PDF, note multi-provider, aggiornamenti) sono mantenute in [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides).
 
 ---
-## ⚡ Novità in v1.25.x
-
-- **v1.25.2 (2026-07-22).** Vocabolario tag Fase 1（doppia fonte eliminata）、Codex OAuth（ChatGPT Plan）、correzione prefisso cartella nei collegamenti correlati、termine `---` del modello di pagina corretto、ESLint 0.4.1 Route A. 2515 test superati.
-- **v1.25.1 (2026-07-20).** Otto correzioni di perdita silenziosa（pagina correlata、sezioni schema、Menzioni legacy）、3 suddivisioni di file grandi、DiskCache<T>、LM Studio senza chiave API、causa principale verifica build. 2274 test superati.
-- **v1.25.0 (2026-07-18).** Ingest PDF solo cache（Livello 1）、crescita cache limitata、sidecar vault opzionale、portale universale Force PDF、prompt trascrizione testuale、ingest annullabile、guida modelli locali、completezza i18n. 2182 test superati.
-
-📋 [Cronologia versioni completa → CHANGELOG.md](../CHANGELOG.md)
 
 ## ✨ Funzionalità
 
-### 📊 Qualità della conoscenza
+### 📚 Qualità della conoscenza
 
-- **🔍 Estrazione di entità/concetti** — l'LLM estrae entità (persone, organizzazioni, prodotti, eventi, ecc.) e concetti (teorie, metodi, termini, ecc.) dalle tue note e genera pagine Wiki autonome. Granularità di estrazione flessibile (minima ~5, grossolana ~10, standard ~50, fine ~100, personalizzata 1–500) bilancia la profondità di analisi con il costo delle API.
-- **🏷️ Alias di pagina obbligatori** — ogni pagina generata include almeno 1 alias (traduzione, abbreviazione, variante) per il rilevamento dei duplicati tra lingue.
-- **🔄 Rilevamento e fusione dei duplicati** — rilevamento semantico a livelli cattura i veri duplicati (traduzioni, abbreviazioni, varianti ortografiche); la fusione intelligente tramite LLM unisce i contenuti preservando gli alias.
-- **🧩 Fusione intelligente della conoscenza** — gli aggiornamenti multi-fonte fondono le nuove informazioni senza duplicati; le contraddizioni vengono preservate con attribuzione della fonte; le pagine `reviewed: true` sono protette dalla sovrascrittura.
-- **📏 Protezione dal troncamento dei contenuti** — I provider con chiave API e quelli locali usano 8000 max_tokens, rilevano automaticamente stop_reason e riprovano con 2× token. Il percorso sperimentale ChatGPT Plan (Codex OAuth) segue la politica di output del backend Codex, che non accetta un limite max_output_tokens lato client.
-- **📝 Conservazione delle citazioni originali** — le sezioni Menzioni nella sorgente conservano le citazioni nella lingua originale (traduzione opzionale) per la tracciabilità completa.
+- **🔍 Estrazione di entità e concetti** — l'LLM estrae entità (persone, organizzazioni, prodotti, eventi) e concetti (teorie, metodi, termini) in pagine autonome. La granularità è configurabile (Minima → Fine, più Personalizzata) così da bilanciare costo e profondità.
+- **🏷️ Alias obbligatori** — ogni pagina viene creata con almeno un alias (traduzione, abbreviazione, variante) così il rilevamento dei duplicati tra lingue funziona.
+- **🔄 Rilevamento duplicati a livelli** — Livello 1 (corrispondenza nome diretta: cross-lingua, abbreviazione, titoli ad alta similarità) sempre verificato; Livello 2 (link condivisi, similarità media) riempie il budget di token rimanente.
+- **🧩 Fusione intelligente e stato contraddizioni** — i duplicati vengono uniti preservando gli alias; le contraddizioni vengono segnalate con attribuzione della fonte; le pagine `reviewed: true` sono protette dalla sovrascrittura.
+- **🎨 Vocabolario tag personalizzabile** — definisci le tue liste di tag per tipo di entità e concetto in Impostazioni → Wiki → Vocabolario tag → *Personalizzato*; Lint segnala ogni pagina i cui tag cadono fuori dal vocabolario attivo.
 
-- **🎨 Vocabolario tag personalizzabile (v1.18.0).** Impostazioni → Wiki → Modalità vocabolario tag → *Personalizzato* ti permette di definire le tue liste di tag per tipo di entità e concetto (es. `Medical_Arzneimittel`, `法规`). Il plugin rispetta il tuo vocabolario nei prompt di estrazione e nella validazione del frontmatter; l'audit Lint (Issue #85 v7) segnala qualsiasi pagina i cui tag cadano fuori dal vocabolario attivo.
+### 📄 Ingest PDF (v1.25.0+)
 
-### 📄 Ingestione PDF (v1.25.0)
+- **🔌 Cancello provider** — Anthropic, OpenAI e Bedrock gestiscono i PDF nativamente. Per qualsiasi altro endpoint compatibile OpenAI/Anthropic, attiva **Force PDF Support** in Impostazioni → Configurazione LLM → Avanzate per consentire al plugin di tentare la chiamata. Per OCR locale su Apple Silicon, estrattori di terze parti (MinerU, Docling, Mathpix, Adobe) e la guida completa all'ingest PDF, vedi [Percorsi OCR PDF](#-percorsi-ocr-pdf) qui sotto e [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md).
+- **🗄️ Cache limitata** — `.obsidian/plugins/karpathywiki/pdf-cache/` memorizza il Markdown convertito indicizzato per hash del contenuto + modello + versione del convertitore. Manutenzione a tre livelli di difesa: 100 MB totali / 1000 voci / 10 MB per singola voce con eviction LRU-by-mtime.
+- **📝 Sidecar vault opzionale** — Impostazioni → Configurazione Wiki → Cartella Wiki → *Write PDF Markdown to Vault* scrive `<basename>.pdf.md` accanto al PDF sorgente (disattivato per default — solo cache è il default).
+- **🛡️ Prompt trascrittore verbatim** — conversione in stile OCR con marcatori anti-allucinazione `[illegible]` / `[figure: ...]`; l'incapsulamento in fence markdown da parte di modelli locali piccoli viene automaticamente pulito prima della scrittura in cache.
 
-Scegli un PDF dal tuo vault — il plugin lo legge tramite l'input file nativo del tuo provider LLM, lo converte in Markdown e rientra nella normale pipeline di ingestione Markdown. Tutti i workflow esistenti entità/concetto/alias/`[[wiki-link]]` restano invariati.
+### 📄 Percorsi OCR PDF
 
-- **🔌 Cancello provider** — Anthropic, OpenAI, Bedrock Anthropic e Bedrock OpenAI gestiscono i PDF nativamente. Per qualsiasi altro endpoint compatibile OpenAI/Anthropic, attiva **Force PDF Support** in Settings → LLM Configuration → Advanced per consentire al plugin di tentare la chiamata (il tuo endpoint decide; i fallimenti generano un Notice localizzato che guida a disattivare il toggle). La configurazione locale consigliata è in [Percorso OCR PDF locale](#-percorso-ocr-pdf-locale-v1250).
-- **🗄️ Cache per hash del contenuto** — PDF + modello + versione di convertitore identici restituiscono il Markdown in cache senza chiamata LLM. La cache vive in `.obsidian/plugins/karpathywiki/pdf-cache/`; la chiave incorpora `converterVersion` così gli upgrade di prompt invalidano automaticamente le voci obsolete.
-- **📏 Crescita limitata** — housekeeping della cache a tre livelli di difesa (100 MB totali / 1000 voci / 10 MB per singola voce) con eviction LRU-by-mtime; le voci vecchie vengono rimosse all'avvio e all'inizio di ogni ingestione in batch. Solo cache — il tuo vault non viene modificato per default.
-- **📝 Sidecar opzionale nel vault** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** scrive un `<basename>.pdf.md` accanto al PDF sorgente dopo la conversione. Disattivato per default (solo cache).
-- **🛡️ Prompt trascrittore verbatim** — il prompt PDF→Markdown è riformulato come conversione verbatim in stile OCR con marcatori anti-allucinazione `[illegible]` / `[figure: ...]` / `[equation: ...]`; i modelli piccoli/locali che avvolgono l'output in fence ```markdown vengono puliti automaticamente prima della scrittura in cache.
-- **⏹ Cancellabile** — cliccare sulla barra di stato durante la conversione interrompe la chiamata LLM in corso (tramite Vercel AI SDK v6).
+Tre percorsi, scegli quello adatto alla tua configurazione:
 
-### 💬 Query e feedback
+1. **☁️ Provider cloud con supporto PDF nativo** — Anthropic, OpenAI o AWS Bedrock leggono i PDF senza configurazione aggiuntiva. Basta ingerire. Per qualsiasi altro endpoint compatibile OpenAI/Anthropic, attiva **Force PDF Support** in Impostazioni → Configurazione LLM → Avanzate.
+2. **🖥️ OCR locale su Apple Silicon** — [oMLX](https://github.com/jundot/omlx) integra Microsoft Markitdown come backend PDF→Markdown integrato. Abilita Markitdown in oMLX, carica [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M-attivi, open-source 2026-06) come modello visivo, punta il plugin a oMLX come provider personalizzato compatibile OpenAI, attiva **Force PDF Support** e scegli il modello multimodale che oMLX sta servendo. Il PDF non lascia mai la tua macchina.
+3. **🛠️ Estrattore di terze parti (MinerU, Docling, Mathpix, Adobe)** — esegui un estrattore separato sui tuoi PDF per produrre file `.md`, poi ingeriscili come normali note Markdown tramite la pipeline standard del plugin. Più affidabile per articoli scientifici, documenti scansionati, PDF con molti contenuti matematici.
 
-- **🔍 Cascata di selezione seed PPR a 5 stadi (v1.24.1 PATCH).** Quando poni una domanda multi-hop, Query Wiki compone la risposta attraverso cinque stadi complementari prima che qualsiasi generazione parta:
-  1. **Percorso rapido Lex** — controllo diretto di sovrapposizione di token contro ogni titolo/alias di entity/concept (gratis, istantaneo; fa da gate per gli stadi successivi)
-  2. **Generazione di keyword via LLM** — l'LLM propone 8–12 keyword cross-language dalla tua query (assorbe sinonimi, abbreviazioni, termini resistenti alla sovrapposizione di token)
-  3. **Scansione locale di sottostringhe** — ogni keyword generata viene ri-matchata localmente contro titoli di pagina, alias e snippet del corpo (nessuna chiamata LLM extra; completa il recall tollerante al rumore)
-  4. **Fallback LLM KB** — quando lex + scansione keyword restituiscono segnali deboli, l'LLM ri-semina i top-N candidati con un passaggio semantico sull'intero wiki
-  5. **Espansione del grafo PPR** — Personalized PageRank (Haveliwala 2002) eseguito sul grafo `[[wiki-link]]` a partire dall'insieme di seed candidati; porta all'LLM il contesto multi-hop consapevole del grafo che la ricerca lineare non raggiunge
+📖 **Guide complete per tutti e tre i percorsi** (provider cloud, livelli hardware oMLX, installazione MinerU, manutenzione cache) → [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-  La cascata si tronca automaticamente allo stadio che restituisce segnale sufficiente — nessun costo fisso di 5 stadi, nessuna chiamata LLM quando Lex basta, nessuna perdita di precisione quando serve l'augmentation LLM. La rilevanza end-to-end (PPR @5 = 27,1% sul corpus di benchmark interno del progetto) supera le baseline knn pure (24,1%) senza opt-in di embedding. Stage 1.5 (stadi 2–3) assorbe i tipi di domanda multi-hop che il Lex puro perde; Stage 1.7 (stadio 4) recupera segnali deboli dalle keyword iniettate dall'LLM; Stage 1.9 (stadio 5) garantisce che l'LLM veda contesto di vicinato invece di una top-N piatta. Sostituisce la vecchia cascata binaria a livelli.
+### 💬 Query e manutenzione
 
-- **🤖 Query conversazionale** — dialogo in stile ChatGPT con output Markdown in streaming, `[[wiki-links]]` automatici e cronologia multi-turno.
-- **🪟 Pannello laterale ancorato a destra (v1.22.1, PR #196).** Query Wiki si apre in un leaf del sidebar destro in stile Copilot (riutilizzando un leaf esistente) invece di un popup centrato. L'icona ribbon `message-circle` e il comando `Query Wiki` attivano/mostrano il pannello; le tue note restano visibili accanto alla conversazione. Tutte le funzionalità sono preservate senza modifiche.
-- **📤 Feedback Query → Wiki** — salva le conversazioni preziose nel Wiki, con estrazione di entità/concetti e deduplicazione semantica pre-salvataggio.
-- **🔒 Guardia salvataggio duplicati** — tracciamento hash che impedisce la ri-valutazione di conversazioni invariate.
+- **🧭 Cascata PPR a 5 stadi** — vedi [Come funziona il recupero](#-come-funziona-il-recupero). Personalized PageRank sul grafo `[[wiki-link]]` fornisce contesto multi-hop consapevole del grafo.
+- **🪟 Pannello laterale ancorato a destra** — Query Wiki si apre in un leaf laterale destro in stile Copilot (v1.22.1+) invece di un modale centrato.
+- **🔍 Scansione salute Lint** — un singolo comando rileva: duplicati, link morti, pagine vuote, orfani, alias mancanti, contraddizioni.
+- **⚡ Smart Fix All** — riparazione in ordine causale con un clic: completa alias → unisci duplicati → correggi link morti → collega orfani → espandi pagine vuote, con report per fase.
+- **📊 Pannello cronologia operazioni** — interfaccia ricercabile e filtrabile per ingestioni passate, report lint ed esecuzioni di manutenzione.
+- **🛡️ Portale di pre-ingest** — le note vuote / solo spazi / solo frontmatter vengono rifiutate prima di qualsiasi chiamata LLM; la deduplicazione per hash del contenuto rileva file identici attraverso i percorsi.
 
-### 🛠️ Manutenzione
+### 🔒 Privacy
 
-- **🔍 Scansione di integrità Lint** — un unico report completo rileva: pagine duplicate, link morti, pagine vuote, orfani, alias mancanti, contraddizioni.
-- **🎯 Rilevamento duplicati semantico a livelli** — Livello 1 (corrispondenza nome diretta: cross-lingua, abbreviazione, titoli ad alta similarità) sempre verificato; Livello 2 (segnali indiretti: link condivisi, similarità media) riempie il budget di token.
-- **⚡ Smart Fix All con un clic** — correzioni in batch in ordine causale: completa alias → unisci duplicati → correggi link morti → collega orfani → espandi pagine vuote, con report popup per fase.
-- **🏷️ Completamento alias** — generazione batch parallela con un clic degli alias mancanti, migliorando il rilevamento futuro dei duplicati.
-- **🔄 Auto-manutenzione** — monitoraggio multi-cartella, Lint programmato, controllo di integrità all'avvio (tutti opzionali).
-- **⚠️ Macchina a stati delle contraddizioni** — `rilevata → revisione-superata → risolta` (correzione AI) o `rilevata → non risolta` (manuale).
-- **🛡️ Portale di pre-ingestione (v1.21.0)** — Ogni file sorgente viene validato *prima* di qualsiasi chiamata LLM: le note vuote/blank/solo frontmatter vengono rifiutate; la deduplicazione per hash del contenuto rileva file identici attraverso i percorsi. Impedisce ai modelli locali di allucinare nomi di entità su input vuoti.
-- **📊 Pannello di cronologia operazioni (v1.21.0)** — UI ricercabile e filtrabile per ingestioni passate, report di lint ed esecuzioni di manutenzione, con card KPI guidate da insight e link cliccabili alle pagine.
-- **🧹 Pulitore di pagine incomplete (v1.21.0)** — Le pagine lasciate in stato parziale a causa di ingestioni interrotte vengono archiviate automaticamente all'avvio (recuperabili dal `.trash` di Obsidian).
+- **🚫 Nessun backend, nessun tracciamento, nessuna analisi.** Funziona interamente dentro Obsidian. La rete è usata solo per comunicare con il provider LLM che configuri.
+- **📁 I file sorgente sono sola lettura.** Il plugin non modifica mai le tue note originali del vault — crea solo nuove pagine in `wiki/`.
+- **🦙 Modalità completamente locale.** Ollama, LM Studio o qualsiasi endpoint locale compatibile OpenAI → le tue note non lasciano mai la tua macchina.
+- **🔐 Permessi minimi.** Accesso ai file del vault per la gestione del wiki. Accesso agli appunti solo quando clicchi il pulsante "Copia" nel modale Query.
 
-### 🌐 LLM e lingua
+### 🦙 Locale prima di tutto
 
-- **🔌 Supporto multi-provider** — Anthropic, Anthropic-compatibile (Coding Plan), Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, endpoint personalizzato.
-- **🔄 Retry automatico 5xx** — backoff esponenziale su HTTP 5xx / 429 / 529 su tutti i client (max 2 retry).
-- **📋 Lista modelli dinamica** — recuperata in tempo reale dall'API del provider.
-- **🌐 Lingua di output del Wiki** — 10 lingue indipendenti dalla UI (EN / ZH simplif / ZH trad / JA / KO / DE / FR / ES / PT / IT), con opzione di input personalizzato.
-- **🌍 Internazionalizzazione completa della UI** — interfaccia plugin in 10 lingue con 269+ campi UI completamente tradotti in espressione locale naturale.
-- **⚡ Guardia rate-limit** — rileva automaticamente quando la generazione parallela innesca rate limit e suggerisce di ridurre la concorrenza, aumentare il delay tra batch o cambiare provider.
-- **🦙 Compatibilità Web Clipper** — aggiunta con un clic della cartella `Clippings/` dell'Obsidian Web Clipper ufficiale alla lista di monitoraggio; le pagine web clippate vengono auto-importate nel Wiki.
+- **🖥️ Ollama, LM Studio, OpenRouter, endpoint personalizzato** — pronti all'uso. I modelli locali funzionano per le query (finestre di contesto più piccole); l'ingest su un vault di 2000 pagine di solito richiede un modello cloud a contesto lungo.
+- **📄 Il percorso OCR PDF è completamente locale su Apple Silicon** — vedi [Percorsi OCR PDF](#-percorsi-ocr-pdf).
+- **🔐 ChatGPT Plan (Codex OAuth)** — callback loopback desktop su `127.0.0.1:1455`; mobile tramite codice dispositivo. Le credenziali vivono solo in Obsidian SecretStorage; il logout le cancella. Compatibilità Codex di terze parti, non una partnership OpenAI.
 
-### 🏗️ Architettura e prestazioni
+### 🌐 Lingua
 
-- **🕸️ PPR sul grafo [[wiki-link]] (v1.24.0+, maturato in v1.24.1 PATCH).** Personalized PageRank (Haveliwala 2002) gira sul grafo diretto di archi `[[wiki-link]]` tra le tue pagine wiki; la cascata ancora i seed PPR sull'insieme di candidati top-N, e il contesto multi-hop viaggia attraverso fino a 3 anelli di espansione. È questo che rende le risposte di Query Wiki consapevoli del grafo (una domanda "fondatori di Microsoft" si risolve via Bill Gates → Microsoft → concorrenti, non solo per sovrapposizione letterale dei titoli). I vault da 2.137 pagine vedono tipicamente <100 ms per warm + espansione a 3 hop, indipendentemente dalla dimensione del vault. È usato da tutti e 4 gli stadi della cascata di selezione dei seed (sezione Query e feedback sopra) e dal rilevamento duplicati di Lint quando link indiretti legano due pagine candidate.
-- **⚡ Generazione parallela delle pagine** — 1–5 pagine concorrenti configurabili, predefinito 3 (parallelo), speedup 2–3× su sorgenti grandi; isolamento errori per pagina.
-- **📚 Estrazione iterativa a batch** — dimensione batch adattiva elimina il collo di bottiglia max_tokens sui documenti lunghi.
-- **🏛️ Architettura a tre livelli** — Le tue note del vault (sola lettura) → `wiki/` (pagine generate dall'LLM, organizzate come `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`) → `schema/` (configurazione co-evoluta).
-- **🧩 Base di codice modulare** — 20+ moduli focalizzati in `src/`.
-
-### 🔒 Privacy e sicurezza
-
-- **Nessun backend, nessun tracciamento.** Il plugin funziona interamente dentro Obsidian — nessun server esterno, nessuna analisi, nessuna raccolta dati di alcun tipo. A meno che tu non configuri attivamente un provider LLM, le tue note non lasciano mai il tuo vault.
-- **I dati restano locali per impostazione predefinita.** Il plugin non memorizza, mette in cache o trasmette i tuoi contenuti al di fuori dell'API LLM che hai scelto. Solo il testo che invii per l'ingest o la query lascia il tuo dispositivo — e solo verso il provider che hai configurato.
-- **Modalità completamente locale tramite Ollama, LM Studio o provider locali.** Per la completa sovranità dei dati, usa un LLM in esecuzione locale. Le tue note sono elaborate interamente sulla tua macchina — senza toccare internet.
-- **Permessi minimi.** L'accesso ai file del vault è usato per la gestione del Wiki (lettura note, generazione pagine, rilevamento link morti). L'accesso alla rete è usato solo per comunicare con l'API del provider LLM scelto. L'accesso agli appunti è limitato al pulsante "Copia" nel modale Query — usato solo quando lo clicchi.
+- **🌍 10 lingue per l'interfaccia** — Inglese, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. L'interfaccia e la lingua di output del wiki sono indipendenti — il tuo wiki può essere in cinese mentre l'interfaccia è in inglese.
+- **📚 10 lingue per l'output del wiki** — stesso set; scegli in Impostazioni → Configurazione Wiki. Opzione *Input personalizzato* per prompt ad-hoc.
+- **🈶 269+ stringhe UI tradotte** — ogni etichetta, modale e notifica. Aggiungere un'undicesima lingua è guidato dai contributori (pattern PR #159).
 
 ---
 
----
+## 🔍 Come funziona il recupero
 
-## 📖 Esempio
+La maggior parte dei plugin di "ricerca AI" frammenta le tue note in chunk e le incorpora in un DB vettoriale. Noi no. L'argomento di Karpathy contro il RAG è che il chunking rompe la capacità dell'LLM di ragionare sull'intero grafo della conoscenza — e quell'argomento regge in pratica. Invece, percorriamo il grafo che già mantieni scrivendo `[[wiki-link]]`.
 
-**Input:** `sources/machine-learning.md`
+### La cascata di selezione seed a 5 stadi
 
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
+Quando chiedi "Chi ha fondato Microsoft?", Query Wiki esegue cinque stadi prima di qualsiasi generazione di risposta:
 
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+1. **Percorso rapido Lex** — controllo diretto di sovrapposizione di token contro ogni titolo di entità/concetto e alias. Gratuito, istantaneo e fa da gate per tutto ciò che segue.
+2. **Generazione di keyword via LLM** — l'LLM propone 8–12 keyword cross-lingua dalla tua domanda (gestisce sinonimi, abbreviazioni e termini resistenti alla sovrapposizione di token in una singola chiamata LLM).
+3. **Scansione locale di sottostringhe** — ogni keyword generata viene ri-matchata localmente contro titoli di pagina, alias e snippet del corpo. Nessuna chiamata LLM extra; completa il recall tollerante al rumore.
+4. **Fallback KB LLM** — quando lex + scansione keyword restituiscono segnali deboli, l'LLM ri-semina i top-N candidati con un passaggio semantico sull'intero wiki.
+5. **Espansione del grafo PPR** — Personalized PageRank (Haveliwala 2002) sul grafo `[[wiki-link]]` a partire dall'insieme di seed candidati. Questo è ciò che fornisce contesto multi-hop consapevole del grafo: "Bill Gates" → "Microsoft" → "concorrenti", non solo sovrapposizione letterale dei titoli.
 
-**Output — Pagina di concetto:** `wiki/concepts/supervised-learning.md`
+La cascata si interrompe allo stadio che ha restituito segnale sufficiente — nessun costo fisso di 5 stadi, nessuna chiamata LLM quando lex basta, nessuna perdita di precisione quando serve l'augmentation LLM.
 
-```markdown
----
-type: concept
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
+### Personalized PageRank su larga scala
 
-### Supervised Learning
+Usiamo Monte Carlo PPR (Fogaras 2005) — 3.000 cammini casuali × 50 passi ciascuno — con la regola dead-end di Haveliwala 2002. Il costo è **O(K × L)** indipendente dal numero di pagine, quindi un vault di 2000 pagine vede la stessa latenza di espansione di uno di 200 pagine.
 
-### Basic Information
-- Type: method
-- Source: [[sources/machine-learning]]
+**PPR @5 = 27,1% vs baseline pura kNN 24,1%** sul corpus di benchmark del progetto (l'unico benchmark di recupero pubblicato in questo spazio open-source LLM-Wiki).
 
-### Description
-Supervised learning is a machine learning paradigm where models learn
-from labeled training data to make predictions on unseen data...
+### Perché niente embedding
 
-### Related Concepts
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### Related Entities
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### Mentions in Source
-- "Supervised learning uses labeled data to train predictive models..."
-```
+Abbiamo deliberatamente rifiutato il percorso degli embedding in [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175). Il segnale del grafo è già lì — ogni `[[wiki-link]]` è un arco "questi sono correlati" curato a mano, e la maggior parte dei provider che supportiamo (Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax) non hanno affatto un endpoint `/v1/embeddings`. Aggiungere un modello di embedding significherebbe un download per pagina, un adattatore per provider e zero benefici sulla qualità del recupero.
 
 ---
 
-## 🤖 Guida alla scelta del modello
+## 🤖 Modelli
 
-Questo plugin segue la filosofia di Karpathy: **fornire all'LLM il contesto Wiki completo, non un recupero RAG frammentato**. I modelli a contesto lungo sono fortemente consigliati — più il tuo Wiki cresce, più contesto serve all'LLM.
+**Provider supportati (12+, tutti verificati su models.dev a luglio 2026):**
 
-> 💡 **Perché non RAG?** La [critica originale di Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) sostiene che il RAG frammenta la conoscenza e compromette la capacità dell'LLM di ragionare sull'intero grafo della conoscenza.
+| Provider | Serie | Note |
+|----------|-------|------|
+| **Anthropic** | Serie Claude 5 | PDF nativo; protocollo `/v1/messages` |
+| **OpenAI** | Serie GPT-5.6 (Sol / Terra / Luna) | PDF nativo; chiave API Platform |
+| **Google Gemini** | Serie Gemini 3.6 | PDF nativo (file part dalla 1.5); endpoint compatibile OpenAI |
+| **DeepSeek** | Serie DeepSeek V4 | Compatibile OpenAI; livello di costo più basso |
+| **Alibaba Qwen** | Serie Qwen3.7/3.8 | Compatibile OpenAI (DashScope) |
+| **xAI Grok** | Serie Grok 4 | Compatibile OpenAI; contesto lungo |
+| **Moonshot Kimi** | Serie Kimi K3 | Compatibile OpenAI; frontiera 2.8T MoE |
+| **Zhipu GLM** | Serie GLM-5 | Compatibile OpenAI; forte bilingue |
+| **MiniMax** | Serie MiniMax M3 | Compatibile OpenAI; 1M di contesto |
+| **Step (阶跃星辰)** | Serie Step 3 (Flash) | Compatibile OpenAI; inferenza veloce |
+| **Tencent Hunyuan** | Serie Hy3 | Compatibile OpenAI; MoE open-weight |
+| **Xiaomi MiMo** | Serie MiMo V2.5 | Open-source MIT; prezzi piatti |
+| **Google Gemma** | Serie Gemma 4 | Open-weight; contesto 262K |
+| **AWS Bedrock** | Varianti Anthropic + OpenAI | Percorso VPC / conformità |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | Accesso via browser/codice dispositivo; SecretStorage |
+| **Locali: Ollama, LM Studio, OpenRouter, Anthropic-Compatibile** | Qualsiasi modello protocollo OpenAI/Anthropic | OpenAI-Compatibile Personalizzato + Anthropic-Compatibile (Token Plan / Coding Plan) |
 
-**💰 Strategia orientata al valore:** non hai bisogno dei modelli di punta. Le seguenti **alternative convenienti** offrono risultati eccellenti a prezzi più bassi:
+Questo plugin alimenta l'LLM con il contesto completo del tuo Wiki per ogni query — quindi **vincono i modelli a contesto lungo**. La tabella completa a livelli (cloud + locale) vive in [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md), verificata su [models.dev](https://models.dev/) per mantenere le scelte aggiornate.
 
-### ☁️ Modelli cloud
+### Cosa conta
 
-| Livello | Modello | Contesto | Perché |
-|------|-------|---------|-----|
-| **🌟 Scelta di valore** | **DeepSeek V4-Flash** | 1M token | Costo più basso ($0.14/M), 284B MoE, ideale per l'acquisizione in batch |
-| **🌟 Scelta di valore** | **Gemini-3.5-Flash** | 1M token | Output 4× più veloce di GPT-5.5, ottimo per i compiti agentici |
-| **🌟 Scelta di valore** | **Qwen3.6-Plus** | 1M token | Forti capacità di coding e agentiche, prezzo competitivo |
-| **🌟 Scelta di valore** | **Grok-4** | 2M token | Modello di punta xAI 2025-07, 2M di contesto, forte nel ragionamento e nei compiti di codice |
-| **Bilanciato** | **Claude Sonnet 4.6** | 1M token | Ottimo equilibrio qualità/costo, $3/$15 per milione di token |
-| **Leggero** | **Claude Haiku 4.5** | 200K token | Veloce ed economico per wiki più piccoli |
-| **Economico** | **Xiaomi MiMo-V2.5** | 1M token | Xiaomi 310B/15B MoE, open-source MIT 2026-04, agentico e multimodale |
-| **Di punta** | Claude Opus 4.7 | 1M token | Qualità massima, costo più elevato — usa in modo selettivo |
-| **Di punta** | GPT-5.5 | 1M token | Ragionamento al top, costo più elevato — usa in modo selettivo |
+- **🧠 Finestra di contesto ≥ 200K token** per vault oltre ~500 pagine. Sotto 200K il contesto assemblato dalla cascata inizia a essere troncato.
+- **⚖️ La qualità nel seguire le istruzioni** conta più del QI grezzo per il compito di estrazione — scegli un modello che segua il template dello schema, non il numero più alto in classifica.
+- **🔌 L'endpoint di embedding è irrilevante** — non usiamo embedding. Un provider che non ha `/v1/embeddings` va bene (la maggior parte dei nostri 12+ provider non lo ha).
+- **🦙 Locale per le query, cloud per l'ingest** — l'ingest su un vault di 2000 pagine di solito richiede un modello cloud a contesto lungo; un modello locale da 262K copre la maggior parte delle query.
 
-### 🦙 Modelli locali (Ollama / LM Studio)
+### Anthropic vs OpenAI vs Codex OAuth — sono provider distinti
 
-L'inferenza locale vince su sovranità dei dati, uso offline e costo API zero. Il compromesso è una finestra di contesto più piccola (spesso tra 8K–128K; le famiglie open-weight recenti arrivano a 262K) e un rispetto delle istruzioni più debole rispetto ai modelli cloud di punta. **Scegli in base al budget hardware:** più parametri = più conoscenza del mondo e migliore fedeltà alle istruzioni (estrazione di qualità superiore, meno allucinazioni); meno parametri = più velocità e margine di memoria, al prezzo di più allucinazioni e ragionamento a lungo contesto più debole. Lo sweet spot su Apple Silicon da 24 GB o su una singola GPU consumer è la classe 27B–35B-A3B.
+- **Anthropic** (e la sua variante Bedrock) — chiave API Anthropic Platform fatturata separatamente.
+- **OpenAI** — chiave API OpenAI Platform fatturata separatamente.
+- **ChatGPT Plan (Codex OAuth)** — provider sperimentale e distinto che usa un'idoneità Codex idonea dopo l'accesso via browser o codice dispositivo; la disponibilità segue le politiche di autenticazione e idoneità di OpenAI Codex, non il nome del piano. Compatibilità Codex di terze parti, non una partnership OpenAI o un'API ChatGPT generale.
 
-| Modello | Parametri | Contesto | Perché |
-|---------|-----------|----------|--------|
-| **Qwen3.5 27B** | 27B dense | 262K | Miglior equilibrio qualità/dimensioni per l'ingestione; MLX 4-bit entra in 24 GB |
-| **Qwen3.5 35B-A3B** | 35B totali / 3B attivi MoE | 262K | Più veloce di 27B dense a qualità simile; ideale per risparmiare memoria |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | Soffitto di qualità; richiede ≥48 GB di VRAM o doppia GPU |
-| **Qwen3.6 27B** | 27B dense | 256K+ | Refresh 2026-04 rispetto a Qwen3.5 27B — preferiscilo se l'hardware lo regge |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Stesso compromesso di Qwen3.5 35B-A3B, con pesi più recenti |
-| **Gemma 4 31B IT** | 31B dense | 262K | Forte rispetto delle istruzioni, output Markdown pulito |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Meno memoria di 31B dense a qualità comparabile |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | Eseguibile in CPU pura; solo per wiki piccoli o anteprime rapide |
-
-**Quantizzazione:** MLX 4-bit su Apple Silicon è in genere 1,5–2× più veloce di GGUF Q4_K_M allo stesso bitrate effettivo. GGUF Q4_K_M è la scelta predefinita multipiattaforma; passa a Q5/Q8 solo se hai margine di VRAM e noti regressioni di qualità a Q4.
-
-**Strategia di contesto:** quando il tuo Wiki supera ~500 pagine, un modello locale da 262K copre ancora la maggior parte del contesto assemblato dal motore di Query, ma l'ingestione di un vault da 2000 pagine lo supera. Schema comune: cloud per l'ingestione + locale per le query. Per setup completamente locali, la classe 27B/35B-A3B è lo sweet spot.
-
-### 📄 Percorso OCR PDF locale (v1.25.0+)
-
-L'ingestione PDF di v1.25.0 funziona con qualsiasi provider che accetti PDF come parte di file. Per una pipeline completamente locale su Apple Silicon (l'unica piattaforma attualmente supportata da oMLX), ecco la configurazione consigliata:
-
-1. Installa [oMLX](https://github.com/jundot/omlx) e attiva il suo backend integrato **Markitdown** (conversione locale PDF→Markdown).
-2. Carica **Baidu Unlimited-OCR** (open-source il 22/06/2026, 3B totali / 0,5B attivi, OCR end-to-end che gestisce documenti lunghi senza la modalità di fallimento "più genera, più va lento" dei vecchi modelli OCR) come modello visivo in oMLX.
-3. In questo plugin: imposta il provider su **Custom OpenAI-Compatible** (oMLX parla il protocollo compatibile con OpenAI), punta la Base URL al server locale di oMLX, attiva **Force PDF Support** in Settings → LLM Configuration → Advanced, e scegli il modello multimodale servito da oMLX per il riepilogo dell'ingestione.
-
-Il PDF non lascia mai la tua macchina — Markitdown esegue la conversione strutturale in locale, Unlimited-OCR il riconoscimento visivo in locale, e l'LLM locale il riepilogo in locale. La cache del plugin (`.obsidian/plugins/karpathywiki/pdf-cache/`) mantiene le re-ingestioni istantanee.
-
-**Fallback:** se oMLX/Markitdown non è disponibile (Linux/Windows o Mac più vecchi), punta **Force PDF Support** direttamente a un LLM multimodale locale che accetti parti di file PDF — la qualità è buona quando il modello è abbastanza grande, ma i requisiti di VRAM crescono in modo ripido con il numero di pagine.
-
-**🔌 Anthropic Compatible (Coding Plan):** se il tuo provider offre un endpoint API compatibile con Anthropic, seleziona "Anthropic Compatible" e inserisci l'URL di base e la chiave API del tuo provider.
-
-> 💡 **Confine di fatturazione OpenAI:** **OpenAI** usa una chiave Platform fatturata separatamente. **ChatGPT Plan (Codex OAuth)** è un provider sperimentale distinto che usa una disponibilità Codex idonea dopo l'accesso via browser o codice dispositivo; il nome del piano non ne garantisce la disponibilità.
-
----
-
-## 🏗️ Architettura
-
-Il design a tre strati di Karpathy:
-
-```
-📄 Le tue note del vault (qualsiasi cartella)   # 📖 Scegli tu quali note ingerire
-  ↓ ingest
-wiki/                                            # Pagine Wiki generate dall'LLM (wiki/sources/, wiki/entities/, wiki/concepts/)
-  ↓ query / maintain
-schema/                                          # Configurazione struttura Wiki
-```
-
-> 📖 Vedi la struttura completa del codice in [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure).
-
-**Pagine generate:**
-- wiki/sources/nomefile.md — Riepilogo fonte
-- wiki/entities/nome-entita.md — Pagine entita (persone, organizzazioni, progetti, ecc.)
-- wiki/concepts/nome-concetto.md — Pagine concetto (teorie, metodi, termini, ecc.)
-- wiki/index.md — Indice generato automaticamente
-- wiki/log.md — Registro operazioni
-
----
+> 📖 **Tabella di scelta completa** (cloud + locale + OCR PDF + Codex OAuth + quantizzazione + livelli hardware) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
 ---
 
 ## ❓ FAQ
 
-> **Mantieni il plugin aggiornato.** **Impostazioni → Plugin della community → Verifica aggiornamenti** regolarmente.
->
-> 📖 Altre FAQ su [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28).
+### Cosa fa esattamente il plugin?
 
-**Cosa fa questo plugin?**
-Scegli una qualsiasi nota, cartella o selezione multipla dal tuo vault; l'LLM estrae entità e concetti e genera un Wiki interconnesso con `[[wiki-link]]`. Ottieni risposte conversazionali basate sulle *tue* note — non ricerche su Internet. I riassunti generati vivono sotto `wiki/sources/`, le entità sotto `wiki/entities/`, i concetti sotto `wiki/concepts/` — le tue note originali del vault non vengono mai modificate.
+Scegli una nota, cartella o selezione; l'LLM estrae entità e concetti e genera un wiki interconnesso con `[[collegamenti bidirezionali]]`. Fai domande e ottieni risposte conversazionali basate sulle *tue* note, non su internet. Le tue note originali del vault non vengono mai modificate.
 
-**I miei dati vengono inviati a terze parti?**
-Privacy prima di tutto. Nessun backend, nessun tracciamento. Solo il testo inviato esplicitamente lascia il dispositivo. Usa fornitore locale (Ollama/LM Studio) per totale località.
+### Come si inizia?
 
-**Differenza dai chatbot RAG?**
-LLM-Wiki usa Personalized PageRank sul grafo [[wiki-link]] — zero costo embedding.
+Installa da Obsidian Community Plugins → scegli un provider → **Test Connection** → esegui **Ingest single source** su una qualsiasi nota. Le prime pagine wiki appaiono in pochi secondi. Vedi [Avvio rapido](#-avvio-rapido).
 
-**Quale LLM usare?**
-Modelli >=200K token. Economici: DeepSeek V4-Flash ($0.14/M), Gemini 3.5 Flash, Qwen3.6-Plus.
+### Il mio wiki esistente è al sicuro?
 
-**Come iniziare?**
-Installa → scegliere fornitore → **Test Connection** → esegui **Ingest single source** (o **Ingest from folder**) su una qualsiasi nota del tuo vault → le prime pagine Wiki appaiono in pochi secondi. Vedi [Avvio rapido](#-avvio-rapido) sopra.
+✅ Retrocompatibile dalla v1.0.0. Imposta `reviewed: true` su qualsiasi pagina per proteggerla dalla sovrascrittura. L'aggiornamento dalla v1.24.x non riscrive il tuo vault; l'ingest PDF della v1.25.0 è solo cache per default.
 
-**Controllare costi API?**
-Granularità Grossolana/Minima per lotti. Smart Batch Skip. Manutenzione automatica DISATTIVATA.
+### I miei dati vengono inviati da qualche parte?
 
-**Wiki esistente al sicuro?**
-✅ Retrocompatibile dalla v1.0.0. `reviewed: true` protegge le pagine dalla sovrascrittura. Il plugin non modifica mai le tue note originali del vault — genera solo nuove pagine nella cartella `wiki/`.
+🚫 Nessun backend, nessuna analisi — il plugin funziona interamente dentro Obsidian. Solo il testo che invii esplicitamente per ingest/query lascia il tuo dispositivo, e solo verso il provider LLM che configuri. Per la completa località dei dati, usa Ollama o LM Studio.
 
-**Lingue?**
-10 lingue per interfaccia e Wiki: EN, ZH, ZH-Hant, JA, KO, DE, FR, ES, PT, IT.
+### Posso usare il plugin nella mia lingua?
 
-**Requisiti?**
-Obsidian v1.11.4+ (desktop o mobile). È necessaria una chiave API LLM, Ollama/LM Studio locale o credenziali autorizzate ChatGPT Plan (Codex OAuth). llmReady richiede Test Connection.
+🌍 10 lingue sia per l'interfaccia che per l'output del wiki. Interfaccia e lingua del wiki sono indipendenti. Aggiungere un'undicesima lingua è guidato dai contributori (pattern PR #159).
 
-**Annullare operazione?**
-Barra di stato o Cmd+P → Cancel current ingestion.
+### In cosa si differenzia da un chatbot RAG?
 
-**Aiuto?**
-- GitHub Issues - segnalare bug
-- GitHub Discussions - domande e feedback
+🚫 Nessun chunking. 🚫 Nessun embedding. 🚫 Nessun DB vettoriale. ✅ Personalized PageRank sul tuo grafo `[[wiki-link]]` esistente — contesto multi-hop consapevole del grafo, costo embedding zero, supporto completo per modelli locali.
 
-## 🔒 Trasparenza e conformità
+### Quale LLM dovrei usare?
+
+I modelli a contesto lungo (≥200K token) funzionano meglio. La [sezione Modelli](#-modelli) copre i principi; la tabella completa a livelli è in [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md).
+
+### Esiste un benchmark pubblicato?
+
+Sì — PPR @5 = 27,1% vs baseline pura kNN 24,1% sul corpus del progetto. La pipeline completa e lo script di benchmark sono descritti in [Come funziona il recupero](#-come-funziona-il-recupero).
+
+### Come controllo i costi API?
+
+Usa la granularità di estrazione Grossolana o Minima per l'ingest in batch. Smart Batch Skip rileva automaticamente i file già elaborati. La manutenzione automatica è DISATTIVATA per default. Lint mostra i conteggi prima di eseguire le correzioni — nulla viene addebitato senza la tua approvazione.
+
+### Come annullo un'operazione in corso?
+
+Clicca sulla barra di stato (mostra "Ingesting… click to cancel") o `Cmd+P/Ctrl+P` → "Cancel current ingestion". Si ferma pulitamente al prossimo limite di lotto.
+
+### Dove trovo aiuto?
+
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) per segnalazioni di bug · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) per domande e richieste di funzionalità · Console sviluppatore (`Ctrl+Shift+I` / `Cmd+Option+I`) per i log del plugin.
+
+---
+
+## 🔒 Privacy
 
 Questo plugin è elencato sul Marketplace dei plugin della community di Obsidian ed è sottoposto a una verifica automatizzata di sicurezza e permessi.
 
-**Il plugin non ha backend, nessuna infrastruttura server e nessuna raccolta di dati di alcun tipo.** È software puramente locale eseguito all'interno di Obsidian. Il plugin non può e non raccoglie, archivia o trasmette i tuoi dati ad alcun server — perché tale server non esiste.
+- **🚫 Nessun backend, nessun server, nessuna raccolta dati.** Software puramente locale eseguito all'interno di Obsidian. Il plugin non può e non raccoglie, archivia o trasmette i tuoi dati ad alcun server — perché tale server non esiste.
+- **🔐 L'accesso alla rete è opt-in.** Usato solo per comunicare con il provider LLM che configuri. Scegli tu il provider, inserisci tu la chiave API, decidi tu dove vanno i tuoi dati.
+- **📁 L'accesso ai file del vault** è usato per la gestione del wiki (leggere note, generare pagine, scansionare link morti, rilevare duplicati). Il plugin non modifica mai i tuoi file sorgente.
+- **📋 L'accesso agli appunti** è usato esclusivamente dal pulsante "Copia" nel modale Query — e solo quando ci clicchi sopra.
 
-**L'accesso alla rete** è usato solo per comunicare con il provider LLM che configuri — non viene effettuata nessun'altra chiamata di rete. Questo è interamente sotto il tuo controllo: scegli il provider, inserisci la chiave API, decidi dove vanno i tuoi dati.
+Per la completa località dei dati, usa Ollama o LM Studio. Con un provider locale, i tuoi dati non lasciano mai la tua macchina.
 
-**L'accesso al file system** (enumerazione del vault) è necessario per costruire e mantenere il wiki: leggere le tue note sorgente, generare pagine, scansionare i collegamenti interrotti e rilevare pagine duplicate. Il plugin non modifica mai i tuoi file sorgente — solo i file all'interno della cartella wiki.
+---
 
-**L'accesso agli appunti** è usato esclusivamente dal pulsante "Copy" nella finestra modale Query, e solo quando ci clicchi sopra.
+## 💖 Supporto
 
-Se preferisci la completa località dei dati, usa un provider LLM locale come Ollama o LM Studio. Con un provider locale, i tuoi dati non lasciano mai la tua macchina.
+Se LLM-Wiki è diventato una parte significativa del tuo flusso di lavoro della conoscenza:
 
-## 💖 Sostenere il progetto
-
-Se LLM-Wiki è diventato una parte significativa del tuo flusso di lavoro di conoscenza, puoi sostenere il suo sviluppo continuo:
-
-- ☕ **[Offrimi un caffè su Ko-fi](https://ko-fi.com/greenerdalii)** — supporto una tantum o mensile tramite Ko-fi
-- 💳 **[Mancia tramite PayPal](https://paypal.me/greenerdalii)** — mancia una tantum tramite PayPal
+- ☕ **[Offrimi un caffè su Ko-fi](https://ko-fi.com/greenerdalii)** — supporto una tantum o mensile
+- 💳 **[Mancia tramite PayPal](https://paypal.me/greenerdalii)** — mancia una tantum
 
 La sponsorizzazione è completamente facoltativa. Il plugin resta con licenza Apache-2.0 e completo nelle funzionalità.
 
-### Sponsor
+Grazie a [@jameses-cyber](https://github.com/jameses-cyber) e [@issaqua](https://github.com/issaqua) per aver sostenuto il progetto.
 
-Grazie alle seguenti persone per sostenere il progetto:
+---
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
+## 📜 Licenza e crediti
 
-## 📜 Licenza
+Licenza Apache, Versione 2.0 — vedi [LICENSE](../LICENSE) e [NOTICE](../NOTICE).
 
-Licenza Apache-2.0 — vedi [LICENSE](../LICENSE) e [NOTICE](../NOTICE).
+**Costruito su:**
+- 💡 [LLM Wiki di Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — il concetto originale
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) e [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — algoritmi di recupero
 
-## 🙏 Ringraziamenti
+**Manutentore:** [@green-dalii](https://github.com/green-dalii)
 
-- **💡 Concetto:** [LLM Wiki di Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — la visione originale che ha ispirato questo plugin
-- **🛠️ Piattaforma:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 Trasporto LLM:** [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -2,9 +2,9 @@
 
 # 🧠 Karpathy LLM Wiki Plugin for Obsidian
 
-> AI駆動の構造化知識ベース — ノートを自動的にWikiに変換。[Andrej KarpathyのLLM Wiki概念](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)に基づく実装。
+> AI駆動の構造化知識ベース — ノートを自動的にWikiに変換。[Andrej KarpathyのLLM Wiki概念](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)に基づく実装。Obsidianプラグインとしてワンクリックインストール。
 
-> **Obsidian公式評価95/100 | 10言語ネイティブ対応 | 埋め込み不要のグラフ検索 | 完全なデータ主権 | あらゆるLLMプロバイダー対応**
+> **埋め込み不要のグラフ検索 • 10言語ネイティブ対応 • あらゆるLLMプロバイダー対応**
 
 ![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
@@ -12,480 +12,328 @@
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | **日本語** | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md) | [Italiano](README_IT.md)
 
-[公式サイト](https://llmwiki.greenerai.top/) | [Obsidian マーケットプレース](https://community.obsidian.md/plugins/karpathywiki) | [ブログ](https://llmwiki.greenerai.top/blog/) | [フィードバック](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[公式サイト](https://llmwiki.greenerai.top/) | [Obsidianマーケットプレース](https://community.obsidian.md/plugins/karpathywiki) | [ブログ](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [クイックスタート](#-クイックスタート) | ✨ [特徴](#-特徴) | 🤖 [モデル推奨](#-モデル推奨) | 🔒 [透明性とコンプライアンス](#-透明性とコンプライアンス) | ❓ [FAQ](#-faq)
+🚀 [クイックスタート](#-クイックスタート) • ✨ [特徴](#-特徴) • 🔍 [検索の仕組み](#-検索の仕組み) • 🤖 [モデル](#-モデル) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← このプラグインが役に立ったら、コーヒー一杯♥️を奢ってくれたら嬉しいです、またはスター🌟を付けてね↗
 
 ---
 
-> **⚡ 素早い更新のお知らせ：** 本プロジェクトは急速に進化しており、バグ修正、パフォーマンス改善、新機能、UX の最適化を頻繁に行っています。Obsidian で常に最新バージョンに更新することをお勧めします（**設定 → コミュニティプラグイン → 更新を確認**）。プラグインの自動更新を有効にすることもできます。
 ## 📑 Contents
 
-- [🧠 Karpathy LLM Wiki Plugin for Obsidian](#-karpathy-llm-wiki-plugin-for-obsidian)
-  - [📑 Contents](#-contents)
-  - [💡 LLM-Wikiとは？](#-llm-wikiとは)
-  - [⚡ なぜ Obsidian + LLM-Wiki？](#-なぜ-obsidian--llm-wiki)
-  - [🚀 クイックスタート](#-クイックスタート)
-    - [📦 インストール](#-インストール)
-    - [🔄 アップデート](#-アップデート)
-    - [🔑 LLMプロバイダーの設定](#-llmプロバイダーの設定)
-    - [🎮 使い方](#-使い方)
-    - [⚠️ 旧バージョンからのアップグレード](#️-旧バージョンからのアップグレード)
-  - [⚡ 最新情報 v1.25.x](#-最新情報-v125x)
-  - [✨ 特徴](#-特徴)
-    - [📊 ナレッジ品質](#-ナレッジ品質)
-    - [📄 PDF 取り込み (v1.25.0)](#-pdf-取り込み-v1250)
-    - [💬 クエリとフィードバック](#-クエリとフィードバック)
-    - [🛠️ メンテナンス](#️-メンテナンス)
-    - [🌐 LLMと言語](#-llmと言語)
-    - [🏗️ アーキテクチャとパフォーマンス](#️-アーキテクチャとパフォーマンス)
-    - [🔒 プライバシーとセキュリティ](#-プライバシーとセキュリティ)
-  - [📖 例](#-例)
-  - [🤖 モデル推奨](#-モデル推奨)
-    - [☁️ クラウドモデル推奨](#️-クラウドモデル推奨)
-    - [🦙 ローカルモデル推奨 (Ollama / LM Studio)](#-ローカルモデル推奨-ollama--lm-studio)
-    - [📄 ローカル PDF OCR パス (v1.25.0+)](#-ローカル-pdf-ocr-パス-v1250)
-  - [🏗️ アーキテクチャ](#️-アーキテクチャ)
-  - [❓ FAQ](#-faq)
-  - [🔒 透明性とコンプライアンス](#-透明性とコンプライアンス)
-  - [💖 プロジェクトを支援する](#-プロジェクトを支援する)
-    - [スポンサー](#スポンサー)
-  - [📜 ライセンス](#-ライセンス)
-  - [🙏 謝辞](#-謝辞)
-  - [Star History](#star-history)
-
-## 💡 LLM-Wikiとは？
-
-書くのはあなた。整理するのはAI。質問するだけ。それがすべて。
-
-**🎯 問題点。** ノートは宝の山です — 人物、概念、アイデア、その関連性。しかし今は、フォルダ内の単なるファイルに過ぎません。何が何に関連しているかを見つけるには、検索、タグ付け、そして記憶を頼りにする必要があります。
-
-**✨ 解決策。** [Andrej Karpathyが提案した](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)エレガントなアプローチ：ノートを原材料として扱い、LLMがアーキテクトの役割を担う。LLMがあなたの書いたものを読み、エンティティと概念を抽出し、構造化されたWikiを構築する — `[[双方向リンク]]`、自動生成インデックス、そしてあなたの知識ベースに質問できるチャットインターフェースを備えたWikiです。
-
-**📚 図書館員の役割は終わり。** 何をページにするか決める必要も、相互リンクを維持する必要も、情報が古くなったか心配する必要もありません。vault 内の任意のノート（またはフォルダ、複数選択）を選べば、LLM が読み取り、抽出、書き込み、リンク作成、矛盾のフラグ付けを行い — あなたは作業の流れに集中できます。
-
-**🤖 これは単なるチャットボットではない。** ChatGPTはインターネットを知っています。LLM-Wikiは*あなた*を知っている — 正確には、あなたが教えた内容を。すべての回答は`[[wiki-links]]`を伴って知識グラフに戻ります。すべてのレスポンスは道の始点であり、終点ではありません。
-
-**🏆 主な差別化 — ゼロ埋込コストのグラフ駆動検索。** 多くのナレッジベースプラグインはベクトル埋込（高コスト、プロバイダ依存、インターネット必須）を使います。LLM-Wikiは既存の`[[wiki-link]]`グラフ上でPersonalized PageRankを実行 — API呼び出しゼロ、新しい依存関係なし、ローカルモデル完全対応で、埋込並みの検索品質を実現します。i18n対応の**ゼロLLM Tier Bセクション抽出**（10言語）を加えることで、あらゆるプロバイダで動作するナレッジエンジンが完成します。
+- [なぜこのプラグインなのか？](#-なぜこのプラグインなのか)
+- [こんな方に](#-こんな方に)
+- [クイックスタート](#-クイックスタート)
+- [特徴](#-特徴)
+- [検索の仕組み](#-検索の仕組み)
+- [モデル](#-モデル)
+- [FAQ](#-faq)
+- [プライバシー](#-プライバシー)
+- [サポート](#-サポート)
+- [ライセンスとクレジット](#-ライセンスとクレジット)
 
 ---
 
-## ⚡ なぜ Obsidian + LLM-Wiki？
+## 🤔 なぜこのプラグインなのか？
 
-Obsidianはリンク思考において卓越しています。しかし、すべてのリンクを自分で作らなければならないという課題があります。
+あなたはノートを書きます。それらはフォルダに眠っています。何が何と関係しているか見つけるには、何ヶ月も前に忘れたスレッドを思い出す必要があります。
 
-LLM-Wikiはその構造を反転させます。あなたが手作業でグラフを構築する代わりに、AIが一緒にグラフを育ててくれます。新しい概念についてノートを追加すれば、見落としていたつながりを見つけてくれます。質問をすれば、あなた自身の知識グラフを辿り、引用付きの回答を返してくれます。
+**KarpathyのLLM Wikiコンセプトを再実装したオープンソースツールは他にもありますが、ワンクリックで使えるObsidianプラグインとして提供しているものはありません。** 他の実装のほとんどはCLIツール、Claude Codeスキル、または独立したデスクトップアプリです。LLM-Wikiプラグインは、ネイティブUI、vault内ストレージ、Obsidianのグラフビューを内蔵した唯一の実装です。
 
-- **🔗 グラフビューが動き出す。** 新しいノートはただ置かれるだけでなく、エンティティ、概念、ソースへのリンクを芽吹かせます。グラフは有機的に成長し、プラグインがそれを維持します——重複の検出、リンク切れの修正、エイリアスによる言語間の橋渡し。
-- **💬 ノートが会話できるように。** 検索が対話になります。「Xについて何を書いた？」がダイアログになり、ストリーミングレスポンスと`[[wiki-links]]`がパンくずリストとなります。すべての回答は、あなた自身の知識へと深く踏み込む道です。
-- **🧠 Obsidianが思考パートナーに。** ノートの保管庫から、あなたが*考える*のを助けるものへと変わります——隠れたつながりを浮き彫りにし、矛盾を指摘し、自分が忘れていたことを思い出させてくれます。
+### 他実装との比較
+
+| | Karpathy LLM Wiki（本プラグイン） | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **提供形態** | ✅ ワンクリックObsidianプラグイン | ❌ 独立Tauriデスクトップアプリ | ❌ Claude Codeスキル | ❌ Claude Code / Codexスキル | ❌ CLI + SDK + MCPサーバー |
+| **セットアップ時間** | ✅ **5分** — コミュニティプラグイン→インストール→プロバイダー選択→取り込み | ❌ 30分以上 — バイナリのコンパイル/ダウンロード、CLI設定 | ❌ 15分 — Claude Code契約＋スキルインストール | ❌ 10分 — Claude Code/Codex契約＋セットアップ | ❌ 30分以上 — pip install + SDK + MCP設定 |
+| **インストール方法** | ✅ Obsidian→コミュニティプラグイン→検索→インストール | ❌ 別バイナリのコンパイルまたはダウンロード、CLI設定 | ❌ Claude Code契約＋インストールガイド | ❌ Claude CodeまたはCodex契約＋セットアップ手順 | ❌ pip install + Python SDK + ローカルサーバー |
+| **アーキテクチャの複雑さ** | ✅ **依存関係ゼロ** — ベクトルDB不要、埋め込みモデル不要、外部プロセス不要 | 🟡 独自のPythonランタイム + sigma.js + sqliteを内蔵 | 🟡 Claude Code環境を利用 — 自己完結型ではない | 🟡 別プラットフォームのランタイムが必要 | ❌ Python、埋め込みモデル、ベクトルDBが必要 |
+| **i18n（UI+Wiki出力）** | ✅ 10言語（UIと出力は独立設定） | 🟡 2言語（EN/中文） | ❌ 英語のみ | ❌ 英語のみ | ❌ 英語のみ |
+| **LLMプロバイダー** | ✅ 12以上（Codex OAuth、Bedrock、LM Studio、Ollama、Anthropic互換、Kimi、GLM、MiniMax、DeepSeekなど） | 🟡 OpenAI互換 | 🟡 Claude Code契約経由 | 🟡 Claude Code / Codex契約経由 | 🟡 OpenAI互換 |
+| **検索アルゴリズム** | ✅ Personalized PageRank（Haveliwala 2002）+ Monte Carlo（Fogaras 2005） | 🟡 4信号ヒューリスティック（Adamic-Adar + 2ホップ減衰） | ❌ Louvainコミュニティ検出のみ | ❌ Louvain + kホッププレビュー | ❌ ハイブリッド: BM25 + セマンティック + wikilink |
+| **クエリパイプライン** | ✅ 5段階カスケード（Lex→LLMキーワード→部分文字列スキャン→LLM KBフォールバック→PPR拡張、最初の十分な信号で打ち切り） | 🟡 2ホップ減衰のみ | ❌ Louvainクラスタリングのみ | ❌ kホッププレビュー（LLM拡張なし） | ❌ BM25 + チャンク上のセマンティック検索（グラフなし） |
+| **埋め込みが必要？** | ✅ いいえ（設計上ゼロコスト） | 🟡 オプション、デフォルトオフ | ✅ 不要 | ✅ 不要 | ❌ **必須** |
+| **グラフ可視化** | ✅ Obsidianネイティブのグラフビュー（内蔵、サイズ増加ゼロ） | ❌ カスタムsigma.js + graphology（デスクトップアプリ） | 🟡 vis.js graph.html（別ファイル） | ❌ カスタムsigma.jsオフラインHTML | ❌ 読み取り専用ブラウザビューアー |
+| **Wikiの正直さ** | ✅ Wikiソースがクエリに一致しない場合「Stage FALLBACK」バナーを表示 | ❌ 同等機能なし | ❌ 同等機能なし | ❌ 同等機能なし | ❌ 同等機能なし |
+| **公開検索ベンチマーク** | ✅ PPR @5 = 27.1%（純粋kNN 24.1%を上回る、この分野で唯一の公開数値） | ❌ 埋め込み有効時のみ58%→71%（apples-to-apples比較不可） | ❌ 未公開 | ❌ 未公開 | ❌ 未公開 |
+
+### 意図的に選んだ3つの設計判断
+
+- **🪟 Obsidianがランタイム。** ターミナルも別アプリもDockerもPythonも不要。コミュニティプラグインからインストールして「取り込み」をクリックするだけで、最初の一秒からWikiはあなたのvaultの中に存在します。Obsidianネイティブのグラフビューが`[[wiki-link]]`グラフをレンダリング — 内蔵、バンドルサイズ増加ゼロ。
+- **🧭 クリーンで自己完結。** 依存関係ゼロ。埋め込みモデルもベクトルDBもpipパッケージも不要 — ノートを読み、LLMと通信し、Wikiページを書き出す単一のプラグインです。すべてがObsidian内部で動作します。
+- **🔌 すでに支払っているモデルをそのまま使える。** Anthropic、Bedrock、OpenAI、ChatGPT Plan（Codex OAuth）、DeepSeek、Kimi、GLM、MiniMax、LM Studio、Ollama、OpenRouter、Anthropic互換、カスタムエンドポイント — 12以上のプロバイダー。埋め込みエンドポイントを必要とするものは一つもありません。
+
+---
+
+## 🎯 こんな方に
+
+**✅ こんな方におすすめ：**
+
+- **5分でセットアップして、5時間かけるプロジェクトにはしたくない。** コミュニティプラグインからインストール → プロバイダーを選択 → ノートを取り込み。CLIもPythonも別ランタイムもベクトルDBも不要。数秒で`wiki/`以下にWikiページが生成されます。
+- **クリーンで自己完結したものが欲しい。** 外部依存ゼロ：埋め込みモデルもベクトルDBもpipパッケージもDockerコンテナも不要。ノートを読み、LLMと通信し、Wikiページをvaultに書き出す単一のObsidianプラグインです。すべてがObsidian内部で動作します。
+- **インターネットではなく*自分のノート*から答えてくれる、クエリ可能なチャットが欲しい。** すべての回答には`[[wiki-links]]`が付き、あなたの知識グラフに戻れます。
+- **データ主権を重視する。** OllamaやLM Studioで完全ローカル運用 — インターネットに触れません。
+- **10言語対応で読み書きしている。** UIとWiki出力言語は独立して設定可能（UIは英語のまま、Wikiは日本語で出力できます）。
+- **`[[wiki-links]]`を書くことでグラフを育てている。** あなたが書くすべてのリンクが検索を強化します。別途タグ付けや埋め込み、インデックス作成は不要。
+- **ワンクリックでメンテナンスしたい。** Lintヘルススキャン＋スマート全自動修復で、重複やリンク切れ、孤立ページを手作業なしで管理。
+
+**❌ こんな方には不向き：**
+
+- **汎用のChatGPT代替品が欲しい。** 本プラグインは*あなたの知識*だけから回答します。
+- **PDFやWebページ、外部コーパスに対するRAGパイプラインが必要。** このプラグインはvault内パスに焦点を当てています（PDFはv1.25.0から対応）。
+- **ホスト型SaaSを探している。** バックエンドもサーバーもアカウントもありません。
 
 ---
 
 ## 🚀 クイックスタート
 
-### 📦 インストール
+1. **インストール。** Obsidian → 設定 → コミュニティプラグイン → ブラウズ → 「Karpathy LLM Wiki」を検索 → インストール → 有効化。または[コミュニティプラグインページ](https://community.obsidian.md/plugins/karpathywiki)にアクセスして「Add to Obsidian」をクリック。
+2. **プロバイダーを設定。** 設定 → Karpathy LLM Wiki → プロバイダーを選択（OpenAI、Anthropic、Ollama、ChatGPT Plan（Codex OAuth）など）→ APIキーを入力（ローカルは不要）→ **Test Connection** → 保存。
+3. **ノートを取り込む。** `Cmd+P/Ctrl+P` → 「Ingest single source」 → Markdown（またはPDF、v1.25.0+）ファイルを選択。数秒で最初のWikiページが`wiki/sources/`、`wiki/entities/`、`wiki/concepts/`に生成されます。
 
-**🌟 推奨 — Obsidianコミュニティプラグインマーケット：**
+以上です。元のノートは一切変更されません — `wiki/`フォルダ以下に新しいページを作成するだけです。Wikiとチャットするには：`Cmd+P/Ctrl+P` → 「Query wiki」。（Macは`Cmd`、Windows/Linuxは`Ctrl`。）
 
-1. Obsidianで **設定 → コミュニティプラグイン** を開く
-2. **ブラウズ** をクリックして「Karpathy LLM Wiki」を検索
-3. **インストール** をクリックし、**有効化** する
+### 基本コマンド
 
-**🌐 コミュニティプラグインのWebサイトから —** [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) にアクセスし、**Obsidianに追加** をクリックして直接インストールできます。
+| コマンド | 内容 |
+|---------|------|
+| **📥 Ingest single source** | `Cmd+P/Ctrl+P` → 「Ingest single source」 — Markdownまたは**PDF（v1.25.0+）**ファイルを選択し、エンティティ・概念ページを生成 |
+| **📂 Ingest from folder** | `Cmd+P/Ctrl+P` → 「Ingest from folder」 — フォルダ内の全ノートを一括取り込み（スマートバッチスキップ対応） |
+| **📑 Ingest multiple files** | `Cmd+P/Ctrl+P` → 「Ingest multiple files」 — 2ペインファイルツリーでサブセットを選択（ライブキュー＋ファイル単位キャンセル） |
+| **🔍 Query wiki** | `Cmd+P/Ctrl+P` → 「Query wiki」 — 右側サイドパネルでWikiとチャット、回答に`[[wiki-links]]`付き |
+| **🛠️ Lint wiki** | `Cmd+P/Ctrl+P` → 「Lint wiki」 — 重複・リンク切れ・空ページ・孤立ページ・欠落エイリアス・矛盾をフルスキャン |
+| **⚡ Smart Fix All** | Lintモーダル内 — ワンクリック因果順修復（フェーズごとにレポート表示） |
+| **📋 Regenerate index** | `Cmd+P/Ctrl+P` → 「Regenerate index」 — `wiki/index.md`を現在のページとエイリアスで再構築 |
+| **⏹ Cancel** | `Cmd+P/Ctrl+P` → 「Cancel current ingestion」またはステータスバーをクリック — 次のバッチ境界でクリーンに停止 |
+| **📊 Ingestion history** | `Cmd+P/Ctrl+P` → 「View Ingestion History」 — 過去の取り込み・Lintレポート・メンテナンス実行を検索可能なUIで表示 |
 
-**⚙️ 手動インストール（代替方法）：**
+| Before | After |
+|--------|-------|
+| `notes/machine-learning.md`（フラットなファイル） | `wiki/concepts/supervised-learning.md` — `[[双方向リンク]]`、エイリアス、ソース帰属、`wiki/index.md`のエントリ付き |
 
-1. [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases) から `main.js`、`manifest.json`、`styles.css` をダウンロード
-2. Obsidianで 設定 → コミュニティプラグイン を開く。**インストール済みプラグイン** タブでフォルダアイコンをクリックし、プラグインディレクトリを開く
-3. `karpathywiki` という名前のフォルダを作成し、3つのファイルを配置
-4. Obsidianに戻り、更新アイコンをクリック — **Karpathy LLM Wiki** がインストール済みプラグインに表示される
-5. トグルをオンにして有効化
-
-**🔨 開発用：** `git clone`、`pnpm install`、`pnpm build`
-
-### 🔄 アップデート
-
-本プロジェクトは急速に進化しており、新機能、バグ修正、改善が頻繁にリリースされます。最新の状態に保つことをお勧めします：
-
-**オプションA — 手動アップデート（推奨）：**
-1. **設定 → コミュニティプラグイン** を開く
-2. **更新を確認** をクリック
-3. **Karpathy LLM Wiki** を見つけ、**更新** をクリック
-
-**オプションB — 自動更新を有効にする：**
-1. **設定 → コミュニティプラグイン** を開く
-2. **プラグインの自動更新を確認** をオンにする
-3. 新しいバージョンが自動的に検出されます。都合の良いタイミングで手動で更新してください
-
-> 💡 **なぜ最新版を保つべき？** 各リリースには新機能、パフォーマンス改善、重要なバグ修正が含まれている場合があります。
-
-### 🔑 LLMプロバイダーの設定
-
-1. 設定 → Karpathy LLM Wiki を開く
-2. ドロップダウンからプロバイダーを選択（OpenAI または ChatGPT Plan (Codex OAuth) を含む）
-3. APIプロバイダーではAPIキーを入力（Ollama、LM Studio、ChatGPT Plan (Codex OAuth) は不要）
-4. Codex以外のプロバイダーでは **Fetch Models** またはモデル名の手動入力を使用。ChatGPT Plan (Codex OAuth) は厳選モデルのドロップダウンを自動設定
-5. **Test Connection** をクリックし、**Save Settings** を保存
-
-**🦙 Ollama（ローカル、APIキー不要）：** [Ollama](https://ollama.com) をインストールし、モデルをpull（`ollama pull gemma4` または `ollama pull qwen3.5:27b`）、プロバイダードロップダウンで「Ollama (Local)」を選択。
-
-**🎛️ LM Studio（ローカル、APIキー不要）：** [LM Studio](https://lmstudio.ai) をインストールし、ローカルサーバーを起動（デフォルト `http://localhost:1234/v1`）、プロバイダードロップダウンで「LM Studio (Local)」を選択。
-
-**🔐 ChatGPT Plan (Codex OAuth)（実験的）：** OpenAI Platform APIキーを使い別途従量課金される **OpenAI** プロバイダーとは独立しています。このプロバイダーを選択し、デスクトップでは**ブラウザーでサインイン**（localhostコールバック）、デスクトップ/モバイルでは**デバイスコードを使用**してOpenAIページで認証します。プラグインはログイン中のCodexアカウントから選択可能なモデルを同期し、整理済みカタログメタデータのみをキャッシュします。**アカウントモデルを更新**で手動更新でき、一時的な障害時は最後のキャッシュまたは最小フォールバックを保持します。接続テスト後に保存してください。OAuth資格情報はObsidian SecretStorageだけに保存され、**サインアウト**で消去されます。可用性はOpenAI Codexの認証、モデル、利用枠ポリシーに従います。これは第三者互換機能であり、OpenAIとの提携や汎用ChatGPT APIではありません。
-
-### 🎮 使い方
-
-| 方法 | 使い方 |
-|------|--------|
-| **📥 単一ソースの取り込み** | `Cmd+P` → "Ingest single source" — ノート（Markdown または **PDF、v1.25.0+**）を選択し、エンティティと概念を抽出 |
-| **📂 フォルダーからの取り込み** | `Cmd+P` → "Ingest from folder" — フォルダを選択し、Wikiを一括生成 |
-| **📑 複数ファイルの取り込み** | `Cmd+P` → "Ingest multiple files" — 再帰的フォルダツリー + ファイル別チェックボックスの2ペイン選択モーダルでノートを選び、ライブキュー付きで一括取り込み |
-| **🎯 現在のファイルを取り込み** | 左リボンの`sticker`アイコンをクリック、または `Cmd+P` → "Ingest current file" — 編集中のファイルを取り込み |
-| **🔍 Wikiに問い合わせ** | `Cmd+P` → "Query wiki" — 会話型Q&A、ストリーミング回答、`[[wiki-links]]`付き |
-| **🛠️ WikiのLint** | `Cmd+P` → "Lint wiki" — 重複、リンク切れ、空ページ、孤立ページ、欠落エイリアス、矛盾のフルヘルススキャン |
-| **📋 インデックスの再生成** | `Cmd+P` → "Regenerate index" — `wiki/index.md` を現在のページとエイリアスで再構築 |
-| **📊 取り込み履歴の表示 (v1.21.0)** | `Cmd+P` → "View Ingestion History" — 過去の取り込み、Lintレポート、メンテナンス実行を検索・フィルタ可能なUIで閲覧 |
-| **⏹ 現在の操作をキャンセル** | `Cmd+P` → "Cancel current ingestion" — 進行中の操作を次のバッチ境界でクリーンに停止 |
-| **🎉 ウェルカムノートを再作成 (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — 初回起動時のウェルカムノートを再生成 |
-
-同じソースを再取り込みすると、エンティティ・概念ページに増分更新が行われ（新情報がマージ）、概要ページは再生成されます。
-
-> 💡 **スマートバッチスキップ:** フォルダ取り込み時、処理済みファイルを自動検出してスキップし、時間とAPIコストを削減します。バッチレポートにスキップ数が表示されます。
-
-### ⚠️ 旧バージョンからのアップグレード
-
-> 🔧 **v1.24.x からのアップグレード。** PDF 取り込み（v1.25.0）はキャッシュを `.obsidian/plugins/karpathywiki/pdf-cache/` に書き込みます（上限 100 MB / 1000 件 / 単一 10 MB；起動時とバッチ取り込み開始時に LRU-by-mtime で退避）。Vault は **デフォルトでは変更されません** —— Settings → Wiki Configuration → Wiki Folder で **Write PDF Markdown to Vault** を有効にした場合にのみ、ソース PDF の隣に `<basename>.pdf.md` サイドカーを書き込みます。2 つの新しい設定 — **Force PDF Support**（上級、デフォルトオフ）と **Write PDF Markdown to Vault**（デフォルトオフ）— は完全な後方互換：古い `data.json` にこれらが無い場合は `false` にフォールバックします。
-
-> 🔧 **v1.24.0 からのアップグレード。** ページの *Mentions in Source* セクションのみを保護していた内部コメントマーカー `<!-- reviewed: keep -->`（v1.24.0、#244）は削除されました。整理済みの Mentions セクションを保持するには、ページの frontmatter に `reviewed: true` を設定してください。ページ全体（Mentions を含む）を保護し、隠れたコメントと異なりプロパティパネルに表示され、Markdown リンターでも壊れません。
-
-**後方互換性があります。** v1.0.0以降、破壊的変更はありません — 既存のWikiページ、設定、ワークフローは再設定なしで保持されます。
-
-**アップグレード後**、**Lint Wiki** → **Smart Fix All** でワンクリックの因果順修復を実行してください：
-1. 🏷️ エイリアス補完（翻訳、略語、別名をLLMがバッチ生成）
-2. 🔄 重複マージ（言語間、略語、高類似度マッチ）
-3. 🔗 リンク切れ / 孤立ページリンク / 空ページ拡張の修正
-
-その後 **Regenerate Index** で `wiki/index.md` を再構築し、すべてのページのエイリアスエントリーを有効にします — エイリアス対応検索が可能になります（例：「DSA」で「DeepSeek-Sparse-Attention」を検出）。
-
-> 📖 特定のバージョン間アップグレードの詳細な手順（v1.20.3 slug fingerprint、v1.16.0 二重ネストリンクなど）は [GitHub Discussions / Upgrading](https://github.com/green-dalii/obsidian-llm-wiki/discussions) で管理されています。
-
-**確認すべき設定:** Force PDF Support（Settings → LLM Configuration → Advanced、デフォルトオフ — 非 NATIVE プロバイダーのみ必要）、Write PDF Markdown to Vault（Settings → Wiki Configuration → Wiki Folder、デフォルトオフ）、Wiki Output Language（UIとは独立）、Extraction Granularity（Minimal–Fine、+ Custom）、Page Generation Concurrency（デフォルト3）、Batch Delay（デフォルト300ms）。
+> 💡 **最新版を保ちましょう。** 新機能・修正・パフォーマンス改善は頻繁にリリースされます。設定 → コミュニティプラグイン → 更新を確認、または自動プラグイン更新を有効にしてください。
+> 📖 詳細なチュートリアル（インストール、PDF設定、マルチプロバイダー設定、アップグレード手順）は [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides) で管理されています。
 
 ---
-## ⚡ 最新情報 v1.25.x
 
-- **v1.25.2（2026-07-22）.**
-  タグ語彙 Phase 1（二重ソース解消）、Codex OAuth（ChatGPT Plan）、関連リンクフォルダ接頭辞修正、ページテンプレート裸 `---` 修正、ESLint 0.4.1 路線 A。2515 テスト合格。
-- **v1.25.1（2026-07-20）.**
-  8 件のサイレント消失修正（関連ページ、スキーマセクション、レガシー Mentions）、3 つの大ファイル分割、DiskCache&lt;T&gt;、LM Studio の API キー不要取込、ビルド検証根本原因。2274 テスト合格。
-- **v1.25.0（2026-07-18）.**
-  キャッシュのみの PDF 取込（Level 1）、制限付きキャッシュ成長、オプションの Vault sidecar、Force PDF ユニバーサルゲート、忠実文字起こしプロンプト、キャンセル可能な取込、ローカルモデルガイダンス、i18n 完全対応。2182 テスト合格。
-
-📋 [完全なバージョン履歴 → CHANGELOG.md](../CHANGELOG.md)
 ## ✨ 特徴
 
-### 📊 ナレッジ品質
+### 📚 ナレッジ品質
 
-- **🔍 エンティティ・概念の抽出** — LLMがノートからエンティティ（人物、組織、製品、イベントなど）と概念（理論、方法、用語など）を抽出します。抽出粒度（最小〜5項目、粗め〜10、標準〜50、詳細〜100、カスタム1〜500）を柔軟に調整でき、分析の深さとAPIコストを両立できます。
-- **🏷️ 必須ページエイリアス** — 生成される各ページに最低1つのエイリアス（翻訳、略語、別名）が含まれ、言語をまたいだ重複検出が有効になります。
-- **🔄 重複検出とマージ** — セマンティック階層化により真の重複（言語間の翻訳、略語、表記ゆれ）を発見。LLMによる知的なマージが内容を統合し、エイリアスを保持します。
-- **🧩 スマート知識融合** — 複数ソースからの更新で冗長性なく新情報をマージ。矛盾は出典を伴って保持され、`reviewed: true` ページは上書きから保護されます。
-- **📏 コンテンツ切り詰め保護** — API キー型およびローカル Provider では 8000 max_tokens、自動 stop_reason 検出、2倍トークンでの再試行を使用します。実験的な ChatGPT Plan（Codex OAuth）経路は Codex バックエンドの出力ポリシーに従い、クライアント側の max_output_tokens 上限を受け付けません。
-- **📝 原文引用の保持** — 元の言語で引用を保持し、オプションの翻訳で完全なトレーサビリティを確保。
+- **🔍 エンティティ・概念の抽出** — LLMがエンティティ（人物、組織、製品、イベントなど）と概念（理論、方法、用語など）を独立したページに抽出。粒度はMinimal〜Fine＋Customから設定可能で、コストと深さのバランスを調整できます。
+- **🏷️ 必須エイリアス** — すべてのページに最低1つのエイリアス（翻訳、略語、別名）が含まれ、言語間の重複検出が機能します。
+- **🔄 階層化重複検出** — Tier 1（直接名称一致：言語間、略語、高類似度タイトル）は常時LLM検証。Tier 2（リンク共有、中程度類似度）が残りのトークン予算を埋めます。
+- **🧩 スマートマージと矛盾状態管理** — 重複マージ時にエイリアスを保持。矛盾は出典付きでフラグ。`reviewed: true`のページは上書きから保護。
+- **🎨 カスタムタグ語彙** — 設定→Wiki→タグ語彙モード→*カスタム*で、独自のエンティティタイプ・概念タイプタグリストを定義可能。アクティブ語彙から外れたタグはLintが報告。
 
-- **🎨 カスタマイズ可能なタグ語彙 (v1.18.0)。** 設定 → Wiki → タグ語彙モード → *カスタム* で、エンティティタイプ・概念タイプのタグリストを独自に定義できます（例：`Medical_Arzneimittel`、`法规`）。プラグインは抽出プロンプトとフロントマター検証の両方であなたの語彙を尊重します；既存の Lint 監査 (#85 v7) はアクティブな語彙から外れたタグを持つページを報告します。
+### 📄 PDF取り込み（v1.25.0+）
 
-### 📄 PDF 取り込み (v1.25.0)
+- **🔌 プロバイダーゲート** — Anthropic、OpenAI、BedrockはPDFをネイティブ処理。その他のOpenAI/Anthropic互換エンドポイントでは、設定→LLM Configuration→Advancedの **Force PDF Support** を有効にするとプラグインが呼び出しを試行します。Apple SiliconでのローカルOCR、サードパーティ抽出ツール（MinerU、Docling、Mathpix、Adobe）の詳細と完全なPDF取り込みチュートリアルは、以下の[PDF OCRパス](#-pdf-ocrパス)および[docs/PDF-OCR-GUIDE.md](PDF-OCR-GUIDE.md)を参照。
+- **🗄️ 有界キャッシュ** — `.obsidian/plugins/karpathywiki/pdf-cache/`に、コンテンツハッシュ＋モデル＋コンバーターバージョンでキー付けされた変換済みMarkdownを保存。三層防御のハウスキーピング：合計100MB/1000エントリ/単一10MB上限＋LRU-by-mtimeエビクション。
+- **📝 任意のVaultサイドカー** — 設定→Wiki Configuration→Wiki Folder→*Write PDF Markdown to Vault*で、ソースPDFの隣に`<basename>.pdf.md`を書き出し（デフォルトはオフ。キャッシュのみがデフォルト）。
+- **🛡️ 逐語転写プロンプト** — `[illegible]`/`[figure: ...]`の反幻覚マーカー付きOCRスタイル変換。小型ローカルモデルが出力をmarkdownフェンスで囲んでしまう場合、キャッシュ書き込み前に自動クリーンアップ。
 
-Vault から PDF を 1 つ選ぶ — プラグインはあなたの LLM プロバイダーのネイティブファイル入力経由で読み取り、Markdown に変換して、通常の Markdown 取り込みパイプラインに合流します。既存のエンティティ/概念/エイリアス/`[[wiki-link]]` のワークフローはすべてそのまま適用されます。
+### 📄 PDF OCRパス
 
-- **🔌 プロバイダーゲート** — Anthropic、OpenAI、Bedrock Anthropic、Bedrock OpenAI は PDF をネイティブに扱えます。その他の OpenAI/Anthropic 互換エンドポイントでは、Settings → LLM Configuration → Advanced で **Force PDF Support** を有効にするとプラグインが呼び出しを試行します（成否の判定はエンドポイント側。失敗時はトグルをオフにするよう案内するローカライズ Notice が表示されます）。ローカルでの推奨構成は [ローカル PDF OCR パス](#-ローカル-pdf-ocr-パス-v1250) を参照。
-- **🗄️ コンテンツハッシュキャッシュ** — 同じ PDF + 同じモデル + 同じ converter version は LLM 呼び出しなしでキャッシュ済み Markdown を返します。キャッシュは `.obsidian/plugins/karpathywiki/pdf-cache/` に格納され、キーには `converterVersion` が埋め込まれるためプロンプト更新時に自動的に無効化されます。
-- **📏 有界成長** — 三層防御のキャッシュ管理（合計 100 MB / 1000 件 / 単一 10 MB 上限）+ LRU-by-mtime エビクション。古いエントリは起動時とバッチ取り込み開始時に整理されます。デフォルトはキャッシュのみ — vault には書き込みません。
-- **📝 任意の Vault サイドカー** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** を有効にすると、変換後にソース PDF の隣に `<basename>.pdf.md` を書き出します（デフォルトはオフ、キャッシュのみ）。
-- **🛡️ 逐語転写プロンプト** — PDF→Markdown プロンプトは OCR スタイルの逐語変換として再設計され、`[illegible]` / `[figure: ...]` / `[equation: ...]` の反ハルシネーションマーカーを備えます。出力を ```markdown フェンスで囲ってしまう小型/ローカルモデルはキャッシュ書き込み前に自動クリーンアップされます。
-- **⏹ キャンセル可能** — 変換中にステータスバーをクリックすると、進行中の LLM 呼び出しが中断されます（Vercel AI SDK v6 経由）。
+3つのパスから環境に合ったものを選択：
 
-### 💬 クエリとフィードバック
+1. **☁️ クラウドプロバイダー（ネイティブPDF対応）** — Anthropic、OpenAI、またはAWS BedrockがそのままPDFを読み取り。追加設定不要で取り込み可能。その他のOpenAI/Anthropic互換エンドポイントでは、設定→LLM Configuration→Advancedの **Force PDF Support** を有効にするとプラグインが呼び出しを試行。
+2. **🖥️ Apple SiliconでのローカルOCR** — [oMLX](https://github.com/jundot/omlx)はMicrosoft Markitdownを内蔵のPDF→Markdownバックエンドとして統合。oMLXでMarkitdownを有効化し、[Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR)（3B/570M-active、2026-06オープンソース）をビジョンモデルとしてロード。プラグインをカスタムOpenAI互換プロバイダーに設定し、**Force PDF Support**をオンにして、oMLXが提供するマルチモーダルモデルを選択。PDFがマシンを離れることはありません。
+3. **🛠️ サードパーティ抽出ツール（MinerU、Docling、Mathpix、Adobe）** — PDFに対して別の抽出ツールを実行して`.md`ファイルを生成し、その後プラグインの標準パイプラインで通常のMarkdownノートとして取り込み。学術論文、スキャン文書、数式の多いPDFに最も信頼性の高い方法です。
 
-- **🔍 5 段 PPR シード選択カスケード（v1.24.1 PATCH）** — マルチホップ質問を投げると、Query Wiki は生成を開始する前に 5 つの補完的な段階で回答を構成します：
-  1. **Lex 高速パス** — 全エンティティ/コンセプトのタイトルとエイリアスに対する直接のトークン重複チェック（無料・即時、後段のゲート）
-  2. **LLM キーワード生成** — LLM がクエリから 8–12 個の多言語キーワードを生成（同義語、略語、トークン重複に弱い語を吸収）
-  3. **ローカル部分文字列スキャン** — 生成された各キーワードを、ページタイトル・エイリアス・本文断片に対してローカルで再マッチ（追加 LLM 呼び出しなし、ノイズ許容のリコールを補完）
-  4. **LLM KB フォールバック** — lex + キーワードスキャンのシグナルが弱い場合、LLM がトップ N 候補を wiki 全体に対して 1 回だけ意味的に再シード
-  5. **PPR グラフ拡張** — 候補シード集合から `[[wiki-link]]` グラフ上で Personalized PageRank（Haveliwala 2002）を実行；LLM にグラフ認識のマルチホップ文脈を提供（線形検索では到達不可）
+📖 **3つのパスすべての完全セットアップ手順**（クラウドプロバイダー、oMLXハードウェア階層、MinerUインストール、キャッシュ管理）→ [docs/PDF-OCR-GUIDE.md](PDF-OCR-GUIDE.md)
 
-  カスケードは十分なシグナルを返した段階で自動的に打ち切られます —— 固定の 5 ステップコストはなし、lex で十分な時は LLM 呼び出しなし、LLM 拡張が必要な時は精度を損なわない。エンドツーエンドの関連性（プロジェクトの独自ベンチマークで PPR @5 = 27.1%）は、埋め込みをオプトインせずに純粋 knn ベースライン（24.1%）を上回ります。Stage 1.5（ステップ 2–3）が純粋 lex で漏れるマルチホップを扱い、Stage 1.7（ステップ 4）が LLM 注入キーワードのシグナル不足をリカバリし、Stage 1.9（ステップ 5）が LLM にフラットな top-N ではなく隣接文脈を保証。従来の二分 tier カスケードを置換。
+### 💬 クエリとメンテナンス
 
-- **🤖 会話型クエリ** — ChatGPTスタイルのダイアログ、ストリーミングMarkdown出力、自動的に`[[wiki-links]]`が付き、複数ターンの履歴を保持。
-- **🪟 右側ドッキングサイドパネル (v1.22.1, PR #196)。** Query Wiki は中央ポップアップではなく、Copilot スタイルの右サイドバー leaf（既存 leaf を再利用）で開きます。`message-circle` リボンアイコンと `Query Wiki` コマンドでパネルを起動/表示。ノートは会話の横に常時表示。すべての機能は変更なし。
-- **📤 クエリ→Wikiフィードバック** — 価値ある会話をWikiに保存し、エンティティ・概念の抽出、保存前のセマンティック重複排除を実行。
-- **🔒 重複保存防止** — ハッシュ追跡により変更のない会話の再評価を防止。
+- **🧭 5段階PPRカスケード** — [検索の仕組み](#-検索の仕組み)を参照。`[[wiki-link]]`上のPersonalized PageRankがグラフ認識のマルチホップコンテキストを提供。
+- **🪟 右側ドッキングサイドパネル** — Query Wikiは中央モーダルではなく、Copilotスタイルの右サイドバーリーフで開きます（v1.22.1+）。
+- **🔍 Lintヘルススキャン** — 単一コマンドで以下を検出：重複、リンク切れ、空ページ、孤立ページ、欠落エイリアス、矛盾。
+- **⚡ Smart Fix All** — ワンクリック因果順修復：エイリアス補完→重複マージ→リンク切れ修正→孤立ページリンク→空ページ拡張。フェーズごとにレポート表示。
+- **📊 操作履歴パネル** — 過去の取り込み・Lintレポート・メンテナンス実行を検索・フィルタ可能なUIで表示。
+- **🛡️ 取り込み前ゲート** — 空・空白・frontmatterのみのノートはLLM呼び出し前に拒否。コンテンツハッシュによる重複排除でパス間の同一ファイルを検出。
 
-### 🛠️ メンテナンス
+### 🔒 プライバシー
 
-- **🔍 Lintヘルススキャン** — 重複、リンク切れ、空ページ、孤立ページ、欠落エイリアス、矛盾を検出する単一の包括的レポート。
-- **🎯 セマンティック階層化重複検出** — 階層1（常時LLM検証）は言語間マッチ・略語・類似度の高いタイトルを取得。階層2が残りのトークン予算を中程度の類似度の候補で埋めます。
-- **⚡ スマート全自動修復 (Smart Fix All)** — 因果関係順に一括修復：エイリアス補完 → 重複マージ → リンク切れ修正 → 孤立ページリンク → 空ページ拡張。
-- **🏷️ エイリアス補完** — ワンクリックで欠落エイリアスを並列バッチ生成し、今後の重複検出の精度を向上。
-- **🔄 自動メンテナンス** — 複数フォルダ監視、定期Lint、起動時ヘルスチェック（すべて任意）。
-- **⚠️ 矛盾状態機械** — `検出 → レビュー済み → 解決`（AI修復）または`検出 → 未対応`（手動）。
-- **🛡️ インゲスト前要件ゲート (v1.21.0)** — すべてのLLM呼び出しの前にソースファイルを検証：空・空白・frontmatterのみのノートは拒否され、コンテンツハッシュによる重複排除でパス間の同一ファイルを検出。ローカルモデルが空白入力でエンティティ名を幻覚するのを防止します。
-- **📊 操作履歴パネル (v1.21.0)** — 過去のインゲスト、Lintレポート、メンテナンス実行を、検索・フィルタ可能なUIで確認。インサイト駆動のKPIカードとクリッカブルなページリンク付き。
-- **🧹 未完了ページクリーナー (v1.21.0)** — 中断されたインゲストで未完成のまま残ったページを起動時に自動アーカイブ（Obsidianの`.trash`から復元可能）。
+- **🚫 バックエンドなし、トラッキングなし、分析なし。** Obsidian内部でのみ動作。ネットワークは設定したLLMプロバイダーとの通信のみに使用。
+- **📁 ソースファイルは読み取り専用。** プラグインは元のvaultノートを決して変更せず、`wiki/`以下に新しいページを作成するのみ。
+- **🦙 完全ローカルモード。** Ollama、LM Studio、または任意のローカルOpenAI互換エンドポイントで — ノートがマシンを離れることはありません。
+- **🔐 最小限の権限。** VaultファイルアクセスはWiki管理用。クリップボードアクセスはQueryモーダルの「コピー」ボタンをクリックした時のみ。
 
-### 🌐 LLMと言語
+### 🦙 ローカルファースト
 
-- **🔌 マルチプロバイダー対応** — Anthropic、Anthropic互換（Coding Plan）、Gemini、OpenAI、DeepSeek、Kimi、GLM、MiniMax、LM Studio、OpenRouter、Ollama、カスタムエンドポイント。
-- **🔄 5xx自動再試行** — 全クライアントでHTTP 5xx/429/529エラー時に指数バックオフで再試行（最大2回）。
-- **📋 動的モデル一覧** — プロバイダーAPIからリアルタイム取得。
-- **🌐 Wiki出力言語** — UI言語と独立した10言語（English / 简体中文 / 繁體中文 / 日本語 / 한국어 / Deutsch / Français / Español / Português / Italiano）、カスタム入力オプション対応。
-- **🌍 UI完全国際化** — プラグインUIは10言語対応（EN / ZH / ZH-Hant / JA / KO / DE / FR / ES / PT / IT）、277以上のUI項目を自然な現地表現で完全翻訳。
-- **⚡ レート制限ガード** — 並列生成でレート制限が発生した場合、自動的に検出し並列度の低下・バッチ遅延の増加・プロバイダー切り替えを提案。
-- **🦙 Web Clipper互換** — 公式Obsidian Web Clipperの`Clippings/`フォルダをワンクリックで監視リストに追加し、クリップしたWebページを自動的にWikiに取り込み。
+- **🖥️ Ollama、LM Studio、OpenRouter、カスタムエンドポイント** — そのまま動作。ローカルモデルはクエリに使用可能（コンテキストウィンドウは小さめ）。2000ページのvault取り込みには通常、長コンテキストのクラウドモデルが必要。
+- **📄 Apple Silicon上で完全ローカルのPDF OCRパス** — 上記[PDF OCRパス](#-pdf-ocrパス)を参照。
+- **🔐 ChatGPT Plan（Codex OAuth）** — デスクトップは`127.0.0.1:1455`でのループバックコールバック、モバイルはデバイスコード経由。認証情報はObsidian SecretStorageのみに保存。サインアウトで消去。OpenAIのパートナーシップではなく、サードパーティのCodex互換機能。
 
-### 🏗️ アーキテクチャとパフォーマンス
+### 🌐 言語
 
-- **🕸️ PPR over [[wiki-link]] グラフ（v1.24.0+、v1.24.1 PATCH で成熟）** — Personalized PageRank（Haveliwala 2002）は wiki ページ間の `[[wiki-link]]` 辺で構成される有向グラフ上で動作；カスケードは PPR のシードを top-N 候補集合に固定し、マルチホップ文脈は最大 3 つの拡張リングを伝わります。これが Query Wiki の回答にグラフ認識能力を持たせる仕組みです（「Microsoft の創業者」という問いが Bill Gates → Microsoft → 競合、とたどって解決される。単なる字面タイトル一致ではない）。2,137 ページの vault でも典型的には warm + 3 ホップ拡張が < 100 ms で完結し、vault サイズに依存しません。クエリ＆フィードバック節の全 4 段シードカスケードで利用され、また lint の重複検出（間接リンクで 2 つの候補ページが結ばれる場合）でも使われます。
-- **⚡ 並列ページ生成** — 1〜5の同時ページをカスタマイズ可能（デフォルト3、並列）、大容量ソースで2〜3倍高速化、ページ単位のエラー分離。
-- **📚 反復バッチ抽出** — 適応的バッチサイジングにより、長文ドキュメントの最大トークンボトルネックを解消。
-- **🏛️ 3層アーキテクチャ** — vault 内のノート（読み取り専用）→ `wiki/`（LLM 生成ページ。`wiki/sources/`、`wiki/entities/`、`wiki/concepts/` に分類）→ `schema/`（共進化設定）。
-- **🧩 モジュール化されたコードベース** — `src/`内に20以上の特化モジュール。
-
-### 🔒 プライバシーとセキュリティ
-
-- **バックエンドなし、テレメトリなし。** プラグインは完全にObsidian内部で動作します——外部サーバー、分析、データ収集は一切ありません。LLMプロバイダーを明示的に設定しない限り、ノートがVaultから出ることはありません。
-- **データはデフォルトでローカルに保存。** プラグインは、選択したLLM API以外の場所にコンテンツを保存、キャッシュ、送信することはありません。取り込みやクエリのために送信するテキストのみがデバイスを離れます——それも設定したプロバイダーのみです。
-- **Ollama、LM Studio、またはローカルプロバイダーによる完全ローカルモード。** 完全なデータ主権のために、ローカルで動作するLLMを使用してください。ノートは完全にあなたのマシン上で処理され——インターネットに触れることはありません。
-- **最小限の権限。** VaultファイルアクセスはWiki管理に必要です（ノートの読み取り、ページの生成、リンク切れの検出）。ネットワークアクセスは設定したプロバイダーへのLLM API呼び出しのみに使用されます。クリップボードアクセスはQueryモーダルの「コピー」ボタンのみ——クリックした時だけです。
-
----
----
-
-## 📖 例
-
-**入力:** `sources/machine-learning.md`
-
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
-
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
-
-**出力 — Entityページ:** `wiki/entities/supervised-learning.md`
-
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
-
-### Supervised Learning
-
-### 基本情報
-- タイプ: method
-- ソース: [[sources/machine-learning]]
-
-### 説明
-Supervised learning（教師あり学習）は、ラベル付き訓練データから学習し、
-未知のデータに対して予測を行う機械学習パラダイムです...
-
-### 関連概念
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### 関連Entity
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### ソース内の記述
-- "Supervised learning uses labeled data to train predictive models..."
-```
+- **🌍 10のUI言語** — English、简体中文、繁體中文、日本語、한국어、Deutsch、Français、Español、Português、Italiano。UI言語とWiki出力言語は独立して設定可能（UIは英語のまま、Wikiは日本語で出力できます）。
+- **📚 10のWiki出力言語** — 同じセット。設定→Wiki Configurationで選択。*Custom input*オプションでアドホックプロンプトも可能。
+- **🈶 269以上の翻訳済みUI文字列** — すべてのラベル、モーダル、通知。11言語目の追加はコントリビューター主導（PR #159パターン）。
 
 ---
 
-## 🤖 モデル推奨
+## 🔍 検索の仕組み
 
-本プラグインはKarpathyの核となる理念に従う：**Wikiの完全なコンテキストをLLMに直接渡し、RAG検索の断片化は行わない**。長いコンテキストウィンドウを持つモデルを強く推奨します。Wikiが大きくなるほど、LLMはページ間の整合性を維持するためにより多くのコンテキストを必要とするためです。
+ほとんどの「AI検索」プラグインはノートをチャンクに分割し、ベクトルDBに埋め込みます。このプラグインはそうしません。KarpathyがRAGに対して指摘した通り、チャンク化はLLMが知識グラフ全体を横断して推論する能力を損なうからです。代わりに、あなたが`[[wiki-links]]`を書くことで維持しているグラフをそのまま活用します。
 
-> 💡 なぜRAGを使わないのか？Karpathyは[オリジナルコンセプト](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)で、RAGは知識を断片化し、完全な知識グラフにわたるLLMの推論能力を損なうと指摘した。
+### 5段階シード選択カスケード
 
-**💰 コスパ優先戦略：** フラッグシップモデルは不要。以下の**経済的な代替案**で低コストで優れた結果を得られる：
+「Microsoftの創業者は誰ですか？」と尋ねると、Query Wikiは回答生成前に5つの段階を実行します：
 
-### ☁️ クラウドモデル推奨
+1. **Lex高速パス** — すべてのエンティティ・概念タイトルとエイリアスに対してストレートなトークン重複チェック。無料・即時。以降の段階のゲートとなります。
+2. **LLMキーワード生成** — LLMがクエリから8〜12の多言語キーワードを生成（類義語、略語、トークン重複に弱い語を1回のLLM呼び出しで吸収）。
+3. **ローカル部分文字列スキャン** — 生成された各キーワードを、ページタイトル・エイリアス・本文断片に対してローカルで再マッチ。追加LLM呼び出しなし、ノイズ許容の再現率を補完。
+4. **LLM KBフォールバック** — lex＋キーワードスキャンのシグナルが弱い場合、LLMがwiki全体からトップN候補を1回だけ意味的に再シード。
+5. **PPRグラフ拡張** — 候補シード集合から`[[wiki-link]]`グラフ上でPersonalized PageRank（Haveliwala 2002）を実行。これがグラフ認識のマルチホップコンテキストを提供する仕組みです：「Bill Gates」→「Microsoft」→「競合他社」というように、単なる文字面のタイトル一致ではありません。
 
-| ティア | モデル | コンテキスト | 理由 |
-|-------|--------|-------------|------|
-| **🌟 コスパ最高** | **DeepSeek V4-Flash** | 1M tokens | 最安($0.14/M)、284B MoE、バッチ処理に最適 |
-| **🌟 コスパ最高** | **Gemini-3.5-Flash** | 1M tokens | GPT-5.5の4倍速、エージェントタスク優秀 |
-| **🌟 コスパ最高** | **Qwen3.6-Plus** | 1M tokens | コーディング・エージェント能力強、競争力価格 |
-| **🌟 コスパ最高** | **Grok-4** | 2M tokens | xAI 2025-07 フラッグシップ、2M コンテキスト、推論・コードタスクに強力 |
-| **バランス型** | **Claude Sonnet 4.6** | 1M tokens | 品質とコストの良いバランス、$3/$15 per 1M tokens |
-| **軽量型** | **Claude Haiku 4.5** | 200K tokens | 高速経済、小型Wiki向け |
-| **エコノミー型** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE、2026-04 MIT オープンソース、エージェント・マルチモーダル |
-| **フラッグシップ型** | Claude Opus 4.7 | 1M tokens | 最高品質、高コスト — 選択的に使用 |
-| **フラッグシップ型** | GPT-5.5 | 1M tokens | トップ推論、高コスト — 選択的に使用 |
+カスケードは十分なシグナルが得られた段階で打ち切られます — 固定の5段階コストではなく、lexで十分な時はLLM呼び出しなし、LLM拡張が必要な時は精度を損なわない設計です。
 
-### 🦙 ローカルモデル推奨 (Ollama / LM Studio)
+### Personalized PageRankのスケーリング
 
-ローカル推論の最大の利点はデータ主権・オフライン利用・ゼロ API コスト。一方、コンテキストウィンドウは小さめ（多くは 8K〜128K、最近のオープンウェイトは 262K まで届く）で、フラッグシップのクラウドモデルと比べると指示追従も控えめです。**ハードウェア予算に応じて選ぶ：** パラメータ数が大きいほど世界知識と指示追従が強くなり（抽出品質が上がり、ハルシネーションが減る）、小さいほど速度と VRAM に余裕が出る代わりにハルシネーションや長文コンテキスト推論が弱くなる。24 GB Apple Silicon またはシングル一般 GPU のスイートスポットは 27B〜35B-A3B クラス。
+Monte Carlo PPR（Fogaras 2005）を使用 — 3,000ランダムウォーク×50ステップ、Haveliwala 2002のデッドエンドルール付き。コストは**O(K×L)**でページ数に依存しないため、2,000ページのvaultでも200ページのvaultと同じ拡張レイテンシです。
 
-| モデル | パラメータ | コンテキスト | 理由 |
-|--------|----------|-------------|------|
-| **Qwen3.5 27B** | 27B dense | 262K | 取り込み用途で品質とサイズの最良バランス；MLX 4-bit で 24 GB に収まる |
-| **Qwen3.5 35B-A3B** | 35B 総 / 3B アクティブ MoE | 262K | 27B dense より高速で同等の品質；VRAM 節約に最適 |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | 品質上限；≥48 GB VRAM またはデュアル GPU が必要 |
-| **Qwen3.6 27B** | 27B dense | 256K+ | Qwen3.5 27B の 2026-04 リフレッシュ版、ハードウェアが許すならこちらを優先 |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Qwen3.5 35B-A3B と同じトレードオフ、新しいウェイト |
-| **Gemma 4 31B IT** | 31B dense | 262K | 指示追従が強く、Markdown 出力がきれい |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | 31B dense より省メモリで同等の品質 |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | 純 CPU でも動作；小型 Wiki またはクイックプレビュー向け |
+**PPR @5 = 27.1%（純粋kNNベースライン24.1%を上回る）** — このオープンソースLLM-Wiki分野で唯一公開されている検索ベンチマーク数値です。
 
-**量子化の目安：** Apple Silicon 上の MLX 4-bit は、同等の実効ビットレートの GGUF Q4_K_M より 1.5〜2× 速い傾向。GGUF Q4_K_M はクロスプラットフォームのデフォルト選択。VRAM に余裕があり Q4 で品質劣化が見えるときのみ Q5/Q8 を検討。
+### なぜ埋め込みを使わないのか
 
-**コンテキスト戦略：** Wiki が約 500 ページを超えると、262K のローカルモデルでもクエリエンジンが組み立てるコンテキストの大部分をカバーできるが、2000 ページの vault 取り込みには不足する。一般的な組み合わせは「取り込みはクラウド、クエリはローカル」。完全ローカルにこだわるなら、27B/35B-A3B クラスがスイートスポット。
-
-### 📄 ローカル PDF OCR パス (v1.25.0+)
-
-v1.25.0 の PDF 取り込みは、PDF をファイルパートとして受け付けるあらゆるプロバイダーで動作する。Apple Silicon（oMLX が現在サポートする唯一のプラットフォーム）上で完全ローカルパイプラインを組む場合の推奨構成は次のとおり：
-
-1. [oMLX](https://github.com/jundot/omlx) をインストールし、内蔵の **Markitdown** バックエンド（ローカル PDF→Markdown 変換）を有効化する。
-2. **Baidu Unlimited-OCR**（2026-06-22 オープンソース、3B 総 / 0.5B アクティブ、エンドツーエンド OCR、長文書で「生成するほど遅くなる」旧モデルの問題に取り組んだ）を oMLX のビジョンモデルとして読み込む。
-3. 本プラグイン側：プロバイダーを **Custom OpenAI-Compatible** に設定（oMLX は OpenAI 互換プロトコルで通信）、Base URL を oMLX のローカルサーバーに向ける、Settings → LLM Configuration → Advanced で **Force PDF Support** を有効化し、取り込みサマリーには oMLX が提供するマルチモーダルモデルを選ぶ。
-
-PDF はあなたのマシンを一切離れない — Markitdown が構造変換を、Unlimited-OCR が視覚認識を、ローカル LLM が要約を担う。本プラグインのキャッシュ（`.obsidian/plugins/karpathywiki/pdf-cache/`）が再取り込みを即時に保つ。
-
-**フォールバック：** oMLX/Markitdown が利用できない場合（Linux/Windows、または古い Mac）は、**Force PDF Support** を PDF ファイルパートを受け付けるローカルマルチモーダル LLM に直接向ける。モデルが大きければ品質は良いが、VRAM 要件はページ数とともに急峻に立ち上がる。
-
-**🔌 Anthropic Compatible（Coding Plan）:** ProviderがAnthropic互換APIエンドポイントを提供している場合、「Anthropic Compatible」を選択し、ProviderのBase URLとAPI Keyを入力してください。
-
-**🦙 Ollama（ローカル、API キー不要）：** [Ollama](https://ollama.com) をインストールし、モデルを pull（`ollama pull gemma4` または `ollama pull qwen3.5:27b`）、プロバイダードロップダウンで「Ollama (Local)」を選択。
-
-**🎛️ LM Studio（ローカル、API キー不要）：** [LM Studio](https://lmstudio.ai) をインストールし、ローカルサーバーを起動（デフォルト `http://localhost:1234/v1`）、プロバイダードロップダウンで「LM Studio (Local)」を選択。LM Studio は OpenAI 互換のサーバーを内蔵しており、API キーフィールドは任意。
-
-> 💡 **OpenAIの課金区分：** **OpenAI** は別途課金されるPlatform APIキーを使用します。**ChatGPT Plan (Codex OAuth)** はブラウザーまたはデバイスコードでサインインし、対象となるCodex利用枠を使う独立した実験的プロバイダーです。プラン名だけで利用を保証するものではありません。
+[Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175)で埋め込みパスを意図的に却下しました。グラフ信号はすでにそこにあります — すべての`[[wiki-link]]`は手作業で作成された「これらは関連している」というエッジであり、対応するプロバイダー（Ollama、LM Studio、Anthropic、Bedrock、Kimi、GLM、MiniMax）のほとんどは`/v1/embeddings`エンドポイントすら提供していません。埋め込みモデルを追加すれば、ページごとのダウンロード、プロバイダーごとのアダプターが必要になり、検索品質への効果はゼロです。
 
 ---
 
-## 🏗️ アーキテクチャ
+## 🤖 モデル
 
-Karpathyの3層分離設計に基づく：
+**対応プロバイダー（12以上、2026-07月 models.dev クロスチェック済み）：**
 
-```
-📄 vault 内のノート（任意のフォルダ）  # 📖 取り込むノートをユーザーが選択
-  ↓ ingest
-wiki/                                  # 🧠 LLM生成のWikiページ（wiki/sources/、wiki/entities/、wiki/concepts/）
-  ↓ query / maintain
-schema/                                # 📋 Wiki構造設定（命名規則、ページテンプレート、分類ルール）
-```
+| プロバイダー | シリーズ | 備考 |
+|----------|--------|-------|
+| **Anthropic** | Claude 5シリーズ | ネイティブPDF、`/v1/messages`プロトコル |
+| **OpenAI** | GPT-5.6シリーズ（Sol / Terra / Luna） | ネイティブPDF、Platform APIキー |
+| **Google Gemini** | Gemini 3.6シリーズ | ネイティブPDF（1.5以降ファイルパーツ対応）、OpenAI互換エンドポイント |
+| **DeepSeek** | DeepSeek V4シリーズ | OpenAI互換、最安価格帯 |
+| **Alibaba Qwen** | Qwen3.7/3.8シリーズ | OpenAI互換（DashScope） |
+| **xAI Grok** | Grok 4シリーズ | OpenAI互換、長コンテキスト |
+| **Moonshot Kimi** | Kimi K3シリーズ | OpenAI互換、2.8T MoEフロンティア |
+| **Zhipu GLM** | GLM-5シリーズ | OpenAI互換、強力なバイリンガル |
+| **MiniMax** | MiniMax M3シリーズ | OpenAI互換、1Mコンテキスト |
+| **Step（階躍星辰）** | Step 3シリーズ（Flash） | OpenAI互換、高速推論 |
+| **Tencent Hunyuan** | Hy3シリーズ | OpenAI互換、オープンウェイトMoE |
+| **Xiaomi MiMo** | MiMo V2.5シリーズ | MITオープンソース、フラットプライシング |
+| **Google Gemma** | Gemma 4シリーズ | オープンウェイト、262Kコンテキスト |
+| **AWS Bedrock** | Anthropic + OpenAI派生 | VPC/コンプライアンスパス |
+| **ChatGPT Plan（Codex OAuth）** | Codex Responses API | ブラウザ/デバイスコードサインイン、SecretStorage |
+| **ローカル：Ollama、LM Studio、OpenRouter、Anthropic互換** | 任意のOpenAI-/Anthropic-プロトコルモデル | Custom OpenAI-Compatible + Anthropic-Compatible（Token Plan / Coding Plan） |
 
-> 📖 完全なコード構造は[CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure)をご覧ください。
+このプラグインはLLMにWikiコンテキスト全体を1回のクエリで渡すため、**長コンテキストのモデルが有利**です。完全な階層テーブル（クラウド＋ローカル）は [docs/MODEL-GUIDE.md](MODEL-GUIDE.md) にあります（[models.dev](https://models.dev/)でクロスチェック済み）。
 
-**生成されるページ:**
-- `wiki/sources/filename.md` — 📄 ソース要約
-- `wiki/entities/entity-name.md` — 👤 エンティティページ（人物、組織、プロジェクトなど）
-- `wiki/concepts/concept-name.md` — 💡 概念ページ（理論、方法、用語など）
-- `wiki/index.md` — 📑 自動生成インデックス
-- `wiki/log.md` — 📝 操作ログ
+### 重要な選択基準
+
+- **🧠 コンテキストウィンドウ 200Kトークン以上** — 約500ページ以上のvaultに推奨。200K未満だとカスケードが組み立てるコンテキストが切り詰められる可能性があります。
+- **⚖️ 指示追従の品質** — 抽出タスクでは生のIQよりも重要。スキーマテンプレートに従うモデルを選び、リーダーボードの最大値で選ばないでください。
+- **🔌 埋め込みエンドポイントは無関係** — 埋め込みは使用しません。`/v1/embeddings`がないプロバイダーでも問題ありません（対応プロバイダーのほとんどにありません）。
+- **🦙 ローカルはクエリ向き、クラウドは取り込み向き** — 2000ページのvault取り込みには通常、長コンテキストのクラウドモデルが必要。262Kのローカルモデルでほとんどのクエリはカバーできます。
+
+### Anthropic vs OpenAI vs Codex OAuth — それぞれ独立したプロバイダー
+
+- **Anthropic**（およびBedrock派生） — 別途請求されるAnthropic Platform APIキー。
+- **OpenAI** — 別途請求されるOpenAI Platform APIキー。
+- **ChatGPT Plan（Codex OAuth）** — 実験的かつ独立したプロバイダー。ブラウザまたはデバイスコードサインイン後、対象となるCodex利用枠を使用。提供状況はOpenAI Codexの認証・モデル・利用枠ポリシーに従い、プラン名だけで利用を保証するものではありません。OpenAIとのパートナーシップや汎用ChatGPT APIではなく、サードパーティのCodex互換機能です。
+
+> 📖 **完全な選択肢テーブル**（クラウド＋ローカル＋PDF OCR＋Codex OAuth＋量子化＋ハードウェア階層）→ [docs/MODEL-GUIDE.md](MODEL-GUIDE.md)
 
 ---
 
 ## ❓ FAQ
 
-> **プラグインを最新に保ってください。** 新機能と修正が頻繁にリリースされます。**設定 → コミュニティプラグイン → 更新を確認** を定期的に実行してください。
->
-> 📖 その他のFAQは [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28) をご覧ください。
+### このプラグインは実際に何をするのですか？
 
-**このプラグインは実際に何をしますか？**
-vault 内の任意のノート、フォルダ、複数選択を選ぶと、LLM がエンティティと概念を抽出し、`[[双方向リンク]]`で接続されたWikiを生成します。質問すると、インターネット検索ではなく*あなたのノート*に基づいた会話型の回答が得られます。生成された要約は `wiki/sources/`、エンティティは `wiki/entities/`、概念は `wiki/concepts/` に配置され、元の vault ノートは一切変更されません。
+任意のノート、フォルダ、複数選択から、LLMがエンティティと概念を抽出し、`[[双方向リンク]]`で相互リンクされたWikiを生成します。質問すると、インターネットではなく*あなたのノート*に基づいた会話型の回答が得られます。元のvaultノートは一切変更されません。
 
-**データは第三者に送信されますか？**
-🔒 **プライバシー最重視。** バックエンドなし、トラッキングなし、分析なし — プラグインは完全にObsidian内部で動作します。取り込み/クエリのために明示的に送信したテキストのみがデバイスを離れ、それも設定したLLMプロバイダーにのみ送られます。完全なデータローカリティにはローカルプロバイダー（OllamaまたはLM Studio、APIキー不要）を使用してください — データはインターネットに触れません。
+### どうやって始めるのですか？
 
-**RAGチャットボットとは何が違いますか？**
-チャンク化されたRAGがコンテキストを断片化するのに対し、LLM-Wikiは既存の`[[wiki-link]]`グラフ上で**Personalized PageRank**エンジンを実行 — リンク構造で関連ページを見つけます。これにより、埋込コストゼロ、新しい依存関係なし、ローカル/オフラインモデルでも完全に動作します。
+Obsidianコミュニティプラグインからインストール → プロバイダーを選択 → **Test Connection** → 任意のノートに対して **Ingest single source** を実行。数秒で最初のWikiページが生成されます。[クイックスタート](#-クイックスタート)を参照。
 
-**どのLLMを使うべきですか？**
-長いコンテキストウィンドウ（≥200Kトークン）のモデルが最適です。コスパ重視: DeepSeek V4-Flash（$0.14/M）、Gemini 3.5 Flash、Qwen3.6-Plus。Ollama/LM Studioのローカルモデルはクエリに使えますが、コンテキストウィンドウは小さめ（8K–128K）です。詳細は[モデル推奨](#-モデル推奨)を参照。
+### 既存のWikiは安全ですか？
 
-**始め方は？**
-Obsidianコミュニティプラグインからインストール → LLMプロバイダーを選択 → **Test Connection** → vault 内の任意のノートに対して **Ingest single source**（または **Ingest from folder**）を実行 → 最初のWikiページが数秒で生成されます。詳細は上記の[クイックスタート](#-クイックスタート)を参照。
+✅ v1.0.0以降後方互換。任意のページに`reviewed: true`を設定すると上書きから保護。v1.24.xからのアップグレードでvaultが書き換えられることはありません。v1.25.0のPDF取り込みはデフォルトでキャッシュのみ。
 
-**APIコストをどう管理できますか？**
-バッチ取り込みには粗い/最小の抽出粒度を使用（LLM呼び出しを削減）。スマートバッチスキップが既に取り込んだファイルを自動検出。自動メンテナンスはデフォルトでOFF（必要な場合のみ有効化）。Lintは実行前に件数を表示 — 承認なしでは課金されません。
+### データは外部に送信されますか？
 
-**既存のWikiは安全ですか？**
-✅ v1.0.0以降後方互換性があります。上書きから保護するには任意のページに`reviewed: true`を設定してください。プラグインは元の vault ノートを決して変更しません — `wiki/` フォルダ内に新しいページを生成するだけです。
+🚫 バックエンドなし、分析なし — Obsidian内部でのみ動作。取り込み/クエリのために明示的に送信したテキストだけがデバイスを離れ、設定したLLMプロバイダーにのみ送られます。完全なデータローカリティにはOllamaやLM Studioを使用してください。
 
-**自分の言語で使えますか？**
-🌐 UIとWiki出力の両方で**10言語**対応：English、简体中文、繁體中文、日本語、한국어、Deutsch、Français、Español、Português、Italiano。UI言語とWiki言語は独立 — インターフェースは英語のまま、Wikiを日本語で出力できます。11言語目はコントリビューター主導（Italian PR #159のパターンに従う）。
+### 自分の言語で使えますか？
 
-**必要な最小セットアップは？**
-Obsidian v1.11.4+（デスクトップまたはモバイル）。LLMプロバイダーのAPIキー、ローカルのOllama/LM Studio、または認証済みChatGPT Plan (Codex OAuth)資格情報が必要です。コア機能のロックを解除するには、プラグインの**llmReadyガード**が成功した接続テストを要求します。
+🌍 UIとWiki出力の両方で10言語対応。UI言語とWiki言語は独立。11言語目の追加はコントリビューター主導（PR #159パターン）。
 
-**実行中の操作をキャンセルするには？**
-ステータスバーのテキスト（「取り込み中… クリックでキャンセル」と表示）をクリックするか、`Cmd+P` → "Cancel current ingestion"を実行。次のバッチ境界でクリーンに停止し、完了した作業は保持されます。
+### RAGチャットボットと何が違うのですか？
 
-**ヘルプはどこで得られますか？**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — バグ報告
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — 質問、機能リクエスト、アップグレードヘルプ
-- 開発者コンソール（`Ctrl+Shift+I` / `Cmd+Option+I`）— モジュール名プレフィックス付きのログをコピーして、より高速な診断に
+🚫 チャンク化なし。🚫 埋め込みなし。🚫 ベクトルDBなし。✅ 既存の`[[wiki-link]]`グラフ上のPersonalized PageRank — グラフ認識のマルチホップコンテキスト、埋め込みコストゼロ、ローカルモデル完全対応。
 
-## 🔒 透明性とコンプライアンス
+### どのLLMを使うべきですか？
 
-このプラグインはObsidianコミュニティプラグインマーケットに掲載されており、セキュリティと権限の自動レビューを受けています。
+長コンテキストモデル（200Kトークン以上）が最適。[モデル](#-モデル)セクションで原則を解説。完全な階層テーブルは[docs/MODEL-GUIDE.md](MODEL-GUIDE.md)を参照。
 
-**このプラグインにはバックエンドもサーバーインフラもなく、いかなるデータ収集も行いません。** Obsidian内で動作する純粋なローカルソフトウェアです。プラグインはいかなる方法でもデータを収集、保存、送信することはできません——そのようなサーバーは存在しないからです。
+### 公開ベンチマークはありますか？
 
-**ネットワークアクセス**は設定したLLMプロバイダーとの通信のみに使用され、他のネットワーク呼び出しは行われません。これは完全にあなたの管理下にあります：どのプロバイダーを選ぶか、APIキーを入力するか、データの送信先を決めるのはあなたです。
+はい — PPR @5 = 27.1%（純粋kNNベースライン24.1%を上回る）。完全なパイプラインとベンチマークスクリプトは[検索の仕組み](#-検索の仕組み)で解説。
 
-**ファイルシステムアクセス**（Vault列挙）はWikiの構築と保守に必要です：ソースノートの読み取り、ページの生成、リンク切れのスキャン、重複ページの検出。プラグインがソースファイルを変更することは決してありません——wikiフォルダ内のファイルのみです。
+### APIコストはどう管理すればよいですか？
 
-**クリップボードアクセス**はQueryモーダルの「コピー」ボタンのみに使用され、クリックした時だけです。
+バッチ取り込みにはCoarseまたはMinimalの抽出粒度を使用。スマートバッチスキップが既取り込みファイルを自動検出。自動メンテナンスはデフォルトでOFF。Lintは実行前に件数を表示 — 承認なしに課金されません。
 
-完全なデータローカリティを希望する場合は、OllamaやLM StudioなどのローカルLLMプロバイダーを使用してください。ローカルプロバイダーでは、データがマシンから出ることは決してありません。
+### 実行中の操作をキャンセルするには？
 
-## 💖 プロジェクトを支援する
+ステータスバー（「Ingesting… click to cancel」と表示）をクリック、または`Cmd+P/Ctrl+P` → 「Cancel current ingestion」。次のバッチ境界でクリーンに停止。
 
-LLM-Wikiがあなたのナレッジワークフローの重要な一部になっているなら、継続的な開発を以下の方法で支援できます：
+### ヘルプはどこで得られますか？
 
-- ☕ **[Ko-fiでコーヒー一杯](https://ko-fi.com/greenerdalii)** — Ko-fiで単発または月額サポート
-- 💳 **[PayPalでチップを送る](https://paypal.me/greenerdalii)** — PayPalで単発チップ
-
-スポンサーシップは完全に任意です。プラグインは引き続きApache-2.0ライセンスで、機能完備を維持します。
-
-### スポンサー
-
-以下の皆様にプロジェクトの支援を感謝します：
-
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
-
-## 📜 ライセンス
-
-Apache License 2.0 — [LICENSE](LICENSE) と [NOTICE](NOTICE) を参照
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — バグ報告 · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — 質問・機能リクエスト · 開発者コンソール（`Ctrl+Shift+I` / `Cmd+Option+I`）— プラグインログ。
 
 ---
 
-## 🙏 謝辞
+## 🔒 プライバシー
 
-- **💡 Concept:** [Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — Original LLM Wiki concept
-- **🛠️ Platform:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 LLM transport:** [Vercel AI SDK v6](https://ai-sdk.dev/)（`@ai-sdk/openai`、`@ai-sdk/anthropic`、`@ai-sdk/openai-compatible`）via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
+このプラグインはObsidianコミュニティプラグインマーケットに掲載されており、セキュリティと権限の自動レビューを受けています。
 
-## Star History
+- **🚫 バックエンドもサーバーもデータ収集もありません。** Obsidian内部で動作する純粋なローカルソフトウェアです。プラグインはあなたのデータを収集、保存、送信することはできません — そのようなサーバーは存在しないからです。
+- **🔐 ネットワークアクセスはオプトイン。** 設定したLLMプロバイダーとの通信のみに使用。プロバイダーの選択、APIキーの入力、データの送信先はすべてあなたが決定します。
+- **📁 Vaultファイルアクセス**はWiki管理（ノートの読み取り、ページ生成、リンク切れスキャン、重複検出）に使用。プラグインがソースファイルを変更することは決してありません。
+- **📋 クリップボードアクセス**はQueryモーダルの「コピー」ボタンでのみ使用 — クリックした時だけです。
 
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+完全なデータローカリティには、OllamaやLM Studioを使用してください。ローカルプロバイダーでは、データがマシンを離れることは決してありません。
+
+---
+
+## 💖 サポート
+
+LLM-Wikiがあなたのナレッジワークフローの重要な一部になっているなら：
+
+- ☕ **[Ko-fiでコーヒーを](https://ko-fi.com/greenerdalii)** — 単発または月額サポート
+- 💳 **[PayPalでチップを](https://paypal.me/greenerdalii)** — 単発チップ
+
+スポンサーシップは完全に任意です。プラグインは引き続きApache-2.0ライセンスで、機能完備を維持します。
+
+[@jameses-cyber](https://github.com/jameses-cyber) と [@issaqua](https://github.com/issaqua) の皆様、プロジェクトの支援をありがとうございます。
+
+---
+
+## 📜 ライセンスとクレジット
+
+Apache License, Version 2.0 — [LICENSE](../LICENSE) と [NOTICE](../NOTICE) を参照。
+
+**ベースとなったもの：**
+- 💡 [Andrej KarpathyのLLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — オリジナルコンセプト
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/)（`@ai-sdk/openai`、`@ai-sdk/anthropic`、`@ai-sdk/openai-compatible`）via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank（Haveliwala 2002）](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) と [Monte Carlo PPR（Fogaras 2005）](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — 検索アルゴリズム
+
+**メンテナー：** [@green-dalii](https://github.com/green-dalii)
+
+---
+
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
 
 
 ---

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -2,490 +2,332 @@
 
 # 🧠 Karpathy LLM Wiki — Obsidian 플러그인
 
-> [Andrej Karpathy의 LLM Wiki 개념](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)을 기반으로 한 지식베이스 생성 시스템. 노트에서 Entity와 Concept을 자동 추출해 연결된 Wiki 페이지를 구축합니다.
+> 노트를 연결된 질의 가능한 지식베이스로 바꿔주는 Obsidian 플러그인 — [Andrej Karpathy의 LLM Wiki 개념](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)을, 여러분이 이미 글을 쓰고 있는 편집기에 구현했습니다.
 
-> **Obsidian 공식 평점 95/100 | 10개 언어 네이티브 지원 | 제로 임베딩 그래프 검색 | 완전한 데이터 주권 | 모든 LLM 공급업체 호환**
+> **제로 임베딩 그래프 검색 • 10개 언어 네이티브 지원 • 모든 LLM 공급업체 호환**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | [日本語](README_JA.md) | **한국어** | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md) | [Italiano](README_IT.md)
 
-[공식 사이트](https://llmwiki.greenerai.top/) | [옵시디언 마켓플레이스](https://community.obsidian.md/plugins/karpathywiki) | [블로그](https://llmwiki.greenerai.top/blog/) | [피드백 토론](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[공식 사이트](https://llmwiki.greenerai.top/) | [옵시디언 마켓플레이스](https://community.obsidian.md/plugins/karpathywiki) | [블로그](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [빠른 시작](#-빠른-시작) | ✨ [주요 기능](#-주요-기능) | 🤖 [모델 권장 사항](#-모델-권장-사항) | 🔒 [투명성 및 규정 준수](#-투명성-및-규정-준수) | ❓ [FAQ](#-faq)
+📑 [목차](#-목차) • 🚀 [빠른 시작](#-빠른-시작) • ✨ [주요 기능](#-주요-기능) • 🔍 [검색 작동 방식](#-검색-작동-방식) • 🤖 [모델](#-모델) • ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 이 플러그인이 도움이 되었다면, 커피 한 잔♥️ 사주시거나 별표🌟 하나 부탁드려요↗
 
 ---
 
-> **⚡ 빠른 업데이트 알림:** 이 프로젝트는 빠르게 진화하며 버그 수정, 성능 개선, 새로운 기능 및 UX 최적화를 자주 제공합니다. Obsidian에서 항상 최신 버전으로 업데이트하고(**설정 → 커뮤니티 플러그인 → 업데이트 확인**), 플러그인 자동 업데이트를 활성화하세요.
+## 📑 목차
 
-## 📑 Contents
-
-- [🧠 Karpathy LLM Wiki — Obsidian 플러그인](#-karpathy-llm-wiki--obsidian-플러그인)
-  - [📑 Contents](#-contents)
-  - [💡 LLM-Wiki란?](#-llm-wiki란)
-  - [⚡ 왜 Obsidian + LLM-Wiki인가?](#-왜-obsidian--llm-wiki인가)
-  - [🚀 빠른 시작](#-빠른-시작)
-    - [📦 설치](#-설치)
-    - [🔄 업데이트](#-업데이트)
-    - [🔑 LLM 프로바이더 설정](#-llm-프로바이더-설정)
-    - [🎮 사용법](#-사용법)
-    - [⚠️ 이전 버전에서 업그레이드?](#️-이전-버전에서-업그레이드)
-  - [⚡ 최신 소식 v1.25.x](#-최신-소식-v125x)
-  - [✨ 주요 기능](#-주요-기능)
-    - [📊 지식 품질](#-지식-품질)
-    - [📄 PDF 수집 (v1.25.0)](#-pdf-수집-v1250)
-    - [💬 조회 및 피드백](#-조회-및-피드백)
-    - [🛠️ 유지 관리](#️-유지-관리)
-    - [🌐 LLM 및 언어](#-llm-및-언어)
-    - [🏗️ 아키텍처 및 성능](#️-아키텍처-및-성능)
-    - [🔒 개인정보 보호 및 보안](#-개인정보-보호-및-보안)
-  - [📖 예시](#-예시)
-  - [🤖 모델 권장 사항](#-모델-권장-사항)
-    - [☁️ 클라우드 모델 추천](#️-클라우드-모델-추천)
-    - [🦙 로컬 모델 추천 (Ollama / LM Studio)](#-로컬-모델-추천-ollama--lm-studio)
-    - [📄 로컬 PDF OCR 경로 (v1.25.0+)](#-로컬-pdf-ocr-경로-v1250)
-  - [🏗️ 아키텍처](#️-아키텍처)
-  - [❓ FAQ](#-faq)
-  - [🔒 투명성 및 규정 준수](#-투명성-및-규정-준수)
-  - [💖 프로젝트 지원하기](#-프로젝트-지원하기)
-    - [후원자](#후원자)
-  - [📜 라이선스](#-라이선스)
-  - [🙏 감사의 말](#-감사의-말)
-  - [Star History](#star-history)
-
-## 💡 LLM-Wiki란?
-
-작성은 당신이, 정리는 AI가, 질문은 다시 당신이. 이것이 전부입니다.
-
-**🎯 문제.** 노트는 인물, 개념, 아이디어, 연결고리의 금광입니다. 하지만 현재는 단지 폴다 안의 파일일 뿐입니다. 무엇이 무엇과 연결되는지 찾기 위해선 검색과 태깅, 그리고 기억에 의존해야 합니다.
-
-**✨ 해결책.** [Andrej Karpathy가 제안한](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) 우아한 방식: 노트를 원재료로 취급하고 LLM이 설계를 담당합니다. LLM이 작성 내용을 읽고 Entity와 Concept을 추출하여 구조화된 Wiki를 구축합니다 — `[[bidirectional links]]`, 자동 생성 인덱스, 그리고 지식베이스에 질문할 수 있는 채팅 인터페이스를 포함합니다.
-
-**📚 당신은 더 이상 사서가 아닙니다.** 어떤 내용을 페이지로 만들지 결정할 필요도, 교차 링크를 유지할 필요도, 정보가 오래되었는지 걱정할 필요도 없습니다. vault의 아무 노트(또는 폴다, 다중 선택)를 선택하면 LLM이 읽고, 추출하고, 작성하고, 연결하며, 심지어 모순까지 표시합니다 — 당신은 몰입을 유지하면서 작업을 계속합니다.
-
-**🤖 그리고 이것은 또 다른 챗봇이 아닙니다.** ChatGPT는 인터넷을 알고 있습니다. LLM-Wiki는 *당신*을 압니다 — 정확히 말하자면 당신이 가르친 내용을 압니다. 모든 답변은 `[[wiki-links]]`를 통해 지식 그래프로 연결됩니다. 모든 응답은 끝이 아닌 탐색의 시작점입니다.
-
-**🏆 핵심 차별화 — ゼ로 임베딩 비용의 그래프 기반 검색.** 대부분의 지식베이스 플러그인은 벡터 임베딩(비용 높음, 공급업체 의존, 인터넷 필요)을 사용합니다. LLM-Wiki는 기존의 `[[wiki-link]]` 그래프 위에서 Personalized PageRank를 실행 — API 호출 ゼ로, 새로운 의존성 없이, 로컬 모델 완전 지원으로 임베딩급 검색 품질을 실현합니다. i18n 대응 **ゼ로 LLM Tier B 섹션 추출**(10개 언어)을 더하면 모든 공급업체에서 작동하는 지식 엔진이 완성됩니다.
+- [🤔 이 플러그인이 필요한 이유?](#-이-플러그인이-필요한-이유)
+- [🎯 이런 분들께 추천합니다](#-이런-분들께-추천합니다)
+- [🚀 빠른 시작](#-빠른-시작)
+- [✨ 주요 기능](#-주요-기능)
+- [🔍 검색 작동 방식](#-검색-작동-방식)
+- [🤖 모델](#-모델)
+- [❓ FAQ](#-faq)
+- [🔒 개인정보](#-개인정보)
+- [💖 프로젝트 지원하기](#-프로젝트-지원하기)
+- [📜 라이선스 및 크레딧](#-라이선스-및-크레딧)
 
 ---
 
-## ⚡ 왜 Obsidian + LLM-Wiki인가?
+## 🤔 이 플러그인이 필요한 이유?
 
-Obsidian은 연결된 사고에 탁월합니다. 하지만 한 가지 문제가 있습니다: 모든 연결을 직접 만들어야 한다는 점입니다.
+여러분은 노트를 작성합니다. 그 노트들은 폴더에 쌓여갑니다. 무엇이 무엇과 연결되는지 찾으려면 몇 달 전에 잊어버린 맥락을 기억해야 합니다.
 
-LLM-Wiki는 이 구조를 뒤집습니다. 직접 그래프를 수작업으로 만드는 대신, AI가 여러분과 함께 그래프를 키워줍니다. 새로운 개념에 대한 노트를 추가하면 놓쳤을 연결을 찾아주고, 질문을 던지면 여러분만의 지식 그래프를 탐색하여 인용과 함께 답변을 가져다줍니다.
+**Karpathy의 LLM Wiki 아이디어를 구현한 다른 오픈소스 프로젝트도 존재합니다 — 하지만 그중 어느 것도 원클릭 Obsidian 플러그인으로 제공되지는 않습니다.** 대부분은 CLI 도구, Claude Code 스킬, 또는 별도의 데스크톱 앱입니다. 저희는 네이티브 UI, 볼트 내 저장소, Obsidian의 Graph View가 내장된 유일한 플러그인입니다.
 
-- **🔗 그래프 뷰가 살아납니다.** 새로운 노트는 단순히 저장되는 것이 아니라 Entity, 개념, 소스로의 링크를 뻗어냅니다. 그래프는 유기적으로 성장하고, 플러그인이 이를 관리합니다: 중복 감지, 데드 링크 수정, 에일리어스를 통한 언어 간 연결.
-- **💬 노트가 대화하기 시작합니다.** 검색이 대화가 됩니다. "X에 대해 무엇을 썼지?"가 스트리밍 응답과 `[[wiki-links]]`라는 빵조각과 함께 하나의 대화가 됩니다. 모든 답변은 여러분의 지식 속으로 더 깊이 들어가는 길입니다.
-- **🧠 Obsidian이 사고의 파트너가 됩니다.** 더 이상 노트의 창고가 아니라, 여러분이 *생각*하는 것을 돕는 존재가 됩니다. 숨겨진 연결을 발견하고, 모순을 표시하고, 잊고 있던 것을 기억해줍니다.
+### 경쟁 제품과의 비교
+
+|  | Karpathy LLM Wiki (이 플러그인) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **제공 형태** | ✅ 원클릭 Obsidian 플러그인 | ❌ 별도 Tauri 데스크톱 앱 | ❌ Claude Code 스킬 | ❌ Claude Code / Codex 스킬 | ❌ CLI + SDK + MCP 서버 |
+| **설정 시간** | ✅ **5분** — 커뮤니티 플러그인 → 설치 → 공급자 선택 → 수집 | ❌ 30분+ — 컴파일/바이너리 다운로드, CLI 설정 | ❌ 15분 — Claude Code 구독 + 스킬 설치 필요 | ❌ 10분 — Claude Code/Codex 구독 + 스킬 설정 필요 | ❌ 30분+ — pip 설치 + SDK + MCP 설정 |
+| **설치 경로** | ✅ Obsidian → 커뮤니티 플러그인 → 검색 → 설치 | ❌ 별도 바이너리 컴파일 또는 다운로드 후 CLI 설정 | ❌ Claude Code 구독 + 설치 가이드 필요 | ❌ Claude Code 또는 Codex 구독 + 설정 단계 필요 | ❌ pip install + Python SDK + 로컬 서버 |
+| **아키텍처 복잡도** | ✅ **의존성 제로** — 벡터 DB, 임베딩 모델, 외부 프로세스 불필요 | 🟡 자체 Python 런타임 + sigma.js + sqlite 내장 | 🟡 Claude Code 환경 사용 — 자체 완결적이지 않음 | 🟡 별도 플랫폼 런타임 필요 | ❌ Python, 임베딩 모델, 벡터 DB 필요 |
+| **i18n (UI + Wiki 출력)** | ✅ 10개 언어 (UI/출력 독립) | 🟡 2개 (EN / 中文) | ❌ 영어 전용 | ❌ 영어 전용 | ❌ 영어 전용 |
+| **LLM 공급자** | ✅ 12+ (Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-compatible, Kimi, GLM, MiniMax, DeepSeek 포함) | 🟡 OpenAI 호환 | 🟡 Claude Code를 통한 구독 | 🟡 Claude Code / Codex를 통한 구독 | 🟡 OpenAI 호환 |
+| **검색 알고리즘** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 4-신호 휴리스틱 (Adamic-Adar + 2홉 감쇠) | ❌ Louvain 커뮤니티 탐지만 사용 | ❌ Louvain + k홉 미리보기 | ❌ 하이브리드: BM25 + 시맨틱 + wikilink |
+| **쿼리 파이프라인 (5단계 캐스케이드)** | ✅ Lex → LLM 키워드 → 부분문자열 스캔 → LLM KB 폴백 → PPR 확장 (첫 충분 신호에서 절단) | 🟡 2홉 감쇠만 사용 | ❌ Louvain 클러스터링만 사용 | ❌ k홉 미리보기 (LLM 보강 없음) | ❌ BM25 + 시맨틱 (그래프 없음) |
+| **임베딩 필요 여부** | ✅ 아니오 (설계상 임베딩 비용 제로) | 🟡 선택 사항, 기본 꺼짐 | ✅ 아니오 | ✅ 아니오 | ❌ **예 — 필수** |
+| **그래프 시각화** | ✅ Obsidian 네이티브 Graph View (내장, 추가 크기 제로) | ❌ 데스크톱 앱 내 커스텀 sigma.js + graphology | 🟡 vis.js graph.html (별도 파일) | ❌ 커스텀 sigma.js 오프라인 HTML | ❌ 읽기 전용 브라우저 뷰어 |
+| **Wiki 정직성** | ✅ 쿼리와 일치하는 Wiki 소스가 없을 때 "Stage FALLBACK" 배너 표시 | ❌ 동등 기능 없음 | ❌ 동등 기능 없음 | ❌ 동등 기능 없음 | ❌ 동등 기능 없음 |
+| **검색 벤치마크 공개** | ✅ PPR @5 = 27.1% vs 순수 kNN 24.1% (이 분야 유일한 공개 수치) | ❌ 임베딩 활성화 시에만 58% → 71%, 동등 비교 불가 | ❌ 미공개 | ❌ 미공개 | ❌ 미공개 |
+
+### 의도적으로 선택한 세 가지 설계 원칙
+
+- **🪟 Obsidian이 런타임입니다.** 터미널, 별도 앱, Docker, Python이 필요 없습니다. 커뮤니티 플러그인에서 설치하고, 수집을 클릭하면 Wiki가 첫 순간부터 볼트 안에 만들어집니다. Obsidian 네이티브 Graph View가 여러분의 `[[wiki-link]]` 그래프를 렌더링합니다 — 내장 기능이며 번들 크기가 전혀 늘어나지 않습니다.
+- **🧭 깔끔하고 자체 완결적입니다.** 의존성이 전혀 없습니다. 임베딩 모델, 벡터 데이터베이스, pip 패키지가 없습니다 — 노트를 읽고 LLM과 통신하며 Wiki 페이지를 작성하는 단일 플러그인입니다. 모든 것이 Obsidian 안에서 동작합니다.
+- **🔌 이미 비용을 지불하고 있는 어떤 모델이든 사용 가능합니다.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-compatible, 커스텀 엔드포인트 — 12개 이상의 공급자 중 어느 것도 임베딩 엔드포인트를 가질 필요가 없습니다.
+
+---
+
+## 🎯 이런 분들께 추천합니다
+
+**✅ 네, 다음에 해당한다면:**
+
+- **5시간 프로젝트가 아닌 5분 설정을 원하신다면.** 커뮤니티 플러그인에서 설치 → 공급자 선택 → 노트 하나 수집. CLI, Python, 별도 런타임, 벡터 DB가 필요 없습니다. 몇 초 만에 `wiki/`에 Wiki 페이지가 나타납니다.
+- **깔끔하고 자체 완결적인 무언가를 원하신다면.** 플러그인의 외부 의존성은 정확히 0개입니다: 임베딩 모델, 벡터 데이터베이스, pip 패키지, Docker 컨테이너가 없습니다. 노트를 읽고, LLM과 통신하며, 볼트에 Wiki 페이지를 작성하는 단일 Obsidian 플러그인입니다. 모든 것이 Obsidian 안에 있습니다.
+- **인터넷이 아닌 *여러분의 노트*에서 답변하는 질의 가능한 채팅** — 모든 답변에 `[[wiki-links]]`가 포함되어 지식 그래프로 연결됩니다.
+- **데이터 주권을 중요시한다면** — Ollama나 LM Studio와 함께 완전히 로컬에서 실행되며, 인터넷에 전혀 연결되지 않습니다.
+- **지원되는 10개 언어 중 하나로 글을 쓰거나 읽는다면** — UI와 Wiki 출력 언어는 독립적입니다 (Wiki는 중국어로, 인터페이스는 영어로 유지 가능).
+- **`[[wiki-links]]`를 작성하여 그래프를 유지 관리한다면** — 여러분이 작성하는 모든 링크가 이미 검색을 풍부하게 합니다; 별도의 태깅/임베딩/인덱싱 단계가 필요 없습니다.
+- **원클릭 유지관리를 원하신다면** — Lint 상태 검사 + Smart Fix All로 중복, 데드 링크, 고아 페이지를 직접 관리하지 않고도 관리할 수 있습니다.
+
+**❌ 아니오, 다음에 해당한다면:**
+
+- **범용 ChatGPT 대체품을 원하신다면** — 이 플러그인은 *여러분의 지식*에서만 답변합니다.
+- **PDF/웹 페이지/외부 코퍼스에 대한 RAG 파이프라인이 필요하다면** — 저희는 볼트 내 경로에 집중합니다 (PDF는 v1.25.0부터 지원).
+- **호스팅형 SaaS를 찾고 있다면** — 백엔드, 서버, 계정이 없습니다.
 
 ---
 
 ## 🚀 빠른 시작
 
-### 📦 설치
+1. **설치.** Obsidian → 설정 → 커뮤니티 플러그인 → 찾아보기 → "Karpathy LLM Wiki" 검색 → 설치 → 활성화. 또는 [커뮤니티 플러그인 페이지](https://community.obsidian.md/plugins/karpathywiki)에서 **Add to Obsidian** 클릭.
+2. **공급자 설정.** 설정 → Karpathy LLM Wiki 열기 → 공급자 선택 (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth) 등) → API 키 입력 (로컬은 불필요) → **Test Connection** 클릭 → 저장.
+3. **노트 하나 수집.** `Cmd+P/Ctrl+P` → "Ingest single source" → Markdown (또는 PDF, v1.25.0+) 파일 선택. 몇 초 안에 첫 Wiki 페이지가 `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`에 생성됩니다.
 
-**🌟 권장 — Obsidian 커뮤니티 플러그인 마켓:**
+이게 전부입니다. 플러그인은 원본 노트를 전혀 수정하지 않습니다 — `wiki/` 아래에 새 페이지만 생성합니다. Wiki와 대화하려면: `Cmd+P/Ctrl+P` → "Query wiki". (`Cmd`는 macOS, `Ctrl`은 Windows/Linux.)
 
-1. Obsidian에서 **설정 → 커뮤니티 플러그인**으로 이동
-2. **찾아보기**를 클릭하고 "Karpathy LLM Wiki"를 검색
-3. **설치**를 클릭한 다음 **활성화**
+### 핵심 명령어
 
-**🌐 커뮤니티 플러그인 웹사이트에서 —** [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki)에 방문하여 **Obsidian에 추가**를 클릭하면 직접 설치할 수 있습니다.
+| 명령어 | 기능 |
+|--------|------|
+| **📥 단일 소스 수집** | `Cmd+P/Ctrl+P` → "Ingest single source" — Markdown 또는 **PDF (v1.25.0+)** 파일을 선택하여 Entity/Concept/Wiki 페이지 생성 |
+| **📂 폴더에서 수집** | `Cmd+P/Ctrl+P` → "Ingest from folder" — 폴더의 모든 노트를 스마트 배치 스킵과 함께 일괄 수집 |
+| **📑 여러 파일 수집** | `Cmd+P/Ctrl+P` → "Ingest multiple files" — 2패널 파일 트리에서 하위 집합 선택 (라이브 큐 + 파일별 취소) |
+| **🔍 Wiki 질의** | `Cmd+P/Ctrl+P` → "Query wiki" — 우측 도킹 사이드 패널에서 Wiki와 대화; 답변에 `[[wiki-links]]` 포함 |
+| **🛠️ Wiki 린트** | `Cmd+P/Ctrl+P` → "Lint wiki" — 전체 상태 검사: 중복, 데드 링크, 빈 페이지, 고아, 누락된 alias, 모순 |
+| **⚡ Smart Fix All** | Lint 모달 내부 — 원클릭 인과순서 수리, 단계별 보고서 제공 |
+| **📋 인덱스 재생성** | `Cmd+P/Ctrl+P` → "Regenerate index" — 현재 페이지와 alias로 `wiki/index.md` 재구축 |
+| **⏹ 작업 취소** | `Cmd+P/Ctrl+P` → "Cancel current ingestion" 또는 상태 표시줄 클릭 — 다음 배치 경계에서 깔끔하게 중지 |
+| **📊 수집 기록** | `Cmd+P/Ctrl+P` → "View Ingestion History" — 과거 수집, lint 보고서, 유지보수 실행을 검색 가능한 UI로 조회 |
 
-**⚙️ 수동 설치 (대안):**
+| 전 | 후 |
+|---|------|
+| `notes/machine-learning.md` (평범한 파일) | `wiki/concepts/supervised-learning.md` — `[[양방향 링크]]`, alias, 출처 정보, `wiki/index.md` 항목 포함 |
 
-1. [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)에서 `main.js`, `manifest.json`, `styles.css`를 다운로드
-2. Obsidian에서 설정 → 커뮤니티 플러그인으로 이동. **설치된 플러그인** 탭에서 폴다 아이콘을 클릭하여 플러그인 디렉토리를 엽니다
-3. `karpathywiki`라는 이름의 폴다를 만들고 세 파일을 넣습니다
-4. Obsidian으로 돌아가 새로고침 아이콘을 클릭 — **Karpathy LLM Wiki**가 설치된 플러그인에 나타납니다
-5. 켜기 토글을 눌러 활성화
-
-**🔨 개발용:** `git clone`, `pnpm install`, `pnpm build`
-
-### 🔄 업데이트
-
-이 프로젝트는 빠르게 진화하며 새로운 기능, 버그 수정, 개선 사항이 자주 제공됩니다. 최신 상태를 유지하는 것을 권장합니다:
-
-**옵션 A — 수동 업데이트 (권장):**
-1. **설정 → 커뮤니티 플러그인**으로 이동
-2. **업데이트 확인** 클릭
-3. 목록에서 **Karpathy LLM Wiki**를 찾아 **업데이트** 클릭
-
-**옵션 B — 자동 업데이트 활성화:**
-1. **설정 → 커뮤니티 플러그인**으로 이동
-2. **플러그인 자동 업데이트 확인** 켜기
-3. 새 버전이 자동으로 감지됩니다. 편리한 때에 수동으로 업데이트하세요
-
-> 💡 **왜 업데이트를 유지해야 하나요?** 각 릴리즈에는 새로운 기능, 성능 개선, 중요한 버그 수정이 포함될 수 있습니다.
-
-### 🔑 LLM 프로바이더 설정
-
-1. 설정 → Karpathy LLM Wiki 열기
-2. 드롭다운에서 프로바이더 선택 (OpenAI 또는 ChatGPT Plan (Codex OAuth) 포함)
-3. API 프로바이더는 API 키 입력 (Ollama, LM Studio, ChatGPT Plan (Codex OAuth)은 불필요)
-4. Codex 외 프로바이더는 **Fetch Models** 또는 모델 이름 수동 입력을 사용합니다. ChatGPT Plan (Codex OAuth)은 엄선된 모델 드롭다운을 자동으로 채웁니다
-5. **Test Connection** 클릭 후 **Save Settings** 저장
-
-**🦙 Ollama (로컬, API 키 불필요):** [Ollama](https://ollama.com)를 설치하고 모델을 pull(`ollama pull gemma4` 또는 `ollama pull qwen3.5:27b`)한 다음 프로바이더 드롭다운에서 "Ollama (Local)"을 선택하세요.
-
-**🎛️ LM Studio (로컬, API 키 불필요):** [LM Studio](https://lmstudio.ai)를 설치하고 로컬 서버(기본 `http://localhost:1234/v1`)를 시작한 다음 프로바이더 드롭다운에서 "LM Studio (Local)"을 선택하세요.
-
-**🔐 ChatGPT Plan (Codex OAuth) (실험적):** OpenAI Platform API 키를 사용하고 별도로 사용량이 청구되는 **OpenAI** 프로바이더와 독립적입니다. 이 프로바이더를 선택한 뒤 데스크톱에서는 **브라우저로 로그인**(localhost 콜백), 데스크톱/모바일에서는 **기기 코드 사용**으로 OpenAI 페이지에서 인증하세요. 플러그인은 로그인한 Codex 계정에서 선택 가능한 모델을 동기화하고 정리된 카탈로그 메타데이터만 캐시합니다. **계정 모델 새로고침**으로 수동 갱신할 수 있으며 일시적 장애에는 마지막 캐시나 최소 대체 목록을 유지합니다. 연결 테스트 후 저장하세요. OAuth 자격 증명은 Obsidian SecretStorage에만 저장되며 **로그아웃**하면 삭제됩니다. 사용 가능 여부는 OpenAI Codex 인증, 모델, 사용 한도 정책을 따릅니다. 이는 타사 호환 기능이며 OpenAI 파트너십이나 범용 ChatGPT API가 아닙니다.
-
-### 🎮 사용법
-
-| 방법 | 사용법 |
-|------|--------|
-| **📥 단일 소스 수집** | `Cmd+P` → "Ingest single source" — 노트(Markdown 또는 **PDF, v1.25.0+**)를 선택하여 Entity와 Concept를 추출 |
-| **📂 폴다에서 수집** | `Cmd+P` → "Ingest from folder" — 폴다를 선택하여 Wiki를 일괄 생성 |
-| **📑 여러 파일 수집** | `Cmd+P` → "Ingest multiple files" — 재귀 폴다 트리 + 파일별 체크박스의 2패널 모달로 노트를 선택하고, 라이브 큐를 통해 일괄 수집 |
-| **🎯 현재 파일 수집** | 왼쪽 리본의 `sticker` 아이콘 클릭 또는 `Cmd+P` → "Ingest current file" — 편집 중인 파일을 수집 |
-| **🔍 위키 질의** | `Cmd+P` → "Query wiki" — 대화형 Q&A, 스트리밍 답변, `[[wiki-links]]` 포함 |
-| **🛠️ 위키 린트** | `Cmd+P` → "Lint wiki" — 중복, 데드 링크, 빈 페이지, 고아 페이지, 누락된 alias, 모순의 전체 상태 검사 |
-| **📋 인덱스 재생성** | `Cmd+P` → "Regenerate index" — `wiki/index.md`를 현재 페이지와 alias로 다시 빌드 |
-| **📊 수집 기록 보기 (v1.21.0)** | `Cmd+P` → "View Ingestion History" — 과거 수집, lint 보고서, 유지보수 실행을 검색·필터링 가능한 UI에서 조회 |
-| **⏹ 현재 작업 취소** | `Cmd+P` → "Cancel current ingestion" — 진행 중인 작업을 다음 배치 경계에서 깔끔하게 중지 |
-| **🎉 환영 노트 다시 만들기 (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — 최초 실행 시 환영 노트를 다시 생성 |
-
-동일한 소스를 다시 수집하면 Entity/Concept 페이지에 증분 업데이트가 적용(새 정보가 병합)되고 요약 페이지는 재생성됩니다.
-
-> 💡 **스마트 배치 스킵:** 폴다 수집 시 플러그인이 이미 처리된 파일을 자동 감지하여 걸너뜀으로써 시간과 API 비용을 절약합니다. 배치 보고서에 걸너뜀 수가 표시됩니다.
-
-![명령 팔레트 — "karpa" 검색으로 모든 Karpathy LLM Wiki 명령어 보기](assets/command-panel.png)
-
-### ⚠️ 이전 버전에서 업그레이드?
-
-> 🔧 **v1.24.x에서 업그레이드.** PDF 수집(v1.25.0)은 캐시를 `.obsidian/plugins/karpathywiki/pdf-cache/`에 작성합니다(상한 100 MB / 1000개 / 단일 10 MB; 시작 시와 배치 수집 시작 시 LRU-by-mtime으로 축출). vault는 **기본값으로 수정되지 않습니다** —— Settings → Wiki Configuration → Wiki Folder에서 **Write PDF Markdown to Vault**를 켠 경우에만 소스 PDF 옆에 `<basename>.pdf.md` 사이드카를 작성합니다. 두 개의 새 설정 — **Force PDF Support**(고급, 기본값 꺼짐)와 **Write PDF Markdown to Vault**(기본값 꺼짐) — 는 완전한 하위 호환: 이전 `data.json`에 이 필드가 없으면 `false`로 폴백합니다.
-
-> 🔧 **v1.24.0에서 업그레이드.** 페이지의 *Mentions in Source* 섹션만 보호하던 내부 주석 마커 `<!-- reviewed: keep -->`(v1.24.0, #244)가 제거되었습니다. 정리한 Mentions 섹션을 유지하려면 페이지 frontmatter에 `reviewed: true`를 설정하세요. 전체 페이지(Mentions 포함)를 보호하며, 숨겨진 주석과 달리 속성 패널에 표시되고 Markdown 린터에서도 손상되지 않습니다.
-
-**하위 호환됩니다.** v1.0.0 이후 파괴적 변경이 없습니다 — 기존 Wiki 페이지, 설정, 워크플로우가 재구성 없이 보존처리됩니다.
-
-**업그레이드 후** **Lint Wiki** → **Smart Fix All**을 실행하여 원클릭 인과순서 수리를 하세요:
-1. 🏷️ Alias 완성 (LLM이 번역, 약어, 대체 이름을 배치 생성)
-2. 🔄 중복 병합 (교차 언어, 약어, 높은 유사도 일치)
-3. 🔗 데드 링크 / 고아 페이지 연결 / 빈 페이지 확장 수정
-
-그런 다음 **Regenerate Index**로 `wiki/index.md`를 재구축하여 모든 페이지의 alias 항목을 활성화합니다 — alias 인식 검색이 가능해집니다(예: "DSA"로 "DeepSeek-Sparse-Attention" 검색).
-
-> 📖 특정 버전 간 업그레이드에 대한 자세한 연습(v1.20.3 slug fingerprint, v1.16.0 이중 중첩 링크 등)은 [GitHub Discussions / Upgrading](https://github.com/green-dalii/obsidian-llm-wiki/discussions)에서 관리처리됩니다.
-
-**확인할 설정:** Force PDF Support(Settings → LLM Configuration → Advanced, 기본값 꺼짐 — 비-NATIVE 공급자에만 필요), Write PDF Markdown to Vault(Settings → Wiki Configuration → Wiki Folder, 기본값 꺼짐), Wiki Output Language(UI와 독립), Extraction Granularity(Minimal–Fine, + Custom), Page Generation Concurrency(기본값 3), Batch Delay(기본값 300ms).
+> 💡 **최신 상태 유지.** 새 기능, 수정 사항, 성능 개선이 자주 릴리스됩니다. 설정 → 커뮤니티 플러그인 → 업데이트 확인, 또는 플러그인 자동 업데이트를 활성화하세요.
+> 📖 상세 가이드 (설치, PDF 설정, 멀티 공급자, 업그레이드)는 [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides)에서 확인하세요.
 
 ---
-## ⚡ 최신 소식 v1.25.x
-
-- **v1.25.2 (2026-07-22).** 태그 어휘 Phase 1（이중 소스 제거）、Codex OAuth（ChatGPT Plan）、관련 링크 폴더 접두사 수정、페이지 템플릿 `---` 종료 수정、ESLint 0.4.1 Route A。2515개 테스트 통과。
-- **v1.25.1 (2026-07-20).** 8건의 무음 데이터 손실 수정（관련 페이지、스키마 섹션、레거시 Mentions）、3개 대용량 파일 분할、DiskCache\<T\>、LM Studio API 키 불필요、빌드 검증 근본 원인。2274개 테스트 통과。
-- **v1.25.0 (2026-07-18).** 캐시 전용 PDF 인제스트（Level 1）、제한된 캐시 성장、선택적 볼트 sidecar、Force PDF 범용 게이트、정확한 받아쓰기 프롬프트、취소 가능한 인제스트、로컬 모델 가이드、i18n 완전 대응。2182개 테스트 통과。
-
-📋 [전체 버전 기록 → CHANGELOG.md](../CHANGELOG.md)
 
 ## ✨ 주요 기능
 
-### 📊 지식 품질
+### 📚 지식 품질
 
-- **Entity/Concept 추출** — LLM이 노트에서 Entity(인물, 조직, 제품, 이벤트)와 Concept(이론, 방법, 용어)을 추출합니다. 유연한 추출 세분화（최소~5개、굵음~10、표준~50、세밀~100、사용자 정의1~500）로 분석 깊이와 API 비용의 balance
-- **필수 페이지 Alias** — 생성된 각 페이지에 최소 1개의 alias(번역, 약어, 대체 이름)를 포함해 교차 언어 중복 감지를 활성화합니다
-- **중복 감지 및 병합** — Semantic tiering이 실제 중복(교차 언어 번역, 약어, 철자 변형)을 포착합니다. 지능형 LLM 병합이 콘텐츠를 융합하고 alias를 보존합니다
-- **스마트 지식 융합** — 다중 source 업데이트가 새 정보를 중복 없이 병합하고, 모순은 출처와 함께 보존하고, `reviewed: true` 페이지는 덮어쓰기에서 보호됩니다
-- **콘텐츠 잘림 보호** — API 키 및 로컬 Provider는 8000 max_tokens, 자동 stop_reason 감지, 2× token 재시도를 사용합니다. 실험적인 ChatGPT Plan(Codex OAuth) 경로는 Codex 백엔드의 출력 정책을 따르며 클라이언트 측 max_output_tokens 상한을 받지 않습니다.
-- **원문 Source 인용 보존** — 원어 인용문을 보존하고 선택적 번역으로 추적 가능성을 확보합니다
+- **🔍 Entity/Concept 추출** — LLM이 Entity(인물, 조직, 제품, 이벤트)와 Concept(이론, 방법, 용어)을 독립 페이지로 추출합니다. 세분화 설정 가능 (Minimal ~ Fine, Custom 포함)으로 비용과 깊이를 조절할 수 있습니다.
+- **🏷️ 필수 Alias** — 생성된 각 페이지에 최소 1개의 alias(번역, 약어, 변형)를 포함하여 교차 언어 중복 감지가 작동합니다.
+- **🔄 계층형 중복 감지** — Tier 1 (직접 이름 일치: 교차 언어, 약어, 높은 유사도 제목)은 항상 검증됩니다. Tier 2 (공유 링크, 중간 유사도)는 남은 토큰 예산을 채웁니다.
+- **🧩 스마트 병합 및 모순 상태** — 중복 병합 시 alias 보존; 모순은 출처와 함께 표시; `reviewed: true` 페이지는 덮어쓰기에서 보호됩니다.
+- **🎨 사용자 정의 태그 어휘** — 설정 → Wiki → Tag Vocabulary → *Custom*에서 자체 Entity/Concept 타입 태그 목록을 정의할 수 있습니다. Lint가 활성 어휘를 벗어난 태그가 있는 페이지를 보고합니다.
 
-- **🎨 사용자 정의 태그 어휘 (v1.18.0).** 설정 → Wiki → 태그 어휘 모드 → *사용자 정의*로 자체 엔티티 및 개념 타입 태그 목록을 정의할 수 있습니다 (예: `Medical_Arzneimittel`, `法规`). 플러그인은 추출 프롬프트와 frontmatter 검증에서 사용자 어휘를 존중합니다; 기존 Lint 감사(#85 v7)는 활성 어휘에서 벗어난 태그가 있는 페이지를 보고합니다.
+### 📄 PDF 수집 (v1.25.0+)
 
-### 📄 PDF 수집 (v1.25.0)
+- **🔌 공급자 게이트** — Anthropic, OpenAI, Bedrock이 PDF를 네이티브로 처리합니다. 다른 OpenAI/Anthropic 호환 엔드포인트에서는 설정 → LLM Configuration → Advanced에서 **Force PDF Support**를 활성화하여 호출을 시도할 수 있습니다. Apple Silicon에서의 로컬 OCR, 서드파티 추출기(MinerU, Docling, Mathpix, Adobe), 전체 PDF 수집 워크스루에 대해서는 아래 [PDF OCR 경로](#-pdf-ocr-경로)와 [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)를 참조하세요.
+- **🗄️ 제한된 캐시** — `.obsidian/plugins/karpathywiki/pdf-cache/`에 변환된 Markdown을 저장하며, 콘텐츠 해시 + 모델 + converter version으로 키가 지정됩니다. 3계층 방어 하우스키핑: 총 100MB / 1000개 항목 / 단일 10MB 상한, LRU-by-mtime 축출.
+- **📝 선택적 볼트 사이드카** — 설정 → Wiki Configuration → Wiki Folder → *Write PDF Markdown to Vault*를 켜면 소스 PDF 옆에 `<basename>.pdf.md`를 작성합니다 (기본값 꺼짐 — 캐시 전용이 기본).
+- **🛡️ Verbatim 트랜스크립터 프롬프트** — OCR 스타일 변환, `[illegible]` / `[figure: ...]` 반환각 마커 포함; 소형 로컬 모델의 markdown 펜스 래핑은 캐시 쓰기 전에 자동 정리됩니다.
 
-vault에서 PDF 하나를 고르면 — 플러그인이 LLM 프로바이더의 네이티브 파일 입력으로 읽어 Markdown으로 변환하고, 표준 Markdown 수집 파이프라인으로 다시 진입합니다. 기존 엔티티/개념/별칭/`[[wiki-link]]` 워크플로는 모두 그대로 적용됩니다.
+### 📄 PDF OCR 경로
 
-- **🔌 프로바이더 게이트** — Anthropic, OpenAI, Bedrock Anthropic, Bedrock OpenAI는 PDF를 네이티브로 처리합니다. 그 외의 OpenAI/Anthropic 호환 엔드포인트에서는 Settings → LLM Configuration → Advanced에서 **Force PDF Support**를 활성화하면 플러그인이 호출을 시도합니다(성공/실패의 판단은 엔드포인트 측에 달려 있으며, 실패 시 토글을 끄도록 안내하는 로컬라이즈된 Notice가 표시됩니다). 로컬 권장 구성은 [로컬 PDF OCR 경로](#-로컬-pdf-ocr-경로-v1250)를 참조하세요.
-- **🗄️ 콘텐츠 해시 캐시** — 동일한 PDF + 동일한 모델 + 동일한 converter version은 LLM 호출 없이 캐시된 Markdown을 반환합니다. 캐시는 `.obsidian/plugins/karpathywiki/pdf-cache/`에 저장되며, 키에 `converterVersion`이 내장되어 프롬프트 업그레이드 시 자동으로 무효화됩니다.
-- **📏 제한된 증가** — 3계층 방어의 캐시 관리(총 100MB / 1000개 / 단일 10MB 상한) + LRU-by-mtime 축출. 구 항목은 시작 시 및 배치 수집 시작 시 정리됩니다. 기본값은 캐시 전용이며 vault를 수정하지 않습니다.
-- **📝 선택적 vault 사이드카** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault**를 켜면 변환 후 소스 PDF 옆에 `<basename>.pdf.md`를 작성합니다(기본값은 꺼짐, 캐시 전용).
-- **🛡️ Verbatim 트랜스크립터 프롬프트** — PDF→Markdown 프롬프트는 OCR 스타일의 문자 단위 변환으로 재구성되었으며 `[illegible]` / `[figure: ...]` / `[equation: ...]` 반환 환각 마커를 포함합니다. 출력을 ```markdown 펜스로 감싸는 소형/로컬 모델은 캐시 쓰기 전에 자동으로 정리됩니다.
-- **⏹ 취소 가능** — 변환 중 상태 표시줄을 클릭하면 진행 중인 LLM 호출이 중단됩니다(Vercel AI SDK v6 경유).
+세 가지 경로, 설정에 맞게 선택하세요:
 
-### 💬 조회 및 피드백
+1. **☁️ PDF를 네이티브 지원하는 클라우드 공급자** — Anthropic, OpenAI, AWS Bedrock이 PDF를 기본 지원합니다. 수집만 하면 됩니다; 추가 설정 불필요. 다른 OpenAI/Anthropic 호환 엔드포인트에서는 설정 → LLM Configuration → Advanced에서 **Force PDF Support**를 활성화하세요.
+2. **🖥️ Apple Silicon 로컬 OCR** — [oMLX](https://github.com/jundot/omlx)가 Microsoft Markitdown을 내장 PDF→Markdown 백엔드로 통합합니다. oMLX에서 Markitdown 활성화, [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M 활성, 2026-06 오픈소스)을 비전 모델로 로드, 플러그인을 Custom OpenAI-Compatible 공급자로 oMLX에 연결, **Force PDF Support** 켜기, oMLX가 서빙하는 멀티모달 모델 선택. PDF가 기기를 떠나지 않습니다.
+3. **🛠️ 서드파티 추출기 (MinerU, Docling, Mathpix, Adobe)** — PDF에 대해 별도 추출기를 실행하여 `.md` 파일을 생성한 다음, 플러그인의 표준 파이프라인을 통해 일반 Markdown 노트로 수집합니다. 과학 논문, 스캔 문서, 수학 중심 PDF에 가장 안정적입니다.
 
-- **🔍 5단계 PPR 시드 선택 캐스케이드 (v1.24.1 PATCH)** — 멀티홉 질문을 던지면 Query Wiki는 생성을 시작하기 전에 5개의 보완적 단계를 거쳐 답변을 구성합니다:
-  1. **Lex 빠른 경로** — 모든 엔티티/컨셉 제목과 별칭에 대한 직접 토큰 중복 체크(무료·즉시, 후속 단계의 게이트)
-  2. **LLM 키워드 생성** — LLM이 쿼리로부터 8–12개의 다국어 키워드를 생성(동의어·약어·토큰 중복에 약한 용어 흡수)
-  3. **로컬 부분 문자열 스캔** — 생성된 각 키워드를 페이지 제목·별칭·본문 스니펫에 대해 로컬에서 재매칭(추가 LLM 호출 없음, 노이즈 허용 재현율 보완)
-  4. **LLM KB 폴백** — lex + 키워드 스캔의 신호가 약할 때 LLM이 top-N 후보에 대해 전체 wiki를 대상으로 한 번 의미적으로 재시드
-  5. **PPR 그래프 확장** — 후보 시드 집합에서 `[[wiki-link]]` 그래프 위 Personalized PageRank(Haveliwala 2002) 실행; LLM에 그래프 인지 멀티홉 문맥을 제공(선형 검색으로는 도달 불가)
+📖 **세 가지 경로 모두에 대한 전체 설정 워크스루** (클라우드 공급자, oMLX 하드웨어 계층, MinerU 설치, 캐시 하우스키핑) → [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-  캐스케이드는 충분한 신호를 반환한 단계에서 자동으로 잘립니다 —— 고정된 5단계 비용 없음, lex로 충분할 땐 LLM 호출 없음, LLM 보강이 필요할 땐 정밀도 손실 없음. 엔드투엔드 관련성(프로젝트 자체 벤치마크에서 PPR @5 = 27.1%)은 임베딩을 옵트인하지 않고도 순수 knn 베이스라인(24.1%)을 능가합니다. Stage 1.5(단계 2–3)는 순수 lex가 놓치는 멀티홉을 처리하고, Stage 1.7(단계 4)는 LLM 주입 키워드의 신호 부족을 복구하며, Stage 1.9(단계 5)는 LLM이 평탄한 top-N이 아닌 이웃 문맥을 보도록 보장합니다. 기존의 이진 tier 캐스케이드를 대체.
+### 💬 조회 및 유지관리
 
-- **대화형 조회** — ChatGPT 스타일 대화, 스트리밍 Markdown 출력, `[[wiki-links]]`, 다중 턴 이력
-- **🪟 우측 도킹 사이드 패널 (v1.22.1, PR #196).** Query Wiki가 중앙 팝업 대신 Copilot 스타일의 우측 사이드바 leaf(기존 leaf 재사용)에서 열립니다. `message-circle` 리본 아이콘과 `Query Wiki` 명령으로 패널 활성화/표시; 노트가 대화 옆에 계속 표시됩니다. 모든 기능은 그대로 유지됩니다.
-- **조회에서 Wiki로 피드백** — 가치 있는 대화를 Wiki에 저장하고 Entity/Concept 추출 및 저장 전 semantic dedup을 수행합니다
-- **중복 저장 방지** — Hash 추적이 변경되지 않은 대화의 재평가를 방지합니다
+- **🧭 5단계 PPR 캐스케이드** — [검색 작동 방식](#-검색-작동-방식) 참조. `[[wiki-link]]` 그래프 위의 Personalized PageRank가 그래프 인지 멀티홉 컨텍스트를 제공합니다.
+- **🪟 우측 도킹 사이드 패널** — Query Wiki가 중앙 팝업 대신 Copilot 스타일의 우측 사이드바 리프에서 열립니다 (v1.22.1+).
+- **🔍 Lint 상태 검사** — 단일 명령어로 감지: 중복, 데드 링크, 빈 페이지, 고아, 누락된 alias, 모순.
+- **⚡ Smart Fix All** — 원클릭 인과순서 수리: alias 채우기 → 중복 병합 → 데드 링크 수정 → 고아 연결 → 빈 페이지 확장, 단계별 보고서 포함.
+- **📊 작업 이력 패널** — 과거 수집, lint 보고서, 유지보수 실행을 검색 및 필터링 가능한 UI로 조회.
+- **🛡️ 사전 수집 게이트** — 빈/공백/frontmatter 전용 노트는 LLM 호출 전에 거부됨; 콘텐츠 해시 중복 제거가 경로 간 동일 파일을 감지합니다.
 
-### 🛠️ 유지 관리
+### 🔒 개인정보
 
-- **Lint 상태 검사** — 포괄적인 보고서에서 중복, dead link, 빈 페이지, orphan, 누락된 alias, 모순을 감지합니다
-- **Semantic-Tier 중복 감지** — Tier 1(직접 이름 일치: 교차 언어, 약어, 높은 유사도 제목)은 항상 검증됩니다. Tier 2(간접 신호: 공유 링크, 중간 유사도)은 token 예산을 채웁니다
-- **스마트 일괄 수정** — 인과 관계 순서로 배치 수정: alias 완성 → 중복 병합 → dead link 해결 → orphan 연결 → 빈 페이지 확장
-- **Alias 완성** — 누락된 alias의 일괄 병렬 생성을 원클릭으로 수행해 향후 중복 감지를 개선합니다
-- **자동 유지 관리** — Startup Quick Fixes 기본 ON(시작 시 1회 건강 검사), 다중 폴다 파일 감시와 주기적 lint는 기본 OFF(필요 시 활성화)
-- **모순 상태 머신** — `detected → review_ok → resolved`(AI 수정) 또는 `detected → pending_fix`(수동)
-- **사전 수집 검사 게이트 (v1.21.0)** — 모든 LLM 호출 전에 소스 파일을 검증합니다: 빈/공백/frontmatter 전용 노트는 거부되며, 콘텐츠 해시 중복 제거로 경로 간 동일 파일을 감지합니다. 로컬 모델이 빈 입력에서 엔티티 이름을 만들어내는 것을 방지.
-- **작업 이력 패널 (v1.21.0)** — 과거 인게스트, lint 보고서, 유지보수 실행을 검색·필터링 가능한 UI로 확인. 인사이트 기반 KPI 카드와 클릭 가능한 페이지 링크 제공.
-- **불완전 페이지 정리 (v1.21.0)** — 중단된 인게스트로 남은 불완전 페이지를 시작 시 자동 보관 처리(Obsidian의 `.trash`에서 복구 가능).
+- **🚫 백엔드 없음, 추적 없음, 분석 없음.** 완전히 Obsidian 내부에서 실행됩니다. 네트워크는 설정한 LLM 공급자와의 통신에만 사용됩니다.
+- **📁 소스 파일은 읽기 전용입니다.** 플러그인은 원본 볼트 노트를 절대 수정하지 않습니다 — `wiki/` 아래에 새 페이지만 생성합니다.
+- **🦙 완전 로컬 모드.** Ollama, LM Studio, 또는 모든 로컬 OpenAI 호환 엔드포인트 → 노트가 기기를 떠나지 않습니다.
+- **🔐 최소 권한.** Wiki 관리를 위한 볼트 파일 접근. Query 모달의 "Copy" 버튼 클릭 시에만 클립보드 접근.
 
-### 🌐 LLM 및 언어
+### 🦙 로컬 우선
 
-- **다중 Provider 지원** — Anthropic, Anthropic Compatible(Coding Plan), Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, custom endpoint
-- **5xx 자동 재시도** — 모든 클라이언트에서 HTTP 5xx/429/529 오류 시 지수 백오프 재시도(최대 2회)
-- **동적 모델 목록** — Provider API에서 실시간 가져오기
-- **Wiki 출력 언어** — 인터페이스와 독립적인 10개 언어(English / 简体中文 / 繁體中文 / 日本語 / 한국어 / Deutsch / Français / Español / Português / Italiano), custom 입력 지원
-- **🌍 전면 UI 국제화** — 플러그인 UI 10개 언어 지원(EN/ZH/ZH-Hant/JA/KO/DE/FR/ES/PT/IT), 277+ UI 필드 완전 번역, 자연스러운 로컬 표현
-- **⚡ Rate Limit Guardian** — 병렬 생성에서 rate limit 발생 시 자동 감지 및 제안: 동시성 낮춤, 배치 지연 증가, Provider 변경
-- **🦙 Web Clipper Compatible** — Obsidian Web Clipper의 `Clippings/` 폴다를 1클릭으로 감시 목록에 추가, 웹 클립 자동 Wiki화
+- **🖥️ Ollama, LM Studio, OpenRouter, 커스텀 엔드포인트** — 즉시 사용 가능. 로컬 모델은 조회에 적합 (작은 컨텍스트 창); 2000페이지 볼트 수집은 보통 긴 컨텍스트 클라우드 모델이 필요합니다.
+- **📄 Apple Silicon에서 PDF OCR 경로 완전 로컬 지원** — [PDF OCR 경로](#-pdf-ocr-경로) 참조.
+- **🔐 ChatGPT Plan (Codex OAuth)** — 데스크톱: `127.0.0.1:1455` 루프백 콜백; 모바일: 기기 코드 로그인. 자격 증명은 Obsidian SecretStorage에만 저장되며 로그아웃 시 삭제됩니다. 서드파티 Codex 호환 기능이며, OpenAI 파트너십이나 범용 ChatGPT API가 아닙니다.
 
-### 🏗️ 아키텍처 및 성능
+### 🌐 언어
 
-- **🕸️ PPR over [[wiki-link]] 그래프 (v1.24.0+, v1.24.1 PATCH에서 성숙)** — Personalized PageRank(Haveliwala 2002)는 wiki 페이지 간 `[[wiki-link]]` 엣지로 구성된 유향 그래프 위에서 동작; 캐스케이드는 PPR 시드를 top-N 후보 집합에 고정하며, 멀티홉 문맥은 최대 3개의 확장 링을 따라 전달됩니다. 이것이 Query Wiki 답변에 그래프 인지 능력을 부여하는 메커니즘입니다("Microsoft 창업자" 질문이 Bill Gates → Microsoft → 경쟁사를 거쳐 해결되며, 단순한 표제어 일치에 그치지 않음). 2,137 페이지의 vault에서도 일반적으로 warm + 3홉 확장이 < 100 ms에 완료되어 vault 크기와 무관합니다. 조회 및 피드백 섹션의 4단계 시드 캐스케이드 전부에서 사용되며, lint 중복 감지(간접 링크로 두 후보 페이지가 연결될 때)에서도 사용됩니다.
-- **병렬 페이지 생성** — 구성 가능한 1–5개 동시 페이지, 기본값 3(병렬), 큰 source에서 2–3× 속도 향상, 페이지별 오류 격리
-- **반복적 배치 추출** — 적응형 배치 크기, 긴 문서의 max_tokens 병목을 해소합니다
-- **3계층 아키텍처** — vault의 노트(읽기 전용) → `wiki/`(LLM 생성 페이지, `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`로 구성) → `schema/`(공동 진화 구성)
-- **모듈형 코드베이스** — `src/`의 20+개 초점 모듈
-
-### 🔒 개인정보 보호 및 보안
-
-- **백엔드 없음, 원격 측정 없음.** 플러그인은 완전히 Obsidian 내부에서 실행됩니다——외부 서버, 분석, 데이터 수집이 전혀 없습니다. LLM 제공자를 명시적으로 설정하지 않는 한 노트가 Vault를 떠나지 않습니다.
-- **데이터는 기본적으로 로컬에 유지됩니다.** 플러그인은 선택한 LLM API 이외의 장소에 콘텐츠를 저장, 캐시 또는 전송하지 않습니다. 수집 또는 쿼리를 위해 보내는 텍스트만 기기를 떠납니다——그것도 설정한 제공자에게만.
-- **Ollama, LM Studio 또는 로컬 제공자를 통한 완전 로컬 모드.** 완전한 데이터 주권을 위해 로컬에서 실행되는 LLM을 사용하세요. 노트는 완전히 귀하의 기기에서 처리됩니다——인터넷에 연결되지 않습니다.
-- **최소한의 권한.** Vault 파일 접근은 Wiki 관리에 필요합니다(노트 읽기, 페이지 생성, 데드 링크 감지). 네트워크 접근은 설정한 제공자와의 LLM API 호출에만 사용됩니다. 클립보드 접근은 Query 모달의 "복사" 버튼으로 제한됩니다——클릭할 때만입니다.
+- **🌍 10개 UI 언어** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI와 Wiki 출력 언어는 독립적입니다 — Wiki는 중국어로, 인터페이스는 영어로 유지 가능합니다.
+- **📚 10개 Wiki 출력 언어** — 동일한 세트; 설정 → Wiki Configuration에서 선택. *Custom input* 옵션으로 임시 프롬프트 사용 가능.
+- **🈶 269개 이상의 번역된 UI 문자열** — 모든 라벨, 모달, Notice. 11번째 언어 추가는 기여자 주도입니다 (PR #159 패턴).
 
 ---
 
-## 📖 예시
+## 🔍 검색 작동 방식
 
-**입력:** `sources/machine-learning.md`
+대부분의 "AI 검색" 플러그인은 노트를 청크로 분할하고 벡터 DB에 임베딩합니다. 저희는 그렇게 하지 않습니다. Karpathy가 RAG에 반대한 이유는 청킹이 LLM의 전체 지식 그래프 추론 능력을 저해하기 때문이며 — 이 주장은 실제로도 유효합니다. 대신, 여러분이 `[[wiki-links]]`를 작성하여 이미 유지 관리하고 있는 그래프를 탐색합니다.
 
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
+### 5단계 시드 선택 캐스케이드
 
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+"Microsoft 창업자는 누구인가?"라고 질문하면, Query Wiki는 답변 생성 전에 5단계를 실행합니다:
 
-**출력 — Concept 페이지:** `wiki/concepts/supervised-learning.md`
+1. **Lex 빠른 경로** — 모든 Entity/Concept 제목 및 alias에 대한 직접 토큰 중복 체크. 무료, 즉시, 이후 모든 단계의 게이트 역할.
+2. **LLM 키워드 생성** — LLM이 쿼리로부터 8–12개의 다국어 키워드 생성 (동의어, 약어, 토큰 중복에 취약한 용어를 단일 LLM 호출로 처리).
+3. **로컬 부분문자열 스캔** — 생성된 각 키워드를 페이지 제목, alias, 본문 스니펫에 대해 로컬에서 재매칭. 추가 LLM 호출 없음, 노이즈 허용 재현율 보완.
+4. **LLM KB 폴백** — lex + 키워드 스캔의 신호가 약할 때, LLM이 전체 Wiki에 대해 top-N 후보를 한 번 의미적으로 재시드.
+5. **PPR 그래프 확장** — 후보 시드 집합에서 `[[wiki-link]]` 그래프 위 Personalized PageRank (Haveliwala 2002) 실행. 이것이 그래프 인지 멀티홉 컨텍스트를 제공합니다: "Bill Gates" → "Microsoft" → "경쟁사", 단순한 제목 일치가 아닌.
 
-```markdown
----
-type: concept
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
+캐스케이드는 충분한 신호를 반환한 단계에서 자동으로 절단됩니다 — 고정된 5단계 비용 없음, lex로 충분할 때는 LLM 호출 없음, LLM 보강이 필요할 때는 정밀도 손실 없음.
 
-### Supervised Learning
+### 규모에 맞는 Personalized PageRank
 
-### 기본 정보
-- 타입: method
-- 소스: [[sources/machine-learning]]
+Monte Carlo PPR (Fogaras 2005)을 사용합니다 — 3,000개의 랜덤 워크 × 각 50단계, Haveliwala 2002의 데드엔드 규칙 적용. 비용은 **O(K × L)**로 페이지 수와 무관하므로, 2000페이지 볼트에서도 200페이지 볼트와 동일한 확장 지연 시간을 보입니다.
 
-### 설명
-Supervised learning(지도 학습)은 레이블이 있는 훈련 데이터에서 학습하고
-새로운 데이터에 대해 예측을 수행하는 머신러닝 패러다임입니다...
+**PPR @5 = 27.1% vs 순수 kNN 기준 24.1%** (이 오픈소스 LLM-Wiki 분야에서 유일하게 공개된 검색 벤치마크).
 
-### 관련 개념
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
+### 임베딩을 사용하지 않는 이유
 
-### 관련 Entity
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### 소스 내 언급
-- "Supervised learning uses labeled data to train predictive models..."
-```
+[Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175)에서 임베딩 경로를 의도적으로 거부했습니다. 그래프 신호는 이미 존재합니다 — 모든 `[[wiki-link]]`는 "이것들은 서로 관련있다"는 직접 큐레이팅된 엣지이며, 저희가 지원하는 대부분의 공급자(Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax)는 `/v1/embeddings` 엔드포인트를 전혀 제공하지 않습니다. 임베딩 모델을 추가하면 페이지당 다운로드, 공급자별 어댑터가 필요하고 검색 품질에는 이점이 전혀 없을 것입니다.
 
 ---
 
-## 🤖 모델 권장 사항
+## 🤖 모델
 
-이 플러그인은 Karpathy의 핵심 철학을 따릅니다: **전체 Wiki 컨텍스트를 직접 LLM에 제공하고 RAG 검색으로 단편화하지 않음**. 긴 컨텍스트 창을 가진 모델을 강력히 권장합니다 — Wiki가 커질수록 LLM이 교차 페이지 일관성을 유지하는 데 더 많은 컨텍스트가 필요합니다.
+**지원 공급자 (12+, 2026-07 기준 models.dev 교차 확인):**
 
-> 💡 **왜 RAG를 사용하지 않나요?** Karpathy는 [원 개념](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)에서 RAG가 지식을 단편화하고 완전한 지식 그래프에서 LLM의 추론 능력을 저해한다고 지적했습니다.
+| 공급자 | 시리즈 | 비고 |
+|--------|--------|------|
+| **Anthropic** | Claude 5 시리즈 | 네이티브 PDF; `/v1/messages` 프로토콜 |
+| **OpenAI** | GPT-5.6 시리즈 (Sol / Terra / Luna) | 네이티브 PDF; Platform API 키 |
+| **Google Gemini** | Gemini 3.6 시리즈 | 네이티브 PDF (1.5부터 파일 파트); OpenAI 호환 엔드포인트 |
+| **DeepSeek** | DeepSeek V4 시리즈 | OpenAI 호환; 최저 비용 계층 |
+| **Alibaba Qwen** | Qwen3.7/3.8 시리즈 | OpenAI 호환 (DashScope) |
+| **xAI Grok** | Grok 4 시리즈 | OpenAI 호환; 긴 컨텍스트 |
+| **Moonshot Kimi** | Kimi K3 시리즈 | OpenAI 호환; 2.8T MoE 프론티어 |
+| **Zhipu GLM** | GLM-5 시리즈 | OpenAI 호환; 강력한 이중 언어 |
+| **MiniMax** | MiniMax M3 시리즈 | OpenAI 호환; 1M 컨텍스트 |
+| **Step (阶跃星辰)** | Step 3 시리즈 (Flash) | OpenAI 호환; 빠른 추론 |
+| **Tencent Hunyuan** | Hy3 시리즈 | OpenAI 호환; 오픈웨이트 MoE |
+| **Xiaomi MiMo** | MiMo V2.5 시리즈 | MIT 오픈소스; 플랫 가격 |
+| **Google Gemma** | Gemma 4 시리즈 | 오픈웨이트; 262K 컨텍스트 |
+| **AWS Bedrock** | Anthropic + OpenAI 변형 | VPC / 규정 준수 경로 |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | 브라우저/기기 코드 로그인; SecretStorage |
+| **로컬: Ollama, LM Studio, OpenRouter, Anthropic-Compatible** | 모든 OpenAI/Anthropic 프로토콜 모델 | Custom OpenAI-Compatible + Anthropic-Compatible (Token Plan / Coding Plan) |
 
-**💰 가성비 우선 전략:** 플래그십 모델이 필요 없습니다. 다음 **경제적인 대안**으로 더 낮은 비용으로 훌륭한 결과를 얻을 수 있습니다:
+이 플러그인은 LLM에 전체 Wiki 컨텍스트를 제공하므로 — **긴 컨텍스트 모델이 유리합니다**. 전체 계층형 표 (클라우드 + 로컬)는 [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)에 있으며, [models.dev](https://models.dev/)와 교차 확인되어 최신 상태를 유지합니다.
 
-### ☁️ 클라우드 모델 추천
+### 중요한 요소
 
-| 등급 | 모델 | 컨텍스트 창 | 이유 |
-|------|------|-------------|------|
-| **🌟 가성비 최고** | **DeepSeek V4-Flash** | 1M tokens | 최저가($0.14/M), 284B MoE, 배치 처리에 최적 |
-| **🌟 가성비 최고** | **Gemini-3.5-Flash** | 1M tokens | GPT-5.5보다 4배 빠른 출력, 에이전트 작업 우수 |
-| **🌟 가성비 최고** | **Qwen3.6-Plus** | 1M tokens | 코딩 및 에이전트 능력 강력, 경쟁력 있는 가격 |
-| **🌟 가성비 최고** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **균형형** | **Claude Sonnet 4.6** | 1M tokens | 품질과 비용의 좋은 균형, $3/$15 per 1M tokens |
-| **경량형** | **Claude Haiku 4.5** | 200K tokens | 고속 경제, 소형 Wiki에 적합 |
-| **경제형** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE, 2026-04 MIT 오픈소스, Agent·멀티모달 |
-| **플래그십형** | Claude Opus 4.7 | 1M tokens | 최고 품질, 비용 높음 — 선택적으로 사용 |
-| **플래그십형** | GPT-5.5 | 1M tokens | 최고 수준 추론, 비용 높음 — 선택적으로 사용 |
+- **🧠 컨텍스트 창 ≥ 200K 토큰** — 약 500페이지 이상의 볼트에서 필요. 200K 미만이면 캐스케이드의 조립된 컨텍스트가 잘리기 시작합니다.
+- **⚖️ 명령 수행 품질** — 추출 작업에서는 원시 IQ보다 명령 수행 능력이 더 중요합니다. 스키마 템플릿을 따르는 모델을 선택하세요, 가장 큰 리더보드 숫자가 아닙니다.
+- **🔌 임베딩 엔드포인트는 무관합니다** — 저희는 임베딩을 사용하지 않습니다. `/v1/embeddings`가 없는 공급자도 괜찮습니다 (저희 12+ 공급자 대부분이 그렇습니다).
+- **🦙 조회는 로컬, 수집은 클라우드** — 2000페이지 볼트 수집은 보통 긴 컨텍스트 클라우드 모델이 필요합니다; 262K 로컬 모델은 대부분의 조회를 커버합니다.
 
-### 🦙 로컬 모델 추천 (Ollama / LM Studio)
+### Anthropic vs OpenAI vs Codex OAuth — 서로 다른 공급자입니다
 
-로컬 추론의 최대 강점은 데이터 주권, 오프라인 사용, API 비용 제로입니다. 반면 컨텍스트 창이 작고(대부분 8K–128K, 최근 오픈웨이트는 262K까지 도달) 플래그십 클라우드 모델 대비 명령 수행력도 떨어집니다. **하드웨어 예산에 맞춰 선택하세요:** 파라미터 수가 클수록 세계 지식과 명령 수행이 강해지고(추출 품질이 올라가고 환각이 줄어듦), 작을수록 속도와 VRAM 여유는 늘어나는 대신 환각과 장문 컨텍스트 추론이 약해집니다. 24GB Apple Silicon 또는 단일 소비자 GPU의 스윗 스팟은 27B–35B-A3B 클래스입니다.
+- **Anthropic** (및 Bedrock 변형) — 별도 청구되는 Anthropic Platform API 키.
+- **OpenAI** — 별도 청구되는 OpenAI Platform API 키.
+- **ChatGPT Plan (Codex OAuth)** — 실험적, 별도 공급자로 브라우저 또는 기기 코드 로그인 후 적격 Codex 사용 한도를 사용합니다. 사용 가능 여부는 OpenAI Codex 인증 및 사용 한도 정책을 따르며, 플랜 이름으로 보장되지 않습니다. 서드파티 Codex 호환 기능이며, OpenAI 파트너십이나 범용 ChatGPT API가 아닙니다.
 
-| 모델 | 파라미터 | 컨텍스트 | 이유 |
-|------|----------|----------|------|
-| **Qwen3.5 27B** | 27B dense | 262K | 수집 용도에서 품질과 크기의 최优 균형; MLX 4-bit로 24GB에 수용 가능 |
-| **Qwen3.5 35B-A3B** | 35B 총 / 3B 활성 MoE | 262K | 27B dense보다 빠르면서 동등한 품질; VRAM 절약에 이상적 |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | 품질 상한; ≥48GB VRAM 또는 듀얼 GPU 필요 |
-| **Qwen3.6 27B** | 27B dense | 256K+ | 2026-04 Qwen3.5 27B 리프레시, 하드웨어가 받쳐주면 우선 선택 |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Qwen3.5 35B-A3B와 동일한 트레이드오프, 더 새로운 가중치 |
-| **Gemma 4 31B IT** | 31B dense | 262K | 명령 수행 강하고 Markdown 출력이 깔끔 |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | 31B dense 대비 VRAM 절약, 동등한 품질 |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | 순수 CPU 실행 가능; 소형 Wiki 또는 빠른 미리보기 전용 |
-
-**양자화 가이드:** Apple Silicon에서 MLX 4-bit는 동일 실효 비트레이트의 GGUF Q4_K_M 대비 보통 1.5–2배 빠릅니다. GGUF Q4_K_M은 크로스 플랫폼 기본 선택. VRAM 여유가 있고 Q4에서 품질 열화가 보일 때만 Q5/Q8을 고려하세요.
-
-**컨텍스트 전략:** Wiki가 약 500페이지를 넘으면 262K 로컬 모델도 Query 엔진이 구성하는 대부분의 컨텍스트를 커버할 수 있지만, 2000페이지 vault 수집에는 부족합니다. 일반적인 조합은 "수집은 클라우드, 조회는 로컬". 완전 로컬을 고수한다면 27B/35B-A3B 클래스가 스윗 스팟입니다.
-
-### 📄 로컬 PDF OCR 경로 (v1.25.0+)
-
-v1.25.0 PDF 수집은 PDF를 파일 파트로 받는 모든 프로바이더에서 동작합니다. Apple Silicon(oMLX가 현재 지원하는 유일한 플랫폼)에서 완전 로컬 파이프라인을 구성할 때의 권장 설정은 다음과 같습니다:
-
-1. [oMLX](https://github.com/jundot/omlx)를 설치하고 내장 **Markitdown** 백엔드(로컬 PDF→Markdown 변환)를 활성화합니다.
-2. **Baidu Unlimited-OCR**(2026-06-22 오픈소스, 3B 총 / 0.5B 활성, 엔드투엔드 OCR로 긴 문서에서 "생성할수록 느려지는" 구 모델의 문제를 해결)을 oMLX의 비전 모델로 로드합니다.
-3. 본 플러그인 측: 프로바이더를 **Custom OpenAI-Compatible**로 설정하고(oMLX는 OpenAI 호환 프로토콜 사용) Base URL을 oMLX 로컬 서버로 지정합니다. Settings → LLM Configuration → Advanced에서 **Force PDF Support**를 켜고, 수집 요약에는 oMLX가 제공하는 멀티모달 모델을 선택합니다.
-
-PDF는 사용자의 기기를 떠나지 않습니다 — Markitdown이 구조 변환을, Unlimited-OCR이 시각 인식을, 로컬 LLM이 요약을 담당합니다. 플러그인의 캐시(`.obsidian/plugins/karpathywiki/pdf-cache/`)가 재수집을 즉시 처리합니다.
-
-**대안:** oMLX/Markitdown을 사용할 수 없는 경우(Linux/Windows 또는 구형 Mac)에는 **Force PDF Support**를 PDF 파일 파트를 받는 로컬 멀티모달 LLM으로 직접 지정하세요. 모델이 충분히 크면 품질이 좋지만, VRAM 요구량이 페이지 수에 따라 급격히 증가합니다.
-
-**🔌 Anthropic Compatible(Coding Plan):** Provider가 Anthropic 호환 API 엔드포인트를 제공하는 경우, "Anthropic Compatible"을 선택하고 Provider의 Base URL과 API Key를 입력하세요.
-
-**🦙 Ollama (로컬, API 키 불필요):** [Ollama](https://ollama.com)를 설치하고 모델을 pull(`ollama pull gemma4` 또는 `ollama pull qwen3.5:27b`)한 다음 Provider 드롭다운에서 "Ollama (Local)"을 선택하세요.
-
-**🎛️ LM Studio (로컬, API 키 불필요):** [LM Studio](https://lmstudio.ai)를 설치하고 로컬 서버(기본 `http://localhost:1234/v1`)를 시작한 다음 Provider 드롭다운에서 "LM Studio (Local)"을 선택하세요. LM Studio는 OpenAI 호환 서버를 내장하고 있어 API 키 필드는 선택사항입니다.
-
-> 💡 **OpenAI 결제 경계:** **OpenAI** 는 별도 청구되는 Platform API 키를 사용합니다. **ChatGPT Plan (Codex OAuth)** 은 브라우저나 기기 코드로 로그인해 대상 Codex 사용 한도를 이용하는 독립적인 실험적 프로바이더이며, 플랜 이름만으로 사용 가능성이 보장되지는 않습니다.
-
----
-
-## 🏗️ 아키텍처
-
-Karpathy의 3계층 분리 설계를 기반으로 합니다:
-
-```
-📄 vault의 노트(임의 폴다)         # 📖 사용자가 수집할 노트를 선택
-  ↓ ingest
-wiki/                                # 🧠 LLM 생성 Wiki 페이지 (wiki/sources/, wiki/entities/, wiki/concepts/ 구성)
-  ↓ query / maintain
-schema/                              # 📋 Wiki 구성 설정(명명 규칙, 페이지 템플릿, 분류 규칙)
-```
-
-> 📖 전체 코드 구조는 [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure) 참조.
-
-**생성된 페이지:**
-- `wiki/sources/filename.md` — 📄 Source 요약
-- `wiki/entities/entity-name.md` — 👤 Entity 페이지(인물, 조직, 프로젝트 등)
-- `wiki/concepts/concept-name.md` — 💡 Concept 페이지(이론, 방법, 용어 등)
-- `wiki/index.md` — 📑 자동 생성 인덱스
-- `wiki/log.md` — 📝 작업 로그
+> 📖 **전체 선택 표** (클라우드 + 로컬 + PDF OCR + Codex OAuth + 양자화 + 하드웨어 계층) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
 ---
 
 ## ❓ FAQ
 
-> **플러그인을 최신 상태로 유지하세요.** 새로운 기능과 수정 사항이 자주 릴리스됩니다. **설정 → 커뮤니티 플러그인 → 업데이트 확인**을 정기적으로 실행하세요.
->
-> 📖 더 많은 FAQ는 [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28)에서 확인하세요.
+### 이 플러그인은 실제로 무엇을 하나요?
 
-**이 플러그인은 실제로 무엇을 하나요?**
-vault의 아무 노트, 폴다, 다중 선택을 선택하면 LLM이 Entity와 Concept을 추출하고 `[[양방향 링크]]`로 연결된 Wiki를 생성합니다. 질문하면 *당신의 노트*를 기반으로 한 대화형 답변을 받습니다 — 인터넷 검색이 아닙니다. 생성된 요약은 `wiki/sources/`, Entity는 `wiki/entities/`, Concept은 `wiki/concepts/`에 배치되며, 원본 vault 노트는 전혀 변경되지 않습니다.
+노트, 폴더, 선택 항목을 고르면 LLM이 Entity와 Concept을 추출하고 `[[양방향 링크]]`로 연결된 Wiki를 생성합니다. 질문하면 *여러분의 노트*에 기반한 대화형 답변을 받습니다 — 인터넷이 아닙니다. 원본 볼트 노트는 절대 수정되지 않습니다.
 
-**데이터가 제3자에게 전송되나요?**
-🔒 **개인정보 최우선.** 백엔드 없음, 추적 없음, 분석 없음 — 플러그인은 완전히 Obsidian 내부에서 실행됩니다. 수집/조회를 위해 명시적으로 전송한 텍스트만 기기를 떠나며, 설정한 LLM 제공자에게만 전송됩니다. 완전한 데이터 로컬리티를 원하면 로컬 제공자(Ollama 또는 LM Studio, API 키 불필요)를 사용하세요 — 데이터는 인터넷에 접촉하지 않습니다.
+### 어떻게 시작하나요?
 
-**RAG 챗봇과의 차이점은 무엇인가요?**
-청크화된 RAG가 컨텍스트를 단편화하는 것과 달리, LLM-Wiki는 기존의 `[[wiki-link]]` 그래프 위에서 **Personalized PageRank** 엔진을 실행 — 링크 구조로 관련 페이지를 찾습니다. 이는 임베딩 비용 ゼ로, 새로운 의존성 없음, 로컬 및 오프라인 모델 완전 지원을 의미합니다.
+Obsidian 커뮤니티 플러그인에서 설치 → 공급자 선택 → **Test Connection** → 아무 노트에 대해 **Ingest single source** 실행. 첫 Wiki 페이지가 몇 초 안에 나타납니다. [빠른 시작](#-빠른-시작) 참조.
 
-**어떤 LLM을 사용해야 하나요?**
-긴 컨텍스트 창(≥200K 토큰)의 모델이 가장 적합합니다. 가성비 우선: DeepSeek V4-Flash($0.14/M), Gemini 3.5 Flash, Qwen3.6-Plus. Ollama/LM Studio의 로컬 모델은 조회에 사용할 수 있지만 컨텍스트 창이 작습니다(8K–128K). 자세한 내용은 [모델 권장 사항](#-모델-권장-사항)을 참조하세요.
+### 기존 Wiki는 안전한가요?
 
-**시작 방법은?**
-Obsidian 커뮤니티 플러그인에서 설치 → LLM 제공자 선택 → **Test Connection** → vault의 아무 노트에 대해 **Ingest single source**(또는 **Ingest from folder**) 실행 → 몇 초 안에 첫 Wiki 페이지가 생성됩니다. 자세한 내용은 위의 [빠른 시작](#-빠른-시작)을 참조하세요.
+✅ v1.0.0 이후 하위 호환성 유지. 덮어쓰기로부터 보호하려면 페이지에 `reviewed: true`를 설정하세요. v1.24.x에서 업그레이드해도 볼트가 다시 작성되지 않습니다; v1.25.0의 PDF 수집은 기본적으로 캐시 전용입니다.
 
-**API 비용을 어떻게 관리할 수 있나요?**
-배치 수집에는 거친/최소 추출 세분화를 사용(LLM 호출 감소). 스마트 배치 스킵이 이미 수집된 파일을 자동 감지합니다. 자동 유지보리는 기본적으로 OFF(필요한 경우에만 활성화). Lint는 실행 전 건수를 표시 — 승인 없이는 과금되지 않습니다.
+### 내 데이터가 외부로 전송되나요?
 
-**기존 Wiki는 안전한가요?**
-✅ v1.0.0 이후 하위 호환성이 있습니다. 덮어쓰기로부터 보호하려면 원하는 페이지에 `reviewed: true`를 설정하세요. 플러그인은 원본 vault 노트를 절대 수정하지 않습니다 — `wiki/` 폴다 안에 새 페이지를 생성할 뿐입니다.
+🚫 백엔드 없음, 분석 없음 — 플러그인은 완전히 Obsidian 내부에서 실행됩니다. 수집/조회를 위해 명시적으로 보낸 텍스트만 기기를 떠나며, 설정한 LLM 공급자에게만 전송됩니다. 완전한 데이터 로컬리티를 위해 Ollama나 LM Studio를 사용하세요.
 
-**내 언어로 사용할 수 있나요?**
-🌐 UI와 Wiki 출력 모두 **10개 언어** 지원: English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI 언어와 Wiki 언어는 독립 — 인터페이스는 영어로 유지하면서 Wiki를 한국어로 출력할 수 있습니다. 11번째 언어는 기여자 주도(Italian PR #159 패턴을 따르세요).
+### 내 언어로 사용할 수 있나요?
 
-**필요한 최소 설정은?**
-Obsidian v1.11.4+(데스크톱 또는 모바일). LLM 제공자 API 키, 로컬 Ollama/LM Studio 또는 인증된 ChatGPT Plan (Codex OAuth) 자격 증명이 필요합니다. 플러그인의 **llmReady 가드**는 코어 기능 잠금 해제를 위해 성공적인 연결 테스트를 요구합니다.
+🌍 UI와 Wiki 출력 모두 10개 언어 지원. UI와 Wiki 언어는 독립적입니다. 11번째 언어 추가는 기여자 주도입니다 (PR #159 패턴).
 
-**실행 중인 작업을 취소하려면?**
-상태 표시줄 텍스트("수집 중… 클릭하여 취소" 표시)를 클릭하거나 `Cmd+P` → "Cancel current ingestion"을 실행합니다. 다음 배치 경계에서 깔끔하게 중지하고 완료된 작업은 보존합니다.
+### RAG 챗봇과 어떻게 다른가요?
 
-**도움은 어디서 받나요?**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — 버그 신고
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — 질문, 기능 요청, 업그레이드 도움말
-- 개발자 콘솔(`Ctrl+Shift+I` / `Cmd+Option+I`) — 모듈 이름 접두사가 있는 로그를 복사하여 더 빠른 진단
+🚫 청킹 없음. 🚫 임베딩 없음. 🚫 벡터 DB 없음. ✅ 기존 `[[wiki-link]]` 그래프 위의 Personalized PageRank — 그래프 인지 멀티홉 컨텍스트, 임베딩 비용 제로, 로컬 모델 완전 지원.
 
-## 🔒 투명성 및 규정 준수
+### 어떤 LLM을 사용해야 하나요?
 
-이 플러그인은 Obsidian 커뮤니티 플러그인 마켓에 등록되어 있으며 보안 및 권한에 대한 자동 검토를 받습니다.
+긴 컨텍스트 모델(≥200K 토큰)이 가장 적합합니다. [모델 섹션](#-모델)에서 원칙을 다루고, 전체 계층형 표는 [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)에 있습니다.
 
-**이 플러그인에는 백엔드도, 서버 인프라도, 어떠한 데이터 수집도 없습니다.** Obsidian 내에서 실행되는 순수한 로컬 소프트웨어입니다. 플러그인은 어떤 방식으로도 데이터를 수집, 저장, 전송할 수 없습니다——그러한 서버가 존재하지 않기 때문입니다.
+### 공개된 벤치마크가 있나요?
 
-**네트워크 접근**은 설정한 LLM 제공자와의 통신에만 사용되며, 다른 네트워크 호출은 이루어지지 않습니다. 이는 완전히 귀하의 통제 하에 있습니다: 제공자를 선택하고, API 키를 입력하고, 데이터를 어디로 보낼지 결정하는 것은 귀하입니다.
+네 — PPR @5 = 27.1% vs 순수 kNN 기준 24.1% (프로젝트 자체 코퍼스 기준). 전체 파이프라인과 벤치마크 스크립트는 [검색 작동 방식](#-검색-작동-방식)에 설명되어 있습니다.
 
-**파일 시스템 접근**（Vault 열거）은 Wiki 구축 및 유지 관리에 필요합니다: 소스 노트 읽기, 페이지 생성, 데드 링크 스캔, 중복 페이지 감지. 플러그인은 소스 파일을 절대 수정하지 않습니다——wiki 폴다 내의 파일만.
+### API 비용을 어떻게 관리하나요?
 
-**클립보드 접근**은 Query 모달의 "복사" 버튼에만 사용되며, 클릭할 때만입니다.
+배치 수집에는 Coarse 또는 Minimal 추출 세분화를 사용하세요. Smart Batch Skip이 이미 수집된 파일을 자동 감지합니다. Auto-Maintenance는 기본적으로 꺼져 있습니다. Lint는 수정 실행 전에 건수를 표시합니다 — 승인 없이 비용이 청구되지 않습니다.
 
-완전한 데이터 로컬리티를 원하시면 Ollama나 LM Studio와 같은 로컬 LLM 제공자를 사용하세요. 로컬 제공자를 사용하면 데이터가 기기를 떠나지 않습니다.
+### 실행 중인 작업을 취소하려면?
 
-## 💖 프로젝트 지원하기
+상태 표시줄 클릭 ("수집 중… 클릭하여 취소" 표시) 또는 `Cmd+P/Ctrl+P` → "Cancel current ingestion". 다음 배치 경계에서 깔끔하게 중지됩니다.
 
-LLM-Wiki가 지식 워크플로의 중요한 부분이 되었다면, 지속적인 개발을 다음과 같이 지원할 수 있습니다:
+### 도움은 어디서 받나요?
 
-- ☕ **[Ko-fi에서 커피 한 잔 사기](https://ko-fi.com/greenerdalii)** — Ko-fi를 통한 일회성 또는 월간 지원
-- 💳 **[PayPal로 팁 보내기](https://paypal.me/greenerdalii)** — PayPal을 통한 일회성 팁
-
-후원은 전적으로 자발적입니다. 플러그인은 Apache-2.0 라이선스로 유지되며 기능이 완전한 상태를 유지합니다.
-
-### 후원자
-
-다음 분들께 프로젝트 지원을 감사드립니다:
-
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
-
-## 📜 라이선스
-
-Apache License, Version 2.0 — [LICENSE](LICENSE) 및 [NOTICE](NOTICE)를 참조하세요.
-
-## 🙏 감사의 말
-
-- **💡 개념:** [Andrej Karpathy의 LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 이 플러그인에 영감을 준 원본 비전
-- **🛠️ 플랫폼:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 LLM transport:** [Vercel AI SDK v6](https://ai-sdk.dev/)(`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
-
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — 버그 신고 · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — 질문 및 기능 요청 · 개발자 콘솔 (`Ctrl+Shift+I` / `Cmd+Option+I`) — 플러그인 로그 확인.
 
 ---
 
-**공식 사이트:** [llmwiki.greenerai.top](https://llmwiki.greenerai.top/)
+## 🔒 개인정보
+
+이 플러그인은 Obsidian 커뮤니티 플러그인 마켓에 등록되어 있으며 보안 및 권한에 대한 자동 검토를 받습니다.
+
+- **🚫 백엔드 없음, 서버 없음, 데이터 수집 없음.** Obsidian 내에서 실행되는 순수 로컬 소프트웨어입니다. 플러그인은 데이터를 수집, 저장, 전송할 수 없으며 실제로 그러지 않습니다 — 그러한 서버가 존재하지 않기 때문입니다.
+- **🔐 네트워크 접근은 옵트인입니다.** 설정한 LLM 공급자와의 통신에만 사용됩니다. 공급자를 선택하고, API 키를 입력하고, 데이터가 어디로 갈지 결정하는 것은 여러분입니다.
+- **📁 볼트 파일 접근**은 Wiki 관리에 사용됩니다 (노트 읽기, 페이지 생성, 데드 링크 스캔, 중복 감지). 플러그인은 소스 파일을 절대 수정하지 않습니다.
+- **📋 클립보드 접근**은 Query 모달의 "Copy" 버튼에서만 사용됩니다 — 클릭할 때만입니다.
+
+완전한 데이터 로컬리티를 위해 Ollama 또는 LM Studio를 사용하세요. 로컬 공급자를 사용하면 데이터가 기기를 떠나지 않습니다.
+
+---
+
+## 💖 프로젝트 지원하기
+
+LLM-Wiki가 여러분의 지식 워크플로에서 중요한 부분이 되었다면:
+
+- ☕ **[Ko-fi에서 커피 한 잔 사기](https://ko-fi.com/greenerdalii)** — 일회성 또는 월간 지원
+- 💳 **[PayPal로 팁 보내기](https://paypal.me/greenerdalii)** — 일회성 팁
+
+후원은 전적으로 선택 사항입니다. 플러그인은 Apache-2.0 라이선스로 유지되며 기능이 완전한 상태를 유지합니다.
+
+프로젝트를 지원해 주신 [@jameses-cyber](https://github.com/jameses-cyber)와 [@issaqua](https://github.com/issaqua)님께 감사드립니다.
+
+---
+
+## 📜 라이선스 및 크레딧
+
+Apache License, Version 2.0 — [LICENSE](../LICENSE) 및 [NOTICE](../NOTICE) 참조.
+
+**다음을 기반으로 구축되었습니다:**
+- 💡 [Andrej Karpathy의 LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 원본 개념
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) 및 [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — 검색 알고리즘
+
+**유지관리자:** [@green-dalii](https://github.com/green-dalii)
+
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_PT.md
+++ b/docs/README_PT.md
@@ -1,484 +1,332 @@
 ![llm_wiki_banner](assets/llm_wiki_banner.webp)
 
-# 🧠 Karpathy LLM Wiki Plugin para Obsidian
+# 🧠 Plugin Karpathy LLM Wiki para Obsidian
 
-> Base de conhecimento estruturada com IA que consome suas notas e gera uma Wiki conectada — baseada no [LLM Wiki concept de Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+> Um plugin Obsidian que transforma as suas notas numa base de conhecimento conectada e pesquisável — a ideia do [LLM Wiki do Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f), construída no editor onde você já escreve.
 
-> **Pontuação oficial Obsidian 95/100 | Suporte nativo a 10 idiomas | Pesquisa por grafo sem embedding | Soberania total de dados | Compatível com qualquer provedor LLM**
+> **Recuperação por grafo sem embeddings • 10 idiomas nativos • Funciona com qualquer provedor**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | [繁體中文](README_ZH-Hant.md) | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | **Português** | [Italiano](README_IT.md)
 
-[Site oficial](https://llmwiki.greenerai.top/) | [Mercado Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Feedback e discussão](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[Site oficial](https://llmwiki.greenerai.top/) | [Mercado Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussões](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [Início rápido](#-início-rápido) | ✨ [Funcionalidades](#-funcionalidades) | 🤖 [Guia de Seleção de Modelo](#-guia-de-seleção-de-modelo) | 🔒 [Transparência e conformidade](#-transparência-e-conformidade) | ❓ [Perguntas Frequentes (FAQ)](#-perguntas-frequentes-faq)
+📑 [Conteúdo](#-conteúdo) • 🚀 [Início rápido](#-início-rápido) • ✨ [Funcionalidades](#-funcionalidades) • 🔍 [Como funciona a recuperação](#-como-funciona-a-recuperação) • 🤖 [Modelos](#-modelos) • ❓ [FAQ](#-faq)
 
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Se este plugin te ajudou, pague-me um café♥️ ou deixe uma estrela🌟↗
-
----
-
-> **⚡ Aviso de atualização rápida：** Este projeto evolui rapidamente – correções de bugs, melhorias de desempenho, novos recursos e otimizações de UX são lançados com frequência. Recomendamos atualizar regularmente no Obsidian (**Configurações → Plugins da comunidade → Verificar atualizações**) ou ativar a atualização automática de plugins.
-## 📑 Contents
-
-- [🧠 Karpathy LLM Wiki Plugin para Obsidian](#-karpathy-llm-wiki-plugin-para-obsidian)
-  - [📑 Contents](#-contents)
-  - [💡 O que é LLM-Wiki?](#-o-que-é-llm-wiki)
-  - [⚡ Por que Obsidian + LLM-Wiki?](#-por-que-obsidian--llm-wiki)
-  - [🚀 Início rápido](#-início-rápido)
-    - [📦 Instalação](#-instalação)
-    - [🔄 Atualização](#-atualização)
-    - [🔑 Configurar um provedor LLM](#-configurar-um-provedor-llm)
-    - [🎮 Uso](#-uso)
-    - [⚠️ Atualizando de uma versão anterior?](#️-atualizando-de-uma-versão-anterior)
-  - [⚡ Novidades na v1.25.x](#-novidades-na-v125x)
-  - [✨ Funcionalidades](#-funcionalidades)
-    - [📊 Qualidade do Conhecimento](#-qualidade-do-conhecimento)
-    - [📄 Ingestão de PDF (v1.25.0)](#-ingestão-de-pdf-v1250)
-    - [💬 Consulta e Feedback](#-consulta-e-feedback)
-    - [🛠️ Manutenção](#️-manutenção)
-    - [🌐 LLM e Idioma](#-llm-e-idioma)
-    - [🏗️ Arquitetura e Desempenho](#️-arquitetura-e-desempenho)
-    - [🔒 Privacidade e segurança](#-privacidade-e-segurança)
-  - [📖 Exemplo](#-exemplo)
-  - [🤖 Guia de Seleção de Modelo](#-guia-de-seleção-de-modelo)
-    - [☁️ Modelos em nuvem](#️-modelos-em-nuvem)
-    - [🦙 Modelos locais (Ollama / LM Studio)](#-modelos-locais-ollama--lm-studio)
-    - [📄 Caminho OCR PDF local (v1.25.0+)](#-caminho-ocr-pdf-local-v1250)
-  - [🏗️ Arquitetura](#️-arquitetura)
-  - [❓ Perguntas Frequentes (FAQ)](#-perguntas-frequentes-faq)
-  - [🔒 Transparência e conformidade](#-transparência-e-conformidade)
-  - [💖 Apoiar o projeto](#-apoiar-o-projeto)
-    - [Patrocinadores](#patrocinadores)
-  - [📜 Licença](#-licença)
-  - [🙏 Agradecimentos](#-agradecimentos)
-  - [Star History](#star-history)
-
-## 💡 O que é LLM-Wiki?
-
-Você escreve. A IA organiza. Você pergunta. Simples assim.
-
-**🎯 O problema.** Suas notas são uma mina de ouro — pessoas, conceitos, ideias, conexões. Mas agora são apenas arquivos em pastas. Encontrar relações exige buscar, etiquetar e confiar na memória.
-
-**✨ A solução.** [Andrej Karpathy propôs](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) uma abordagem elegante: trate suas notas como matéria-prima e deixe que um LLM atue como arquiteto. Ele lê o que você escreve, extrai Entity e Concept, e os tece em uma Wiki estruturada — completa com `[[bidirectional links]]`, índice gerado automaticamente e interface de chat que responde perguntas baseadas no *seu* conhecimento.
-
-**📚 Você não precisa ser o bibliotecário.** Não decidir o que merece uma página. Não manter links cruzados. Não questionar se algo está desatualizado. Escolha qualquer nota (ou pasta, ou seleção múltipla) do seu vault — o LLM lê, extrai, escreve, vincula e sinaliza contradições — enquanto você permanece no fluxo.
-
-**🤖 Não é apenas outro chatbot.** O ChatGPT conhece a internet. O LLM-Wiki conhece *você* — ou melhor, o que você lhe ensinou. Cada resposta inclui `[[wiki-links]]` de volta ao seu knowledge graph. Cada resposta é um ponto de partida, não um beco sem saída.
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Se este plugin te ajudou, sinta-se à vontade para me pagar um café♥️ ou deixar uma estrela🌟↗
 
 ---
 
-## ⚡ Por que Obsidian + LLM-Wiki?
+## 📑 Conteúdo
 
-Obsidian é brilhante no pensamento conectado. Mas há um problema: quem faz todas as conexões é você.
+- [Por que este plugin?](#-por-que-este-plugin)
+- [É para mim?](#-é-para-mim)
+- [Início rápido](#-início-rápido)
+- [Funcionalidades](#-funcionalidades)
+- [Como funciona a recuperação](#-como-funciona-a-recuperação)
+- [Modelos](#-modelos)
+- [FAQ](#-faq)
+- [Privacidade](#-privacidade)
+- [Apoiar o projeto](#-apoiar-o-projeto)
+- [Licença & Créditos](#-licença--créditos)
 
-O LLM-Wiki inverte isso. Em vez de você construir o grafo manualmente, a IA o desenvolve junto com você. Adicione uma nota sobre um novo conceito — ela encontra as conexões que você perderia. Faça uma pergunta — ela percorre seu próprio grafo de conhecimento e retorna respostas com citações.
+---
 
-- **🔗 Seu Graph View ganha vida.** Novas notas não ficam apenas paradas — elas germinam links para entidades, conceitos e fontes. O grafo cresce organicamente, e o plugin o mantém: detectando duplicatas, corrigindo links mortos, conectando idiomas por meio de aliases.
-- **💬 Suas notas aprendem a conversar.** A busca se torna conversa. "O que eu escrevi sobre X?" vira um diálogo, com respostas em streaming e `[[wiki-links]]` como migalhas de pão. Cada resposta é um caminho mais profundo em seu próprio conhecimento.
-- **🧠 Obsidian se torna um parceiro de pensamento.** Ele deixa de ser um armário de notas e passa a ser algo que ajuda você a *pensar* — revelando conexões ocultas, sinalizando contradições, lembrando o que você esqueceu que sabia.
+## 🤔 Por que este plugin?
+
+Você escreve notas. Elas ficam em pastas. Encontrar o que se relaciona com o quê significa lembrar de fios que você esqueceu há meses.
+
+**Existem outras reimplementações open-source da ideia do LLM Wiki do Karpathy — mas nenhuma delas é um plugin Obsidian de um clique.** A maioria são ferramentas de CLI, skills do Claude Code ou aplicativos desktop separados. Somos o único com UI nativa, armazenamento dentro do vault e o Graph View nativo do Obsidian.
+
+### Como nos comparamos
+
+|  | Karpathy LLM Wiki (este plugin) | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **Forma de entrega** | ✅ Plugin Obsidian de um clique | ❌ Aplicativo desktop Tauri separado | ❌ Skill Claude Code | ❌ Skill Claude Code / Codex | ❌ CLI + SDK + servidor MCP |
+| **Esforço de configuração** | ✅ **5 minutos** — Community Plugins → Instalar → escolher provedor → Ingerir | ❌ 30 min+ — compilar/baixar binário, configurar CLI | ❌ 15 min — requer assinatura Claude Code + instalação da skill | ❌ 10 min — requer assinatura Claude Code/Codex + configuração | ❌ 30 min+ — pip install + SDK + config MCP |
+| **Caminho de instalação** | ✅ Obsidian → Community Plugins → pesquisar → Instalar | ❌ Compilar ou baixar binário separado, depois configurar CLI | ❌ Requer assinatura Claude Code + guia de instalação | ❌ Requer assinatura Claude Code ou Codex + etapas de configuração | ❌ pip install + Python SDK + servidor local |
+| **Complexidade da arquitetura** | ✅ **Zero dependências** — sem BD vetorial, sem modelo de embedding, sem processos externos | 🟡 Embutido seu próprio runtime Python + sigma.js + sqlite | 🟡 Usa o ambiente do Claude Code — não é autocontido | 🟡 Requer runtime de plataforma separada | ❌ Requer Python, modelo de embedding, BD vetorial |
+| **i18n (UI + saída wiki)** | ✅ 10 idiomas (UI / saída independentes) | 🟡 2 (EN / 中文) | ❌ Apenas inglês | ❌ Apenas inglês | ❌ Apenas inglês |
+| **Provedores LLM** | ✅ 12+ (incl. Codex OAuth, Bedrock, LM Studio, Ollama, Anthropic-compatible, Kimi, GLM, MiniMax, DeepSeek) | 🟡 Compatível com OpenAI | 🟡 Assinatura via Claude Code | 🟡 Assinatura via Claude Code / Codex | 🟡 Compatível com OpenAI |
+| **Algoritmo de recuperação** | ✅ Personalized PageRank (Haveliwala 2002) + Monte Carlo (Fogaras 2005) | 🟡 Heurística de 4 sinais (Adamic-Adar + decaimento de 2 saltos) | ❌ Apenas deteção de comunidades Louvain | ❌ Louvain + pré-visualizações k-hop | ❌ Híbrido: BM25 + semântico + wikilink |
+| **Pipeline de consulta (cascata de 5 estágios)** | ✅ Lex → keyword LLM → varredura de substring → fallback KB LLM → expansão PPR (trunca no primeiro sinal suficiente) | 🟡 Apenas decaimento de 2 saltos | ❌ Apenas clustering Louvain | ❌ Pré-visualizações k-hop (sem aumento LLM) | ❌ BM25 + semântico sobre chunks (sem grafo) |
+| **Embeddings necessários** | ✅ Não (custo zero de embedding, por design) | 🟡 Opcional, desligado por padrão | ✅ Não | ✅ Não | ❌ **Sim — obrigatório** |
+| **Visualização do grafo** | ✅ Graph View nativo do Obsidian (integrado, tamanho extra zero) | ❌ sigma.js + graphology personalizados em app desktop | 🟡 graph.html vis.js (arquivo separado) | ❌ sigma.js offline HTML personalizado | ❌ Visualizador de navegador só de leitura |
+| **Honestidade da Wiki** | ✅ Banner "ESTÁGIO FALLBACK" quando nenhuma fonte wiki corresponde à sua consulta | ❌ Sem equivalente | ❌ Sem equivalente | ❌ Sem equivalente | ❌ Sem equivalente |
+| **Benchmark de recuperação publicado** | ✅ PPR @5 = 27,1% vs pure-kNN 24,1% (único número publicado neste espaço) | ❌ 58% → 71% *apenas com embeddings ativados*, não no nosso formato comparável | ❌ Não publicado | ❌ Não publicado | ❌ Não publicado |
+
+### Três coisas que escolhemos de propósito, não por acidente
+
+- **🪟 Obsidian é o runtime.** Sem terminal, sem app separado, sem Docker, sem Python. Instale dos Community Plugins, clique em Ingerir, a wiki vive no seu vault desde o primeiro segundo. O Graph View nativo do Obsidian renderiza o seu grafo `[[wiki-link]]` — integrado, tamanho extra zero no bundle.
+- **🧭 Limpo e autocontido.** Zero dependências. Sem modelo de embedding, sem banco de dados vetorial, sem pacote pip — um único plugin que lê suas notas, conversa com um LLM e escreve páginas wiki. Tudo vive dentro do Obsidian.
+- **🔌 Qualquer modelo pelo qual você já paga.** Anthropic, Bedrock, OpenAI, ChatGPT Plan (Codex OAuth), DeepSeek, Kimi, GLM, MiniMax, LM Studio, Ollama, OpenRouter, Anthropic-compatible, endpoint customizado — doze mais provedores, nenhum deles precisa ter um endpoint de embeddings.
+
+---
+
+## 🎯 É para mim?
+
+**✅ Sim, se você:**
+
+- **Quer uma configuração de 5 minutos, não um projeto de 5 horas.** Instale dos Community Plugins → escolha um provedor → Ingerir uma nota. Sem CLI, sem Python, sem runtime separado, sem BD vetorial. Você vê páginas wiki em `wiki/` em segundos.
+- **Quer algo limpo e autocontido.** O plugin tem exatamente zero dependências externas: sem modelo de embedding, sem banco de dados vetorial, sem pacote pip, sem contêiner Docker. É um único plugin Obsidian que lê suas notas, conversa com um LLM e escreve páginas wiki no seu vault. Tudo vive dentro do Obsidian.
+- **Quer um chat pesquisável que responde a partir das *suas* notas** — não da internet — com cada resposta carregando `[[wiki-links]]` de volta para o seu grafo de conhecimento.
+- **Se importa com a soberania dos dados** — funciona totalmente local com Ollama ou LM Studio, sem nunca tocar a internet.
+- **Escreve ou lê em qualquer um dos 10 idiomas suportados** — o idioma da UI e da saída wiki são independentes (sua wiki pode estar em chinês enquanto a interface está em inglês).
+- **Mantém o grafo escrevendo `[[wiki-links]]`** — cada link que você escreve já enriquece a recuperação; sem etapa separada de marcação/embedding/indexação.
+- **Quer manutenção com um clique** — Lint health scan + Smart Fix All mantêm duplicados, links mortos e páginas órfãs sob controle sem que você precise cuidar manualmente.
+
+**❌ Não, se você:**
+
+- **Quer um substituto geral do ChatGPT** — este plugin responde apenas a partir do *seu* conhecimento.
+- **Precisa de um pipeline RAG sobre PDFs / páginas web / corpora externos** — focamos no caminho dentro do vault (PDFs são suportados a partir da v1.25.0).
+- **Está procurando um SaaS hospedado** — não há backend, nem servidor, nem conta.
 
 ---
 
 ## 🚀 Início rápido
 
-### 📦 Instalação
+1. **Instalar.** Obsidian → Configurações → Plugins da comunidade → Procurar → pesquise "Karpathy LLM Wiki" → Instalar → Ativar. Ou visite a [página do plugin comunitário](https://community.obsidian.md/plugins/karpathywiki) e clique em **Add to Obsidian**.
+2. **Configurar um provedor.** Abra Configurações → Karpathy LLM Wiki → escolha um provedor (OpenAI, Anthropic, Ollama, ChatGPT Plan (Codex OAuth), etc.) → insira a chave API (não necessária para locais) → clique em **Test Connection** → Salvar.
+3. **Ingerir uma nota.** `Cmd+P/Ctrl+P` → "Ingest single source" → escolha qualquer arquivo Markdown (ou **PDF, v1.25.0+**). Suas primeiras páginas wiki aparecem em `wiki/sources/`, `wiki/entities/`, `wiki/concepts/` em segundos.
 
-**🌟 Recomendado — Mercado de plugins comunitários do Obsidian:**
-1. No Obsidian, vá em **Configurações → Plugins da comunidade**
-2. Clique em **Procurar** e pesquise por "Karpathy LLM Wiki"
-3. Clique em **Instalar**, depois **Ativar**
+É isso. O plugin não modifica nada nas suas notas originais — apenas cria novas páginas em `wiki/`. Para conversar com sua wiki: `Cmd+P/Ctrl+P` → "Query wiki". (`Cmd` no macOS, `Ctrl` no Windows/Linux.)
 
-**🌐 Ou pelo site de plugins comunitários —** visite [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki) e clique em **Add to Obsidian**.
+### Comandos principais
 
-**⚙️ Manual (alternativa):**
-1. Baixe `main.js`, `manifest.json`, `styles.css` nas [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases)
-2. No Obsidian, vá em Configurações → Plugins da comunidade. Clique no ícone de pasta para abrir o diretório de plugins
-3. Crie uma pasta chamada `karpathywiki`, coloque os três arquivos dentro
-4. De volta ao Obsidian, clique no ícone de atualizar — **Karpathy LLM Wiki** aparecerá
-5. Ative-o para habilitar
+| Comando | O que faz |
+|---------|-----------|
+| **📥 Ingerir fonte individual** | `Cmd+P/Ctrl+P` → "Ingest single source" — escolha um arquivo Markdown ou **PDF (v1.25.0+)**, obtenha páginas de entidade/conceito/wiki |
+| **📂 Ingerir de pasta** | `Cmd+P/Ctrl+P` → "Ingest from folder" — ingerir em lote todas as notas de uma pasta, com smart batch skip |
+| **📑 Ingerir múltiplos arquivos** | `Cmd+P/Ctrl+P` → "Ingest multiple files" — escolha um subconjunto via árvore de dois painéis (com fila ao vivo + cancelamento por arquivo) |
+| **🔍 Consultar Wiki** | `Cmd+P/Ctrl+P` → "Query wiki" — converse com sua wiki num painel lateral direito; respostas carregam `[[wiki-links]]` |
+| **🛠️ Verificar Wiki** | `Cmd+P/Ctrl+P` → "Lint wiki" — verificação completa de saúde: duplicados, links mortos, páginas vazias, órfãos, aliases ausentes, contradições |
+| **⚡ Smart Fix All** | dentro do Modal Lint — reparo em ordem causal com relatório por fase, num clique |
+| **📋 Regenerar índice** | `Cmd+P/Ctrl+P` → "Regenerate index" — reconstrói `wiki/index.md` com páginas e aliases atuais |
+| **⏹ Cancelar** | `Cmd+P/Ctrl+P` → "Cancel current ingestion" ou clique na barra de status — para com segurança no próximo limite de lote |
+| **📊 Histórico de ingestão** | `Cmd+P/Ctrl+P` → "View Ingestion History" — UI pesquisável para ingestões passadas, relatórios Lint e execuções de manutenção |
 
-**🔨 Desenvolvimento:** `git clone`, `pnpm install`, `pnpm build`.
+| Antes | Depois |
+|-------|--------|
+| `notes/machine-learning.md` (um arquivo simples) | `wiki/concepts/supervised-learning.md` com `[[bidirectional links]]`, aliases, atribuição de fonte e uma entrada em `wiki/index.md` |
 
-### 🔄 Atualização
-
-Este projeto evolui rapidamente. Recomendamos manter-se atualizado:
-
-**Opção A — Atualização manual (recomendada):**
-1. Vá em **Configurações → Plugins da comunidade**
-2. Clique em **Verificar atualizações**
-3. Encontre **Karpathy LLM Wiki** e clique em **Atualizar**
-
-**Opção B — Ativar atualização automática:**
-1. Vá em **Configurações → Plugins da comunidade**
-2. Ative **Verificar automaticamente atualizações de plugins**
-
-> 💡 **Por que manter-se atualizado?** Cada versão pode incluir novos recursos, melhorias de desempenho e correções de bugs importantes.
-
-### 🔑 Configurar um provedor LLM
-
-1. Abra Configurações → Karpathy LLM Wiki
-2. Escolha um provedor no menu suspenso, incluindo OpenAI ou ChatGPT Plan (Codex OAuth)
-3. Para provedores API, insira a chave (não necessária para Ollama, LM Studio ou ChatGPT Plan (Codex OAuth))
-4. Para provedores que não sejam Codex, use **Fetch Models** ou digite um modelo; ChatGPT Plan (Codex OAuth) preenche automaticamente sua lista de modelos selecionados
-5. Clique em **Test Connection**, depois **Salvar configurações**
-
-**🦙 Ollama (local):** Instale o [Ollama](https://ollama.com), baixe um modelo, selecione "Ollama (Local)".
-
-**🎛️ LM Studio (local):** Instale o [LM Studio](https://lmstudio.ai), inicie o servidor local, selecione "LM Studio (Local)".
-
-**🔐 ChatGPT Plan (Codex OAuth) — experimental:** É separado do **OpenAI**, que usa uma chave da OpenAI Platform com cobrança independente. Selecione-o e use **Iniciar sessão com o navegador** no desktop (callback localhost), ou **Usar código do dispositivo** no desktop/mobile e conclua a autorização na página da OpenAI. O plugin sincroniza os modelos selecionáveis da conta Codex conectada e armazena apenas metadados de catálogo higienizados; **Atualizar modelos da conta** faz a atualização manual. Se o catálogo estiver temporariamente indisponível, mantém o último cache ou uma lista mínima de contingência. Depois teste a conexão e salve. As credenciais OAuth são armazenadas apenas no Obsidian SecretStorage; **Terminar sessão** as apaga. A disponibilidade segue as políticas de autenticação, modelos e franquia do OpenAI Codex. É compatibilidade de terceiros, não parceria com a OpenAI nem uma API geral do ChatGPT.
-
-### 🎮 Uso
-
-| Método | Como |
-|--------|------|
-| **📥 Ingerir fonte individual** | `Cmd+P` → "Ingest single source" — selecione uma nota (Markdown ou **PDF, v1.25.0+**) para gerar páginas Wiki com entidades e conceitos |
-| **📂 Ingerir de pasta** | `Cmd+P` → "Ingest from folder" — selecione uma pasta para gerar Wiki em lote |
-| **📑 Ingerir vários ficheiros** | `Cmd+P` → "Ingest multiple files" — escolha notas via árvore de pastas + caixas, ingestão em lote (com fila + cancel por ficheiro) |
-| **🎯 Ingerir ficheiro atual** | Clique no ícone `sticker` da fita esquerda, ou `Cmd+P` → "Ingest current file" |
-| **🔍 Consultar Wiki** | `Cmd+P` → "Query wiki" — Q&A conversacional com streaming e `[[wiki-links]]` |
-| **🛠️ Verificar Wiki** | `Cmd+P` → "Lint wiki" — verificação completa: duplicados, links quebrados, páginas vazias, órfãos, alias ausentes, contradições |
-| **📋 Regenerar índice** | `Cmd+P` → "Regenerate index" — reconstrói `wiki/index.md` com entradas de alias |
-| **📊 Histórico de ingestão (v1.21.0)** | `Cmd+P` → "View Ingestion History" — explore ingestões, relatórios Lint e manutenções |
-| **⏹ Cancelar operação** | `Cmd+P` → "Cancel current ingestion" — para com segurança no próximo limite de lote |
-| **🎉 Recriar nota de boas-vindas (v1.23.0)** | `Cmd+P` → "Recreate Wiki Welcome Note" — regenera a nota de boas-vindas |
-
-A re-ingestão da mesma fonte funde novas informações de forma incremental. Os resumos são regenerados.
-
-> 💡 **Smart Batch Skip:** Ao ingerir uma pasta, o plugin deteta e salta automaticamente ficheiros já processados — poupa tempo e custos de API.
-
-![Paleta de comandos — pesquise "karpa" para ver todos os comandos](assets/command-panel.png)
-
-### ⚠️ Atualizando de uma versão anterior?
-
-> 🔧 **Atualizando de v1.24.x.** A ingestão de PDF (v1.25.0) escreve o seu cache em `.obsidian/plugins/karpathywiki/pdf-cache/` (até 100 MB / 1000 entradas / 10 MB por entrada individual; evasão LRU-by-mtime na inicialização e no início de cada ingestão em lote). O seu vault **não é modificado por padrão** — ative **Write PDF Markdown to Vault** (Settings → Wiki Configuration → Wiki Folder) apenas se quiser um sidecar `<basename>.pdf.md` ao lado do PDF fonte. Duas novas definições — **Force PDF Support** (avançado, desativado por padrão) e **Write PDF Markdown to Vault** (desativado por padrão) — são totalmente retrocompatíveis: um `data.json` antigo sem estes campos volta a `false`.
-
-> 🔧 **Atualizando de v1.24.0.** O marcador de comentário interno `<!-- reviewed: keep -->` (v1.24.0, #244), que protegia apenas a seção *Menções na Source* de uma página, foi removido. Para preservar uma seção de Menções curada manualmente, defina `reviewed: true` no frontmatter da página: ela protege a página inteira (Menções incluídas) e, ao contrário do comentário oculto, permanece visível no painel de Propriedades e resiste a linters de Markdown.
-
-**Retrocompatível.** Sem mudanças incompatíveis desde v1.0.0 — as suas páginas Wiki, configurações e fluxos de trabalho existentes são preservados sem reconfiguração.
-
-**Após atualizar**, execute **Lint Wiki** → **Smart Fix All** para reparação automática:
-1. 🏷️ Completar aliases (LLM gera traduções, abreviaturas, nomes alternativos)
-2. 🔄 Fundir duplicados (multilingue, abreviaturas, alta similaridade)
-3. 🔗 Reparar links quebrados / vincular órfãos / expandir páginas vazias
-
-Depois **Regenerar índice** para reconstruir `wiki/index.md` com entradas de alias.
-
-> 📖 Guias detalhados para saltos de versão específicos em [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions).
-
-**Configurações a rever:** Force PDF Support (Settings → LLM Configuration → Advanced, desativado por padrão — apenas relevante para provedores não NATIVE), Write PDF Markdown to Vault (Settings → Wiki Configuration → Wiki Folder, desativado por padrão), Idioma de saída da Wiki, Granularidade de extração, Concorrência (padrão 3), Atraso de lote (padrão 300ms).
+> 💡 **Mantenha-se atualizado.** Novos recursos, correções e melhorias de desempenho são lançados com frequência. Configurações → Plugins da comunidade → Verificar atualizações, ou ative as atualizações automáticas de plugins.
+> 📖 Tutoriais detalhados (instalação, configuração de PDF, notas multi-provedor, atualizações) são mantidos em [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides).
 
 ---
-## ⚡ Novidades na v1.25.x
-
-- **v1.25.2 (2026-07-22).** Vocabulário de tags Fase 1（fonte dupla eliminada）、Codex OAuth（ChatGPT Plan）、correção de prefixo de pasta em links relacionados、modelo de página `---` final corrigido、ESLint 0.4.1 Route A. 2515 testes aprovados.
-- **v1.25.1 (2026-07-20).** Oito correções de perda silenciosa（página relacionada、seções de esquema、Menções herdadas）、3 divisões de arquivos grandes、DiskCache<T>、LM Studio sem chave de API、causa raiz de verificação de compilação. 2274 testes aprovados.
-- **v1.25.0 (2026-07-18).** Ingestão PDF apenas em cache（Nível 1）、crescimento de cache limitado、sidecar de cofre opcional、portão universal Force PDF、prompt de transcrição textual、ingestão cancelável、guia de modelos locais、integridade i18n. 2182 testes aprovados.
-
-📋 [Histórico completo de versões → CHANGELOG.md](../CHANGELOG.md)
 
 ## ✨ Funcionalidades
 
-### 📊 Qualidade do Conhecimento
+### 📚 Qualidade do Conhecimento
 
-- **🔍 Extração de Entity/Concept** — LLM extrai Entity (pessoas, orgs, produtos, eventos) e Concept (teorias, métodos, termos) de suas notas com granularidade de extração flexível (Mínima~5 itens, Grossa~10, Padrão~50, Fina~100, Personalizada 1–500) para equilibrar profundidade de análise e custos de API
-- **🏷️ Aliases Obrigatórios** — Cada página gerada inclui pelo menos 1 alias (tradução, sigla, nome alternativo), permitindo detecção de duplicados entre idiomas
-- **🔄 Detecção e Mesclagem de Duplicados** — Classificação semântica captura duplicados reais (traduções entre idiomas, abreviações, variantes de grafia); mesclagem inteligente por LLM funde conteúdo e preserva aliases
-- **🧩 Fusão Inteligente de Conhecimento** — Atualizações multi-source mesclam nova informação sem redundância, contradições preservadas com atribuição, páginas `reviewed: true` protegidas de sobrescrita
-- **📏 Proteção contra truncamento de conteúdo** — Os providers com chave de API e locais usam 8000 max_tokens, detetam stop_reason automaticamente e repetem com 2× tokens. O caminho experimental ChatGPT Plan (Codex OAuth) segue a política de saída do backend Codex, que não aceita um limite max_output_tokens do cliente.
-- **📝 Menções Verbatim de Source** — Citações em idioma original preservadas com tradução opcional para rastreabilidade
+- **🔍 Extração de Entidade e Conceito** — O LLM extrai entidades (pessoas, organizações, produtos, eventos) e conceitos (teorias, métodos, termos) em páginas independentes. A granularidade é configurável (Mínima → Fina, além de Personalizada) para que você equilibre custo versus profundidade.
+- **🏷️ Aliases Obrigatórios** — Cada página gerada inclui pelo menos um alias (tradução, abreviatura, variante) para que a deteção de duplicados entre idiomas funcione.
+- **🔄 Deteção de Duplicados por Camadas** — Camada 1 (correspondência direta de nome: entre idiomas, abreviatura, títulos de alta similaridade) sempre verificada; Camada 2 (links compartilhados, similaridade média) preenche o orçamento de tokens restante.
+- **🧩 Fusão Inteligente e Estado de Contradição** — Duplicados são mesclados preservando aliases; contradições são sinalizadas com atribuição de fonte; páginas `reviewed: true` são protegidas contra sobrescrita.
+- **🎨 Vocabulário de Tags Personalizável** — Defina suas próprias listas de tags de tipo de entidade e conceito em Configurações → Wiki → Vocabulário de Tags → *Personalizado*; o Lint relata qualquer página cujas tags estejam fora do vocabulário ativo.
 
-- **🎨 Vocabulário de tags personalizável (v1.18.0).** Configurações → Wiki → Modo de vocabulário de tags → *Personalizado* permite definir suas próprias listas de tags de tipo de entidade e conceito (por exemplo, `Medical_Arzneimittel`, `法规`). O plugin respeita seu vocabulário nos prompts de extração e na validação de frontmatter; a auditoria Lint (Issue #85 v7) reporta qualquer página cujas tags estejam fora do vocabulário ativo.
+### 📄 Ingestão de PDF (v1.25.0+)
 
-### 📄 Ingestão de PDF (v1.25.0)
+- **🔌 Porta do Provedor** — Anthropic, OpenAI e Bedrock lidam com PDF nativamente. Para qualquer outro endpoint compatível com OpenAI/Anthropic, ative **Force PDF Support** em Configurações → Configuração LLM → Avançado para permitir que o plugin tente a chamada. Para OCR local no Apple Silicon, extratores de terceiros (MinerU, Docling, Mathpix, Adobe) e o tutorial completo de ingestão de PDF, veja [Caminhos OCR PDF](#-caminhos-ocr-pdf) abaixo e [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md).
+- **🗄️ Cache com Limites** — `.obsidian/plugins/karpathywiki/pdf-cache/` armazena Markdown convertido, indexado por hash de conteúdo + modelo + versão do conversor. Manutenção de três camadas de defesa: 100 MB total / 1000 entradas / 10 MB por entrada individual com evicção LRU por mtime.
+- **📝 Sidecar Opcional no Vault** — Configurações → Configuração Wiki → Pasta Wiki → *Write PDF Markdown to Vault* escreve `<basename>.pdf.md` ao lado do PDF fonte (desligado por padrão — apenas cache é o padrão).
+- **🛡️ Prompt de Transcrição Literal** — Conversão estilo OCR com marcadores `[illegible]` / `[figure: ...]` anti-alucinação; o encapsulamento em fences markdown de modelos locais pequenos é limpo automaticamente antes da escrita no cache.
 
-Escolha um PDF do seu vault — o plugin lê através da entrada nativa de arquivo do seu provedor LLM, converte para Markdown e reentra no pipeline padrão de ingestão Markdown. Todos os fluxos existentes de entidade/conceito/alias/`[[wiki-link]]` se aplicam inalterados.
+### 📄 Caminhos OCR PDF
 
-- **🔌 Porta de provedor** — Anthropic, OpenAI, Bedrock Anthropic e Bedrock OpenAI tratam PDF nativamente. Para qualquer outro endpoint compatível com OpenAI/Anthropic, ative **Force PDF Support** em Settings → LLM Configuration → Advanced para que o plugin tente a chamada (seu endpoint decide; falhas surgem como Notice localizado que orienta a desativar o toggle). A configuração local recomendada está em [Caminho OCR PDF local](#-caminho-ocr-pdf-local-v1250).
-- **🗄️ Cache por hash de conteúdo** — PDF + modelo + versão de conversor idênticos retornam o Markdown em cache sem chamada LLM. O cache vive em `.obsidian/plugins/karpathywiki/pdf-cache/`; a chave embute `converterVersion` para invalidar automaticamente entradas obsoletas em upgrades de prompt.
-- **📏 Crescimento limitado** — housekeeping de cache em três camadas de defesa (100 MB total / 1000 entradas / 10 MB por entrada individual) com evasão LRU-by-mtime; entradas antigas são purgadas na inicialização e no início de cada ingestão em lote. Apenas cache — seu vault não é modificado por padrão.
-- **📝 Sidecar opcional no vault** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** escreve um `<basename>.pdf.md` ao lado do PDF fonte após a conversão. Desativado por padrão (apenas cache).
-- **🛡️ Prompt transcritor literal** — o prompt de PDF→Markdown é reformulado como conversão literal estilo OCR com marcadores anti-alucinação `[illegible]` / `[figure: ...]` / `[equation: ...]`; modelos pequenos/locais que envolvem sua saída em fences ```markdown são limpos automaticamente antes da escrita em cache.
-- **⏹ Cancelável** — clicar na barra de status durante a conversão interrompe a chamada LLM em curso (via Vercel AI SDK v6).
+Três caminhos, escolha o que se adequa à sua configuração:
 
-### 💬 Consulta e Feedback
+1. **☁️ Provedor cloud com suporte nativo a PDF** — Anthropic, OpenAI ou AWS Bedrock leem PDFs imediatamente. Basta ingerir; sem configuração extra. Para qualquer outro endpoint compatível com OpenAI/Anthropic, ative **Force PDF Support** em Configurações → Configuração LLM → Avançado para permitir que o plugin tente a chamada.
+2. **🖥️ OCR local no Apple Silicon** — [oMLX](https://github.com/jundot/omlx) integra o Microsoft Markitdown como backend PDF→Markdown integrado. Ative o Markitdown no oMLX, carregue o [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR) (3B / 570M ativos, código aberto em 2026-06) como modelo de visão, aponte o plugin para o oMLX como provedor Custom OpenAI-Compatible, ative **Force PDF Support** e escolha o modelo multimodal que o oMLX está servindo. O PDF nunca sai da sua máquina.
+3. **🛠️ Extrator de terceiros (MinerU, Docling, Mathpix, Adobe)** — Execute um extrator separado nos seus PDFs para produzir arquivos `.md`, depois ingira-os como notas Markdown regulares através do pipeline padrão do plugin. Mais confiável para artigos científicos, documentos digitalizados, PDFs com muita matemática.
 
-- **🔍 Cascata de seleção de sementes PPR em 5 etapas (v1.24.1 PATCH).** Quando você faz uma pergunta multi-hop, o Query Wiki compõe a resposta por meio de cinco etapas complementares antes que qualquer geração comece:
-  1. **Caminho rápido Lex** — verificação direta de sobreposição de tokens contra cada título/alias de entity/concept (grátis, instantâneo; gateia as etapas seguintes)
-  2. **Geração de palavras-chave LLM** — o LLM propõe 8–12 palavras-chave inter-idiomas a partir da sua consulta (absorve sinônimos, abreviações, termos resistentes à sobreposição de tokens)
-  3. **Varredura local de substrings** — cada palavra-chave gerada é re-casada localmente contra títulos de página, aliases e trechos de corpo (sem chamada LLM extra; completa o recall tolerante a ruído)
-  4. **Fallback LLM KB** — quando lex + varredura de palavras-chave retornam sinais fracos, o LLM re-semeia os top-N candidatos com uma passagem semântica sobre o wiki inteiro
-  5. **Expansão de grafo PPR** — Personalized PageRank (Haveliwala 2002) executado sobre o grafo `[[wiki-link]]` a partir do conjunto de sementes candidatas; fornece ao LLM o contexto multi-hop ciente do grafo que a busca linear não alcança
+📖 **Tutoriais de configuração completos** para todos os três caminhos (provedores cloud, tiers de hardware oMLX, instalação do MinerU, manutenção do cache) → [docs/PDF-OCR-GUIDE.md](./PDF-OCR-GUIDE.md)
 
-  A cascata se trunca automaticamente na etapa que devolver sinal suficiente — sem custo fixo de 5 etapas, sem chamadas LLM quando Lex basta, sem perda de precisão quando a augmentação LLM é necessária. A relevância end-to-end (PPR @5 = 27,1% no corpus de benchmark interno do projeto) supera as linhas-base knn puras (24,1%) sem opt-in de embedding. Stage 1.5 (passos 2–3) absorve os tipos de pergunta multi-hop que o Lex puro perde; Stage 1.7 (passo 4) recupera sinais fracos de palavras-chave injetadas pelo LLM; Stage 1.9 (passo 5) garante que o LLM veja contexto vizinho em vez de uma top-N plana. Substitui a antiga cascata binária por camadas.
+### 💬 Consulta e Manutenção
 
-- **🤖 Consulta Conversacional** — Diálogo estilo ChatGPT com Markdown em streaming e `[[wiki-links]]`, histórico multi-turn
-- **🪟 Painel lateral acoplado à direita (v1.22.1, PR #196).** Query Wiki abre em um leaf do sidebar direito estilo Copilot (reutilizando um leaf existente) em vez de um popup centralizado. O ícone ribbon `message-circle` e o comando `Query Wiki` ativam/exibem o painel; suas notas ficam visíveis ao lado da conversa. Toda a funcionalidade é preservada sem alterações.
-- **📤 Query-to-Wiki Feedback** — Salve conversas valiosas para a Wiki com extração de Entity/Concept, deduplicação semântica antes de salvar
-- **🔒 Prevenção de Salvamento Duplicado** — Rastreamento por hash evita reavaliação de conversas inalteradas
+- **🧭 Cascata PPR de 5 Estágios** — veja [Como funciona a recuperação](#-como-funciona-a-recuperação). Personalized PageRank sobre o grafo `[[wiki-link]]` fornece contexto multi-hop consciente do grafo.
+- **🪟 Painel Lateral Acoplado à Direita** — Query Wiki abre numa leaf lateral direita estilo Copilot (v1.22.1+) em vez de um modal centralizado.
+- **🔍 Lint Health Scan** — Um comando captura: duplicados, links mortos, páginas vazias, órfãos, aliases ausentes, contradições.
+- **⚡ Smart Fix All** — Reparo em ordem causal com um clique: preencher aliases → mesclar duplicados → corrigir links mortos → vincular órfãos → expandir páginas vazias, com relatório por fase.
+- **📊 Painel de Histórico de Operações** — UI pesquisável e filtrável para ingestões passadas, relatórios Lint e execuções de manutenção.
+- **🛡️ Porta de Pré-Ingestão** — Notas vazias / somente espaços em branco / somente frontmatter são rejeitadas antes de qualquer chamada LLM; a deduplicação por hash de conteúdo captura arquivos idênticos entre caminhos.
 
-### 🛠️ Manutenção
+### 🔒 Privacidade
 
-- **🔍 Lint Health Scan** — Detecta duplicados, dead links, páginas vazias, órfãos, aliases ausentes e contradições em um relatório abrangente
-- **🎯 Detecção de Duplicados por Camada Semântica** — Camada 1 (correspondências diretas de nome: entre idiomas, abreviações, títulos de alta similaridade) sempre verificada; Camada 2 (sinais indiretos: links compartilhados, similaridade moderada) preenche o orçamento de tokens
-- **⚡ Smart Fix All** — Correção em lote ordenada por causalidade: aliases completados → duplicados mesclados → dead links resolvidos → órfãos vinculados → páginas vazias expandidas
-- **🏷️ Completude de Aliases** — Geração em lote paralela de aliases ausentes em um clique, melhorando a detecção futura de duplicados
-- **🔄 Auto-Manutenção** — Observador de arquivos multi-pasta, lint periódico, verificação de saúde na inicialização (Startup Quick Fixes ativado por padrão, File Watcher e Periodic Lint desativados por padrão)
-- **⚠️ Máquina de Estados de Contradição** — `detected → review_ok → resolved` (correção por IA) ou `detected → pending_fix` (manual)
-- **🛡️ Portal de pré-ingestão (v1.21.0)** — Cada arquivo de origem é validado *antes* de qualquer chamada LLM: notas vazias/em branco/somente frontmatter são rejeitadas; a deduplicação por hash de conteúdo detecta arquivos idênticos entre caminhos. Impede que modelos locais alucinem nomes de entidades em entradas vazias.
-- **📊 Painel de histórico de operações (v1.21.0)** — UI pesquisável e filtrável para ingestões passadas, relatórios de lint e execuções de manutenção, com cartões KPI orientados por insights e links clicáveis para páginas.
-- **🧹 Limpador de páginas incompletas (v1.21.0)** — Páginas deixadas em estado parcial após ingestões interrompidas são arquivadas automaticamente na inicialização (recuperáveis da `.trash` do Obsidian).
+- **🚫 Sem backend, sem rastreio, sem análise.** Executa inteiramente dentro do Obsidian. A rede é usada apenas para comunicar com o provedor LLM que você configurar.
+- **📁 Arquivos de origem são somente leitura.** O plugin nunca modifica suas notas originais do vault — apenas cria novas páginas em `wiki/`.
+- **🦙 Modo local completo.** Ollama, LM Studio ou qualquer endpoint compatível com OpenAI local → suas notas nunca saem da sua máquina.
+- **🔐 Permissões mínimas.** Acesso aos arquivos do vault para gestão da wiki. Acesso à área de transferência apenas quando você clica no botão "Copiar" no modal de Consulta.
 
-### 🌐 LLM e Idioma
+### 🦙 Local-Primeiro
 
-- **🔌 Multi-Provider** — Anthropic, Anthropic Compatible (Coding Plan), Gemini, OpenAI, DeepSeek, Kimi, GLM, MiniMax, LM Studio, OpenRouter, Ollama, endpoints custom
-- **🔄 5xx Retry** — Tentativa automática de exponential backoff (máx. 2) em erros HTTP 5xx/429/529 em todos os clientes
-- **📋 Lista Dinâmica de Modelos** — Busca em tempo real das APIs dos providers
-- **🌐 Idioma de Saída Wiki** — 10 idiomas independentes da UI (EN/ZH simplif/ZH trad/JA/KO/DE/FR/ES/PT/IT), com entrada customizada.
-- **🌍 Internacionalização completa da UI** — Interface do plugin em 10 idiomas (EN/ZH simplif/ZH trad/JA/KO/DE/FR/ES/PT/IT), 269+ campos UI totalmente traduzidos, expressões locais naturais.
-- **⚡ Rate Limit Guardian** — Quando geração paralela ativa rate limits, auto-detecção e sugestões: reduzir concorrência, aumentar delay batch, trocar provider
-- **🦙 Web Clipper Compatible** — Adicionar com um clique o folder `Clippings/` do Obsidian Web Clipper à watchlist, clips web auto-ingestados no Wiki
+- **🖥️ Ollama, LM Studio, OpenRouter, endpoint customizado** — funcionam imediatamente. Modelos locais funcionam para consulta (janelas de contexto menores); a ingestão de um vault de 2000 páginas geralmente precisa de um modelo cloud de contexto longo.
+- **📄 O caminho OCR PDF é totalmente local no Apple Silicon** — veja [Caminhos OCR PDF](#-caminhos-ocr-pdf) abaixo.
+- **🔐 ChatGPT Plan (Codex OAuth)** — callback localhost no desktop em `127.0.0.1:1455`; mobile via código de dispositivo. As credenciais vivem apenas no Obsidian SecretStorage; o término de sessão as limpa. Compatibilidade de terceiros com Codex, não uma parceria com a OpenAI.
 
-### 🏗️ Arquitetura e Desempenho
+### 🌐 Idioma
 
-- **🕸️ PPR sobre o grafo [[wiki-link]] (v1.24.0+, amadurecido em v1.24.1 PATCH).** Personalized PageRank (Haveliwala 2002) executa sobre o grafo direcionado de arestas `[[wiki-link]]` entre suas páginas wiki; a cascata ancora as sementes PPR no conjunto de candidatos top-N, e o contexto multi-hop percorre até 3 anéis de expansão. É isso que torna as respostas do Query Wiki cientes do grafo (uma pergunta "fundadores da Microsoft" se resolve via Bill Gates → Microsoft → concorrentes, não só por sobreposição literal de títulos). Vaults de 2.137 páginas costumam ver <100 ms para warm + expansão de 3 saltos, independentemente do tamanho do vault. Usado pelas 4 etapas da cascata de seleção de sementes (seção Consulta e Feedback acima) e pela detecção de duplicados do Lint quando links indiretos conectam duas páginas candidatas.
-- **⚡ Geração de Páginas Paralela** — 1–5 páginas simultâneas configuráveis, padrão 3 (paralelo), 2–3× mais rápido para sources grandes, isolamento de erro por página
-- **📚 Extração em Lote Iterativa** — Dimensionamento adaptativo de lotes elimina o gargalo de max_tokens para documentos longos
-- **🏛️ Arquitetura de Três Camadas** — Suas notas do vault (somente leitura) → `wiki/` (páginas geradas pelo LLM, organizadas como `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`) → `schema/` (config co-evoluída)
-- **🧩 Código Modular** — 20+ módulos focados em `src/`
-
-### 🔒 Privacidade e segurança
-
-- **Sem backend, sem telemetria.** O plugin é executado inteiramente dentro do Obsidian — não há servidor externo, análise ou coleta de dados de qualquer tipo. Suas notas nunca saem do seu cofre, a menos que você configure explicitamente um provedor LLM.
-- **Seus dados permanecem locais por padrão.** O plugin não armazena, armazena em cache ou transmite seu conteúdo para qualquer lugar além da API LLM que você escolher. Apenas o texto que você envia para ingestão ou consulta sai do seu dispositivo — e apenas para o provedor que você configurou.
-- **Modo totalmente local com Ollama, LM Studio ou provedores locais.** Para total soberania de dados, use um LLM executado localmente. Suas notas são processadas inteiramente na sua máquina — nada toca a Internet.
-- **Permissões mínimas.** O acesso aos arquivos do cofre é necessário para a gestão do wiki (ler notas, gerar páginas, detetar links mortos). O acesso à rede é usado exclusivamente para chamadas da API LLM ao provedor que você escolheu. O acesso à área de transferência limita-se ao botão "Copiar" no modal de Consulta — apenas quando você clica nele.
+- **🌍 10 idiomas de interface** — Inglês, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. O idioma da UI e da saída wiki são independentes — sua wiki pode estar em chinês enquanto a interface está em inglês.
+- **📚 10 idiomas de saída wiki** — o mesmo conjunto; escolha em Configurações → Configuração Wiki. Opção *Custom input* para prompts ad-hoc.
+- **🈶 269+ strings de UI traduzidas** — cada rótulo, modal e aviso. Adicionar um 11º idioma é orientado por contribuidores (padrão PR #159).
 
 ---
 
+## 🔍 Como funciona a recuperação
+
+A maioria dos plugins de "busca IA" fragmenta suas notas em chunks e os incorpora num BD vetorial. Nós não fazemos isso. O argumento de Karpathy contra RAG é que a fragmentação quebra a capacidade do LLM de raciocinar através de todo o seu grafo de conhecimento — e esse argumento se sustenta na prática. Em vez disso, percorremos o grafo que você já mantém escrevendo `[[wiki-links]]`.
+
+### A cascata de seleção de sementes de 5 estágios
+
+Quando você pergunta "Quem fundou a Microsoft?", o Query Wiki executa cinco estágios antes de qualquer geração de resposta:
+
+1. **Caminho rápido Lex** — sobreposição direta de tokens contra cada título de entidade/conceito e aliases. Grátis, instantâneo e a etapa de bloqueio para tudo que se segue.
+2. **Geração de keywords pelo LLM** — o LLM propõe 8–12 keywords inter-idiomas a partir da sua consulta (lida com sinônimos, abreviações e termos resistentes à sobreposição de tokens numa única chamada LLM).
+3. **Varredura local de substring** — cada keyword gerada é re-correspondida localmente contra títulos de página, aliases e trechos de corpo. Sem chamada LLM extra; completa o recall tolerante a ruído.
+4. **Fallback KB do LLM** — quando lex + varredura de keywords retornam sinais fracos, o LLM re-semeia os top-N candidatos contra a wiki inteira para uma passagem semântica.
+5. **Expansão de grafo PPR** — Personalized PageRank (Haveliwala 2002) sobre o grafo `[[wiki-link]]` a partir do conjunto de sementes candidatas. É isso que dá contexto multi-hop consciente do grafo: "Bill Gates" → "Microsoft" → "concorrentes", não apenas sobreposição literal de títulos.
+
+A cascata trunca na etapa que retornou sinal suficiente — sem custo fixo de 5 etapas, sem chamadas LLM quando lex é suficiente, sem perda de precisão quando o aumento do LLM é necessário.
+
+### Personalized PageRank em escala
+
+Usamos Monte Carlo PPR (Fogaras 2005) — 3.000 caminhadas aleatórias × 50 passos cada — com a regra de beco sem saída de Haveliwala 2002. O custo é **O(K × L)** independente do número de páginas, então um vault de 2.000 páginas vê a mesma latência de expansão que um de 200 páginas.
+
+**PPR @5 = 27,1% vs baseline pure-kNN 24,1%** no corpus de benchmark interno do projeto (o único benchmark de recuperação publicado neste espaço de LLM-Wiki open-source).
+
+### Por que nenhum embedding
+
+Rejeitamos deliberadamente o caminho de embedding na [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175). O sinal do grafo já está lá — cada `[[wiki-link]]` é uma aresta "estes estão relacionados" curada manualmente, e a maioria dos provedores que suportamos (Ollama, LM Studio, Anthropic, Bedrock, Kimi, GLM, MiniMax) não têm endpoint `/v1/embeddings`. Adicionar um modelo de embedding significaria download por página, um adaptador por provedor e zero benefício na qualidade da recuperação.
 
 ---
 
----
+## 🤖 Modelos
 
-## 📖 Exemplo
+**Provedores suportados (12+, verificados no models.dev em 2026-07):**
 
-**Entrada:** `sources/machine-learning.md`
+| Provedor | Série | Notas |
+|----------|-------|-------|
+| **Anthropic** | Claude 5 series | PDF nativo; protocolo `/v1/messages` |
+| **OpenAI** | GPT-5.6 series (Sol / Terra / Luna) | PDF nativo; chave API Platform |
+| **Google Gemini** | Gemini 3.6 series | PDF nativo (file parts desde 1.5); endpoint compatível com OpenAI |
+| **DeepSeek** | DeepSeek V4 series | Compatível com OpenAI; tier de menor custo |
+| **Alibaba Qwen** | Qwen3.7/3.8 series | Compatível com OpenAI (DashScope) |
+| **xAI Grok** | Grok 4 series | Compatível com OpenAI; contexto longo |
+| **Moonshot Kimi** | Kimi K3 series | Compatível com OpenAI; MoE 2.8T de fronteira |
+| **Zhipu GLM** | GLM-5 series | Compatível com OpenAI; forte bilíngue |
+| **MiniMax** | MiniMax M3 series | Compatível com OpenAI; 1M de contexto |
+| **Step (阶跃星辰)** | Step 3 series (Flash) | Compatível com OpenAI; inferência rápida |
+| **Tencent Hunyuan** | Hy3 series | Compatível com OpenAI; MoE de pesos abertos |
+| **Xiaomi MiMo** | MiMo V2.5 series | Open-source MIT; preço fixo |
+| **Google Gemma** | Gemma 4 series | Pesos abertos; 262K de contexto |
+| **AWS Bedrock** | Variantes Anthropic + OpenAI | Caminho VPC / conformidade |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | Login por navegador/código de dispositivo; SecretStorage |
+| **Local: Ollama, LM Studio, OpenRouter, Anthropic-Compatible** | Qualquer modelo de protocolo OpenAI-/Anthropic | Custom OpenAI-Compatible + Anthropic-Compatible (Token Plan / Coding Plan) |
 
-```markdown
-### Machine Learning
-Machine learning usa algoritmos para aprender com dados.
+Este plugin alimenta o LLM com o contexto completo da sua Wiki por consulta — então **modelos de contexto longo vencem**. A tabela completa por níveis (cloud + local) está em [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md), verificada no [models.dev](https://models.dev/) para que as escolhas se mantenham atuais.
 
-### Tipos
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
+### O que importa
 
-**Saída — Entity Page:** `wiki/entities/supervised-learning.md`
+- **🧠 Janela de contexto ≥ 200K tokens** para vaults com mais de ~500 páginas. Abaixo de 200K, o contexto montado pela cascata começa a ser truncado.
+- **⚖️ Qualidade de seguimento de instruções** importa mais que QI bruto para a tarefa de extração — escolha um modelo que siga o template de esquema, não o maior número no leaderboard.
+- **🔌 Endpoint de embedding é irrelevante** — não usamos embeddings. Um provedor sem `/v1/embeddings` é perfeitamente aceitável (a maioria dos nossos 12+ provedores não tem).
+- **🦙 Local funciona para consulta, cloud para ingestão** — a ingestão num vault de 2000 páginas geralmente precisa de um modelo cloud de contexto longo; um modelo local de 262K cobre a maioria das consultas.
 
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["监督学习", "Supervised Learning"]
----
+### Anthropic vs OpenAI vs Codex OAuth — são provedores distintos
 
-### Supervised Learning
+- **Anthropic** (e sua variante Bedrock) — chave API Anthropic Platform com faturamento separado.
+- **OpenAI** — chave API OpenAI Platform com faturamento separado.
+- **ChatGPT Plan (Codex OAuth)** — experimental, provedor distinto que usa franquia Codex elegível após login por navegador ou código de dispositivo; a disponibilidade segue as políticas de autenticação e franquia da OpenAI Codex, não o nome do plano. Compatibilidade de terceiros com Codex, não uma parceria com a OpenAI ou uma API geral do ChatGPT.
 
-### Informações Básicas
-- Tipo: method
-- Source: [[sources/machine-learning]]
+> 📖 **Tabela de escolha completa** (cloud + local + PDF OCR + Codex OAuth + quantização + tiers de hardware) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
 
-### Descrição
-Supervised learning é um paradigma de machine learning onde modelos aprendem
-de dados de treinamento rotulados para fazer previsões sobre dados não vistos...
+## ❓ FAQ
 
-### Concept Relacionados
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
+### O que o plugin realmente faz?
 
-### Entity Relacionados
-- [[entities/Arthur-Samuel|Arthur Samuel]]
+Escolha qualquer nota, pasta ou seleção; o LLM extrai entidades e conceitos e gera uma wiki interligada com `[[bidirectional links]]`. Faça perguntas e obtenha respostas conversacionais baseadas nas *suas* notas, não na internet. Suas notas originais do vault nunca são modificadas.
 
-### Menções na Source
-- "Supervised learning usa dados rotulados para treinar modelos preditivos..."
-```
+### Como começo?
 
----
+Instale dos Community Plugins do Obsidian → escolha um provedor → **Test Connection** → execute **Ingest single source** em qualquer nota. Primeiras páginas wiki aparecem em segundos. Veja [Início rápido](#-início-rápido).
 
-## 🤖 Guia de Seleção de Modelo
+### Minha wiki existente está segura?
 
-Este plugin segue a filosofia de Karpathy: **alimente o LLM com contexto Wiki completo, não com RAG retrieval fragmentado**. Modelos de longo contexto são fortemente recomendados — quanto maior sua Wiki cresce, mais contexto o LLM precisa.
+✅ Retrocompatível desde a v1.0.0. Defina `reviewed: true` em qualquer página para protegê-la contra sobrescrita. Atualizar da v1.24.x não reescreve seu vault; a ingestão de PDF da v1.25.0 é apenas cache por padrão.
 
-> 💡 **Por que não RAG?** A [crítica original](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) de Karpathy argumenta que RAG fragmenta o conhecimento e quebra a capacidade do LLM de raciocinar através do knowledge graph completo.
+### Meus dados são enviados para algum lugar?
 
-**🌟 Principais recomendações:**
+🚫 Sem backend, sem análise — o plugin executa inteiramente dentro do Obsidian. Apenas o texto que você envia explicitamente para ingestão/consulta sai do seu dispositivo, e apenas para o provedor LLM que você configurar. Para localidade completa dos dados, use Ollama ou LM Studio.
 
-### ☁️ Modelos em nuvem
+### Posso usar o plugin no meu idioma?
 
-| Nível | Modelo | Janela de Contexto | Por quê |
-|-------|--------|-------------------|---------|
-| **🌟 Custo-benefício** | **DeepSeek V4-Flash** | 1M tokens | Preço mais baixo ($0.14/M), 284B MoE, ideal para ingestão batch |
-| **🌟 Custo-benefício** | **Gemini-3.5-Flash** | 1M tokens | 4× mais rápido que GPT-5.5, excelente para tarefas agent |
-| **🌟 Custo-benefício** | **Qwen3.6-Plus** | 1M tokens | Forte capacidade coding & agent, preço competitivo |
-| **🌟 Custo-benefício** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **Balanceado** | **Claude Sonnet 4.6** | 1M tokens | Bom equilíbrio qualidade/custo, $3/$15 por milhão de tokens |
-| **Leve** | **Claude Haiku 4.5** | 200K tokens | Rápido e econômico, para wikis pequenos |
-| **Econômico** | **Xiaomi MiMo-V2.5** | 1M tokens | Xiaomi 310B/15B MoE, open-source MIT 2026-04, agente e multimodal |
-| **Flagship** | Claude Opus 4.7 | 1M tokens | Qualidade máxima, custo alto — usar seletivamente |
-| **Flagship** | GPT-5.5 | 1M tokens | Raciocínio top, custo alto — usar seletivamente |
+🌍 10 idiomas tanto para a interface quanto para a saída wiki. O idioma da UI e da wiki são independentes. Adicionar um 11º idioma é orientado por contribuidores (padrão PR #159).
 
-### 🦙 Modelos locais (Ollama / LM Studio)
+### Como isso é diferente de um chatbot RAG?
 
-A inferência local vence em soberania de dados, uso offline e custo zero de API. O custo é uma janela de contexto menor (geralmente entre 8K–128K; famílias open-weight recentes chegam a 262K) e seguimento de instruções mais fraco em comparação com modelos flagship em nuvem. **Escolha conforme o orçamento de hardware:** mais parâmetros = mais conhecimento de mundo e fidelidade às instruções (extração de melhor qualidade, menos alucinações); menos parâmetros = mais velocidade e folga de memória, ao preço de mais alucinações e raciocínio de longo contexto mais fraco. O sweet spot em 24 GB Apple Silicon ou uma única GPU de consumo é a classe 27B–35B-A3B.
+🚫 Sem fragmentação. 🚫 Sem embeddings. 🚫 Sem BD vetorial. ✅ Personalized PageRank sobre o seu grafo `[[wiki-link]]` existente — contexto multi-hop consciente do grafo, custo zero de embedding, suporte total a modelos locais.
 
-| Modelo | Parâmetros | Contexto | Por quê |
-|--------|------------|----------|---------|
-| **Qwen3.5 27B** | 27B dense | 262K | Melhor equilíbrio qualidade/tamanho para ingestão; MLX 4-bit cabe em 24 GB |
-| **Qwen3.5 35B-A3B** | 35B total / 3B ativos MoE | 262K | Mais rápido que 27B dense com qualidade similar; economia de memória ideal |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | Teto de qualidade; requer ≥48 GB VRAM ou dual GPU |
-| **Qwen3.6 27B** | 27B dense | 256K+ | Refresh 2026-04 sobre o Qwen3.5 27B — prefira este se o hardware aguentar |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | Mesmo trade-off do Qwen3.5 35B-A3B, com pesos mais novos |
-| **Gemma 4 31B IT** | 31B dense | 262K | Forte seguimento de instruções, saída Markdown limpa |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | Menos memória que 31B dense com qualidade comparável |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | Executável em CPU pura; só para wikis pequenos ou pré-visualizações rápidas |
+### Qual LLM devo usar?
 
-**Quantização:** MLX 4-bit em Apple Silicon costuma ser 1,5–2× mais rápido que GGUF Q4_K_M na mesma taxa de bits efetiva. GGUF Q4_K_M é a escolha padrão multiplataforma; só passe para Q5/Q8 se você tiver folga de VRAM e notar regressão de qualidade em Q4.
+Modelos de contexto longo (≥200K tokens) funcionam melhor. A [seção Modelos](#-modelos) cobre os princípios; a tabela completa por níveis está em [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md).
 
-**Estratégia de contexto:** quando a Wiki ultrapassa ~500 páginas, um modelo local de 262K ainda cobre a maior parte do contexto montado pelo motor de Query, mas a ingestão de um vault de 2000 páginas o ultrapassará. Padrão comum: nuvem para ingestão + local para query. Para setups totalmente locais, a classe 27B/35B-A3B é o sweet spot.
+### Existe um benchmark publicado?
 
-### 📄 Caminho OCR PDF local (v1.25.0+)
+Sim — PPR @5 = 27,1% vs baseline pure-kNN 24,1% no corpus do próprio projeto. O pipeline completo e o script de benchmark estão descritos em [Como funciona a recuperação](#-como-funciona-a-recuperação).
 
-A ingestão de PDF da v1.25.0 funciona com qualquer provedor que aceite PDF como parte de arquivo. Para um pipeline totalmente local em Apple Silicon (a única plataforma que o oMLX suporta atualmente), esta é a configuração recomendada:
+### Como controlo os custos de API?
 
-1. Instale o [oMLX](https://github.com/jundot/omlx) e habilite o backend **Markitdown** integrado (conversão local PDF→Markdown).
-2. Carregue **Baidu Unlimited-OCR** (open-source em 22/06/2026, 3B total / 0,5B ativos, OCR de ponta a ponta que trata documentos longos sem o modo de falha "quanto mais gera, mais lento fica" dos modelos OCR antigos) como modelo de visão no oMLX.
-3. Neste plugin: selecione o provedor **Custom OpenAI-Compatible** (o oMLX fala o protocolo compatível com OpenAI), aponte a Base URL para o servidor local do oMLX, ative **Force PDF Support** em Settings → LLM Configuration → Advanced, e escolha o modelo multimodal servido pelo oMLX para o resumo da ingestão.
+Use granularidade Grossa ou Mínima para ingestão em lote. Smart Batch Skip deteta automaticamente arquivos já ingeridos. A Manutenção Automática está DESLIGADA por padrão. O Lint mostra contagens antes de executar correções — nada é cobrado sem sua aprovação.
 
-O PDF nunca sai da sua máquina — o Markitdown faz a conversão estrutural localmente, o Unlimited-OCR faz o reconhecimento visual localmente, e o LLM local faz o resumo localmente. O cache do plugin (`.obsidian/plugins/karpathywiki/pdf-cache/`) mantém as re-ingerções instantâneas.
+### Como cancelo uma operação em execução?
 
-**Fallback:** se o oMLX/Markitdown não estiver disponível (Linux/Windows ou Macs antigos), aponte **Force PDF Support** diretamente para um LLM multimodal local que aceite partes de arquivo PDF — a qualidade é boa quando o modelo é grande o suficiente, mas a demanda por VRAM escala de forma acentuada com o número de páginas.
+Clique na barra de status (mostra "Ingerindo… clique para cancelar") ou `Cmd+P/Ctrl+P` → "Cancel current ingestion". Para com segurança no próximo limite de lote.
 
-**🔌 Anthropic Compatible (Coding Plan):** Se seu provider oferece um endpoint de API compatível com Anthropic, selecione "Anthropic Compatible" e insira o Base URL e API Key do seu provider.
+### Onde obtenho ajuda?
 
-**🦙 Ollama (local, sem chave API):** Instale o [Ollama](https://ollama.com), baixe um modelo (`ollama pull gemma4` ou `ollama pull qwen3.5:27b`), selecione "Ollama (Local)" no menu de providers.
-
-**🎛️ LM Studio (local, sem chave API):** Instale o [LM Studio](https://lmstudio.ai), inicie seu servidor local (padrão `http://localhost:1234/v1`), selecione "LM Studio (Local)" no menu de providers. O LM Studio executa um servidor compatível com OpenAI integrado — o campo de chave API é opcional.
-
-> 💡 **Limite de cobrança da OpenAI:** **OpenAI** usa uma chave da Platform cobrada separadamente. **ChatGPT Plan (Codex OAuth)** é um provedor experimental independente que usa uma franquia Codex elegível após login por navegador ou código do dispositivo; o nome do plano não garante disponibilidade.
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) para relatar bugs · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) para perguntas e pedidos de funcionalidades · Console do Desenvolvedor (`Ctrl+Shift+I` / `Cmd+Option+I`) para logs do plugin.
 
 ---
 
-## 🏗️ Arquitetura
-
-Design de separação em três camadas de Karpathy:
-
-```
-📄 Suas notas do vault (qualquer pasta)   # 📖 Você escolhe quais notas ingerir
-  ↓ ingest
-wiki/                                      # 🧠 Páginas Wiki geradas pelo LLM (wiki/sources/, wiki/entities/, wiki/concepts/)
-  ↓ query / maintain
-schema/                                    # 📋 Configuração da estrutura Wiki (naming, templates, categorias)
-```
-
-> 📖 Ver estrutura completa do código em [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure).
-
-**Páginas geradas:**
-- `wiki/sources/filename.md` — 📄 Resumo da fonte
-- `wiki/entities/entity-name.md` — 👤 Páginas de entidades (pessoas, organizações, projetos, etc.)
-- `wiki/concepts/concept-name.md` — 💡 Páginas de conceitos (teorias, métodos, termos, etc.)
-- `wiki/index.md` — 📑 Índice gerado automaticamente
-- `wiki/log.md` — 📝 Registo de operações
-
----
-
-## ❓ Perguntas Frequentes (FAQ)
-
-> **Mantenha o plugin atualizado.** **Configurações → Plugins da comunidade → Verificar atualizações** regularmente.
->
-> Mais FAQ em [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28).
-
-**O que faz este plugin?**
-Escolha qualquer nota, pasta ou seleção múltipla do seu vault; o LLM extrai entidades e conceitos e gera uma Wiki interligada com `[[wiki-links]]`. Receba respostas baseadas nas *suas* notas — não em pesquisas na Internet. Os resumos gerados ficam em `wiki/sources/`, as entidades em `wiki/entities/`, os conceitos em `wiki/concepts/` — as suas notas originais do vault nunca são modificadas.
-
-**Os meus dados são enviados a terceiros?**
-Privacidade primeiro. Sem backend, sem rastreio. Apenas texto que envia explicitamente sai do dispositivo. Use fornecedor local (Ollama/LM Studio) para total localidade.
-
-**Diferença dos chatbots RAG?**
-LLM-Wiki usa Personalized PageRank sobre o grafo [[wiki-link]] - zero custo de embedding.
-
-**Qual LLM usar?**
-Modelos >=200K tokens. Económicos: DeepSeek V4-Flash (/bin/zsh.14/M), Gemini 3.5 Flash, Qwen3.6-Plus.
-
-**Como começar?**
-Instalar → escolher fornecedor → **Test Connection** → executar **Ingest single source** (ou **Ingest from folder**) sobre qualquer nota do seu vault → as primeiras páginas Wiki aparecem em segundos. Ver [Início rápido](#-início-rápido) acima.
-
-**Controlar custos API?**
-Granularidade Grossa/Minima para lotes. Smart Batch Skip. Manutencao automatica DESLIGADA.
-
-**Wiki existente segura?**
-✅ Retrocompatível desde a v1.0.0. `reviewed: true` protege páginas de sobrescrita. O plugin nunca modifica as suas notas originais do vault — apenas gera novas páginas dentro da pasta `wiki/`.
-
-**Idiomas?**
-10 idiomas para IU e Wiki: EN, ZH, ZH-Hant, JA, KO, DE, FR, ES, PT, IT.
-
-**Requisitos?**
-Obsidian v1.11.4+ (desktop ou mobile). É necessária uma chave API LLM, Ollama/LM Studio local ou credenciais autorizadas do ChatGPT Plan (Codex OAuth). llmReady requer Test Connection.
-
-**Cancelar operacao?**
-Barra de estado ou Cmd+P -> Cancel current ingestion.
-
-**Ajuda?**
-- GitHub Issues - reportar erros
-- GitHub Discussions - perguntas e feedback
-
-## 🔒 Transparência e conformidade
+## 🔒 Privacidade
 
 Este plugin está listado no Mercado de Plugins Comunitários do Obsidian e passa por revisão automatizada de segurança e permissões.
 
-**O plugin não tem backend, nem infraestrutura de servidor, nem qualquer tipo de recolha de dados.** É software puramente local executado dentro do Obsidian. O plugin não pode e não recolhe, armazena ou transmite os seus dados para nenhum servidor — porque tal servidor não existe.
+- **🚫 Sem backend, sem servidor, sem coleta de dados.** Software puramente local executado dentro do Obsidian. O plugin não pode e não coleta, armazena ou transmite seus dados para nenhum servidor — porque tal servidor não existe.
+- **🔐 Acesso à rede é opcional.** Usado apenas para comunicar com o provedor LLM que você configurar. Você escolhe o provedor, você insere a chave API, você decide para onde seus dados vão.
+- **📁 Acesso aos arquivos do vault** é usado para gestão da wiki (ler notas, gerar páginas, verificar links mortos, detetar duplicados). O plugin nunca modifica seus arquivos de origem.
+- **📋 Acesso à área de transferência** é usado exclusivamente pelo botão "Copiar" no modal de Consulta — e apenas quando você clica nele.
 
-**O acesso à rede** é usado apenas para comunicar com o provedor LLM que você configurar — nenhuma outra chamada de rede é feita. Isto está totalmente sob o seu controlo: você escolhe o provedor, você insere a chave API, você decide para onde vão os seus dados.
+Para localidade completa dos dados, use Ollama ou LM Studio. Com um provedor local, seus dados nunca saem da sua máquina.
 
-**O acesso ao sistema de arquivos** (enumeração do cofre) é necessário para construir e manter o wiki: ler as suas notas de origem, gerar páginas, varrer links mortos e detetar páginas duplicadas. O plugin nunca modifica os seus arquivos de origem — apenas os arquivos dentro da pasta wiki.
-
-**O acesso à área de transferência** é usado exclusivamente pelo botão "Copiar" no modal de Consulta, e apenas quando clica nele.
-
-Se preferir total localidade de dados, use um provedor LLM local como Ollama ou LM Studio. Com um provedor local, os seus dados nunca saem da sua máquina.
+---
 
 ## 💖 Apoiar o projeto
 
-Se o LLM-Wiki se tornou uma parte significativa do seu fluxo de trabalho de conhecimento, pode apoiar o seu desenvolvimento contínuo:
+Se o LLM-Wiki se tornou uma parte significativa do seu fluxo de trabalho de conhecimento:
 
-- ☕ **[Pague-me um café no Ko-fi](https://ko-fi.com/greenerdalii)** — apoio pontual ou mensal via Ko-fi
-- 💳 **[Gorjeta via PayPal](https://paypal.me/greenerdalii)** — gorjeta pontual via PayPal
+- ☕ **[Pague-me um café no Ko-fi](https://ko-fi.com/greenerdalii)** — apoio pontual ou mensal
+- 💳 **[Gorjeta via PayPal](https://paypal.me/greenerdalii)** — gorjeta pontual
 
 O patrocínio é inteiramente opcional. O plugin mantém-se sob licença Apache-2.0 e completo em funcionalidades.
 
-### Patrocinadores
+Obrigado a [@jameses-cyber](https://github.com/jameses-cyber) e [@issaqua](https://github.com/issaqua) por apoiarem o projeto.
 
-Obrigado às seguintes pessoas por apoiarem o projeto:
+---
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
+## 📜 Licença & Créditos
 
-## 📜 Licença
+Licença Apache, Versão 2.0 — veja [LICENSE](../LICENSE) e [NOTICE](../NOTICE).
 
-Licença Apache-2.0 — veja [LICENSE](LICENSE) e [NOTICE](NOTICE).
+**Construído sobre:**
+- 💡 [LLM Wiki de Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — o conceito original
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) e [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — algoritmos de recuperação
 
-## 🙏 Agradecimentos
+**Mantenedor:** [@green-dalii](https://github.com/green-dalii)
 
-- **💡 Conceito:** [LLM Wiki de Andrej Karpathy](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — a visão original que inspirou este plugin
-- **🛠️ Plataforma:** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 Transporte LLM:** [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/docs/README_ZH-Hant.md
+++ b/docs/README_ZH-Hant.md
@@ -1,488 +1,332 @@
 ![llm_wiki_banner](assets/llm_wiki_banner.webp)
 
-# 🧠 Karpathy LLM Wiki — Obsidian 插件
+# 🧠 Karpathy LLM Wiki — Obsidian 外掛
 
 > 基於 [Andrej Karpathy 的 LLM Wiki 概念](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) 實現的知識庫生成系統，自動從筆記中提取實體與概念，構建互聯的 Wiki 頁面。
 
-> **Obsidian 官方評分 95/100 | 原生支持 10 種語言 | 零嵌入圖譜檢索 | 完全資料主權 | 相容所有 LLM 供應商**
+> **零嵌入圖譜檢索 • 10 種語言原生支援 • 相容所有 LLM 供應商**
 
-![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian Compatibility](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
+![Version](https://img.shields.io/github/v/release/green-dalii/obsidian-llm-wiki?style=flat-square) ![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square) ![Obsidian](https://img.shields.io/badge/obsidian-1.11.4%2B-purple?style=flat-square) ![Languages](https://img.shields.io/badge/languages-10-informational?style=flat-square) ![Providers](https://img.shields.io/badge/providers-12%2B-cyan?style=flat-square) <br>
 ![Maintenance](https://img.shields.io/badge/maintenance-actively%20maintained-brightgreen?style=flat-square) ![Build Status](https://img.shields.io/github/actions/workflow/status/green-dalii/obsidian-llm-wiki/release.yml?style=flat-square) ![Author](https://img.shields.io/badge/author-Greener--Dalii-blue?style=flat-square) <br>
 ![GitHub Stars](https://img.shields.io/github/stars/green-dalii/obsidian-llm-wiki?style=flat-square) ![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=483699&label=downloads&query=$[karpathywiki].downloads&url=https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/community-plugin-stats.json&style=flat-square) [![Release Obsidian plugin](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml/badge.svg)](https://github.com/green-dalii/obsidian-llm-wiki/actions/workflows/release.yml) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/green-dalii/obsidian-llm-wiki)
 
 [English](../README.md) | [简体中文](README_CN.md) | **繁體中文** | [日本語](README_JA.md) | [한국어](README_KO.md) | [Deutsch](README_DE.md) | [Français](README_FR.md) | [Español](README_ES.md) | [Português](README_PT.md) | [Italiano](README_IT.md)
 
-[官網](https://llmwiki.greenerai.top/) | [Obsidian 插件市集](https://community.obsidian.md/plugins/karpathywiki) | [博客](https://llmwiki.greenerai.top/zh/blog/) | [反饋討論](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
+[官網](https://llmwiki.greenerai.top/) | [Obsidian 插件市集](https://community.obsidian.md/plugins/karpathywiki) | [部落格](https://llmwiki.greenerai.top/zh/blog/) | [討論區](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [快速開始](#-快速開始) | ✨ [核心特性](#-核心特性) | 🤖 [模型選擇建議](#-模型選擇建議) | 🔒 [透明度與合規性](#-透明度與合規性) | ❓ [常見問題 (FAQ)](#-常見問題-faq)
+📑 [目錄](#-目錄) • 🚀 [快速開始](#-快速開始) • ✨ [核心特性](#-核心特性) • 🔍 [檢索原理](#-檢索原理) • 🤖 [模型](#-模型) • ❓ [FAQ](#-faq)
 
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 如果你覺得這個專案幫到你，歡迎請我喝杯咖啡♥️，或為專案點亮🌟↗
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 如果你覺得這個專案幫到你，歡迎請我喝杯咖啡♥️，或為專案點亮一顆星🌟↗
 
 ---
-
-> **⚡ 快速更新提醒：** 本項目迭代速度快，會經常進行 Bug 修復、性能提升或新功能、體驗優化等。建議經常在 Obsidian 中更新到最新版本（**設置 → 社區插件 → 檢查更新**），或開啓插件的自動更新功能以確保獲得最佳體驗。
 
 ## 📑 目錄
 
-- [🧠 Karpathy LLM Wiki — Obsidian 插件](#-karpathy-llm-wiki--obsidian-插件)
-  - [📑 目錄](#-目錄)
-  - [💡 什麼是 LLM-Wiki？](#-什麼是-llm-wiki)
-  - [⚡ 爲什麼選擇 Obsidian + LLM-Wiki？](#-爲什麼選擇-obsidian--llm-wiki)
-  - [🚀 快速開始](#-快速開始)
-    - [📦 安裝](#-安裝)
-    - [🔄 更新插件](#-更新插件)
-    - [🔑 配置 LLM Provider](#-配置-llm-provider)
-    - [🎮 使用方式](#-使用方式)
-    - [⚠️ 從舊版本升級？](#️-從舊版本升級)
-  - [⚡ 最新動態 v1.25.x](#-最新動態-v125x)
-  - [✨ 核心特性](#-核心特性)
-    - [📊 知識質量](#-知識質量)
-    - [📄 PDF 擷取 (v1.25.0)](#-pdf-擷取-v1250)
-    - [💬 查詢與反饋](#-查詢與反饋)
-    - [🛠️ 維護能力](#️-維護能力)
-    - [🌐 LLM 與語言](#-llm-與語言)
-    - [🏗️ 架構與性能](#️-架構與性能)
-    - [🔒 隱私與安全](#-隱私與安全)
-  - [📖 使用示例](#-使用示例)
-  - [🤖 模型選擇建議](#-模型選擇建議)
-    - [☁️ 雲端模型推薦](#️-雲端模型推薦)
-    - [🦙 本地模型推薦 (Ollama / LM Studio)](#-本地模型推薦-ollama--lm-studio)
-    - [📄 本地 PDF OCR 路徑 (v1.25.0+)](#-本地-pdf-ocr-路徑-v1250)
-  - [🏗️ 架構](#️-架構)
-  - [❓ 常見問題 (FAQ)](#-常見問題-faq)
-  - [🔒 透明度與合規性](#-透明度與合規性)
-  - [💖 支持專案](#-支持專案)
-    - [贊助者](#贊助者)
-  - [📜 許可證](#-許可證)
-  - [🙏 致謝](#-致謝)
-  - [Star History](#star-history)
----
-
-## 💡 什麼是 LLM-Wiki？
-
-你寫筆記，AI 來整理，你開口問。就這麼簡單。
-
-**🎯 痛點。** 你的筆記是個金礦——人物、概念、觀點、關聯。但現在它們只是文件夾裏的一堆文檔。找到誰跟誰有關，只能靠搜索、打標籤，以及祈禱自己還記得那條線索。
-
-**✨ 思路。** [Andrej Karpathy 提出了](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)一個優雅的方案：把筆記當原材料，讓 LLM 來做架構師。它讀你寫的東西，提取實體和概念，編織成一個結構化的 Wiki——帶 `[[雙向鏈接]]`、自動索引，還能用自然語言對你的知識庫提問。
-
-**📚 你不再是圖書管理員。** 不用糾結該給誰建頁面，不用手工維護交叉鏈接，不用擔心信息過時。從你的 vault 中任意選擇一篇筆記（或整個資料夾、或多選檔案），LLM 自動閱讀、提取、撰寫、鏈接，甚至標記矛盾——你只管繼續寫。
-
-**🤖 也不是另一個聊天機器人。** ChatGPT 瞭解互聯網，LLM-Wiki 瞭解*你*——準確說，是你教給它的東西。每個回答都帶着 `[[wiki-links]]` 回到你的知識圖譜。每條回覆都是一條探索路徑的起點，而不是終點。
-
-**🏆 核心差異化 —— 零嵌入成本、圖譜驅動的檢索。** 大多數知識庫外掛用向量嵌入（成本高、相依廠商、需要連線）。LLM-Wiki 在你既有的 `[[wiki-link]]` 圖譜上跑 Personalized PageRank —— 零 API 呼叫、無新依賴、本地模型完全支援，檢索品質對標嵌入級。再加上 i18n 感知的**零 LLM Tier B 章節抽取**（10 種語言），無論用什麼供應商，每個使用者都能用上同一個知識引擎。
+- [🤔 爲什麼選擇這個外掛？](#-爲什麼選擇這個外掛)
+- [🎯 適合我嗎？](#-適合我嗎)
+- [🚀 快速開始](#-快速開始)
+- [✨ 核心特性](#-核心特性)
+- [🔍 檢索原理](#-檢索原理)
+- [🤖 模型](#-模型)
+- [❓ 常見問題 (FAQ)](#-常見問題-faq)
+- [🔒 隱私](#-隱私)
+- [💖 支持專案](#-支持專案)
+- [📜 許可證與致謝](#-許可證與致謝)
 
 ---
 
-## ⚡ 爲什麼選擇 Obsidian + LLM-Wiki？
+## 🤔 爲什麼選擇這個外掛？
 
-Obsidian 是鏈接思考的利器。但有個問題：連線的那個人一直是你自己。
+你寫筆記，它們躺在資料夾裡。要找出哪些內容彼此相關，你得回憶幾個月前已經忘記的線索。
 
-LLM-Wiki 把這個關係翻轉了。不是你手工構建圖譜，而是 AI 隨着你的筆記一起成長。你寫一篇新筆記——它幫你找出你可能會錯過的關聯。你提一個問題——它在你自己的知識圖譜裏穿行，帶着引用回來見你。
+**Karpathy 的 LLM Wiki 概念有其他開源實作，但沒有一個是一鍵安裝的 Obsidian 外掛。** 大部分是 CLI 工具、Claude Code 技能或獨立桌面應用。我們是唯一一個擁有原生 UI、vault 內儲存和 Obsidian 圖譜檢視的選擇。
 
-- **🔗 你的圖譜視圖活起來了。** 新筆記不再靜靜躺在文件夾裏——它們自動生長出指向實體、概念和來源的鏈接。圖譜有機生長，插件持續維護：檢測重複、修復斷鏈、用別名橋接不同語言。
-- **💬 你的筆記學會了對話。** 搜索變成了聊天。"我之前寫過什麼關於 X 的內容？"變成了對話，流式回答帶着 `[[wiki-links]]` 作爲路標。每個回答都是深入你自己知識的一條路徑。
-- **🧠 Obsidian 成爲你的思考夥伴。** 它不再只是裝筆記的櫃子，而是幫你*思考*的東西——浮現隱藏的關聯、標記矛盾、記起你忘了自己知道的事。
+### 同類比較
+
+|  | Karpathy LLM Wiki（此外掛） | nashsu / llm_wiki | SamurAIGPT / llm-wiki-agent | sdyckjq / llm-wiki-skill | atomicstrata / llm-wiki-compiler |
+|---|---|---|---|---|---|
+| **交付形式** | ✅ 一鍵安裝 Obsidian 外掛 | ❌ 獨立 Tauri 桌面應用 | ❌ Claude Code 技能 | ❌ Claude Code / Codex 技能 | ❌ CLI + SDK + MCP 伺服器 |
+| **安裝時間** | ✅ **5 分鐘** — 社群外掛 → 安裝 → 選 Provider → 攝入 | ❌ 30 分鐘以上 — 編譯/下載二進位檔，設定 CLI | ❌ 15 分鐘 — 需要 Claude Code 訂閱 + 安裝技能 | ❌ 10 分鐘 — 需要 Claude Code/Codex 訂閱 + 設定 | ❌ 30 分鐘以上 — pip 安裝 + SDK + MCP 設定 |
+| **安裝路徑** | ✅ Obsidian → 社群外掛 → 搜尋 → 安裝 | ❌ 編譯或下載獨立的二進位檔，再設定 CLI | ❌ 需要 Claude Code 訂閱 + 安裝指南 | ❌ 需要 Claude Code 或 Codex 訂閱 + 設定步驟 | ❌ pip 安裝 + Python SDK + 本地伺服器 |
+| **架構複雜度** | ✅ **零依賴** — 無向量 DB、無嵌入模型、無外部程序 | 🟡 內建 Python 執行環境 + sigma.js + sqlite | 🟡 依賴 Claude Code 環境 — 非自包含 | 🟡 需要獨立的平台執行環境 | ❌ 需要 Python、嵌入模型、向量 DB |
+| **國際化（UI + Wiki 輸出）** | ✅ 10 種語言（UI/Wiki 互相獨立） | 🟡 2 種（EN / 中文） | ❌ 僅英文 | ❌ 僅英文 | ❌ 僅英文 |
+| **LLM Provider** | ✅ 12 種以上（含 Codex OAuth、Bedrock、LM Studio、Ollama、Anthropic 相容、Kimi、GLM、MiniMax、DeepSeek） | 🟡 OpenAI 相容 | 🟡 透過 Claude Code 訂閱 | 🟡 透過 Claude Code / Codex 訂閱 | 🟡 OpenAI 相容 |
+| **檢索演算法** | ✅ Personalized PageRank（Haveliwala 2002）+ Monte Carlo（Fogaras 2005） | 🟡 4 信號啟發式（Adamic-Adar + 2 跳衰減） | ❌ 僅 Louvain 社群偵測 | ❌ Louvain + k-hop 預覽 | ❌ 混合：BM25 + 語義 + wikilink |
+| **查詢管線（5 階段級聯）** | ✅ Lex → LLM 關鍵詞 → 子字串掃描 → LLM KB 回退 → PPR 擴展（在第一個足夠信號處截斷） | 🟡 僅 2 跳衰減 | ❌ 僅 Louvain 聚類 | ❌ k-hop 預覽（無 LLM 增強） | ❌ 基於區塊的 BM25 + 語義（無圖譜） |
+| **需要嵌入** | ✅ 不需要（刻意為之，零嵌入成本） | 🟡 可選，預設關閉 | ✅ 不需要 | ✅ 不需要 | ❌ **強制需要** |
+| **圖譜視覺化** | ✅ Obsidian 原生圖譜檢視（內建，零額外體積） | ❌ 桌面應用中自訂 sigma.js + graphology | 🟡 vis.js graph.html（獨立檔案） | ❌ 自訂 sigma.js 離線 HTML | ❌ 唯讀瀏覽器檢視器 |
+| **Wiki 誠實度** | ✅ 當查詢沒有匹配的 Wiki 來源時顯示「Stage FALLBACK」提示 | ❌ 無對應功能 | ❌ 無對應功能 | ❌ 無對應功能 | ❌ 無對應功能 |
+| **公開檢索基準** | ✅ PPR @5 = 27.1% vs 純 kNN 24.1%（此領域唯一公開的數字） | ❌ 58% → 71% *僅在有嵌入時*，格式不可直接比較 | ❌ 未公開 | ❌ 未公開 | ❌ 未公開 |
+
+### 我們刻意選擇的三件事
+
+- **🪟 Obsidian 就是執行環境。** 不需要終端機、獨立應用、Docker 或 Python。從社群外掛市集安裝，按一下「攝入」，Wiki 從第一秒就存在你的 vault 中。Obsidian 原生的圖譜檢視會呈現你的 `[[wiki-link]]` 圖譜——內建功能，完全不增加套件體積。
+- **🧭 簡潔且自包含。** 零依賴。不需要嵌入模型、向量資料庫或 pip 套件——單一外掛就能讀取筆記、與 LLM 溝通、並寫入 Wiki 頁面。一切都在 Obsidian 內部運作。
+- **🔌 任何你已付費的模型都能用。** Anthropic、Bedrock、OpenAI、ChatGPT Plan (Codex OAuth)、DeepSeek、Kimi、GLM、MiniMax、LM Studio、Ollama、OpenRouter、Anthropic 相容、自訂端點——十二種以上的 Provider，沒有一個需要嵌入端點。
+
+---
+
+## 🎯 適合我嗎？
+
+**✅ 適合，如果你：**
+
+- **想要 5 分鐘設定，而不是 5 小時的專案。** 從社群外掛安裝 → 選擇 Provider → 攝入一則筆記。不需要 CLI、Python、獨立執行環境或向量 DB。幾秒內就能在 `wiki/` 中看到 Wiki 頁面。
+- **想要簡潔且自包含的解決方案。** 此外掛完全零外部依賴：沒有嵌入模型、向量資料庫、pip 套件或 Docker 容器。它就是一個讀取筆記、與 LLM 溝通、並將 Wiki 頁面寫入 vault 的單一 Obsidian 外掛。一切都在 Obsidian 內部運作。
+- **想要一個能從*你的筆記*中回答問題的對話式查詢**——而不是網際網路——每個回答都附帶 `[[wiki-links]]` 引回你的知識圖譜。
+- **重視資料主權**——搭配 Ollama 或 LM Studio 可完全本地執行，永不觸網。
+- **使用或閱讀 10 種支援語言中的任何一種**——UI 和 Wiki 輸出語言互相獨立（你的 Wiki 可以用中文，介面用英文）。
+- **透過編寫 `[[wiki-links]]` 來維護圖譜**——你寫的每個連結都在增強檢索；不需要額外的標籤/嵌入/索引步驟。
+- **想要一鍵維護**——Lint 健康掃描 + 一鍵智慧修復讓重複、斷鏈和孤立頁面保持整潔，無需手動整理。
+
+**❌ 不適合，如果你：**
+
+- **想要一個通用 ChatGPT 替代品**——此外掛只從*你的知識庫*回答問題。
+- **需要對 PDF/網頁/外部語料庫進行 RAG 管線處理**——我們專注於 vault 內路徑（v1.25.0 起支援 PDF）。
+- **正在尋找託管式 SaaS**——沒有後端、沒有伺服器、沒有帳號。
 
 ---
 
 ## 🚀 快速開始
 
-### 📦 安裝
+1. **安裝。** Obsidian → 設定 → 社群外掛 → 瀏覽 → 搜尋「Karpathy LLM Wiki」→ 安裝 → 啟用。或造訪 [社群外掛頁面](https://community.obsidian.md/plugins/karpathywiki) 點選 **Add to Obsidian**。
+2. **設定 Provider。** 開啟設定 → Karpathy LLM Wiki → 選擇 Provider（OpenAI、Anthropic、Ollama、ChatGPT Plan (Codex OAuth) 等）→ 輸入 API Key（本地模型不需要）→ 點選 **測試連線** → 儲存。
+3. **攝入一則筆記。** `Cmd+P/Ctrl+P` →「攝入單個源文件」→ 選擇任意 Markdown（或 PDF，v1.25.0+）檔案。幾秒內你的第一篇 Wiki 頁面就會出現在 `wiki/sources/`、`wiki/entities/` 和 `wiki/concepts/` 中。
 
-**🌟 推薦 — Obsidian 社區插件市場：**
+就是這麼簡單。外掛不會修改你原本的筆記——只會在 `wiki/` 下建立新頁面。要與你的 Wiki 對話：`Cmd+P/Ctrl+P` →「查詢 Wiki」。（macOS 使用 `Cmd`，Windows/Linux 使用 `Ctrl`。）
 
-1. 在 Obsidian 中打開 **設置 → 第三方插件**
-2. 點擊 **瀏覽**，搜索 "Karpathy LLM Wiki"
-3. 點擊 **安裝**，然後 **啓用**
+### 核心指令
 
-**🌐 或從社區插件網站安裝 —** 訪問 [community.obsidian.md/plugins/karpathywiki](https://community.obsidian.md/plugins/karpathywiki)，點擊 **Add to Obsidian** 即可直接安裝。
+| 指令 | 功能說明 |
+|------|----------|
+| **📥 攝入單個源文件** | `Cmd+P/Ctrl+P` →「攝入單個源文件」— 選擇 Markdown 或 **PDF (v1.25.0+)** 檔案，產生實體/概念/Wiki 頁面 |
+| **📂 從文件夾攝入** | `Cmd+P/Ctrl+P` →「從文件夾攝入」— 批次處理資料夾內所有筆記，含智慧批次跳過 |
+| **📑 多選文件攝入** | `Cmd+P/Ctrl+P` →「多選文件攝入」— 透過雙面板檔案樹選擇子集（含即時佇列 + 按檔案取消） |
+| **🔍 查詢 Wiki** | `Cmd+P/Ctrl+P` →「查詢 Wiki」— 在右側停靠側邊欄與你的 Wiki 對話；回答附帶 `[[wiki-links]]` |
+| **🛠️ 維護 Wiki** | `Cmd+P/Ctrl+P` →「維護 Wiki」— 全面健康掃描：重複頁面、斷鏈、空頁面、孤立頁面、缺失別名、矛盾 |
+| **⚡ 一鍵智慧修復** | 在 Lint Modal 內部 — 一鍵按因果順序修復，附各階段執行報告 |
+| **📋 重新生成索引** | `Cmd+P/Ctrl+P` →「重新生成索引」— 以目前頁面和別名重建 `wiki/index.md` |
+| **⏹ 取消** | `Cmd+P/Ctrl+P` →「取消目前提取」或點擊狀態列 — 在下一批次邊界安全停止 |
+| **📊 檢視攝入歷史** | `Cmd+P/Ctrl+P` →「檢視攝入歷史」— 可搜尋 UI，瀏覽歷史攝入、Lint 報告和維護記錄 |
 
-**⚙️ 手動安裝（備用）：**
-
-1. 從 [Releases](https://github.com/green-dalii/obsidian-llm-wiki/releases) 下載 `main.js`、`manifest.json`、`styles.css`
-2. 在 Obsidian 中打開 設置 → 第三方插件，在 **已安裝插件** 標籤頁點擊文件夾圖標，打開插件目錄
-3. 新建一個 `karpathywiki` 文件夾，將三個文件放入其中
-4. 回到 Obsidian，點擊刷新圖標 — **Karpathy LLM Wiki** 會出現在已安裝插件列表中
-5. 打開開關啓用
-
-**🔨 開發構建：** `git clone` 後執行 `pnpm install` 和 `pnpm build`。
-
-### 🔄 更新插件
-
-本項目迭代迅速，新功能、修復和改進會頻繁發佈。建議保持更新：
-
-**方式一 — 手動更新（推薦）：**
-1. 打開 **設置 → 第三方插件**
-2. 點擊 **檢查更新**
-3. 在列表中找到 **Karpathy LLM Wiki**，點擊 **更新**
-
-**方式二 — 開啓自動更新：**
-1. 打開 **設置 → 第三方插件**
-2. 開啓 **自動檢查插件更新**
-3. 新版本會被自動檢測，你可以擇機手動更新
-
-> 💡 **爲什麼要保持更新？** 每次發佈都可能包含新功能、性能優化和重要修復。我們會積極維護此插件——錯過更新意味着錯過更好的體驗。
-
-### 🔑 配置 LLM Provider
-
-1. 打開 設置 → Karpathy LLM Wiki
-2. 從下拉菜單選擇 Provider（包括 OpenAI 或 ChatGPT Plan (Codex OAuth)）
-3. API Provider 需填入 API Key（Ollama、LM Studio 和 ChatGPT Plan (Codex OAuth) 不需要）
-4. 非 Codex Provider 可點擊**獲取模型列表**或手動輸入模型名；ChatGPT Plan (Codex OAuth) 登入後會同步帳戶模型目錄，並提供**重新整理帳戶模型**按鈕
-5. 點擊 **測試連接**，然後 **保存設置**
-
-**Ollama 本地模型（無需 API Key）：** 安裝 [Ollama](https://ollama.com)，拉取模型（如 `ollama pull gemma4` 或 `ollama pull qwen3.5:27b`），在 Provider 下拉選擇 "Ollama (本地)"。
-
-**LM Studio 本地模型（無需 API Key）：** 安裝 [LM Studio](https://lmstudio.ai)，啓動其本地服務（默認 `http://localhost:1234/v1`），在 Provider 下拉選擇 "LM Studio（本地）"。LM Studio 內置 OpenAI 兼容服務，API Key 字段可選。
-
-**Anthropic 兼容（Coding Plan）：** 如果你的服務商提供 Anthropic 兼容的 API 端點（常見於 Coding Plan 訂閱），選擇 "Anthropic 兼容"，填入服務商提供的 Base URL 和 API Key。
-
-**ChatGPT Plan (Codex OAuth)（實驗性）：** 這與使用 OpenAI Platform API Key 並另行計費的 **OpenAI** Provider 相互獨立。選擇該 Provider 後，桌面端可點擊**使用瀏覽器登入**（localhost 回呼），桌面端和行動端均可點擊**使用裝置代碼**並在 OpenAI 頁面完成授權。外掛會從目前登入的 Codex 帳戶同步可選模型，只快取清理後的模型中繼資料；可用**重新整理帳戶模型**手動更新。目錄暫時無法使用時會保留上次成功快取或最小內建回退清單。之後測試連線並儲存。OAuth 憑據只存入 Obsidian SecretStorage，**登出**會清除憑據。可用性取決於 OpenAI Codex 的驗證、模型和額度政策；這是第三方相容功能，並非 OpenAI 合作項目或通用 ChatGPT API。
-
-### 🎮 使用方式
-
-| 方式 | 操作 |
+| 之前 | 之後 |
 |------|------|
-| **📥 攝入單個源文件** | `Cmd+P` → "攝入單個源文件" — 選擇筆記（Markdown 或 **PDF，v1.25.0+**），提取實體和概念生成 Wiki 頁面 |
-| **📂 從文件夾攝入** | `Cmd+P` → "從文件夾攝入" — 選擇文件夾，批量處理其中所有筆記 |
-| **📑 多選文件攝入** | `Cmd+P` → "多選文件攝入" — 通過遞迴文件夾樹 + 每文件複選框精確選擇筆記，批次攝取（帶實時佇列 + 按文件取消）|
-| **🎯 攝入當前文件** | 點擊左側 ribbon 的 `sticker` 圖示，或 `Cmd+P` → "攝入當前文件" — 直接攝入目前開啟的筆記 |
-| **🔍 查詢 Wiki** | `Cmd+P` → "查詢 Wiki" — 對話式提問，串流回答中自帶 `[[wiki-links]]` |
-| **🛠️ 維護 Wiki** | `Cmd+P` → "維護 Wiki" — 全面健康掃描：重複頁、斷鏈、空頁面、孤頁、缺失別名、矛盾。Schema 建議顯示在 Lint Modal 內 |
-| **📋 重新生成索引** | `Cmd+P` → "重新生成索引" — 重建 `wiki/index.md`，包含別名資訊 |
-| **📊 檢視攝入歷史 (v1.21.0)** | `Cmd+P` → "檢視攝入歷史" — 可搜尋、可篩選的介面瀏覽歷史攝入、Lint 報告和維護執行 |
-| **⏹ 取消目前操作** | `Cmd+P` → "取消目前提取" — 安全停止進行中的操作，保留已完成工作 |
-| **🎉 重建歡迎筆記 (v1.23.0)** | `Cmd+P` → "重建 Wiki 歡迎筆記" — 重新生成首次執行的歡迎筆記 |
+| `notes/machine-learning.md`（一個平面檔案） | `wiki/concepts/supervised-learning.md` 含 `[[雙向鏈接]]`、別名、來源引用，以及 `wiki/index.md` 中的條目 |
 
-重複攝入同一來源文件時，實體/概念頁以增量方式合併新資訊，摘要頁會重新生成。
+> 💡 **保持更新。** 新功能、修復和效能改善會頻繁推出。請前往設定 → 社群外掛 → 檢查更新，或開啟自動外掛更新。
+> 📖 詳細操作指南（安裝、PDF 設定、多 Provider 注意事項、升級）請見 [GitHub Discussions → Guides](https://github.com/green-dalii/obsidian-llm-wiki/discussions/categories/guides)。
+---
 
-> 💡 **批次智慧跳過：** 文件夾攝入時，外掛自動偵測已處理文件並跳過，節省時間和 API 成本。
-
-![命令面板 — 搜尋 "karpa" 檢視所有 Karpathy LLM Wiki 命令](assets/command-panel.png)
-
-### ⚠️ 從舊版本升級？
-
-> 🔧 **從 v1.24.x 升級。** PDF 擷取（v1.25.0）將快取寫入 `.obsidian/plugins/karpathywiki/pdf-cache/`（上限 100 MB / 1000 條 / 單條 10 MB；啟動時與每次批次擷取開始時按 LRU-by-mtime 淘汰）。你的 vault **預設不會被修改** —— 僅當在 Settings → Wiki Configuration → Wiki Folder 中開啟 **Write PDF Markdown to Vault** 時，才會於來源 PDF 旁寫一份 `<basename>.pdf.md` sidecar。兩個新設定 —— **Force PDF Support**（進階，預設關閉）與 **Write PDF Markdown to Vault**（預設關閉）—— 完全向後相容：舊 `data.json` 不帶這兩個欄位時會預設為 `false`。
-
-> 🔧 **從 v1.24.0 升級。** 此前僅保護頁面*來源提及*章節的內部註解標記 `<!-- reviewed: keep -->`（v1.24.0，#244）已移除。如需保留手動整理的來源提及章節，請在頁面 frontmatter 中設定 `reviewed: true`——它保護整個頁面（含來源提及），且不同於隱藏的註解標記，會顯示在屬性面板中、也不會被 Markdown linter 破壞。
-
-**向後相容。** 自 v1.0.0 起無破壞性變更——現有 Wiki 頁面、設定和工作流全部保留，無需重新配置。
-
-**升級後**，執行 **維護 Wiki** → **一鍵智慧修復** 按因果關係自動處理：
-1. 🏷️ 補全別名（LLM 批次產生翻譯、縮寫、變體名）
-2. 🔄 合併重複頁面（跨語言、縮寫、高相似度匹配）
-3. 🔗 修復斷鏈 / 連結孤頁 / 擴充空頁面
-
-然後**重建索引**，為每個頁面附加別名條目，啟用別名感知搜尋。
-
-> 📖 特定版本跳躍的詳細升級指南見 [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)。
-
-**建議檢查的設定項：** Force PDF Support（Settings → LLM Configuration → Advanced，預設關閉 —— 僅對非 NATIVE provider 有意義）、Write PDF Markdown to Vault（Settings → Wiki Configuration → Wiki Folder，預設關閉）、Wiki 輸出語言（獨立於介面）、提取粒度（極簡–精細 + 自訂）、頁面生成並行度（預設 3）、批次延遲（預設 300ms）。
-
-## ⚡ 最新動態 v1.25.x
-
-- **v1.25.2 (2026-07-22).** 標籤詞表 Phase 1（消除雙重來源）、Codex OAuth（ChatGPT Plan）、關聯連結資料夾前綴修復、頁面模板裸 `---` 修復、ESLint 0.4.1 路線 A。2515 個測試通過。
-- **v1.25.1 (2026-07-20).** 8 個靜默丟失修復（關聯頁面、Schema 章節、舊版 Mentions）、3 個大檔案拆分、DiskCache&lt;T&gt;、LM Studio 無需 API 金鑰攝入、建置驗證根因。2274 個測試通過。
-- **v1.25.0 (2026-07-18).** 僅快取 PDF 攝入（Level 1）、有界快取增長、可選的 Vault sidecar、Force PDF 通用開關、逐字提示詞、可取消攝入、本地模型指導、i18n 完整。2182 個測試通過。
-
-📋 [完整版本歷史 → CHANGELOG.md](../CHANGELOG.md)
 ## ✨ 核心特性
 
-### 📊 知識質量
+### 📚 知識品質
 
-- **🔍 實體/概念提取** — LLM 從筆記中提取實體（人物、組織、產品、事件等）和概念（理論、方法、術語等），生成獨立 Wiki 頁面，支持靈活提取粒度（極簡~5個、粗略~10、標準~50、精細~100、自定義1–500）平衡分析深度與 API 成本
-- **🏷️ 強制頁面別名** — 每個生成的頁面至少包含 1 個別名（翻譯、縮寫、變體名），支持跨語言重複檢測
-- **🔄 重複檢測與合併** — 語義分級捕獲真正的重複頁面（跨語言翻譯、縮寫、拼寫變體）；智能 LLM 融合合併內容並保留別名
-- **🧩 智能知識融合** — 多源更新時智能合併新信息不重複；矛盾保留並註明歸屬；`reviewed: true` 頁面受保護不被覆蓋
-- **📏 內容截斷保護** — API Key 與本機 Provider 使用 8000 max_tokens、自動檢測 stop_reason 並以 2× token 重試。實驗性的 ChatGPT Plan（Codex OAuth）路徑遵循 Codex 後端的輸出策略，不接受用戶端 max_output_tokens 上限。
-- **📝 原文引用保留** — 來源提及章節保留原語言引用，可選翻譯，確保可追溯性
+- **🔍 實體與概念提取** — LLM 從筆記中提取實體（人物、組織、產品、事件等）和概念（理論、方法、術語等），生成獨立頁面。粒度可設定（極簡 → 精細，外加自訂），讓你在成本與深度之間取得平衡。
+- **🏷️ 強制頁面別名** — 每個頁面至少包含一個別名（翻譯、縮寫、變體名），讓跨語言重複檢測能夠運作。
+- **🔄 分級重複檢測** — Tier 1（直接名稱匹配：跨語言、縮寫、高相似度標題）全部驗證；Tier 2（共享鏈接、中等相似度）填補剩餘 token 預算。
+- **🧩 智慧合併與矛盾狀態** — 重複頁面合併時保留別名；矛盾標記來源歸屬；`reviewed: true` 頁面受保護不被覆蓋。
+- **🎨 自訂標籤詞彙** — 在設定 → Wiki → 標籤詞彙模式 → *自訂* 中定義自己的實體類型和概念類型標籤清單；Lint 會報告任何使用了不在活動詞彙表內標籤的頁面。
 
-- **🎨 自訂標籤詞彙 (v1.18.0)。** 設定 → Wiki → 標籤詞彙模式 → *自訂* 可定義自己的實體類型和概念類型標籤清單（例如 `Medical_Arzneimittel`、`法规`）。外掛在提取 prompt 和 frontmatter 校驗中都會尊重你的詞彙表；現有的 Lint 稽核 (#85 v7) 會報告任何使用了不在活動詞彙表內標籤的頁面。
+### 📄 PDF 擷取 (v1.25.0+)
 
-![自訂標籤詞彙晶片輸入](assets/custom-tags.png)
+- **🔌 Provider 准入** — Anthropic、OpenAI 和 Bedrock 原生支援 PDF。對於其他任何 OpenAI/Anthropic 相容端點，請在設定 → LLM Configuration → Advanced 中開啟 **Force PDF Support**，讓外掛嘗試呼叫。關於 Apple Silicon 上的本地 OCR、第三方提取器（MinerU、Docling、Mathpix、Adobe）以及完整的 PDF 攝入指南，請參閱下方 [PDF OCR 路徑](#-pdf-ocr-路徑) 和 [docs/PDF-OCR-GUIDE.md](PDF-OCR-GUIDE.md)。
+- **🗄️ 有界快取** — `.obsidian/plugins/karpathywiki/pdf-cache/` 儲存以內容雜湊 + 模型 + converterVersion 為鍵值的轉換後 Markdown。三層防禦清理機制：總計 100 MB / 1000 條 / 單條 10 MB 上限，搭配 LRU-by-mtime 淘汰。
+- **📝 可選 vault sidecar** — 設定 → Wiki Configuration → Wiki Folder → *Write PDF Markdown to Vault* 在來源 PDF 旁寫入 `<basename>.pdf.md`（預設關閉 — 僅快取是預設行為）。
+- **🛡️ 逐字轉錄 Prompt** — OCR 風格的轉換，搭配 `[illegible]` / `[figure: ...]` 反幻覺標記；來自小型本地模型的 markdown 圍欄包裹會在寫入快取前自動清洗。
 
-### 📄 PDF 擷取 (v1.25.0)
+### 📄 PDF OCR 路徑
 
-從 vault 裡挑一份 PDF — 外掛透過你的 LLM Provider 原生檔案輸入讀取它，轉成 Markdown，再回到標準的 Markdown 擷取流程。所有既有的實體/概念/別名/`[[wiki-link]]` 工作流程保持不變。
+三種路徑，根據你的環境選擇：
 
-- **🔌 Provider 准入** — Anthropic、OpenAI、Bedrock Anthropic 和 Bedrock OpenAI 原生支援 PDF。其他任何 OpenAI/Anthropic 相容端點，請在 Settings → LLM Configuration → Advanced 中開啟 **Force PDF Support**，讓外掛嘗試呼叫（你的端點做最終判斷；失敗時會以本地化 Notice 引導使用者關閉該開關）。本地推薦設定請見 [本地 PDF OCR 路徑](#-本地-pdf-ocr-路徑-v1250)。
-- **🗄️ 內容雜湊快取** — 相同的 PDF + 相同模型 + 相同 converter version 直接回傳快取的 Markdown，無需 LLM 呼叫。快取位於 `.obsidian/plugins/karpathywiki/pdf-cache/`；快取鍵內嵌 `converterVersion`，prompt 升級時自動失效舊條目。
-- **📏 有界增長** — 三層防禦快取治理（總計 100 MB / 1000 條 / 單條 10 MB 上限）+ LRU-by-mtime 淘汰；啟動時與每次批次擷取開始時清理舊條目。預設僅快取 — 不會修改你的 vault。
-- **📝 可選 vault sidecar** — Settings → Wiki Configuration → Wiki Folder → **Write PDF Markdown to Vault** 在轉換完成後於來源 PDF 旁寫一份 `<basename>.pdf.md`。預設關閉（僅快取）。
-- **🛡️ 逐字轉錄 Prompt** — PDF→Markdown prompt 重寫為 OCR 風格的逐字轉換，搭配 `[illegible]` / `[figure: ...]` / `[equation: ...]` 反幻覺標記；小模型/本地模型把輸出包在 ```markdown 圍欄裡的，會在寫入快取前自動清洗。
-- **⏹ 可取消** — 轉換過程中點擊狀態列可中斷正在進行的 LLM 呼叫（經由 Vercel AI SDK v6）。
+1. **☁️ 雲端 Provider 原生 PDF 支援** — Anthropic、OpenAI 或 AWS Bedrock 直接讀取 PDF。直接攝入即可，無需額外設定。對於其他任何 OpenAI/Anthropic 相容端點，請在設定 → LLM Configuration → Advanced 中開啟 **Force PDF Support**。
+2. **🖥️ Apple Silicon 本地 OCR** — [oMLX](https://github.com/jundot/omlx) 整合了 Microsoft Markitdown 作為內建 PDF→Markdown 後端。在 oMLX 中啟用 Markitdown，載入 [Baidu Unlimited-OCR](https://huggingface.co/baidu/Unlimited-OCR)（3B / 570M 活躍參數，2026-06 開源）作為視覺模型，將外掛指向 oMLX 作為 Custom OpenAI-Compatible Provider，開啟 **Force PDF Support**，然後選擇 oMLX 正在服務的多模態模型。PDF 全程不離開你的機器。
+3. **🛠️ 第三方提取器（MinerU、Docling、Mathpix、Adobe）** — 對 PDF 執行獨立的提取器產生 `.md` 檔案，然後透過外掛的標準管線將它們作為一般 Markdown 筆記攝入。對於科學論文、掃描文件和數學密集的 PDF 最為可靠。
 
-### 💬 查詢與反饋
+📖 **三種路徑的完整設定指南**（雲端 Provider、oMLX 硬體分級、MinerU 安裝、快取維護）→ [docs/PDF-OCR-GUIDE.md](PDF-OCR-GUIDE.md)
 
-- **🔍 5 級 PPR 種子選擇級聯（v1.24.1 PATCH）** — 當你提出多跳問題時，Query Wiki 在任何生成啓動之前會通過五個互補階段組合答案：
-  1. **Lex 快速路徑** — 直接對每個實體/概念標題與別名做 token 重疊匹配（免費、即時；爲後續階段把關）
-  2. **LLM 關鍵詞生成** — LLM 從你的查詢中提出 8–12 個跨語言關鍵詞（處理同義詞、縮寫、對 token 重疊不敏感的術語）
-  3. **本地子串掃描** — 每個生成的關鍵詞在本地對頁面標題、別名與正文片段重新匹配（無額外 LLM 呼叫；補滿噪聲容忍的召回）
-  4. **LLM KB 回退** — 當 lex + 關鍵詞掃描信號不足時，LLM 對 top-N 候選重新針對完整 wiki 做一次語義篩選
-  5. **PPR 圖擴展** — 在 `[[wiki-link]]` 圖上從候選種子集運行 Personalized PageRank（Haveliwala 2002）；爲 LLM 提供圖感知的多跳上下文，線性檢索無法達到
+### 💬 查詢與維護
 
-  級聯會自動截斷到給出足夠信號的步驟 —— 沒有固定的 5 步開銷，lex 足夠時無 LLM 呼叫，需要 LLM 增強時精度不丟失。端到端相關性（專案自有基準語料上 PPR @5 = 27.1%）超過純 knn 基線（24.1%），無需嵌入。Stage 1.5（步驟 2–3）處理純 lex 漏掉的多跳問題；Stage 1.7（步驟 4）在 LLM 注入關鍵詞信號不足時回補；Stage 1.9（步驟 5）保證 LLM 看到的是鄰居上下文而非扁平 top-N 列表。取代了舊的二分 tier 級聯。
+- **🧭 5 階段 PPR 級聯** — 參閱 [檢索原理](#-檢索原理)。在 `[[wiki-link]]` 圖譜上執行 Personalized PageRank，提供圖感知的多跳上下文。
+- **🪟 右側停靠側邊欄** — 查詢 Wiki 以 Copilot 風格的右側 sidebar leaf 開啟（v1.22.1+），取代置中彈窗。
+- **🔍 Lint 健康掃描** — 單一指令即可檢測：重複頁面、斷鏈、空頁面、孤立頁面、缺失別名、矛盾。
+- **⚡ 一鍵智慧修復** — 按因果順序一鍵修復：補全別名 → 合併重複 → 修復斷鏈 → 鏈接孤立頁 → 擴充空頁面，附各階段執行報告。
+- **📊 操作歷史面板** — 可搜尋、可篩選的 UI，瀏覽歷史攝入、Lint 報告和維護記錄。
+- **🛡️ 攝入前置檢查** — 空檔案/純空白/僅含 frontmatter 的筆記會在 LLM 呼叫前被拒絕；內容雜湊去重可識別跨路徑的相同檔案。
 
-- **🤖 對話式查詢** — ChatGPT 風格對話框，流式 Markdown 輸出，自帶 `[[wiki-links]]`，多輪歷史
-- **🪟 右側停靠側邊欄 (v1.22.1, PR #196)。** Query Wiki 在 Copilot 風格的右側 sidebar leaf 中開啟（若已存在則複用），不再以居中彈窗出現。`message-circle` ribbon 圖示和 `Query Wiki` 指令啟動/顯示側邊欄，筆記與對話並排可見。所有功能保持不變。
+### 🔒 隱私
 
-![Query Wiki 側邊欄](assets/query-side-panel.png)
-- **📤 查詢到 Wiki 反饋** — 將有價值的對話保存到 Wiki，含實體/概念提取，保存前語義去重
-- **🔒 重複保存防護** — Hash 跟蹤阻止未變化對話的重複評估
+- **🚫 無後端、無追蹤、無分析。** 完全在 Obsidian 內部執行。網路僅用於與你設定的 LLM Provider 通訊。
+- **📁 來源檔案為唯讀。** 外掛從不修改你原始的 vault 筆記——只會在 `wiki/` 下建立新頁面。
+- **🦙 完全本地模式。** Ollama、LM Studio 或任何本地 OpenAI 相容端點 → 你的筆記永不離開你的機器。
+- **🔐 最小化權限。** Vault 檔案存取用於 Wiki 管理。剪貼簿存取僅在你於查詢 Modal 中點選「複製」按鈕時使用。
 
-### 🛠️ 維護能力
+### 🦙 本地優先
 
-- **🔍 Lint 健康掃描** — 一次全面報告檢測：重複頁面、斷鏈、空洞頁面、孤立頁面、缺失別名、矛盾
-- **🎯 語義分級重複檢測** — Tier 1（直接名稱匹配：跨語言、縮寫、高相似度標題）全部驗證；Tier 2（間接信號：共享鏈接、中等相似度）按 token 預算填充
-- **⚡ 一鍵智能修復** — 按因果關係順序批量修復：補全別名 → 合併重複 → 修復斷鏈 → 鏈接孤立頁 → 擴充空洞頁，完成後彈窗報告各階段執行結果
-- **🏷️ 別名補全** — 一鍵並行批量生成缺失別名，提升後續重複檢測準確率
-- **🔄 自動維護** — 多文件夾監聽、定時 Lint、啓動健康檢查（均可選）
-- **⚠️ 矛盾狀態機** — `檢測 → 審覈通過 → 已解決`（AI 修復）或 `檢測 → 待修復`（手動）
-- **🛡️ 攝入前置檢查（v1.21.0）** — 在任何 LLM 調用之前驗證每個源文件：空文件/純空白/僅含 frontmatter 的筆記會被直接拒絕；通過內容哈希去重識別跨路徑的相同文件。防止小模型在空白輸入上編造實體名。
-- **📊 操作歷史面板（v1.21.0）** — 可搜索、可篩選的 UI，用於查看歷史攝入、Lint 報告和維護運行記錄，含洞察驅動的 KPI 卡片和可點擊的頁面鏈接。
+- **🖥️ Ollama、LM Studio、OpenRouter、自訂端點** — 開箱即用。本地模型可用於查詢（較小的上下文窗口）；2000 頁 vault 的攝入通常需要長上下文雲端模型。
+- **📄 Apple Silicon 上 PDF OCR 路徑完全本地** — 請參閱上方 [PDF OCR 路徑](#-pdf-ocr-路徑)。
+- **🔐 ChatGPT Plan (Codex OAuth)** — 桌面端透過 `127.0.0.1:1455` 的迴圈回呼；行動端透過裝置代碼。憑證僅存在 Obsidian SecretStorage 中；登出會清除憑證。第三方 Codex 相容功能，並非 OpenAI 合作項目。
 
-![歷史面板](assets/history-panel.png)
-- **🧹 不完整頁面清理（v1.21.0）** — 中途中斷的攝入留下的半成品頁面會在啓動時自動歸檔至 Obsidian 的 `.trash`（可恢復）。
+### 🌐 語言
 
-### 🌐 LLM 與語言
-
-- **🔌 多 Provider 支持** — Anthropic、Anthropic 兼容（Coding Plan）、Gemini、OpenAI、DeepSeek、Kimi、GLM、MiniMax、LM Studio、OpenRouter、Ollama、自定義接口
-- **🔄 5xx 自動重試** — 全部客戶端在 HTTP 5xx/429/529 錯誤時指數退避重試（最多 2 次）
-- **📋 動態模型列表** — 從 Provider API 實時獲取
-- **🌐 Wiki 輸出語言** — 10 種語言獨立於界面（英/簡中/繁中/日/韓/德/法/西/葡/意），支持自定義輸入。
-- **🌍 全界面國際化** — 插件 UI 支持 10 種語言（英/簡中/繁中/日/韓/德/法/西/葡/意），269+ UI 字段完整翻譯，自然本地表達。
-- **⚡ 速率限制守護** — 並行生成觸發限流時自動檢測並提示：降低併發度、增大批次延遲、切換 Provider
-- **🦙 Web Clipper 高度兼容** — 一鍵添加官方 Obsidian Web Clipper 的 `Clippings/` 文件夾到監聽列表，網頁剪藏自動攝入 Wiki
-
-### 🏗️ 架構與性能
-
-- **🕸️ PPR over [[wiki-link]] 圖（v1.24.0+，v1.24.1 PATCH 完善）** — Personalized PageRank（Haveliwala 2002）在你 wiki 頁面之間 `[[wiki-link]]` 邊的有向圖上運行；級聯把 PPR 種子錨定在 top-N 候選集，多跳上下文最多經過 3 層擴展環。正是這個機制讓 Query Wiki 答案具備圖感知能力（"微軟創始人"問題通過 Bill Gates → Microsoft → 競爭者 解決，而非僅靠字面標題重疊）。2,137 頁的 vault 典型情況下熱路徑 + 3 跳擴展 < 100 ms，與 vault 規模無關。被查詢與反饋區所有 4 級種子級聯使用，並在 lint 重複檢測（間接鏈接把兩個候選頁面關聯起來時）也會用到。
-- **⚡ 並行頁面生成** — 可配置 1–5 併發頁面，默認 3（並行），大源文件 2–3× 加速，單頁錯誤隔離
-- **📚 迭代批量提取** — 自適應批次大小，消除長文檔的 max_tokens 瓶頸
-- **🏛️ 三層架構** — 你的 vault 筆記（唯讀）→ `wiki/`（LLM 生成的頁面，組織為 `wiki/sources/`、`wiki/entities/`、`wiki/concepts/`）→ `schema/`（共進化配置）
-- **🧩 模塊化代碼庫** — 20+ 個聚焦模塊，位於 `src/`
-
-### 🔒 隱私與安全
-
-- **無後端、無追蹤。** 插件完全在 Obsidian 內部運行——沒有外部服務器、沒有數據分析、沒有任何形式的數據收集。除非你主動配置 LLM 提供商，否則你的筆記永遠不會離開你的 vault。
-- **數據默認保留在本地。** 插件不會存儲、緩存或傳輸你的內容到你所選 LLM API 之外的任何地方。只有你發送用於攝入或查詢的文本會離開你的設備——且僅發往你配置的提供商。
-- **通過 Ollama、LM Studio 或本地提供商實現完全本地模式。** 爲了完全的數據主權，請使用本地運行的 LLM。你的筆記完全在你的機器上處理——不觸碰互聯網。
-- **最小化權限。** Vault 文件訪問用於 Wiki 管理（閱讀筆記、生成頁面、檢測死鏈）。網絡訪問僅用於與你所選提供商的 LLM API 通信。剪貼板訪問僅限於 Query 模態框中的"複製"按鈕——僅在您點擊時使用。
-
----
-## 📖 使用示例
-
-**輸入：** `sources/machine-learning.md`
-
-```markdown
-### Machine Learning
-Machine learning uses algorithms to learn from data.
-
-### Types
-- Supervised learning
-- Unsupervised learning
-- Reinforcement learning
-```
-
-**輸出 — 實體頁：** `wiki/entities/supervised-learning.md`
-
-```markdown
----
-type: entity
-created: 2025-12-01
-updated: 2026-05-15
-sources: ["[[sources/machine-learning]]"]
-tags: [method]
-aliases: ["監督學習", "Supervised Learning"]
----
-
-### Supervised Learning
-
-### 基本信息
-- 類型：method
-- 來源：[[sources/machine-learning]]
-
-### 描述
-監督學習是一種機器學習範式，模型從帶標籤的訓練數據中學習，
-從而對未見數據做出預測……
-
-### 相關概念
-- [[concepts/Machine-Learning|Machine Learning]]
-- [[concepts/Unsupervised-Learning|Unsupervised Learning]]
-
-### 相關實體
-- [[entities/Arthur-Samuel|Arthur Samuel]]
-
-### 來源提及
-- "Supervised learning uses labeled data to train predictive models..."
-```
+- **🌍 10 種 UI 語言** — 英文、簡體中文、繁體中文、日文、韓文、德文、法文、西班牙文、葡萄牙文、義大利文。UI 和 Wiki 輸出語言互相獨立——你的 Wiki 可以是中文而介面是英文。
+- **📚 10 種 Wiki 輸出語言** — 同上；在設定 → Wiki Configuration 中選擇。*自訂輸入* 選項用於臨時提示。
+- **🈶 269+ 個翻譯 UI 字串** — 每個標籤、彈窗和通知。新增第 11 種語言由貢獻者驅動（PR #159 模式）。
 
 ---
 
-## 🤖 模型選擇建議
+## 🔍 檢索原理
 
-本插件遵循 Karpathy 的核心理念：**將完整 Wiki 上下文直接餵給 LLM，而非切成碎片做 RAG 檢索**。強烈推薦選擇長上下文窗口的模型——Wiki 越大，LLM 越需要足夠的上下文來保持跨頁面一致性。
+大多數「AI 搜尋」外掛會將你的筆記切成區塊並嵌入向量資料庫。我們不這麼做。Karpathy 反對 RAG 的理由是：區塊化破壞了 LLM 在整個知識圖譜上推理的能力——而這個論點在實務上是成立的。我們的做法是：在你透過編寫 `[[wiki-links]]` 已經維護的圖譜上直接走訪。
 
-> 💡 爲什麼不使用 RAG？Karpathy 在[原始構想](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)中指出，RAG 將知識碎片化，破壞了 LLM 在完整知識圖譜上的推理能力。
+### 5 階段種子選擇級聯
 
-**💰 性價比優先策略：** 不必追求旗艦模型。以下**經濟實惠的替代方案**能以更低成本獲得出色效果：
+當你問「誰創辦了 Microsoft？」時，查詢 Wiki 在生成任何答案之前會執行五個階段：
 
-### ☁️ 雲端模型推薦
+1. **Lex 快速路徑** — 直接對每個實體/概念標題與別名做 token 重疊匹配。免費、即時，且為後續階段的把關步驟。
+2. **LLM 關鍵詞生成** — LLM 從你的查詢中提出 8–12 個跨語言關鍵詞（一次 LLM 呼叫即可處理同義詞、縮寫和 token 重疊不敏感的術語）。
+3. **本地子字串掃描** — 每個生成的關鍵詞在本地對頁面標題、別名與正文片段重新匹配。無額外 LLM 呼叫；補滿雜訊容忍的召回。
+4. **LLM KB 回退** — 當 lex + 關鍵詞掃描信號不足時，LLM 對 top-N 候選針對完整 wiki 重新做一次語義篩選。
+5. **PPR 圖擴展** — 從候選種子集開始，在 `[[wiki-link]]` 圖譜上執行 Personalized PageRank（Haveliwala 2002）。這就是提供圖感知多跳上下文的機制：「比爾蓋茲」→「Microsoft」→「競爭對手」，而非僅靠字面標題重疊。
 
-| 檔位 | 模型 | 上下文窗口 | 推薦理由 |
-|------|------|-----------|----------|
-| **🌟 性價比首選** | **DeepSeek V4-Flash** | 1M tokens | 最低價($0.14/M)，284B MoE，批量攝入首選 |
-| **🌟 性價比首選** | **Gemini-3.5-Flash** | 1M tokens | 輸出速度比 GPT-5.5 快 4 倍，智能體任務出色 |
-| **🌟 性價比首選** | **Qwen3.6-Plus** | 1M tokens | 編碼和智能體能力強勁，價格有競爭力 |
-| **🌟 性價比首選** | **Grok-4** | 2M tokens | xAI 2025-07 flagship, 2M context, strong reasoning & code tasks |
-| **均衡型** | **Claude Sonnet 4.6** | 1M tokens | 質量與成本平衡佳，$3/$15 每百萬 token |
-| **輕量型** | **Claude Haiku 4.5** | 200K tokens | 快速經濟，適合小型 Wiki |
-| **經濟型** | **Xiaomi MiMo-V2.5** | 1M tokens | 小米 310B/15B MoE，2026-04 MIT 開源，Agent 與多模態 |
-| **旗艦型** | Claude Opus 4.7 | 1M tokens | 極致質量，成本較高 — 選擇性使用 |
-| **旗艦型** | GPT-5.5 | 1M tokens | 頂級推理，成本較高 — 選擇性使用 |
+級聯會在第一個提供足夠信號的步驟處截斷——沒有固定的 5 步開銷，lex 足夠時無需 LLM 呼叫，需要 LLM 增強時也不會損失精度。
 
-### 🦙 本地模型推薦 (Ollama / LM Studio)
+### 規模化的 Personalized PageRank
 
-本地推理的最大優勢是資料主權、離線可用、零 API 費用；代價是上下文窗口較小（多為 8K–128K，近期開源權重可達 262K）以及指令遵循能力不及旗艦雲端模型。**依硬體預算選型：** 參數越大，世界知識與指令遵循越強（抽取品質越高、幻覺越少）；參數越小，速度與顯存越省，但幻覺與長上下文推理能力會明顯下降。24 GB Apple Silicon 或單張消費級 GPU 上的甜蜜點是 27B–35B-A3B 級別。
+我們使用 Monte Carlo PPR（Fogaras 2005）——3,000 條隨機漫步 × 每條 50 步——搭配 Haveliwala 2002 的 dead-end 規則。成本為 **O(K × L)**，與頁面數量無關，因此 2000 頁的 vault 與 200 頁的 vault 有相同的擴展延遲。
 
-| 模型 | 參數量 | 上下文 | 推薦理由 |
-|------|--------|--------|----------|
-| **Qwen3.5 27B** | 27B dense | 262K | 攝入場景下品質與體積的最佳平衡；MLX 4-bit 可裝進 24 GB |
-| **Qwen3.5 35B-A3B** | 35B 總 / 3B 啟用 MoE | 262K | 速度優於 27B dense，品質相當；理想的顯存節省方案 |
-| **Qwen3.5 122B-A10B** | 122B / 10B MoE | 262K | 品質上限；需要 ≥48 GB 顯存或雙卡 |
-| **Qwen3.6 27B** | 27B dense | 256K+ | 2026-04 在 Qwen3.5 27B 之上的更新版，硬體能扛得住時優先選這個 |
-| **Qwen3.6 35B-A3B** | 35B / 3B MoE | 262K | 與 Qwen3.5 35B-A3B 同樣的取捨，權重更新 |
-| **Gemma 4 31B IT** | 31B dense | 262K | 指令遵循強，Markdown 輸出乾淨 |
-| **Gemma 4 26B A4B IT** | 26B / 4B MoE | 262K | 比 31B dense 更省顯存，品質相當 |
-| **Gemma 4 E2B / E4B IT** | 2B / 4B | 131K | 可純 CPU 運行；僅適合小型 Wiki 或快速預覽 |
+**PPR @5 = 27.1% vs 純 kNN 基線 24.1%**——以專案自有基準語料庫測試（此開源 LLM-Wiki 領域唯一公開的檢索基準）。
 
-**量化建議：** Apple Silicon 上 MLX 4-bit 通常比同等有效位元率的 GGUF Q4_K_M 快 1.5–2×。GGUF Q4_K_M 是跨平台的預設選擇；只有當顯存有富餘且發現 Q4 品質有可見回歸時再考慮 Q5/Q8。
+### 爲什麼不使用嵌入
 
-**上下文策略：** Wiki 超過 ~500 頁時，262K 本地模型仍能覆蓋 Query 引擎組裝的大多數上下文，但 2000 頁 vault 的攝入會超出其能力。常見組合：雲端攝入 + 本地查詢。若堅持全程本地，27B/35B-A3B 級別是甜蜜點。
-
-### 📄 本地 PDF OCR 路徑 (v1.25.0+)
-
-v1.25.0 的 PDF 擷取支援任何接受 PDF 作為檔案部分的 Provider。要在 Apple Silicon（oMLX 目前唯一支援的平台）上搭建完全本地的管線，推薦設定如下：
-
-1. 安裝 [oMLX](https://github.com/jundot/omlx)，啟用其內建的 **Markitdown** 後端（本地 PDF→Markdown 轉換）。
-2. 載入 **百度 Unlimited-OCR**（2026-06-22 開源，3B 總參 / 0.5B 啟用，端到端 OCR，攻克長文檔「越生成越慢」的舊模型通病）作為 oMLX 的視覺模型。
-3. 在本外掛中：Provider 選 **Custom OpenAI-Compatible**（oMLX 走 OpenAI 相容協議），把 Base URL 指向 oMLX 的本地服務地址，Settings → LLM Configuration → Advanced 中開啟 **Force PDF Support**，擷取總結時選用 oMLX 提供的多模態模型。
-
-PDF 全程不離開你的機器 — Markitdown 做結構化轉換，Unlimited-OCR 做視覺識別，本地 LLM 做摘要。本外掛的快取（`.obsidian/plugins/karpathywiki/pdf-cache/`）讓重複擷取保持即時。
-
-**回退方案：** 若 oMLX/Markitdown 不可用（Linux/Windows 或較舊的 Mac），把 **Force PDF Support** 直接指向接受 PDF 檔案部分的本地多模態 LLM — 模型足夠大時品質不錯，但顯存需求隨頁數急劇上升。
-
-**🔌 Anthropic Compatible (Coding Plan):** 如果你的 Provider 提供 Anthropic 兼容 API 端點，選擇 "Anthropic Compatible" 並輸入 Provider 的 Base URL 和 API Key。
-
-> 💡 **OpenAI 計費邊界：** **OpenAI** 使用另行計費的 Platform API Key；**ChatGPT Plan (Codex OAuth)** 是獨立的實驗性 Provider，透過瀏覽器或裝置代碼登入後使用符合資格的 Codex 方案額度，不能僅憑方案名稱保證可用。
+我們在 [Issue #175](https://github.com/green-dalii/obsidian-llm-wiki/issues/175) 中刻意拒絕了嵌入路徑。圖譜訊號已經存在——每個 `[[wiki-link]]` 都是一條手工維護的「這些內容相關」的邊，而且我們支援的大多數 Provider（Ollama、LM Studio、Anthropic、Bedrock、Kimi、GLM、MiniMax）根本沒有 `/v1/embeddings` 端點。加入嵌入模型意味著每次頁面下載、每個 Provider 適配器，而檢索品質上沒有任何提升。
 
 ---
 
-## 🏗️ 架構
+## 🤖 模型
 
-基於 Karpathy 的三層分離設計：
+**支援的 Provider（12 種以上，2026-07 經 models.dev 交叉驗證）：**
 
-```
-📄 你的 vault 筆記（任意資料夾）  # 📖 你選擇哪些筆記進行攝取
-  ↓ ingest
-wiki/                              # 🧠 LLM 生成的 Wiki 頁面（wiki/sources/、wiki/entities/、wiki/concepts/）
-  ↓ query / maintain
-schema/                            # 📋 Wiki 結構配置（命名規範、頁面範本、分類規則）
-```
+| Provider | 系列 | 備註 |
+|----------|------|------|
+| **Anthropic** | Claude 5 系列 | 原生 PDF；`/v1/messages` 協定 |
+| **OpenAI** | GPT-5.6 系列（Sol / Terra / Luna） | 原生 PDF；Platform API Key |
+| **Google Gemini** | Gemini 3.6 系列 | 原生 PDF（自 1.5 起支援檔案部分）；OpenAI 相容端點 |
+| **DeepSeek** | DeepSeek V4 系列 | OpenAI 相容；最低成本 |
+| **Alibaba Qwen** | Qwen3.7/3.8 系列 | OpenAI 相容（DashScope） |
+| **xAI Grok** | Grok 4 系列 | OpenAI 相容；長上下文 |
+| **Moonshot Kimi** | Kimi K3 系列 | OpenAI 相容；2.8T MoE 前沿模型 |
+| **Zhipu GLM** | GLM-5 系列 | OpenAI 相容；雙語能力強 |
+| **MiniMax** | MiniMax M3 系列 | OpenAI 相容；1M 上下文 |
+| **Step（階躍星辰）** | Step 3 系列（Flash） | OpenAI 相容；推理速度快 |
+| **Tencent Hunyuan** | Hy3 系列 | OpenAI 相容；開源權重 MoE |
+| **Xiaomi MiMo** | MiMo V2.5 系列 | MIT 開源；平價方案 |
+| **Google Gemma** | Gemma 4 系列 | 開源權重；262K 上下文 |
+| **AWS Bedrock** | Anthropic + OpenAI 變體 | VPC / 合規路徑 |
+| **ChatGPT Plan (Codex OAuth)** | Codex Responses API | 瀏覽器/裝置代碼登入；SecretStorage |
+| **本地：Ollama、LM Studio、OpenRouter、Anthropic 相容** | 任何 OpenAI/Anthropic 協定模型 | Custom OpenAI-Compatible + Anthropic-Compatible（Token Plan / Coding Plan） |
 
-> 📖 完整程式碼結構見 [CONTRIBUTING.md → Project Structure](../CONTRIBUTING.md#project-structure)。
+此外掛在每次查詢時會將完整的 Wiki 上下文餵給 LLM——所以**長上下文模型勝出**。完整的分級表（雲端 + 本地）請見 [docs/MODEL-GUIDE.md](MODEL-GUIDE.md)，已與 [models.dev](https://models.dev/) 交叉驗證以確保建議保持最新。
 
-**生成的頁面結構：**
-- `wiki/sources/檔名.md` — 📄 來源文件摘要
-- `wiki/entities/實體名.md` — 👤 實體頁（人物、組織、專案等）
-- `wiki/concepts/概念名.md` — 💡 概念頁（理論、方法、術語等）
-- `wiki/index.md` — 📑 自動生成的索引
-- `wiki/log.md` — 📝 操作日誌
+### 什麼才重要
+
+- **🧠 上下文窗口 ≥ 200K tokens**——適用於超過 ~500 頁的 vault。低於 200K 時，級聯組合的上下文會開始被截斷。
+- **⚖️ 指令遵循品質比原始 IQ 更重要**——提取任務選擇能正確遵循 schema 模板的模型，而不是排行榜上最大的數字。
+- **🔌 嵌入端點無關緊要**——我們不使用嵌入。沒有 `/v1/embeddings` 的 Provider 完全沒問題（我們 12 種以上的 Provider 大多如此）。
+- **🦙 本地用於查詢，雲端用於攝入**——2000 頁 vault 的攝入通常需要長上下文雲端模型；262K 的本地模型可涵蓋大多數查詢。
+
+### Anthropic vs OpenAI vs Codex OAuth——三者是不同的 Provider
+
+- **Anthropic**（及其 Bedrock 變體）——單獨計費的 Anthropic Platform API Key。
+- **OpenAI**——單獨計費的 OpenAI Platform API Key。
+- **ChatGPT Plan (Codex OAuth)**——實驗性的獨立 Provider，在瀏覽器或裝置代碼登入後使用符合資格的 Codex 方案額度；可用性取決於 OpenAI Codex 的驗證和額度政策，而非僅憑方案名稱。這是第三方 Codex 相容功能，並非 OpenAI 合作項目或通用 ChatGPT API。
+
+> 📖 **完整選擇表**（雲端 + 本地 + PDF OCR + Codex OAuth + 量化 + 硬體分級）→ [docs/MODEL-GUIDE.md](MODEL-GUIDE.md)
 
 ---
 
 ## ❓ 常見問題 (FAQ)
 
-> **請保持外掛更新** — 新功能和修復頻繁推出。在 Obsidian 中定期前往 **設定 → 第三方外掛 → 檢查更新**。
->
-> 📖 更多問答見 [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions/28)。
+### 此外掛到底能做什麼？
 
-**這個外掛到底能做什麼？**
-從你的 vault 中任意選擇一篇筆記、一個資料夾或一組檔案，LLM 自動提取實體與概念，生成帶 `[[雙向連結]]` 的互聯 Wiki。提問時獲得基於*你的*筆記的對話式答案——而非網際網路搜尋。生成的摘要放在 `wiki/sources/`，實體放在 `wiki/entities/`，概念放在 `wiki/concepts/`，而你原始的 vault 筆記不會被任何修改。
+選擇任意筆記、資料夾或選取範圍；LLM 提取實體和概念，生成帶有 `[[雙向鏈接]]` 的互聯 Wiki。提出問題，獲得基於*你的*筆記的對話式答案——而非網際網路。你的原始 vault 筆記永遠不會被修改。
 
-**我的資料會被發送給第三方嗎？**
-🔒 **隱私優先。** 無後端、無追蹤、無分析——外掛完全在 Obsidian 內部執行。只有你主動發送用於攝入/查詢的文字才會離開你的裝置，且僅發往你配置的 LLM 提供商。如需完全資料本地化，使用本地 Provider（Ollama 或 LM Studio，無需 API key）——你的資料永不觸網。
+### 如何開始使用？
 
-**這和 RAG 聊天機器人有何不同？**
-不同於碎片化上下文的 RAG，LLM-Wiki 執行**個性化 PageRank** 引擎，基於你現有的 `[[wiki-link]]` 圖結構查詢相關頁面——而非向量 embedding。這意味著零 embedding 成本、無新依賴、完全支援本地和離線模型。
+從 Obsidian 社群外掛安裝 → 選擇 Provider → **測試連線** → 在任何筆記上執行 **攝入單個源文件**。第一篇 Wiki 頁面在幾秒內就會出現。請見 [快速開始](#-快速開始)。
 
-**該選哪個 LLM？**
-推薦長上下文模型（≥200K tokens）。價效比首選：DeepSeek V4-Flash ($0.14/M)、Gemini 3.5 Flash、Qwen3.6-Plus。本地模型（Ollama/LM Studio）可用於查詢，但上下文視窗較小（8K–128K）。詳見[模型選擇建議](#-模型選擇建議)。
+### 我現有的 Wiki 安全嗎？
 
-**如何開始使用？**
-從 Obsidian 社群外掛市場安裝 → 選擇 LLM Provider → **測試連線** → 在 vault 中任意筆記上執行 **攝取單個來源檔案**（或 **從資料夾攝取**）→ 數秒內即可生成首批 Wiki 頁面。詳見[快速開始](#-快速開始)。
+✅ 自 v1.0.0 起向後相容。在任何頁面設定 `reviewed: true` 以保護不被覆蓋。從 v1.24.x 升級不會改寫你的 vault；v1.25.0 的 PDF 攝入預設為僅快取。
 
-**如何控制 API 成本？**
-使用粗略或極簡提取粒度進行批次攝入（更少 LLM 呼叫）。批次智慧跳過自動偵測已處理檔案。自動維護預設關閉（按需開啟）。Lint 在執行修復前顯示計數——不經你確認不會產生費用。
+### 我的資料會被傳送到任何地方嗎？
 
-**我的現有 Wiki 安全嗎？**
-✅ 自 v1.0.0 向後相容。在任何頁面設定 `reviewed: true` 以保護不被覆蓋。外掛從不修改你原始的 vault 筆記——只會在 `wiki/` 資料夾內生成新頁面。
+🚫 沒有後端、沒有分析——此外掛完全在 Obsidian 內部執行。只有你明確用於攝入/查詢的文字會離開你的裝置，且僅發往你設定的 LLM Provider。如需完全資料本地化，請使用 Ollama 或 LM Studio。
 
-**可以用我的語言使用嗎？**
-🌐 **10 種語言** 支援介面和 Wiki 輸出：English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano。介面語言和 Wiki 語言互相獨立。
+### 可以用我的語言使用嗎？
 
-**最低配置要求？**
-Obsidian v1.11.4+（桌面端或行動端）。需要 LLM Provider API Key、Ollama/LM Studio 本地模型，或已授權的 ChatGPT Plan (Codex OAuth) 憑據。外掛的 **llmReady 守衛** 要求先通過連線測試才能使用核心功能——防止因配置錯誤導致的靜默失敗。
+🌍 **10 種語言**支援介面和 Wiki 輸出。介面語言和 Wiki 語言互相獨立。新增第 11 種語言由貢獻者驅動（PR #159 模式）。
 
-**如何取消正在執行的操作？**
-點擊狀態列文字（顯示"攝入中… 點選取消"），或 `Cmd+P` → "取消目前提取"。安全停止於下一批次邊界，保留已完成的工作。
+### 這和 RAG 聊天機器人有何不同？
 
-**如何獲得幫助？**
-- [GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) — 提交 Bug
-- [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) — 提問與反饋
-- 開發者工具（`Ctrl+Shift+I` / `Cmd+Option+I`）— 複製日誌，加速問題排查
+🚫 不切分區塊。🚫 不使用嵌入。🚫 不需要向量 DB。✅ 在你現有的 `[[wiki-link]]` 圖譜上執行 Personalized PageRank——圖感知的多跳上下文，零嵌入成本，完全支援本地模型。
 
-## 🔒 透明度與合規性
+### 該選哪個 LLM？
 
-本插件已上架 Obsidian 社區插件市場，並接受安全與權限的自動化審查。
+長上下文模型（≥200K tokens）效果最佳。[模型](#-模型) 章節涵蓋了選擇原則；完整的分級表請見 [docs/MODEL-GUIDE.md](MODEL-GUIDE.md)。
 
-**本插件沒有後端、沒有服務器基礎設施、不進行任何形式的數據收集。** 它是純粹運行在 Obsidian 內部的本地軟件。插件不能也不會有任何方式收集、存儲或傳輸你的數據到任何服務器——因爲這樣的服務器根本不存在。
+### 有公開的基準測試嗎？
 
-**網絡訪問**僅用於與你配置的 LLM 提供商通信——不會進行其他網絡調用。這完全由你掌控：你選擇提供商、你輸入 API 密鑰、你決定數據發往何處。
+有——PPR @5 = 27.1% vs 純 kNN 基線 24.1%，基於專案自有語料庫。完整的管線和基準測試腳本請見 [檢索原理](#-檢索原理)。
 
-**文件系統訪問**（vault 枚舉）用於構建和維護 Wiki：閱讀你的源筆記、生成頁面、掃描死鏈、檢測重複頁面。插件從不修改你的源文件——僅修改 wiki 文件夾下的文件。
+### 如何控制 API 成本？
 
-**剪貼板訪問**僅用於 Query 模態框中的"複製"按鈕，且僅在你點擊時使用。
+批次攝入時使用粗略或極簡提取粒度。智慧批次跳過自動偵測已處理的檔案。自動維護預設關閉。Lint 在執行修復前會顯示計數——不經你確認不會產生費用。
 
-如果你希望數據完全保留在本地，請使用 Ollama 或 LM Studio 等本地 LLM 提供商。使用本地提供商時，你的數據永遠不會離開你的機器。
+### 如何取消正在執行的操作？
+
+點擊狀態列文字（顯示「攝入中… 點選取消」），或 `Cmd+P/Ctrl+P` →「取消目前提取」。在下一批次邊界安全停止，保留已完成的工作。
+
+### 在哪裡獲得幫助？
+
+[GitHub Issues](https://github.com/green-dalii/obsidian-llm-wiki/issues) 用於回報錯誤 · [GitHub Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions) 用於提問和功能請求 · 開發者主控台（`Ctrl+Shift+I` / `Cmd+Option+I`）用於檢視外掛日誌。
+
+---
+
+## 🔒 隱私
+
+此外掛已上架 Obsidian 社群外掛市集，並接受安全與權限的自動化審查。
+
+- **🚫 無後端、無伺服器、無資料收集。** 純粹在 Obsidian 內部運行的本地軟體。此外掛不能也不會以任何方式收集、儲存或傳輸你的資料到任何伺服器——因為這樣的伺服器根本不存在。
+- **🔐 網路存取為選擇性加入。** 僅用於與你設定的 LLM Provider 通訊。你選擇 Provider、你輸入 API Key、你決定資料前往何處。
+- **📁 Vault 檔案存取**用於 Wiki 管理（讀取筆記、生成頁面、掃描斷鏈、檢測重複）。外掛從不修改你的來源檔案。
+- **📋 剪貼簿存取**僅由查詢 Modal 中的「複製」按鈕使用——且僅在你點擊時使用。
+
+如需完全資料本地化，請使用 Ollama 或 LM Studio。使用本地 Provider 時，你的資料永遠不會離開你的機器。
+
+---
 
 ## 💖 支持專案
 
-如果 LLM-Wiki 已成為你知識工作流程中重要的一部分，你可以透過以下方式支持其持續開發：
+如果 LLM-Wiki 已成為你知識工作流程中重要的一部分：
 
-- ☕ **[在 Ko-fi 上請我喝杯咖啡](https://ko-fi.com/greenerdalii)** — 透過 Ko-fi 提供一次性或月度支持
-- 💳 **[透過 PayPal 打賞](https://paypal.me/greenerdalii)** — 透過 PayPal 一次性打賞
+- ☕ **[在 Ko-fi 上請我喝杯咖啡](https://ko-fi.com/greenerdalii)** — 一次性或月度支持
+- 💳 **[透過 PayPal 打賞](https://paypal.me/greenerdalii)** — 一次性打賞
 
-贊助完全自願。無論是否贊助，外掛始終保持 Apache-2.0 授權且功能完整。
+贊助完全自願。外掛始終保持 Apache-2.0 授權且功能完整。
 
-### 贊助者
+感謝 [@jameses-cyber](https://github.com/jameses-cyber) 和 [@issaqua](https://github.com/issaqua) 對專案的支持。
 
-感謝以下支持專案的人：
+---
 
-- [@jameses-cyber](https://github.com/jameses-cyber)
-- [@issaqua](https://github.com/issaqua)
+## 📜 許可證與致謝
 
-## 📜 許可證
+Apache License, Version 2.0 — 詳見 [LICENSE](../LICENSE) 與 [NOTICE](../NOTICE)。
 
-Apache License 2.0 — 詳見 [LICENSE](LICENSE) 與 [NOTICE](NOTICE)。
+**基於以下專案建構：**
+- 💡 [Andrej Karpathy 的 LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 原始概念
+- 🛠️ [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/)（`@ai-sdk/openai`、`@ai-sdk/anthropic`、`@ai-sdk/openai-compatible`）via Obsidian `requestUrl`
+- 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) 與 [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — 檢索演算法
 
-## 🙏 致謝
+**維護者：** [@green-dalii](https://github.com/green-dalii)
 
-- **💡 概念來源：** [Andrej Karpathy 的 LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — 本插件的原始構想
-- **🛠️ 開發平臺：** [Obsidian Plugin API](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
-- **🔌 LLM 傳輸層：** [Vercel AI SDK v6](https://ai-sdk.dev/)（`@ai-sdk/openai`、`@ai-sdk/anthropic`、`@ai-sdk/openai-compatible`）via Obsidian [`requestUrl`](https://docs.obsidian.md/Reference/TypeScript%20API/requestUrl)
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Re7j5hAKVwsf4431hDF3XjSFlxH6zaRXZ9VDYF_N3A-dMANR-lm7zRjkpsgqvgZf0mJ1ksxNsZk1-g91PBr1DxQDip_kRn2lEuradbANK2Y-q4x17R7RPhF8ML_08Ca9G-AqyPZeJemfXZp2NczsFmjqrJw8fGeBwVpdjS5zV917x4COLQDbEH_j64Pt)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)
+[![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karpathywiki",
-"version": "1.25.2",
+  "version": "1.25.2",
   "packageManager": "pnpm@10.14.0",
   "description": "Karpathy's LLM Wiki implementation - multi-page knowledge generation with conversational query",
   "main": "main.js",

--- a/src/llm-sdk/openai-codex/loopback-flow.ts
+++ b/src/llm-sdk/openai-codex/loopback-flow.ts
@@ -132,8 +132,18 @@ class NodeLoopbackServer implements LoopbackServer {
 }
 
 async function requireNodeHttp(): Promise<typeof import('node:http')> {
+  // Dynamic import (`await import(...)`) returns a fully-typed
+  // `typeof import('node:http')`; the function is declared `async` so the
+  // await is real. This satisfies the Obsidian bot's strict `no-unsafe-*`
+  // family: the value coming out of `require('node:http')` would be `any`
+  // (CommonJS require is typed as `any` per the standard library), but
+  // ESM dynamic import carries its module type through. We still keep the
+  // `require` form as a deliberate choice (loopback callback runs on
+  // desktop only and `require` lets us load the module before the file
+  // is done initializing), but we hide it behind a typed boundary so
+  // downstream callers never see `any`.
   // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef -- loopback callback server runs Node http on desktop only; callers guard via Platform.isDesktopApp. The `import/no-nodejs-modules` lint rule does not flag this line because it is paired with the type-only `import('node:http')` form on the next line, which keeps the static dependency graph explicit for tree-shaking.
-  const http = require('node:http') as typeof import('node:http');
+  const http: typeof import('node:http') = require('node:http') as typeof import('node:http');
   return http;
 }
 


### PR DESCRIPTION
## Summary

- EN README: 491→327 lines, 11-section layout with competition table, 5-stage PPR cascade, 12+ provider table, restructured FAQ
- docs/MODEL-GUIDE.md: cloud + local model picks by tier, hardware tables, models.dev-verified (2026-07-23)
- docs/PDF-OCR-GUIDE.md: cloud providers, local oMLX+Markitdown setup, third-party extractors, bounded cache docs
- loopback-flow.ts: dual-type annotation for Obsidian bot compliance

## Gate 1

- lint: 22 errors / 39 warnings — all pre-existing v1.25.2 baseline, no new issues introduced by this PR
- tsc: 0 errors
- tests: 2515/2515 passed
- build: clean
- css-lint: 0 violations

## Files changed

14 files, +2321/-3615