### PR TITLE
perf(dedup): cache-stable prompt layout — invariant list first, append-only order

### DIFF
--- a/src/__tests__/wiki/page-factory/dedup-prompt-order.test.ts
+++ b/src/__tests__/wiki/page-factory/dedup-prompt-order.test.ts
@@ -1,0 +1,105 @@
+// Cache-stable layout of the semantic dedup prompt.
+//
+// A local KV prefix cache reuses computation only up to the first byte
+// where consecutive prompts differ. Two properties make the dedup call
+// cacheable and both are pinned here:
+//
+//   1. Template order: the invariant {{existing_pages}} list must render
+//      BEFORE the per-call candidate block. With the candidate first,
+//      consecutive calls share only ~200 chars and every call pays the
+//      full prefill (measured: ~69-90 s per ~46K-token full-list call at
+//      520-630 tok/s; with the list first a repeat costs ~1.7 s).
+//
+//   2. List order: pages created during an ingest run must join the list
+//      at the END (ctime ascending). Alphabetical or vault-iteration
+//      order inserts mid-list and re-pays the suffix from the insertion
+//      point (measured: ~30 s for a mid-list insert vs ~1.2 s for
+//      append).
+
+import { describe, it, expect } from 'vitest';
+import { PROMPTS } from '../../../prompts';
+import {
+  resolvePagePath,
+  type PathResolutionContext,
+} from '../../../wiki/page-factory/path-resolution';
+import type { LLMWikiSettings } from '../../../types';
+
+describe('resolveEntityDedup template — invariant prefix first', () => {
+  it('renders the existing-pages list before the per-call candidate block', () => {
+    const t = PROMPTS.resolveEntityDedup;
+    const listPos = t.indexOf('{{existing_pages}}');
+    const namePos = t.indexOf('{{entity_name}}');
+    expect(listPos).toBeGreaterThan(-1);
+    expect(namePos).toBeGreaterThan(-1);
+    expect(listPos).toBeLessThan(namePos);
+  });
+});
+
+interface MockFile {
+  path: string;
+  basename: string;
+  stat?: { ctime: number };
+}
+
+function makeCtx(files: MockFile[], capture: { prompt?: string }): PathResolutionContext {
+  return {
+    settings: { wikiFolder: 'wiki', slugCase: 'preserve' } as LLMWikiSettings,
+    app: {
+      vault: {
+        getMarkdownFiles: () => files,
+        read: async () => '',
+      },
+    },
+    async tryReadFile(): Promise<string | null> { return null; },
+    async createOrUpdateFile(): Promise<void> { /* not reached */ },
+    getClient() {
+      return {
+        createMessage: async (...args: unknown[]) => {
+          const req = args[0] as { messages: Array<{ content: string }> };
+          capture.prompt = req.messages[0].content;
+          return JSON.stringify({ match: false });
+        },
+      };
+    },
+    async buildSystemPrompt(): Promise<string> { return 'system'; },
+  };
+}
+
+describe('resolvePagePath — append-only candidate list order (ctime ascending)', () => {
+  it('renders same-type pages sorted by ctime even when the vault yields them shuffled', async () => {
+    const capture: { prompt?: string } = {};
+    // Vault iteration order deliberately contradicts creation order.
+    const ctx = makeCtx(
+      [
+        { path: 'wiki/entities/newest.md', basename: 'newest', stat: { ctime: 3000 } },
+        { path: 'wiki/entities/oldest.md', basename: 'oldest', stat: { ctime: 1000 } },
+        { path: 'wiki/entities/middle.md', basename: 'middle', stat: { ctime: 2000 } },
+      ],
+      capture,
+    );
+    await resolvePagePath(ctx, 'BrandNewThing', 'entity', 'summary');
+    const p = capture.prompt;
+    expect(p).toBeDefined();
+    const oldest = p!.indexOf('entities/oldest.md');
+    const middle = p!.indexOf('entities/middle.md');
+    const newest = p!.indexOf('entities/newest.md');
+    expect(oldest).toBeGreaterThan(-1);
+    expect(oldest).toBeLessThan(middle);
+    expect(middle).toBeLessThan(newest);
+  });
+
+  it('keeps the vault order for pages without ctime (stable sort, no crash)', async () => {
+    const capture: { prompt?: string } = {};
+    const ctx = makeCtx(
+      [
+        { path: 'wiki/entities/first.md', basename: 'first' },
+        { path: 'wiki/entities/second.md', basename: 'second' },
+      ],
+      capture,
+    );
+    await resolvePagePath(ctx, 'BrandNewThing', 'entity', 'summary');
+    const p = capture.prompt;
+    expect(p).toBeDefined();
+    expect(p!.indexOf('entities/first.md')).toBeLessThan(p!.indexOf('entities/second.md'));
+  });
+});

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -4,7 +4,7 @@ import { parseFrontmatter } from '../../core/frontmatter';
 export async function getExistingWikiPages(
   app: App,
   wikiFolder: string
-): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[] }>> {
+): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; ctime?: number }>> {
   const wikiFiles = app.vault
     .getMarkdownFiles()
     .filter(
@@ -16,7 +16,7 @@ export async function getExistingWikiPages(
         !f.path.includes('/contradictions/')
     );
 
-  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[] }> = [];
+  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; ctime?: number }> = [];
   for (const f of wikiFiles) {
     const relPath = f.path.replace(wikiFolder + '/', '').replace('.md', '');
     const content = await app.vault.read(f);
@@ -45,6 +45,7 @@ export async function getExistingWikiPages(
       title: f.basename,
       wikiLink: `[[${relPath}|${f.basename}]]`,
       aliases: Array.isArray(fm?.aliases) ? fm.aliases : undefined,
+      ctime: f.stat?.ctime,
     });
   }
   return pages;

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -119,7 +119,14 @@ export async function resolvePagePath(
         // Purge polluted entries from LLM input (L2)
         const bn = p.title || '';
         return !/^(entities|concepts|sources)([^\s\-_a-zA-Z0-9])/.test(bn);
-      });
+      })
+      // Append-only ordering (ctime ascending): pages created during a run
+      // join the rendered list at the END, so consecutive dedup calls keep a
+      // byte-identical prefix and a local KV prefix cache can reuse it.
+      // Alphabetical or vault-iteration order inserts new pages mid-list and
+      // re-pays the prefill from the insertion point. Stable sort: pages
+      // without ctime keep their relative order.
+      .sort((a, b) => (a.ctime ?? 0) - (b.ctime ?? 0));
 
     // Same-type slug/alias match is handled above by ConflictResolver.
     // Remaining path: LLM-based semantic dedup for pages that don't match by slug/alias.

--- a/src/wiki/prompts/ingestion.ts
+++ b/src/wiki/prompts/ingestion.ts
@@ -110,15 +110,22 @@ export const INGESTION_PROMPTS = {
 
   // Semantic entity resolution: when slug-based matching fails, use LLM to determine
   // whether a newly extracted entity/concept is semantically equivalent to an existing page.
+  //
+  // Layout constraint: the {{existing_pages}} list MUST stay before the
+  // per-call candidate block. The list is the invariant bulk of the prompt;
+  // with it first, consecutive dedup calls share a byte-identical prefix and
+  // a local KV prefix cache collapses the prefill (~46K tokens) to the short
+  // variable suffix. Candidate-first ordering limits the shared prefix to
+  // ~200 chars and forfeits the cache entirely.
   resolveEntityDedup: `You are an entity resolution engine. Given a newly extracted entity/concept and a list of existing wiki pages, determine if it is semantically equivalent to any existing page.
+
+**Existing {{page_type}} pages:**
+{{existing_pages}}
 
 **New entity/concept:**
 - Name: {{entity_name}}
 - Type: {{entity_type}}
 - Summary: {{entity_summary}}
-
-**Existing {{page_type}} pages:**
-{{existing_pages}}
 
 **Task:** Determine whether the new entity/concept is semantically the SAME as any existing page. Consider:
 - Translations between languages (e.g. "清华大学" = "Tsinghua University")


### PR DESCRIPTION
## Problem

`resolveEntityDedup` renders the per-call candidate block (~200 chars) **before** the `{{existing_pages}}` list. Consecutive dedup calls therefore share only that ~200-char prefix, so a KV prefix cache can never engage and **every** call re-pays the full prefill.

On the reference setup (Gemma-4-26B MoE via LM Studio, prefill measured at 520–630 tok/s) one full-list call is ~46–49K prompt tokens for a 16-token answer, costing **~69 s**. A cost model fitted over four baseline ingest runs attributes **~52% of ingest wall-clock** to these calls.

## Change (one commit, two coordinated parts)

1. **Template swap** — invariant prefix first (intro + existing-pages list), per-call candidate block last; task and output instructions unchanged at the end. Order-neutral in content: the matching criteria already sat after the list, and the only positional reference ("listed above") stays true.
2. **Append-only list order** — `getExistingWikiPages` now exposes each file's `ctime`, and `resolvePagePath` sorts the same-type list by `ctime` ascending. Pages created during a run join the rendered list at the **end**, so the shared prefix stays byte-identical. Alphabetical or vault-iteration order would insert new pages mid-list and re-pay the prefill from the insertion point.

## Measurements

Scripted probes against the local endpoint:

| Scenario | cold | repeat |
|---|---|---|
| Swapped layout, identical list, new candidate | 52–56 s | **1.2–1.7 s** 🎉 |
| … with a ~4K-token page-body call in between | — | 1.2 s (cache survives) |
| … entity and concept lists alternating | — | 1.2–1.3 s (both retained) |
| Current layout (candidate first), control | 54.3 s | 54.0 s (no reuse) |
| List grown by one page, **appended** | — | 1.2 s |
| List grown by one page, **inserted mid-list** | — | 29.6 s (suffix re-paid) |

**54.0 s → 1.2 s on repeat** is the whole point of the change: the prompt content is identical, only its order changed.

Live ingest on a 2805-page vault (single note, 14 dedup calls, same vault state and settings in every arm):

| Build | ingest wall-clock | vs. baseline |
|---|---|---|
| baseline (neither change) | 1836 s (modelled counterfactual) | 1.00× |
| top-K pre-filter only (companion PR) | 1179 s measured | 1.33× |
| **+ this PR** | **784 s measured** | **2.34×** 🎉 |
| this PR without the top-K pre-filter | 638 s measured | 2.19× |

The two measured arms differ by write count (30 vs. 22), not by variant: normalised to seconds per write after subtracting one cold call, they are 23.8 s and 25.9 s — against **52.9–61.5 s in five runs without this change**.

An internal consistency check that needs no baseline: 14 cold full-list calls would be 960 s, but the whole 30-write run finished in 784 s. The calls cannot all have been cold.

## Safety

- **Recall-neutral by construction:** the model sees the same candidate list per call, only arranged differently.
- **Decision-neutrality** is pinned by a fixed-candidate-set smoke check: identical dedup decisions before and after on a held candidate set.
- A layout-constraint comment in `ingestion.ts` keeps future edits from moving the candidate block back above the list.

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | One O(n log n) sort per dedup call; negligible next to the LLM call. |
| Memory | ✅ | One optional `ctime` number per page entry. |
| IO | N/A | No vault reads added; `ctime` comes from the already-loaded `TFile.stat`. |
| Network | ✅ | Same number and size of calls; server-side prefill collapses on cache hits. |
| Token | ✅ | Prompt content unchanged (reordered only). |

## Note for cloud providers

The gain above is local (llama.cpp-style prefix cache). Anthropic requires an explicit `cache_control` breakpoint, which the codebase does not set anywhere today; OpenAI and Gemini cache automatically with a partial discount. This PR is the precondition for such a breakpoint — with the invariant block first, there is a stable prefix to mark. Happy to follow up separately if that is of interest.

## Tests

Baseline self-counted on `ae27f97` with `pnpm build` before `pnpm test`: 2535 tests / 189 files. After: **2538 / 190** (+3: template order, ctime ordering reaching the rendered prompt, stable order without ctime). lint 0/0, tsc 0, build clean, css-lint 0.
