### PR TITLE
perf(dedup): slim the semantic dedup prompt (schema selector + top-K candidate pre-filter)

### DIFF
--- a/src/__tests__/wiki/page-factory/dedup-candidate-selection.test.ts
+++ b/src/__tests__/wiki/page-factory/dedup-candidate-selection.test.ts
@@ -1,0 +1,151 @@
+// Recall gate for the dedup candidate pre-filter (selectDedupCandidates).
+//
+// The semantic dedup call used to ship EVERY same-type page to the LLM. On a
+// real vault (~1285 entities) that is ~77K chars ≈ 40K prompt tokens for a
+// yes/no answer worth 16 completion tokens. The pre-filter ranks candidates
+// with the zero-token lexical matcher and sends only the top K.
+//
+// The risk this file guards: a pre-filter that drops the TRUE duplicate
+// creates a duplicate page — a correctness bug, and in a from-scratch rebuild
+// it happens at scale. So the criterion is RECALL = 100% over every fixture
+// pair: for each (new candidate, true existing target), the target MUST be in
+// the selected set. A failure means raise K or widen the fallback — never
+// lower the bar.
+//
+// Both branches are covered:
+//   - lexical branch: shared tokens exist → top-K must contain the target
+//   - fallback branch: zero lexical overlap (translations, initialisms) → the
+//     full list is returned, so the target is trivially retained
+
+import { describe, it, expect } from 'vitest';
+import { selectDedupCandidates } from '../../../wiki/page-factory/path-resolution';
+import { DEDUP_CANDIDATE_TOP_K } from '../../../constants';
+
+interface Page { path: string; title: string; aliases?: string[] }
+
+function page(title: string, aliases?: string[]): Page {
+  return { path: `wiki/entities/${title}.md`, title, aliases };
+}
+
+describe('selectDedupCandidates — lexical branch keeps the true duplicate', () => {
+  it('finds Typ-2-Diabetes for the candidate "Diabetes-mellitus-Typ-2"', () => {
+    const target = page('Typ-2-Diabetes');
+    const pages = [page('Hypertonie'), target, page('Zöliakie')];
+    const selected = selectDedupCandidates(
+      'Diabetes-mellitus-Typ-2',
+      'Diabetes als chronische Stoffwechselerkrankung mit Insulinresistenz.',
+      pages,
+    );
+    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+
+  it('finds the pre-rename Lactobacillus plantarum for Lactiplantibacillus plantarum', () => {
+    const target = page('Lactobacillus plantarum');
+    const pages = [page('Bifidobacterium longum'), target, page('Escherichia coli')];
+    const selected = selectDedupCandidates(
+      'Lactiplantibacillus plantarum',
+      'Milchsäurebakterium, 2020 aus der Gattung Lactobacillus reklassifiziert.',
+      pages,
+    );
+    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+
+  it('keeps the true match inside top-K against 40+ scoring distractors', () => {
+    // Every distractor shares the token "lactobacillus" (score 3); only the
+    // true target also matches "plantarum" (score 6), so it must sort ahead of
+    // all of them and survive the K cut.
+    const target = page('Lactobacillus plantarum');
+    const distractors = Array.from({ length: 44 }, (_, i) =>
+      page(`Lactobacillus species-${i}`),
+    );
+    const pages = [...distractors.slice(0, 22), target, ...distractors.slice(22)];
+    const selected = selectDedupCandidates(
+      'Lactiplantibacillus plantarum',
+      'Milchsäurebakterium der früheren Gattung Lactobacillus.',
+      pages,
+    );
+    expect(selected.length).toBeLessThanOrEqual(DEDUP_CANDIDATE_TOP_K);
+    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+
+  it('matches via aliases, not only titles', () => {
+    const target = page('Ferritin-Sättigung', ['Transferrinsättigung']);
+    const pages = [page('Hämoglobin'), target];
+    const selected = selectDedupCandidates(
+      'Transferrinsättigung',
+      'Laborwert des Eisenstoffwechsels.',
+      pages,
+    );
+    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+});
+
+describe('selectDedupCandidates — zero-overlap fallback returns the full list', () => {
+  it('retains "Massachusetts Institute of Technology" for the candidate "MIT"', () => {
+    // Pins the NAME-gated fallback: the summary token "in" incidentally
+    // substring-matches "Indiana" and "Institute", so a fallback gated on
+    // the ranked list being empty would take the lexical branch here and
+    // rank on summary noise. The name "MIT" matches nothing → full list.
+    const target = page('Massachusetts Institute of Technology');
+    const pages = [page('Stanford'), page('Indiana University'), target, page('ETH Zürich')];
+    const selected = selectDedupCandidates(
+      'MIT',
+      'Private Forschungsuniversität in Cambridge.',
+      pages,
+    );
+    expect(selected).toEqual(pages);
+    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+
+  it('retains the Chinese page 清华大学 for the candidate "Tsinghua University"', () => {
+    const target = page('清华大学');
+    const pages = [page('北京大学'), target, page('复旦大学')];
+    const selected = selectDedupCandidates(
+      'Tsinghua University',
+      'Research institution founded 1911 in Beijing.',
+      pages,
+    );
+    expect(selected).toEqual(pages);
+    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+
+  it('returns the input unchanged when there are no pages at all', () => {
+    expect(selectDedupCandidates('X', 'y', [])).toEqual([]);
+  });
+});
+
+describe('Gate 1c — token proof: rendered candidate list shrinks by orders of magnitude', () => {
+  it('collapses a 1114-page same-type list to a few thousand characters', () => {
+    // Mirrors the real vault shape (≈1114 concepts) and the exact rendering
+    // used for {{existing_pages}} in path-resolution.ts.
+    const target = page('Typ-2-Diabetes');
+    const vault: Page[] = [
+      target,
+      ...Array.from({ length: 1113 }, (_, i) =>
+        page(`Fachbegriff-Nummer-${i}`, [`Synonym-${i}`, `Abkürzung-${i}`]),
+      ),
+    ];
+    const render = (pages: Page[]): string =>
+      pages
+        .map(p => {
+          const aliasBlock = p.aliases?.length ? `\n  aliases: ${p.aliases.join(', ')}` : '';
+          return `- path: ${p.path}\n  title: ${p.title}${aliasBlock}`;
+        })
+        .join('\n');
+
+    const before = render(vault).length;
+    const selected = selectDedupCandidates(
+      'Diabetes-mellitus-Typ-2',
+      'Diabetes als chronische Stoffwechselerkrankung mit Insulinresistenz.',
+      vault,
+    );
+    const after = render(selected).length;
+
+    // Measured on this fixture: 131,409 chars → 3,405 chars (97.4%
+    // reduction, 1114 → 30 candidates). The 5% bound below enforces the
+    // order-of-magnitude collapse without pinning exact fixture bytes.
+    expect(selected.map(p => p.path)).toContain(target.path);
+    expect(selected.length).toBeLessThanOrEqual(DEDUP_CANDIDATE_TOP_K);
+    expect(after).toBeLessThan(before * 0.05);
+  });
+});

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -127,6 +127,27 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
     expect(result.path).toBe('wiki/entities/Novel.md');
   });
 
+  it('passes the slim "index" schema selector to buildSystemPrompt', async () => {
+    // The dedup question is a same-type yes/no match; the matching criteria
+    // live in the user prompt. Only "Wiki Structure" is needed from the
+    // schema — templates/naming/granularity are ballast for this call.
+    let seenMode: string | undefined;
+    const ctx = makeCtx({
+      mockVault: {
+        getMarkdownFiles: () => [{ path: 'wiki/entities/Other.md', basename: 'Other' }],
+      },
+      client: {
+        createMessage: async () => JSON.stringify({ match: false }),
+      },
+    });
+    ctx.buildSystemPrompt = async (mode: string): Promise<string> => {
+      seenMode = mode;
+      return 'system';
+    };
+    await resolvePagePath(ctx, 'Novel', 'entity', 'desc');
+    expect(seenMode).toBe('index');
+  });
+
   it('returns slug path when LLM throws (defensive fallback)', async () => {
     const ctx = makeCtx({
       mockVault: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -169,6 +169,16 @@ export const TOKENS_CONVERSATION_PAGE = 8000;
 export const TOKENS_DEDUP_RESOLUTION = 1000;
 
 /**
+ * Max candidate pages shown to the LLM in the semantic dedup prompt.
+ * The full same-type list grows with the vault (~77K chars at ~1285
+ * entities) and the call is prefill-bound; the top-K keyword pre-filter
+ * keeps the prompt flat. When the candidate's name shares no token with
+ * any page (translations, initialisms) the full list is sent instead —
+ * recall over cost. Raise K rather than weaken that fallback.
+ */
+export const DEDUP_CANDIDATE_TOP_K = 30;
+
+/**
  * v1.24.0 #216 — max tokens for the merge triage pre-flight classification.
  *
  * v1.24.0 Tier-2 (commit ab23bc0 + amend): the triage output now includes

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -40,7 +40,7 @@ import { isConversationSource, contextualizeError } from './contextualize';
 export interface CreatePageContext extends PathResolutionContext {
   settings: LLMWikiSettings;
   getClient(): LLMClient | null;
-  buildSystemPrompt(mode: 'full' | 'compact' | 'merge' | 'entity' | 'concept'): Promise<string>;
+  buildSystemPrompt(mode: 'full' | 'compact' | 'merge' | 'entity' | 'concept' | 'index'): Promise<string>;
   createOrUpdateFile(path: string, content: string): Promise<void>;
   tryReadFile(path: string): Promise<string | null>;
 }

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -17,15 +17,64 @@
 //     fires; optionally appends includePaths that aren't already in the
 //     list.
 
-import { WIKI_SUBFOLDERS, TOKENS_DEDUP_RESOLUTION } from '../../constants';
+import { WIKI_SUBFOLDERS, TOKENS_DEDUP_RESOLUTION, DEDUP_CANDIDATE_TOP_K } from '../../constants';
 import { slugify } from '../../core/slug';
 import { ConflictResolver } from '../../core/conflict-resolver';
+import { localKeywordMatch } from '../../core/index-search';
 import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { normalizeLLMPath } from '../../core/prompt-builders';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { appendAliases, type AliasesContext } from './aliases';
+
+/** Page shape consumed by the dedup candidate pre-filter. */
+export interface DedupCandidatePage {
+  path: string;
+  title: string;
+  aliases?: string[];
+}
+
+/**
+ * Pre-filter the same-type page list before it is rendered into the
+ * semantic dedup prompt. The full list grows with the vault and made the
+ * call prefill-bound (~40K prompt tokens for a 16-token answer), so only
+ * the top-K lexically ranked candidates are kept.
+ *
+ * Recall guard (binding): the fallback to the FULL list is gated on the
+ * candidate's NAME alone, not on the ranked result. Summary tokens are
+ * ranking signal only — incidental substrings ("in" ⊂ "institute") make
+ * the ranked list non-empty for almost any query on a large vault, so a
+ * ranked-list-empty check would never fire and the translation/initialism
+ * case ("MIT" vs "Massachusetts Institute of Technology", "Tsinghua
+ * University" vs "清华大学") would silently lose its true duplicate. A
+ * missed duplicate becomes a duplicate page, so that rare case pays the
+ * old full-list cost instead of risking correctness.
+ *
+ * The name is additionally matched with hyphens/underscores split so
+ * compound candidates share tokens with reordered variants
+ * ("Diabetes-mellitus-Typ-2" ↔ "Typ-2-Diabetes").
+ */
+export function selectDedupCandidates(
+  name: string,
+  summary: string,
+  sameTypePages: DedupCandidatePage[],
+): DedupCandidatePage[] {
+  const normalized = sameTypePages.map(p => ({
+    path: p.path,
+    title: p.title,
+    aliases: p.aliases ?? [],
+  }));
+  const nameQuery = `${name} ${name.split(/[-_]+/).join(' ')}`;
+  const nameHits = localKeywordMatch(nameQuery, normalized);
+  if (nameHits.length === 0) return sameTypePages;
+  const ranked = localKeywordMatch(`${nameQuery} ${summary.substring(0, 300)}`, normalized);
+  const byPath = new Map(sameTypePages.map(p => [p.path, p]));
+  return ranked
+    .slice(0, DEDUP_CANDIDATE_TOP_K)
+    .map(r => byPath.get(r.path))
+    .filter((p): p is DedupCandidatePage => p !== undefined);
+}
 
 /** Mirrors the subset of PageCreationResult we return. */
 export interface ResolvedPathResult {
@@ -126,7 +175,7 @@ export async function resolvePagePath(
 
     if (sameTypePages.length === 0) return { path: slugPath };
 
-    const pagesList = sameTypePages
+    const pagesList = selectDedupCandidates(name, summary, sameTypePages)
       .map(p => {
         const aliasBlock = p.aliases?.length
           ? `\n  aliases: ${p.aliases.join(', ')}`

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -49,7 +49,7 @@ export interface PathResolutionContext extends AliasesContext {
   app: unknown;
   settings: import('../../types').LLMWikiSettings;
   getClient(): { createMessage: (...args: unknown[]) => Promise<string> } | null;
-  buildSystemPrompt(mode: 'full' | 'compact' | 'merge'): Promise<string>;
+  buildSystemPrompt(mode: 'full' | 'compact' | 'merge' | 'index'): Promise<string>;
 }
 
 /**
@@ -149,7 +149,11 @@ export async function resolvePagePath(
     const response = await client.createMessage({
       model: resolveModelForTask(ctx.settings, 'ingest'),
       max_tokens: TOKENS_DEDUP_RESOLUTION,
-      system: await ctx.buildSystemPrompt('full'),
+      // Slim selector: the dedup decision is same-type and the matching
+      // criteria are fully stated in the user prompt — only the Wiki
+      // Structure section is load-bearing here. 'full' (~8.5K chars of
+      // templates/naming/maintenance) added pure prefill cost per call.
+      system: await ctx.buildSystemPrompt('index'),
       messages: [{ role: 'user', content: prompt }],
       response_format: { type: 'json_object' },
       ...(ctx.settings.disableThinking ? { enableThinking: false } : {}),


### PR DESCRIPTION
## Problem

`resolveEntityDedup` — the LLM fallback that fires when slug and alias matching both fail — asks a single yes/no question ("is this candidate the same thing as an existing page?") but ships two large, mostly signal-free blocks with every call:

1. `{{existing_pages}}` contains **every** same-type page (path + title + aliases). On the reference vault (1285 entities / 1114 concepts) the rendered list is 119K / 126K characters. Measured live: **46,344 prompt tokens against 16 completion tokens** for one call.
2. `system: buildSystemPrompt('full')` — the entire schema (page templates, naming conventions, maintenance policies, ~7.7K chars on the reference vault) for a decision that needs none of it.

The call is prefill-bound on local models, and the cost grows with vault size — worst exactly where it hurts most: large vaults and full rebuilds. This is a second instance of the anti-pattern reported in #306 (there: the slug list in the analyzer; here: the dedup candidate list).

## Change 1 — slim schema selector (`53eadc5`)

`buildSystemPrompt('full')` → `buildSystemPrompt('index')` (Wiki Structure only, ~0.7K chars). The dedup decision is already same-type — the candidate list is filtered to the target folder — and the matching criteria (translations, abbreviations, spelling variants) are fully stated in the user prompt. **~2,500 prompt tokens saved in every single dedup call**, with no behavioural surface at all. A test pins the selector.

## Change 2 — top-K candidate pre-filter (`ca79542`)

New pure function `selectDedupCandidates(name, summary, sameTypePages)` ranks the same-type list with the existing zero-token lexical matcher (`localKeywordMatch`) and keeps the top `DEDUP_CANDIDATE_TOP_K = 30` candidates. On a 1114-page fixture the rendered list collapses from 131,409 to 3,405 characters — **97.4%** 🎉 — and the unit fixture enforces that order-of-magnitude collapse.

**Recall guard (the correctness-sensitive part):** the full list is still sent whenever the candidate's **name** (hyphen/underscore-split) lexically matches no page — the translation/initialism class (`MIT` ↔ `Massachusetts Institute of Technology`, `Tsinghua University` ↔ `清华大学`) where a lexical pre-filter would silently drop the true duplicate and mint a duplicate page. Two deliberate design points:

- The fallback is gated on the **name**, not on the ranked list being empty: summary tokens incidentally substring-match on large vaults (`"in"` ⊂ `"institute"`), so a ranked-empty check would essentially never fire, and it would rank on noise in precisely the dangerous class. A fixture with an `Indiana University` distractor pins this.
- The name is additionally matched hyphen-split so compound candidates share tokens with reordered variants (`Diabetes-mellitus-Typ-2` ↔ `Typ-2-Diabetes`) — `localKeywordMatch` splits on whitespace only.

**Recall gate:** 8 self-contained fixtures covering both branches (lexical top-K including 40+ distractors and alias matching; zero-overlap fallback including a CJK translation case). Criterion: recall = 100% over all pairs — on failure raise K or widen the fallback, never lower the bar.

## Field measurement (2805-page German medical vault, single-note ingest, 14 dedup calls)

- **Prompt tokens across all dedup calls: ~660K → ~372K = −44%.** 🎉
- **Wall-clock: 1.33×**, derived from a two-parameter fit over four baseline runs (68.6 s per full-list dedup call + 29.2 s per write; out-of-fit check: predicted 1179 s vs. 1179 s measured; full-list dedup carried ~52% of baseline runtime).
- **0 losses over 21 writes, no duplicate attributable to the pre-filter.**

## Honest scope of the saving

- **It is corpus-dependent.** On the reference corpus the name-gated fallback is the **majority** path (8 of 14 candidates): acronyms without a lexical anchor (`TRPV5`, `ROMK`, `FGF19`) and long German compounds that occur nowhere as a token substring (`Alterungsachse`, `Phosphathaushalt`) send the full list by design. Corpora whose new names share tokens with existing titles keep proportionally more of the filtered-call saving.
- **Alongside the companion PR** (`fix/dedup-prefix-cache-layout`, cache-stable prompt order) the wall-clock gain of the top-K filter mostly disappears on a local model, because the prefix cache already collapses the repeat cost. What remains is worth having on its own terms:
  - **token cost**, which is money on metered providers rather than time;
  - **context headroom** — the full list grows linearly with the vault (43K tokens at 1285 entities, ~100K at 3000, past a 128K window at 4000), while filtered calls stay flat;
  - **robustness** — when the cache is cold or evicted, the filtered calls stay cheap.

  The two PRs are independent and mergeable in either order.
- A true duplicate whose name shares no token with the query while *other* pages do match (a translated duplicate among same-language pages) can still be missed — inherent to any lexical pre-filter; the fallback catches the common initialism and translation cases.

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | `selectDedupCandidates` is O(n·k) over titles/aliases per dedup call; negligible next to the call it shrinks. |
| Memory | ✅ | One transient normalized copy plus one `Map` per call, released immediately. |
| IO | N/A | No vault reads added or removed. |
| Network | ✅ | Same number of calls; filtered calls shrink to ~2–3K chars of candidate list. |
| Token | ✅ | System prompt ~7.7K → ~0.7K chars; field: −44% prompt tokens across all dedup calls. Fallback calls (majority on the reference corpus) pay the old cost by design. |

## Tests

Baseline self-counted on `ae27f97` with `pnpm build` before `pnpm test`: 2535 tests / 189 files. After: **2544 / 190** (+1 selector pin, +8 recall and token fixtures). lint 0/0, tsc 0, build clean, css-lint 0.
