### PR TITLE
fix(settings): honor typed API key over SecretStorage on provider switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.25.7] - 2026-07-25 (in flight)
+
+> **Status:** PRs #344 + #345 merged to main @ `7ef237a` 2026-07-25 02:04Z. Remaining PATCH scope (fix-runners parallelization, analysis cache, smart-skip controller) ships as the v1.25.7 release commit. This entry will be finalized at release.
+
+### Fixed
+
+- **API key self-restore when switching LLM providers (regression since v1.25.3 #182).** When a user changed the Provider dropdown in Settings, any key typed into the API Key input was silently overwritten on every `tab.display()` re-render with the stale SecretStorage value left over from the previously-active provider. Fetch Models and Test Connection used the same stale key. Two independent fixes:
+  1. New `resolveInitialApiKey(tempSettings, secretStorage)` helper in `provider-api-key-resolver.ts` is called from `provider-section.ts` to paint the API Key input — precedence is `tempSettings.apiKey` (in-memory buffer) > SecretStorage > `''`. The previous `load() ?? tempSettings.apiKey` never fell back because SecretStorage always has the last-flushed key (never null), so the user's pending edit was clobbered on every re-render.
+  2. `resolveProviderApiKey` gained an optional `pendingKey?: string` 3rd parameter — when non-empty, it wins over both SecretStorage and `settings.apiKey`. Threaded through `testLLMConnection(pendingApiKey?)`, `createLLMClient(settings, ..., secretStorage?, pendingApiKey?)`, `createLLMClientFromSettings{,Sync}(settings, pendingApiKey?)`, and the 2 Settings-UI call sites (`model-section.ts` for Fetch Models, `test-connection-section.ts` for Test Connection). Codex Provider remains fully isolated (separate `karpathywiki-openai-codex` SecretStorage slot; `isCodex` UI branch never renders the regular API Key input).
+  **Single-secretId design preserved:** switching providers still overwrites the same `karpathywiki-provider-api-key` slot on tab close (no per-provider slots); the fix honors the in-memory typed key until then. 11 new tests (8 `resolveProviderApiKey` precedence cases + 7 `resolveInitialApiKey` cases + 2 end-to-end integration assertions).
+
+### Performance
+
+- **Dedup prompt cache-stable layout (PR #344 by @DocTpoint).** Two coordinated changes: (1) `resolveEntityDedup` prompt: invariant `{{existing_pages}}` list rendered FIRST, per-call candidate block LAST — local KV prefix cache now reuses the shared prefix across consecutive calls (cold 54s → repeat 1.2s on Gemma-4-26B MoE LM Studio, 520-630 tok/s prefill). (2) `getExistingWikiPages` exposes `ctime`; same-type list sorted by `ctime ascending` so newly-created pages join the rendered list at the end, keeping byte-identical prefix stability for prefix cache invalidation. Recall-neutral by construction (same candidate set, same matching criteria, only ordered differently); decision-neutrality pinned by smoke fixtures.
+- **Slim semantic dedup prompt (PR #345 by @DocTpoint).** Two coordinated changes: (1) `buildSystemPrompt('full')` → `buildSystemPrompt('index')` in the dedup call (Wiki Structure only, ~0.7K chars instead of ~7.7K — saves ~2,500 prompt tokens per call). (2) New `selectDedupCandidates(name, summary, sameTypePages)` pure function ranks same-type list with the existing zero-token `localKeywordMatch` and keeps top `DEDUP_CANDIDATE_TOP_K = 30` candidates. Field measurement on 2805-page German medical vault: prompt tokens 660K → 372K = **−44%**. 8 recall fixtures pin 100% recall over both lexical and fallback branches (incl. CJK translation and acronym cases) — recall gate's contract: "raise K or widen fallback, never lower the bar".
+
+### Tests
+
+- 2566 tests passing (192 files). +19 tests since v1.25.6: 3 dedup-prompt-order fixtures (layout + ctime ordering), 9 dedup-candidate-selection fixtures (4 lexical, 4 fallback, 1 token-collapse proof), and 7 API-key switching regression tests (`resolveInitialApiKey` precedence + `resolveProviderApiKey` `pendingKey` precedence).
+
+---
+
 ## [1.25.3] - 2026-07-23
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-07-24 (v1.25.6 PATCH RELEASED — Obsidian Bot 0/0 first time, lessons codified)
+**Last Updated:** 2026-07-25 (main @ `7ef237a`; v1.25.7 lint-perf in flight — DocTpoint PRs #344/#345 merged)
 
 ---
 
-## Current Phase: v1.25.6 PATCH RELEASED (2026-07-24). Obsidian Bot: **0 errors / 0 warnings** for the first time. v1.25.4/5/6 saga: v1.25.4 inline-disable 反模式 → v1.25.5 Platform.isDesktop guard + getSettingDefinitions stub → v1.25.6 createRequire(__filename) 消除 no-unsafe-* 传播。三次教训已写进 §"Bot compliance invariant" (under Key Design Decisions). v1.26.0 MINOR following.
+## Current Phase: v1.25.7 PATCH (lint-perf, in progress). main @ `7ef237a`. DocTpoint PRs #344 (cache-stable prompt layout) and #345 (slim dedup + top-K pre-filter) merged 2026-07-25 02:04Z with `--merge` — author's commits preserved, no cherry-pick. 12 new tests (recall fixtures + layout fixtures). Bot: **0 errors / 0 warnings** (v1.25.6 invariant intact).
+
+**Remaining v1.25.7 scope:** P0-1 fix-runners parallelization, P1-1 analysis content-hash cache, P1-2 smart-skip controller (programmatic-empty + cache-double-hit). Detailed plan archived in [[project_v1.25.7_lint_perf_plan]]. **🚫 Embedding/RAG/vector index for lint perf: 永久禁止** — see [[feedback_no_rag_embedding_perf]].
 
 **v1.25.1 PATCH (2026-07-20, 11 commits, ~80 files, 2274 tests):**
 
@@ -76,12 +78,6 @@ Full composition + execution plan: [ROADMAP.md](./ROADMAP.md)
 ### Withdrawn / non-issues (kept for archaeology)
 
 - **Windows: `Connection test failed: TypeError: Failed to construct 'Headers'`** — withdrawn 2026-07-10 (user input error: non-ASCII chars in API key field; not a plugin/AI-SDK bug). AI-SDK 5.0.53 has a Windows guard but our `provider-utils@4.0.35` (bundled by `ai@^6.0.214`) does not include the fix; not worth patching given root cause is user-side.
-
----
-
-## 📁 Project Structure
-
-> This section has moved to **[CONTRIBUTING.md](./CONTRIBUTING.md#project-structure)** — it is a contributor-facing reference (your IDEs display the file tree natively) and keeping it in CLAUDE.md was creating a stale copy that drifted from reality. The CONTRIBUTING.md version is maintained alongside code changes.
 
 ---
 
@@ -384,7 +380,7 @@ English, conventional commits. `feat:` `fix:` `docs:` `refactor:` `test:` `chore
 
 ### Auto-close issues via commit message
 
-When a commit resolves tracked Issues, append `Closes #N` (or `Fixes #N` / `Resolves #N`) at the end of the commit body. This triggers GitHub to auto-close the issue when the commit hits the default branch.
+Append `Closes #N` (or `Fixes #N`) at the end of the commit body so GitHub auto-closes when the commit hits the default branch. **NEVER** use `gh issue close` or the GitHub UI to close issues manually — let the commit message do it.
 
 ```bash
 git commit -m "fix: batch P0 fixes
@@ -395,41 +391,16 @@ git commit -m "fix: batch P0 fixes
 Closes #94, #96, #99"
 ```
 
-**NEVER** use `gh issue close` or the GitHub UI to close issues manually — let the commit message do it. This keeps the git history → issue link intact and avoids premature closure before the code reaches default branch.
-
 ### Commit author identity + co-authorship
 
-The Claude Code sandbox uses a placeholder git identity (`Claude Code <claude@anthropic.com>`) that **must not** be the commit author on this project. Every commit attributed to "Claude Code" inflates the GitHub contributor graph with a non-human identity and obscures the actual maintainer trail.
+Canonical maintainer: `green-dalii <654534332@qq.com>` (verified against GitHub user `green-dalii`). Some older commits were authored as `Greener-Dalii` (capitalized, used by GitHub UI on merge). All NEW commits — including `--amend` and squash — MUST use the lowercase canonical form.
 
-**Canonical maintainer identity (verified against GitHub user `green-dalii`):**
+**Rules (canonical source: [[feedback_co_authored_by_format]]):**
 
-```
-name:  green-dalii
-email: 654534332@qq.com
-```
-
-Some older commits on `main` were authored as `Greener-Dalii` (capitalized, used by the GitHub UI on merge operations). All NEW commits — including `--amend` and squash operations — MUST use the lowercase canonical form `green-dalii`. Do not retroactively rewrite history unless the user explicitly asks.
-
-**Rules (added 2026-07-06 after manual test feedback):**
-
-1. **Commit author** MUST be the maintainer:
-   ```bash
-   git -c user.name="green-dalii" -c user.email="654534332@qq.com" commit --amend --no-edit
-   ```
-   Or set it once per session before any commits:
-   ```bash
-   git config user.name "green-dalii"
-   git config user.email "654534332@qq.com"
-   ```
-2. **Every commit MUST list the maintainer as `Co-authored-by`** (in addition to the AI model):
-   ```
-   Co-authored-by: green-dalii <654534332@qq.com>
-   Co-authored-by: Claude Code <noreply@anthropic.com>
-   ```
-   **Format rule**: the AI `Co-authored-by` line MUST be exactly `Claude Code <noreply@anthropic.com>`. Do **NOT** include the specific model name (e.g. `Opus 4.8`), version number, or context-window size (e.g. `1M context`) — these are ad copy that pollutes git history and goes stale when the model is upgraded. (2026-07-15 rule.)
-3. **NEVER** amend/squash a commit in a way that drops the `Co-authored-by: green-dalii` trailer — re-add it after every `git commit --amend`.
-4. The `Co-Authored-By` line must NOT be wrapped in a code block or in any way obfuscated — GitHub reads it as a literal trailer.
-5. When the session ends or you notice a missing co-author on any recent commit, **stop and fix it before continuing** — do not let the oversight propagate to the PR.
+1. **Commit author** MUST be the maintainer (`git config user.name "green-dalii" && git config user.email "654534332@qq.com"`)
+2. **Every commit MUST list the maintainer as `Co-authored-by`** + AI model trailer. AI trailer MUST be exactly `Claude Code <noreply@anthropic.com>` — **no model name, version, or context-window size** (these go stale and pollute git history).
+3. **NEVER** amend/squash away the `Co-authored-by: green-dalii` trailer — re-add it after every `--amend`.
+4. If you notice a missing co-author on a recent commit, **stop and fix it before continuing** — do not let the oversight propagate to the PR.
 
 ## 🧪 Development Quality Closure (TDD + Planning)
 
@@ -486,9 +457,7 @@ it('debug', () => {
 
 ## ✅ Pre-Release Checklist
 
-Use the `obsidian-plugin-release` skill for the full workflow (Steps 1-8). Gate 1 (lint + tsc + test + build + css-lint) must all pass before any commit.
-
----
+Use the `obsidian-plugin-release` skill for the full workflow (Steps 1-8). Gate 1 (lint + tsc + test + build + css-lint) must all pass before any commit. Six-Gate detail: [[feedback_six_gate_framework]]. Pre-release-specific hardening (lockfile regen, CI consistency, AI-SDK drift): [[feedback_build_verification_root_cause]]. Doc review sweep: `doc-review` skill (PASS/WARN/FAIL verdict).
 
 ## ⚠️ Development Protocol: Plan First, Then Execute
 
@@ -500,11 +469,11 @@ Use the `obsidian-plugin-release` skill for the full workflow (Steps 1-8). Gate 
 
 **Exceptions** (no prior approval needed): trivial one-line fixes, running lint/test/build, reading files, documenting existing code.
 
-**Why**: The user is the domain expert on product vision. The AI has tooling capability but lacks product context. Propose, don't dispose.
+**Why**: The user is the domain expert on product vision. The AI has tooling capability but lacks product context. Propose, don't dispose. Full protocol: [[feedback_development_protocol]].
 
 ## 🧪 TDD: Write Tests First
 
-For any new function or behavior change: write a failing test first, then write the implementation, then refactor. When modifying untested core code, add at least one test for the path you're changing. See TDD Standard above.
+For any new function or behavior change: write a failing test first, then write the implementation, then refactor. When modifying untested core code, add at least one test for the path you're changing. Full standard with shell-test anti-pattern + 真实 vault 原则: [[feedback_tdd_standard]].
 
 ---
 
@@ -514,7 +483,7 @@ For any new function or behavior change: write a failing test first, then write 
 
 | File | Responsibility | What belongs | What does NOT belong |
 |------|---------------|--------------|---------------------|
-| **CLAUDE.md** | Dev standards + current phase | Six-Gate / TDD / Git workflow / current state (v1.22.6 released + v1.23.0 in flight) | Old release histories, project structure tree, full version timeline |
+| **CLAUDE.md** | Dev standards + current phase | Six-Gate / TDD / Git workflow / current state | Old release histories, project structure tree, full version timeline |
 | **ROADMAP.md** | Planning | Next Milestone / Version Timeline (condensed) / Deferred & Backlog | Per-version detail (use CHANGELOG) |
 | **CHANGELOG.md** | History (Keep a Changelog) | Per-version Added/Changed/Fixed/Removed — ancient versions are pre-aggregated, **do not re-merge** | Forward-looking plans, dev standards |
 | **CONTRIBUTING.md** | Contributor guide | Project structure tree, architecture, Mermaid, dev setup | User docs, design philosophy |
@@ -523,7 +492,7 @@ For any new function or behavior change: write a failing test first, then write 
 
 **Cross-reference format:** `[section](./OTHER.md#anchor)` — keep one canonical source, link to it.
 
-**i18n rule:** User-facing strings (settings descriptions, error messages, READMEs) = user language, not implementation language. "Close the model's reasoning output" ✅ / "Disable thinking in 3-tier dialect fallback chain" ❌. See [[feedback-d8-welcome-no-hardcoded-i18n]] + v1.23.0 doc lessons.
+**i18n rule:** User-facing strings (settings descriptions, error messages, READMEs) = user language, not implementation language. "Close the model's reasoning output" ✅ / "Disable thinking in 3-tier dialect fallback chain" ❌. See [[feedback-d8-welcome-no-hardcoded-i18n]] + [[feedback_v1_23_0_doc_and_process_lessons]].
 
 **CHANGELOG rule:** Already aggregated per Keep a Changelog spec. Ancient versions (v1.6.x / 0.2.x) are pre-aggregated — do NOT re-merge. "Optimization" that deletes historical version info is a regression, not improvement. Verify with `grep -c "^## \[" CHANGELOG.md` before assuming it needs work.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ src/
 │   ├── tag-chip-input.ts
 │   └── schema-diff-modal.ts
 ├── texts/               # i18n (10 languages: EN/ZH/ZH-Hant/JA/KO/DE/FR/ES/PT/IT)
-└── __tests__/           # Unit tests (vitest, 2515 tests across 186 files; v1.25.2 PATCH 2026-07-22, +241 from v1.25.1)
+└── __tests__/           # Unit tests (vitest, 2547 tests across 191 files; v1.25.7 PATCH in flight 2026-07-25, +12 from DocTpoint PR #344+#345 dedup perf)
 ```
 
 ## Internationalization

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,217 +2,42 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.25.6 PATCH (released 2026-07-24). | **Updated:** 2026-07-24
+**Version:** 1.25.7 PATCH (lint-perf, in progress on main @ `7ef237a`). | **Updated:** 2026-07-25
 
 ## Current Status
 
-**v1.25.6 — RELEASED 2026-07-24.** PATCH scope. Eliminates 14 `@typescript-eslint/no-unsafe-*` Bot warnings in `loopback-flow.ts` by replacing bare `require('node:http')` with typed `module.createRequire(__filename)` via dynamic `import('node:module')`. Bundle-shape test updated to assert the new pattern. Production lint Bot-equivalent. 2535 tests passing (189 files).
+**v1.25.7 — IN FLIGHT (2026-07-25).** PATCH scope. DocTpoint PRs merged:
+- **PR #344** (cache-stable prompt layout: invariant list first + ctime ascending sort). Cold 54s → repeat 1.2s. 2805p field wall-clock 1836s → 784s (2.34×).
+- **PR #345** (slim dedup + top-K candidate pre-filter + 'index' schema selector). Field prompt tokens 660K → 372K (−44%). 8 recall fixtures pin 100% recall over canonical pairs.
+- 12 new tests added. **Bot 0/0 preserved** (Gate 1 all-green). 2547 tests / 191 files.
 
-### v1.25.6 composition
+**v1.25.7 PATCH remaining scope** (this PATCH, main @ `7ef237a`):
 
-| # | Commit subject | Notes |
-|---|----------------|-------|
-| 1 | `fix(lint): use createRequire(__filename) to eliminate no-unsafe-* propagation` | Path A from analysis |
-| 2 | `chore: bump version to 1.25.6 + tsconfig types + CHANGELOG` | Release packaging |
+| Item | LOC | Source |
+|---|---|---|
+| **P0-1 fix-runners parallelization** | ~80 + 5 tests | 5串行 fix phases → `Promise.allSettled` × concurrency (model: `runAliasCompletion`) |
+| **P1-1 analysis content-hash cache** | ~80 + 3 tests | `.obsidian/plugins/karpathywiki/cache/lint-analysis.json`, LRU 50 entries |
+| **P1-2 smart-skip controller** | ~30 + 1 test | programmatic-empty + cache-double-hit → skip both LLM phases |
 
-## Next: v1.26.0 MINOR
-| 7 | `chore(deps): bump pnpm.overrides.fast-uri to 3.1.4 (CVE host-confusion) + brace-expansion 5.0.7` | pnpm audit 0 high |
-| 8 | `feat(i18n): add 3 keys for Migrate Secret Storage across 10 locales` | apiKeyMigrateToSecretStorageButton + 2 more |
-| 9 | `chore(lint): production-side obsidianmd bot warnings fully enforced (0/0); test-side cosmetic warnings relaxed per user direction v1.25.4` | option B layered override |
+Full plan: [[project_v1.25.7_lint_perf_plan]]. Out of scope (v1.26.0 MINOR): embedding/RAG Tier 2 预筛 — 🚫 **永久禁用** per [[feedback_no_rag_embedding_perf]].
 
-### v1.25.3 composition (1 commit, secret-storage + README sync)
+## Next: v1.26.0 MINOR (after v1.25.7 ships)
 
-| # | Commit | Subject | Notes |
-|---|--------|---------|-------|
-| 1 | `d7faef1` | `feat(security): move provider API key to Obsidian SecretStorage (#182)` | `ProviderSecretStore` + `resolveProviderApiKey` + migration. Closes #182 |
+Theme: Kimi Files API + non-routine PDF providers (PR4, AkaSakana contribution) + wiki-engine.ts decomposition (3rd-party audit P1, 2026-07-19) + #220 source-revision awareness Tier 0+1 + #328 Schema Phase 2/3 + DocTpoint open issues (#330/#312/#306 follow-up).
 
-### v1.25.2 composition (7 commits, PRs #329 #324 #331 #332 #333 #334)
-
-### v1.25.1 deferred → v1.25.2 PATCH resolved items
-
-- ✅ **PR #304** (DocTpoint — `updatedPages` split). **MERGED** 2026-07-20 (`3578a9d`). The 4-line ternary inside `runBatchedWithRetry` closure (Phase C-PR1 refactor) was correctly resolved.
-- ✅ **Phase A Obsidian bot compliance** (`prefer-create-el` × 50 + `getSettingDefinitions()`). **COMPLETED 2026-07-21** (`c9fd4ce`). eslint-plugin-obsidianmd 0.3.0→0.4.1 upgrade, flat config test override, `src/types/obsidian-dom.d.ts`, `src/__tests__/__support__/dom-helpers.ts`, 47 prefer-create-el production fixes, no-alert → ConfirmModal replacement. Production lint: 0 errors, 2 warnings (both pre-1.25.1 non-blocking).
-
-### v1.25.1 deferred — still on v1.26.0 MINOR
-
-- **Lint perf** (`controller.ts:151` / `:239` TODOs from v1.18.0+). Phase F was rolled into DiskCache<T> extraction; the controller-level parallel dedup batches + LLM health analysis batches remain v1.26.0 work.
-
-### v1.25.1 composition (11 commits, ~80 files changed)
-
-| # | Commit | Subject | Notes |
-|---|--------|---------|-------|
-| 1 | `65b5d1b` | `fix(related-page): stop persisting raw LLM output on the related path (#288)` | closes #287 silent Mentions loss on re-ingest |
-| 2 | `5f993e6` | `fix: allow LM Studio ingest without API key (#272)` | local-no-key-provider gate |
-| 3 | `5e13ac5` | `chore(build): pin Node 24 + AI-SDK patches + project .npmrc (v1.25.1 Phase E) (#301)` | dual-direction lockfile regen + npmrc |
-| 4 | `039735c` | `perf(cache): extract DiskCache<T> from PdfConversionCache + ledger optimization (Phase F) (#300)` | 100MB / 1000 / 10MB caps + LRU |
-| 5 | `b23257e` | `refactor(wiki-engine): extract 4 internal modules (Phase C-PR1) (#309)` | wiki-engine.ts 1799 → 1617 LOC (4 helpers → `engine-internals/` totaling 657 LOC) |
-| 6 | `1806e29` | `refactor(settings): extract 8 section renderers (Phase C-PR2) (#311)` | settings.ts 1439 → 357 LOC |
-| 7 | `7f37905` | `refactor(main): split main.ts 1304→300 LOC into 6 main-commands modules (#313)` | mixin pattern (Object.assign(prototype)) |
-| 8 | `8852d0a` | `fix(mentions): parse the pre-#244 grouped Mentions shape so legacy pages can heal (#289) (#303)` | DocTpoint PR — LEGACY_GROUP_RE + LEGACY_QUOTE_RE + BULLET_RE |
-| 9 | `2b821d4` | `fix(ingest): preserve schema sections the LLM drops in body rewrites (#292) (#302)` | DocTpoint PR — preserveExistingSections 4-arg signature |
-| 10 | `4891f3d` | `refactor(simplify): v1.25.1 PATCH post-merge cleanup (#314)` | my simplify + correctness fixes (suffix trim, Mentions strip on rewrite, lift stripMentionsSection) |
-
-### Closed issues (v1.25.1 PATCH)
-
-- **#287** (silent Mentions loss on Related re-ingest) — closed by PR #288 (`65b5d1b`)
-- **#292** (LLM rewrite drops schema sections) — closed by PR #302 (`2b821d4`)
-- **#289** (legacy Mentions unparseable on first re-ingest post-#244) — closed by PR #303 (`8852d0a`)
-- **#272** (LM Studio empty-key ingest gate) — closed by commit `5f993e6`
-
-### Six-Gate summary
-
-| Gate | Status |
-|---|---|
-| Code correct (lint/tsc/test/build/css-lint) | ✅ 0/0/2274/clean/0 |
-| No side effects | ✅ Pure refactor + bug fix; 14 Phase A bot warnings deferred to v1.26.x per `feedback_eslint_plugin_obsidianmd_0_4_skip` |
-| No breaking changes | ✅ All new settings opt-in, all PRs additive |
-| No performance regression | ✅ DiskCache ledger optimization; page-batch-runner extracted; no new LLM calls |
-| Docs complete | ✅ 10 READMEs + CHANGELOG + ROADMAP + CLAUDE + CONTRIBUTING + memory |
-| Release clean | ✅ Co-Authored-By trailer (no model version), i18n parity, lockfile drift fixed |
-
-### v1.25.3+ deferred
-
-- **(v1.25.3 items all resolved — see above.)**
+Historic compositions (v1.25.6 and earlier) live in [CHANGELOG.md](./CHANGELOG.md) — kept brief here.
 
 ---
 
-## Next Milestone: v1.26.0 MINOR (target TBD, ~2 weeks)
-
-**Theme:** Kimi Files API + non-routine PDF providers (PR4, AkaSakana) + wiki-engine.ts decomposition + Lint perf opening + #220 source-revision awareness
-
-### Scope
-
-| Item | Source | Status |
-|------|--------|--------|
-| ✅ **PR #319 / #318** — batch delay 2000→10000ms slider | joffroy59 contribution | **MERGED** (`5346ddf`) |
-| ✅ **PR #320 / #305** — truncated response halving retry | DocTpoint contribution | **MERGED** (`34a358a`) |
-| ✅ **PR #273** — ChatGPT Codex OAuth | CCRRAY-DESIGN contribution | **MERGED** (`54bc128`, squash) |
-| ✅ **PR #304** — updatedPages split (created vs updated) | DocTpoint contribution | **MERGED** (`3578a9d`) |
-| ✅ **PR #322 / #308** — dead-link slug-normalized match | DocTpoint contribution | **MERGED** (`292300b`) |
-| ✅ **eslint 0.4.1 Route A** | 2026-07-21 | **COMMITTED** (`c9fd4ce`) |
-| ✅ **E2E fix: thinking-block HierarchyRequestError** | 2026-07-21 — `activeDocument.createEl` auto-attached to document.body broke saved-history load | **COMMITTED** (`d2d401e`) — refactored `renderThinkingBlocksUI(parent)`, caller (`QueryView.renderMarkdownContent`) threads `container` |
-| ✅ **PR #324 / #307** — related-link corrector prefix scope | DocTpoint contribution | **MERGED** (`762bb3c`, squash); follow-up A (`2524bc3`) added case-sensitivity test + comment clarity |
-| ✅ **PR #329 / #310** — bare `---` template trailer stripping | DocTpoint contribution | **MERGED** (`9b0ecad`, squash); removes closing rule from 5 page templates + `stripTrailingSeparators()` net at end of `cleanMarkdownResponse()` |
-| 🚧 **Schema Phase 1 (Option A)** | Issue #328 — user-approved 2026-07-22 (override of "wait 2 weeks for community feedback" public commitment — override justified by Option A being bug-fix nature, not design track) | Eliminate dual-source problem: tag lists move from `buildDefaultSchemaBody()` to runtime injection layer; `schemaHasTagVocab` defensive check removed. (Folder layout stays Phase 2 — alongside per-type registration.) **Test LOC is net ↓** — 5 retired Phase 2 tests deleted, new contract lives in `runtime-injection.test.ts`. Backwards-compat: existing user schemas **not rewritten** — `loadSchema()` sanitizes legacy baked enum in-memory at LLM-facing view; on-disk file untouched. Phase 2/3 of #328 remain in v1.26.0 MINOR / v1.26.0+. |
-| 🔲 #273 UX silent-error fix | ChatGPT OAuth test failure | **WITHDRAWN** 2026-07-21 (user e2e test confirmed actual Notice path works; no real silent bug) |
-| 🔲 NOTICE update (DocTpoint description refresh + 4 new v1.25.0+ contributors) | Carry-over | Uncommitted in working tree, **deferred to v1.25.2 release commit** per Phase 1 commit scope discipline (NOT mixed with code commit) |
-| 🔲 **v1.25.2 version release** | bump + 10 READMEs + CHANGELOG + versions.json | ~2h |
-
-**Total effort**: ~3-4 working days remaining after Schema Phase 1 (~3-4h) + version release (~2h).
-
-**Schema Phase 1 (Issue #328) — Option A user-approved 2026-07-22:**
-
-The original #328 body proposed waiting 2 weeks for community feedback before phasing. User override approved Option A (immediate implementation in v1.25.2 PATCH) on three grounds: (a) Phase 1 is bug-fix nature — eliminating the dual-source problem (schema body baking stale tag list + runtime defensive injection of fresh tag list — LLM sees both → drift), not a design-track feature; (b) Phase 1 is orthogonal to Phase 2 (per-type registration, future Settings-driven `WIKI_SUBFOLDERS` derived list) and Phase 3 (multi-wiki + user-defined placeholders + dynamic scanners) — no future re-work predicted; (c) ~3-4h effort fits PATCH scope.
-
-Implementation order (TDD, revised 2026-07-22):
-
-1. RED: `src/__tests__/schema/runtime-injection.test.ts` (NEW file) — "buildDefaultSchemaBody never contains any baked tag enum regardless of settings" + "Classification Rules section explicitly references runtime injection"
-2. RED: `src/__tests__/wiki/system-prompts-tag-vocab.test.ts` — **REVERSE** the existing duplicate-detection test (count==1 → count>=1): runtime is now authoritative, always appends
-3. RED: `src/__tests__/schema/default-schema.test.ts` — **DELETE** the 5-test "v1.22.0 Phase 2 dynamic tag injection" describe block (`L78-154`) + REWRITE the "preserves entity and concept subtype valid lists" assertion (`L70-75`) to assert NOT-baked. Phase 2 contract is permanently reversed (hard rule in CLAUDE.md), not paused — keeping old tests would re-anchor a retired contract
-4. CONFIRM all REDs fail for the right reason (`pnpm test`)
-5. GREEN: Edit `src/schema/schema-manager.ts:33-153` — `buildDefaultSchemaBody()` drops the 5 `${entityList}/${conceptList}` interpolations (`L50/51/63/80/135/136`); rephrase Wiki Structure / Entity Page Template / Concept Page Template / Classification Rules to defer to the runtime "Active Tag Vocabulary" injection. **Keep `settings` parameter** with JSDoc note that it is unused since Phase 1 (avoid signature churn — `ensureSchemaExists` / `regenerateDefaultSchema` call sites stay byte-identical)
-6. GREEN: Edit `src/wiki/system-prompts.ts:213-235` + `:255` — drop the `schemaHasTagVocab` defensive branch (always append runtime section); rename injected heading "(Issue #85 — user-controlled)" → "(runtime)"
-7. REFACTOR: clean up the obsolete "// v1.22.0 #97 ... in lockstep" comment in `schema-manager.ts:34-40` (no longer applicable since runtime is authoritative — no lockstep needed)
-8. Gate 1: `pnpm lint && npx tsc --noEmit && pnpm test && pnpm build && pnpm css-lint`
-
-**Three implementation decisions resolved 2026-07-22 (recorded for the commit body):**
-
-1. **5 Phase 2 tests in `default-schema.test.ts:78-154`**: DELETED, with the new contract living in the new file `runtime-injection.test.ts`. The runtime-vs-baked split is a permanent design reversal (CLAUDE.md "Schema 三层分离" hard rule), not a temporary contract change — keeping old tests would re-anchor a retired contract and mislead future contributors reading the file
-2. **`buildDefaultSchemaBody(settings)` signature**: KEPT, with JSDoc marking settings as unused since Phase 1. `ensureSchemaExists()` / `regenerateDefaultSchema()` call sites byte-identical. Phase 2 may legitimately need settings again. Signature churn deferred to that PR
-3. **NOTICE update timing**: DEFERRED to v1.25.2 release doc sync (NOT mixed into the Phase 1 commit). The 9-contributor attribution is release-scope; mixing into a code commit is range creep and obscures the Phase 1 git history. The remembered uncommitted NOTICE change from the PR #329 cycle will be re-applied with the v1.25.2 release commit
-
-**Why Option A is safe for backwards compat:**
-
-- Existing users' schema files (with baked-in tag lists) are NOT rewritten — only `ensureSchemaExists()` and explicit `regenerateDefaultSchema()` produce the new clean template
-- Existing users get immediate runtime improvement (no more dual-source — runtime injection is always authoritative)
-- All call sites of `getSchemaContext()` are unchanged — same SchemaTask contract
-- The Title-text change of injected section ("user-controlled" → "runtime") is a minor visual change but functionally identical
-- No prompt-text changes that break existing test fixtures (verified by grep `pnpm test` after each step)
-
-**Why Option A does NOT block Phase 2/3:**
-
-- `buildDefaultSchemaBody()` modification only touches *content* of one specific section (Wiki Structure + Classification Rules); it does NOT change the section *structure* that Phase 2 relies on (`## <Type> Page Template` discovery via `parseSections()` / `selectSections()`)
-- The runtime injection point in `system-prompts.ts:213` is exactly where Phase 2 will add `buildActiveFolderLayoutSection()` — symmetric extension, no refactor
-- `WIKI_SUBFOLDERS` constant remains untouched; Phase 2 will replace it with derived-from-settings without conflicting with Phase 1
-- Phase 3 (multi-wiki, placeholders, scanners) requires no schema-body changes at all — orthogonal
-
-Full decision rationale: [[feedback-schema-phase1-option-a-decision]].
-
-### v1.25.2 version bump notes
-
-- `manifest.json` already at `1.11.4` (set by PR #273).
-- `versions.json` needs `"1.25.2": "1.11.4"` entry.
-- v1.25.1's `minAppVersion` was `1.11.4` (set by #273), but `versions.json` still had `"1.25.1": "1.11.0"` — v1.25.2 must add the correct entry.`
-
-Full design rationale: [[feedback-eslint-0-4-1-upgrade]] + `project_v1.25.1_release.md`.
-
-Full design rationale: [`project_v1.25.1_release.md`](~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1.25.1_release.md).
-
-### v1.25.0 composition (18 commits, 50 files changed, +4841/-66)
-
-| # | Commit | Subject | Notes |
-|---|--------|---------|-------|
-| 1 | `914a81c` | `docs(roadmap): v1.25.0 PDF Level 1 plan (3 PRs, API-native, 0 new deps)` | |
-| 2 | `18e515d` | `feat(pdf): PDF Level 1 core — cache + metadata parser + LLM converter` | PR1 core (pre-pivot) |
-| 3 | `0abf2db` | `feat(pdf): PDF Level 1 ingest integration — orchestrator + 2 commands` | PR1 ingest integration (pre-pivot) |
-| 4 | `3e9eac0` | `docs: v1.25.0 plan — cache-only PDF architecture pivot` | user-confirmed 2026-07-15 |
-| 5 | `145d43b` | `feat(pdf): PR2 redo — cache-only PDF ingest (no sidecar)` | replaced orchestrator |
-| 6 | `7e11b7a` | `feat(pdf): PR3 — PDF Level 1 settings + opt-in sidecar write` | |
-| 7 | `cb16747` | `feat(pdf): PR3 follow-up — universal escape hatch + UX moves` | forcePdfSupport simplified to universal, writePdfMarkdownToVault moved to Wiki Configuration |
-| 8 | `fd4b401` | `feat(pdf): PR3 follow-up #2 — cache filename safety + batch housekeeping + PDF error Notice` | hashCacheKey + prepareBatchIngest |
-| 9 | `06e8724` | `docs(agents): sync AGENTS.md to post-PR3-follow-up-#2 state` | |
-| 10 | `550d704` | `fix(pdf): PR3 follow-up #6 — ENOENT cache + AI-SDK cause chain routing` | Bug A + B |
-| 11 | `63bb287` | `docs(changelog): bump test count to 2144` | |
-| 12 | `56422a0` | `fix(pdf): PR3 follow-up #3 — reapply classifier tightening` | |
-| 13 | `9fff9b7` | `fix(pdf): PR3 follow-up #5 — dismiss stuck "Ingesting:" Notice on ingest throw` | |
-| 14 | `ff140b2` | `fix(ux): PR3 follow-up #7 — status bar + cancel during PDF ingest` | Bug C |
-| 15 | `cf620e2` | `fix(pdf): PR3 follow-up #8 — PDF mid-flow cancel survives re-entry + abortSignal wired` | Bug D |
-| 16 | `dd6af7d` | `fix(pdf): PR3 follow-up #9 — auto-create pdf-cache directory on set()` | Bug E |
-| 17 | `cbf824d` | `refactor(prompts): PR3 follow-up #9 prompt-rewrite — centralize PDF prompt + unwrap helper` | src/wiki/prompts/pdf.ts |
-| 18 | `971581c` | `docs(readme): PR3 follow-up #10 — PDF ingest + local model sections across 10 locales` | |
-
-### Closed issues (v1.25.0 release)
-
-- (none — v1.25.0 is feature work, not bug fixes)
-
-### Six-Gate summary
-
-| Gate | Status |
-|---|---|
-| Code correct (lint/tsc/test/build/css-lint) | ✅ 0/0/2182/clean/0 |
-| No side effects | ✅ Cache-only default; settings opt-in to vault sidecar |
-| No breaking changes | ✅ Settings default false; old data.json safe |
-| No performance regression | ✅ Cache caps 100MB/1000/10MB; LRU; abortSignal threading ~200 ms |
-| Docs complete | ✅ 10 READMEs + CHANGELOG + ROADMAP + memory file |
-| Release clean | ✅ Trailer format (no model name/version), i18n parity |
-
----
-
-## v1.26.0 MINOR (target TBD, ~2 weeks)
-
-**Theme:** Kimi Files API + non-routine PDF providers (PR4, owned by AkaSakana) + wiki-engine.ts decomposition (P1 audit finding) + Lint perf opening (#99 follow-up) + #220 source-revision awareness (Tier 0/1/2).
-
-**Forward-looking scope (no v1.25.0 PDF Level 1 details — see CHANGELOG for shipped design rationale):**
-
-| Item | Source | Notes |
-|------|--------|-------|
-| **PR4 Kimi Files API + non-routine PDF providers** | AkaSakana PR #286 transfer | Scope: Kimi Files API (upload → `file-extract` → delete), transient-retry extension for Files API endpoints, dedicated error regex classifiers. Lives in `core/kimi-document-reader.ts` + `core/pdf-error-classifier.ts`. If AkaSakana schedule slips → 1-day port by us. |
-| **`wiki-engine.ts` 1799 → ≤1500 LOC decomposition** | 3rd-party audit P1 (2026-07-19) | Extract graph-cache + index-generation + log-writer (NOT ingest orchestration — that path is sensitive after v1.25.0 PDF pipeline). Prerequisite for Lint perf work. |
-| **Lint performance opening (controller.ts:151 / :239)** | v1.18.0+ TODO (9 versions unaddressed) | Parallel dedup batches + LLM health analysis parallel; constrained by `MAX_CONCURRENT_LLM_CALLS`. After wiki-engine.ts decomposition. |
-| **#220 Source-revision awareness (Tier 0 + Tier 1)** | DocTpoint's 4-tier design | Tier 0: fingerprint source (normalized body hash) → surgical replace self-source block (no LLM prose regeneration). Tier 1: `supersedes:` frontmatter flag. Tier 3 review-queue UI likely v1.27.0+. |
-| **Generic `provider-capabilities` registry** | Altitude F4 (deferred from v1.25.1 Hotfix) | Replaces `forcePdfSupport` bool + `NATIVE_PDF_PROVIDER_IDS` constants with `getCapability(provider, cap)` lookup. |
-| **Generic `HousekeepingTask` registry** | Altitude F5 (deferred from v1.25.1 Hotfix) | `interface HousekeepingTask { name, run() }`; plugin `onload` iterates registered tasks (each cache registers itself). |
-| **`unwrapFencedMarkdown` generic helper** | Reuse F5 (deferred from v1.25.1 Hotfix) | Promote from `src/wiki/prompts/pdf.ts` to `src/text/unwrap-markdown-fences.ts`; reuse by Lint fix-runs + Query Wiki pre-process. |
-
-**What v1.26.0 does NOT do**: Bedrock Stage 2 (bearer-only via `@ai-sdk/amazon-bedrock@^5`, +0.3 MB) — conditional on 3+ user issues asking for Claude Sonnet 4 / Llama 4 on Bedrock. Bedrock Stage 3 SSO — indefinite deferral.
-
-**Migrated forward design rationale** (kept here for v1.26.0 reader; full design lives in CHANGELOG for v1.25.0):
-
-- **Trust boundary (PDF universal escape hatch, 2026-07-16):** The user is the authoritative source on what their endpoint supports. `forcePdfSupport` does NOT pre-flight whitelist. The LLM endpoint decides. Rejection propagates through `wiki-engine.ingestPdfSource` → `reportSkip` → localized `sourceRejectedPdfUnsupported` Notice. Honors user intent and gives definitive truth signal.
-- **Cache-only architecture (2026-07-15 pivot):** PDF cache (`.obsidian/plugins/karpathywiki/pdf-cache/{sha256}.json`) is the single source of truth. No sidecar file in vault by default (`writePdfMarkdownToVault` advanced toggle opt-in). First-principles rationale: the user-visible product is wiki pages, not intermediate markdown; the original PDF is the canonical artifact; cache in `.obsidian/` already provides persistence; less code.
 ## Version Timeline
 | Version | Date | Headline |
 |---------|------|----------|
+| **1.25.7** | 2026-07-25 | PATCH (in flight): DocTpoint dedup PRs #344+#345 merged. Cache-stable prompt layout (54s→1.2s repeat) + slim dedup + top-K candidate pre-filter (660K→372K prompt tokens, −44%); 12 recall-pinned new tests. Bot 0/0 preserved. 2547 tests / 191 files |
+| **1.25.6** | 2026-07-24 | PATCH: Eliminated 14 `@typescript-eslint/no-unsafe-*` Bot warnings via `createRequire(__filename)` over bare `require('node:http')`. **Bot 0/0 first time.** 2535 tests |
+| **1.25.5** | 2026-07-24 | PATCH: P0 Bot compliance (Platform.isDesktop guard + getSettingDefinitions stub + eslint.config.mjs cleanup) — pathway toward 0/0 |
+| **1.25.4** | 2026-07-24 | PATCH: SecretStorage Win10 regression (#339 fix) + fast-uri CVE bump |
+| **1.25.3** | 2026-07-23 | feat(security): provider API key → Obsidian SecretStorage (#182). Closes #182 |
+| **1.25.2** | 2026-07-22 | Schema Phase 1 (Option A bug-fix #328) + Codex OAuth + ESLint 0.4.1 Route A |
 | **1.25.1** | 2026-07-20 | PATCH: silent Mentions loss on Related re-ingest fixed (#288 closes #287) + LLM rewrite drops schema sections prevented (#302 closes #292) + legacy pre-#244 Mentions shape healed on parse (#303 closes #289) + LM Studio no-key ingest (#272). Big-file splits: `wiki-engine.ts` 1799→1619 with 657 LOC of helpers into `engine-internals/` (Phase C-PR1), `settings.ts` 1439→370 with 1183 LOC across 8 settings-sections (Phase C-PR2), `main.ts` 1304→300 with 915 LOC across 6 main-commands via mixin pattern (Phase C-PR3). `DiskCache<T>` extracted with bounded growth + ledger optimization (Phase F). Node 24 + AI-SDK patches pinned via `.nvmrc` + `.npmrc` + dual-direction lockfile regen from single `node_modules` snapshot (Phase E). 11 commits, ~80 files, 2274 tests |
 | 1.25.0 | 2026-07-18 | MINOR: cache-only PDF Ingest (Level 1) — three-defense-layer bounded cache (100MB / 1000 / 10MB + LRU-by-mtime) + provider gate (anthropic/openai/bedrock-* native, others via `forcePdfSupport` universal escape hatch) + content-hash cache key with `converterVersion` + two new settings (`forcePdfSupport`, `writePdfMarkdownToVault`) + verbatim OCR-style PDF prompt. 2182 tests |
 | 1.24.1 | 2026-07-14 | PATCH: 5-stage PPR cascade (#281) + parseJsonResponse quiet path (#282, closes #255/#274) + redundant Basic Information removal (#283, closes #258) + Bedrock Stage 1 (#277) + LM Studio no-key (#269) + Tier C bypass (#271) + page-factory split (#276) + non-lossy Mentions re-ingest (#267). 2080 tests |
@@ -227,17 +52,17 @@ Full design rationale: [`project_v1.25.1_release.md`](~/.claude/projects/-Users-
 | **1.22.2** | 2026-06-26 | Hotfix — auto-ingest modal→Notice (#204) + log i18n + periodic lint refined |
 | **1.22.1** | 2026-06-24 | Hotfix — fixDeadLink fabrication (#197) + startupCheck migration (#199) + CSS `:has()` + Query side panel (#196) + related-link corrector (#187) |
 | **1.22.0** | 2026-06-23 | Schema one-click apply (#97) + dynamic tag sync + zh-Hant + ingest status bar (#189, @YounianC) |
-| **1.21.1** | 2026-06-22 | Hotfix — #173 Symptom A NFC/NFD + esbuild 0.28.1 |
-| **1.21.0** | 2026-06-21 | Pre-ingest gate (#164) + Schema Phase 1 (#124) + History Panel (#122) + Italian (#159) |
-| **1.20.3** | 2026-06-20 | Hotfix — source-slug fingerprint (#155) + alias dedup (#154) + Stage-4 guard (#158) |
-| **1.20.2** | 2026-06-19 | Anthropic fallback system-role hotfix (PR #151 by @Indexed-Apogrypha, Closes #141/#147) |
-| **1.20.1** | 2026-06-18 | Anthropic prefill rejection hotfix (Closes #141/#147) |
-| **1.20.0** | 2026-06-18 | Provider-first thinking control + reasoning UI (Closes #141/#134/#143) |
-| **1.19.1** | 2026-06-17 | Gemini HTTP 400 hotfix (Closes #137) |
-| **1.19.0** | 2026-06-16 | Ingest quality & cost hardening — advanced LLM params, quote grounding, compact slugs |
-| **1.18.2** | 2026-06-12 | Custom extraction limits hard-enforced (Closes #120) + #114 tags preservation + #111 slug casing |
-| **1.18.1** | 2026-06-11 | Obsidian review compliance (document ban + prefer-active-doc) |
-| **1.18.0** | 2026-06-10 | Tag controlled vocabulary (Closes #85) v6/v7/v8 — chip input UX, end-to-end customTags pipeline |
+| 1.21.1 | 2026-06-22 | Hotfix — #173 Symptom A NFC/NFD + esbuild 0.28.1 |
+| 1.21.0 | 2026-06-21 | Pre-ingest gate (#164) + Schema Phase 1 (#124) + History Panel (#122) + Italian (#159) |
+| 1.20.3 | 2026-06-20 | Hotfix — source-slug fingerprint (#155) + alias dedup (#154) + Stage-4 guard (#158) |
+| 1.20.2 | 2026-06-19 | Anthropic fallback system-role hotfix (PR #151 by @Indexed-Apogrypha, Closes #141/#147) |
+| 1.20.1 | 2026-06-18 | Anthropic prefill rejection hotfix (Closes #141/#147) |
+| 1.20.0 | 2026-06-18 | Provider-first thinking control + reasoning UI (Closes #141/#134/#143) |
+| 1.19.1 | 2026-06-17 | Gemini HTTP 400 hotfix (Closes #137) |
+| 1.19.0 | 2026-06-16 | Ingest quality & cost hardening — advanced LLM params, quote grounding, compact slugs |
+| 1.18.2 | 2026-06-12 | Custom extraction limits hard-enforced (Closes #120) + #114 tags preservation + #111 slug casing |
+| 1.18.1 | 2026-06-11 | Obsidian review compliance (document ban + prefer-active-doc) |
+| 1.18.0 | 2026-06-10 | Tag controlled vocabulary (Closes #85) v6/v7/v8 — chip input UX, end-to-end customTags pipeline |
 | 1.17.0 | 2026-06-08 | Long-document ingestion + source attribution (Closes #90) |
 | 1.16.3 | 2026-06-07 | v1.16.2 P0 hotfix completion |
 | 1.16.2 | 2026-06-07 | Lint cancel + thinking token bleeding + delete empty stubs |
@@ -249,3 +74,5 @@ Full design rationale: [`project_v1.25.1_release.md`](~/.claude/projects/-Users-
 | 1.9.0 | 2026-05-10 | Pollution defense + 14-issue batch |
 | 1.8.1 | 2026-05-05 | Rate limit + smart fix all + 53 tests |
 | 1.0.0 | initial | First Obsidian release |
+
+> **Out of scope for v1.26.0 MINOR:** Bedrock Stage 2 (bearer-only via `@ai-sdk/amazon-bedrock@^5`) — conditional on 3+ user issues for Claude Sonnet 4 / Llama 4 on Bedrock. Bedrock Stage 3 SSO — indefinite deferral.

--- a/src/__tests__/llm-sdk/provider-api-key-resolver.test.ts
+++ b/src/__tests__/llm-sdk/provider-api-key-resolver.test.ts
@@ -51,4 +51,56 @@ describe('resolveProviderApiKey (#182)', () => {
     };
     expect(resolveProviderApiKey({ ...SETTINGS, apiKey: 'sk-fallback' }, broken)).toBe('sk-fallback');
   });
+
+  // Bug fix (#v1.25.7): pendingKey wins over SecretStorage so a freshly-typed
+  // key in the Settings UI is honored immediately by Fetch Models / Test
+  // Connection, instead of being silently overridden by the stale
+  // SecretStorage value from the previously-active provider.
+  describe('pendingKey (in-memory typed buffer)', () => {
+    it('returns trimmed pendingKey when non-empty, ignoring SecretStorage', () => {
+      expect(
+        resolveProviderApiKey(SETTINGS, backendWith('sk-stale-from-old-provider'), '  sk-new-typed  '),
+      ).toBe('sk-new-typed');
+    });
+
+    it('returns trimmed pendingKey when non-empty, ignoring settings.apiKey', () => {
+      expect(
+        resolveProviderApiKey(
+          { ...SETTINGS, apiKey: 'sk-legacy-plaintext' },
+          backendWith('sk-stale-from-old-provider'),
+          'sk-new-typed',
+        ),
+      ).toBe('sk-new-typed');
+    });
+
+    it('falls through to SecretStorage when pendingKey is undefined', () => {
+      expect(resolveProviderApiKey(SETTINGS, backendWith('sk-stored'), undefined)).toBe('sk-stored');
+    });
+
+    it('falls through to SecretStorage when pendingKey is empty string', () => {
+      expect(resolveProviderApiKey(SETTINGS, backendWith('sk-stored'), '')).toBe('sk-stored');
+    });
+
+    it('falls through to SecretStorage when pendingKey is whitespace-only', () => {
+      expect(resolveProviderApiKey(SETTINGS, backendWith('sk-stored'), '   ')).toBe('sk-stored');
+    });
+
+    it('falls through to settings.apiKey when pendingKey is empty and SecretStorage is empty', () => {
+      expect(
+        resolveProviderApiKey({ ...SETTINGS, apiKey: 'sk-legacy' }, backendWith(), ''),
+      ).toBe('sk-legacy');
+    });
+
+    it('returns empty string when all three sources are empty', () => {
+      expect(resolveProviderApiKey(SETTINGS, backendWith(), undefined)).toBe('');
+    });
+
+    it('survives SecretStorage.getSecret throw with non-empty pendingKey', () => {
+      const broken: ProviderSecretStorage = {
+        getSecret: () => { throw new Error('keychain locked'); },
+        setSecret: () => {},
+      };
+      expect(resolveProviderApiKey(SETTINGS, broken, 'sk-typed')).toBe('sk-typed');
+    });
+  });
 });

--- a/src/__tests__/root/openai-codex-lifecycle.test.ts
+++ b/src/__tests__/root/openai-codex-lifecycle.test.ts
@@ -64,14 +64,14 @@ describe('OpenAI Codex plugin lifecycle', () => {
     const plugin = pluginWith(manager);
     plugin.initializeLLMClient();
     expect(plugin.llmClient).not.toBeNull();
-    expect(createLLMClientFromSettingsSync).toHaveBeenCalledWith(expect.objectContaining({ provider: 'openai-codex', codexAuth: manager, codexQuotaMessage: 'ChatGPT Codex allowance reached. Wait for the displayed reset period and try again.' }));
+    expect(createLLMClientFromSettingsSync).toHaveBeenCalledWith(expect.objectContaining({ provider: 'openai-codex', codexAuth: manager, codexQuotaMessage: 'ChatGPT Codex allowance reached. Wait for the displayed reset period and try again.' }), undefined);
   });
   it('injects the selected locale quota message into the Codex client', () => {
     const manager = new CodexAuthManager({ store: memoryCredentialStore(freshCredential()) });
     const plugin = pluginWith(manager);
     plugin.settings.language = 'zh';
     plugin.initializeLLMClient();
-    expect(createLLMClientFromSettingsSync).toHaveBeenCalledWith(expect.objectContaining({ codexQuotaMessage: 'ChatGPT Codex 额度已用尽。请等待显示的重置时间后重试。' }));
+    expect(createLLMClientFromSettingsSync).toHaveBeenCalledWith(expect.objectContaining({ codexQuotaMessage: 'ChatGPT Codex 额度已用尽。请等待显示的重置时间后重试。' }), undefined);
   });
   it('migrates legacy readiness from SecretStorage without an API key', async () => {
     const values = new Map<string, string>([['karpathywiki-openai-codex', JSON.stringify(freshCredential())]]);

--- a/src/__tests__/ui/settings-provider-key-switching.test.ts
+++ b/src/__tests__/ui/settings-provider-key-switching.test.ts
@@ -1,0 +1,149 @@
+/**
+ * v1.25.7 PATCH regression test for the "API key self-restore" bug.
+ *
+ * Bug: when switching LLM providers in the Settings tab, any key the user
+ * typed into the API Key input was silently overwritten by the stale
+ * SecretStorage value from the previously-active provider on every
+ * `tab.display()` re-render. Two independent causes were fixed:
+ *
+ *   1. provider-section.ts input initial value (now `resolveInitialApiKey`):
+ *      `tempSettings.apiKey` non-empty wins over SecretStorage. Without
+ *      this, every re-render painted the OLD provider's key over the
+ *      freshly-typed value.
+ *   2. resolveProviderApiKey gained an optional `pendingKey` parameter
+ *      that wins over SecretStorage. Wired into Fetch Models /
+ *      Test Connection / createLLMClient so the freshly-typed key
+ *      reaches the wire.
+ *
+ * This file pins both contracts by calling the production helpers
+ * directly (no mirror, no drift risk).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveProviderApiKey,
+  resolveInitialApiKey,
+} from '../../llm-sdk/provider-api-key-resolver';
+import type { ProviderSecretStorage } from '../../llm-sdk/provider-secret-store';
+
+const SETTINGS = { apiKey: '', providerApiKeySecretId: 'karpathywiki-provider-api-key' };
+
+function backendWith(raw?: string): ProviderSecretStorage {
+  const values = new Map<string, string>();
+  if (raw !== undefined) values.set('karpathywiki-provider-api-key', raw);
+  return {
+    getSecret: (id) => values.get(id) ?? null,
+    setSecret: (id, value) => { values.set(id, value); },
+  };
+}
+
+describe('v1.25.7 PATCH: resolveInitialApiKey input precedence', () => {
+  it('prefers tempSettings.apiKey over SecretStorage (typed key survives re-render)', () => {
+    expect(
+      resolveInitialApiKey(
+        { apiKey: 'sk-cp-minimax-xxx', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        backendWith('sk-deepseek-old'),
+      ),
+    ).toBe('sk-cp-minimax-xxx');
+  });
+
+  it('falls back to SecretStorage when tempSettings.apiKey is empty', () => {
+    expect(
+      resolveInitialApiKey(
+        { apiKey: '', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        backendWith('sk-stored'),
+      ),
+    ).toBe('sk-stored');
+  });
+
+  it('falls back to SecretStorage when tempSettings.apiKey is whitespace-only', () => {
+    expect(
+      resolveInitialApiKey(
+        { apiKey: '   ', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        backendWith('sk-stored'),
+      ),
+    ).toBe('sk-stored');
+  });
+
+  it('returns empty string when both sources are empty', () => {
+    expect(
+      resolveInitialApiKey(
+        { apiKey: '', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        backendWith(),
+      ),
+    ).toBe('');
+  });
+
+  it('returns empty string when secretStorage is null and tempSettings.apiKey is empty', () => {
+    expect(
+      resolveInitialApiKey(
+        { apiKey: '', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        null,
+      ),
+    ).toBe('');
+  });
+
+  it('trims whitespace from tempSettings.apiKey', () => {
+    expect(
+      resolveInitialApiKey(
+        { apiKey: '  sk-cp-new  ', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        backendWith('sk-stored'),
+      ),
+    ).toBe('sk-cp-new');
+  });
+
+  it('survives SecretStorage.getSecret throw (locked keychain)', () => {
+    const broken: ProviderSecretStorage = {
+      getSecret: () => { throw new Error('keychain locked'); },
+      setSecret: () => {},
+    };
+    expect(
+      resolveInitialApiKey(
+        { apiKey: '', providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+        broken,
+      ),
+    ).toBe('');
+  });
+});
+
+describe('v1.25.7 PATCH: resolveProviderApiKey pendingKey precedence', () => {
+  it('returns typed key (pendingKey wins over SecretStorage)', () => {
+    expect(
+      resolveProviderApiKey(SETTINGS, backendWith('sk-stored'), 'sk-typed'),
+    ).toBe('sk-typed');
+  });
+
+  it('returns typed key when pendingKey is set even with valid SecretStorage', () => {
+    // The scenario the bug describes: switch from deepseek to minimax,
+    // type new key. SecretStorage still has the deepseek key.
+    expect(
+      resolveProviderApiKey(SETTINGS, backendWith('sk-deepseek-stale'), 'sk-minimax-new'),
+    ).toBe('sk-minimax-new');
+  });
+
+  it('falls through to SecretStorage when pendingKey is empty (no pending edit)', () => {
+    expect(
+      resolveProviderApiKey(SETTINGS, backendWith('sk-stored'), ''),
+    ).toBe('sk-stored');
+  });
+
+  it('end-to-end: switch provider + type new key → request uses new key', () => {
+    // Mirror the full UI sequence:
+    //   1. User switches provider from deepseek to minimax
+    //   2. SecretStorage still has the deepseek key (last flush)
+    //   3. User types new key into input
+    //   4. Re-render triggered (display())
+    //   5. Input value should be the typed key, not the stored key
+    const stored = 'sk-deepseek-old';
+    const typed = 'sk-cp-minimax-xxx';
+    const inputValue = resolveInitialApiKey(
+      { apiKey: typed, providerApiKeySecretId: SETTINGS.providerApiKeySecretId },
+      backendWith(stored),
+    );
+    expect(inputValue).toBe(typed);
+
+    //   6. User clicks Fetch Models — resolver should use typed key
+    const effectiveApiKey = resolveProviderApiKey(SETTINGS, backendWith(stored), typed);
+    expect(effectiveApiKey).toBe(typed);
+  });
+});

--- a/src/core/create-plugin-llm-client.ts
+++ b/src/core/create-plugin-llm-client.ts
@@ -27,6 +27,10 @@ export function createLLMClient(
   // Pass `plugin.app.secretStorage` from production code; tests that
   // don't have one can omit it (resolver falls back to settings.apiKey).
   secretStorage?: ProviderSecretStorage | null,
+  // v1.25.7 PATCH: forward the in-memory typed key (tab.tempSettings.apiKey
+  // in the Test Connection flow) so the freshly-typed key wins over the
+  // stale SecretStorage value. Production callers pass undefined.
+  pendingApiKey?: string,
 ): LLMClient {
   const client: LLMClient = createLLMClientFromSettingsSync({
     provider: settings.provider,
@@ -37,7 +41,7 @@ export function createLLMClient(
     codexAuth,
     codexVersion,
     codexQuotaMessage: getText(settings.language, 'codexAuthQuota'),
-  });
+  }, pendingApiKey);
 
   return wrapWithAdvancedSettings(client, {
     maxTokensPerCall: settings.maxTokensPerCall,

--- a/src/llm-sdk/create-llm-client.ts
+++ b/src/llm-sdk/create-llm-client.ts
@@ -107,7 +107,10 @@ function createBedrockClient(
  * Async factory used by callers that can await (Test Connection,
  * settings change handlers, ingestion init).
  */
-export async function createLLMClientFromSettings(settings: ProviderSettings): Promise<LLMClient> {
+export async function createLLMClientFromSettings(
+  settings: ProviderSettings,
+  pendingApiKey?: string,
+): Promise<LLMClient> {
   const { OpenAISdkClient } = await import('./openai-sdk-client');
   const { AnthropicSdkClient } = await import('./anthropic-sdk-client');
   const { OpenAICompatSdkClient } = await import('./openai-compat-sdk-client');
@@ -117,9 +120,13 @@ export async function createLLMClientFromSettings(settings: ProviderSettings): P
   // v1.25.3 #182: read the key through the resolver so SecretStorage is
   // preferred over the (now-empty) settings.apiKey. Falls back to the
   // legacy plaintext for un-migrated installs and tests.
+  // v1.25.7 PATCH: forward the optional pendingApiKey (tab.tempSettings.apiKey
+  // in the Test Connection flow) so the freshly-typed key wins over the
+  // stale SecretStorage value. Production callers pass undefined.
   const apiKey = resolveProviderApiKey(
     { apiKey: settings.apiKey, providerApiKeySecretId: settings.providerApiKeySecretId },
     settings.secretStorage ?? null,
+    pendingApiKey,
   );
   const baseUrl = settings.baseUrl?.trim() || undefined;
 
@@ -214,7 +221,10 @@ export async function preloadLLMClientModules(): Promise<void> {
  * If not preloaded, throws — this signals a bug in the plugin init
  * order, not a runtime config issue.
  */
-export function createLLMClientFromSettingsSync(settings: ProviderSettings): LLMClient {
+export function createLLMClientFromSettingsSync(
+  settings: ProviderSettings,
+  pendingApiKey?: string,
+): LLMClient {
   if (!preloadedModules) {
     throw new Error(
       '[v1.23.0 LLM migration] SDK modules not preloaded. ' +
@@ -227,9 +237,13 @@ export function createLLMClientFromSettingsSync(settings: ProviderSettings): LLM
   // v1.25.3 #182: read the key through the resolver so SecretStorage is
   // preferred over the (now-empty) settings.apiKey. Falls back to the
   // legacy plaintext for un-migrated installs and tests.
+  // v1.25.7 PATCH: forward the optional pendingApiKey (tab.tempSettings.apiKey
+  // in the Test Connection flow) so the freshly-typed key wins over the
+  // stale SecretStorage value. Production callers pass undefined.
   const apiKey = resolveProviderApiKey(
     { apiKey: settings.apiKey, providerApiKeySecretId: settings.providerApiKeySecretId },
     settings.secretStorage ?? null,
+    pendingApiKey,
   );
   const baseUrl = settings.baseUrl?.trim() || undefined;
 

--- a/src/llm-sdk/provider-api-key-resolver.ts
+++ b/src/llm-sdk/provider-api-key-resolver.ts
@@ -29,23 +29,38 @@ export interface ApiKeySettings {
  * Resolve the effective provider API key.
  *
  * Order:
- *   1. SecretStorage.getSecret(providerApiKeySecretId) — trimmed,
+ *   1. pendingKey (optional in-memory buffer). When the user types a new key
+ *      into the Settings UI, `tab.tempSettings.apiKey` holds the pending
+ *      value until `hide()` flushes it to SecretStorage. Callers that want
+ *      to honor a freshly-typed key immediately (e.g. "Fetch Models" /
+ *      "Test Connection" buttons) pass it as the 3rd argument so the
+ *      user's intent isn't silently overridden by the stale SecretStorage
+ *      value left over from the previously-active provider. A
+ *      whitespace-only or undefined pendingKey falls through.
+ *   2. SecretStorage.getSecret(providerApiKeySecretId) — trimmed,
  *      non-empty → returned as-is.
- *   2. settings.apiKey.trim() — legacy plaintext fallback. After
+ *   3. settings.apiKey.trim() — legacy plaintext fallback. After
  *      the v1.25.3 migration this is normally '' but tests and
  *      un-migrated installs still rely on this path.
- *   3. '' — both sources empty; caller treats as "no key configured".
+ *   4. '' — all sources empty; caller treats as "no key configured".
  *
  * @param settings - the LLMWikiSettings-like object (only `apiKey` and
  *   `providerApiKeySecretId` are read).
  * @param secretStorage - the live Obsidian SecretStorage, or null in
  *   environments where it's not available (some unit tests, server-side
  *   fixtures). When null, only the settings.apiKey fallback is used.
+ * @param pendingKey - optional in-memory buffer (Settings UI's
+ *   `tempSettings.apiKey`). When non-empty (after trim) it wins over
+ *   both SecretStorage and settings.apiKey. Pass `undefined` to skip
+ *   this tier entirely (backward compatible with pre-#v1.25.7 callers).
  */
 export function resolveProviderApiKey(
   settings: ApiKeySettings,
   secretStorage: ProviderSecretStorage | null,
+  pendingKey?: string,
 ): string {
+  const pending = pendingKey?.trim();
+  if (pending) return pending;
   if (secretStorage !== null) {
     try {
       const raw = secretStorage.getSecret(settings.providerApiKeySecretId);
@@ -61,4 +76,41 @@ export function resolveProviderApiKey(
     }
   }
   return (settings.apiKey ?? '').trim();
+}
+
+/**
+ * Resolve the initial value for the Settings UI's API Key input field.
+ *
+ * Same precedence as `resolveProviderApiKey` minus the legacy plaintext
+ * tier — the Settings UI must NEVER paint the persisted plaintext
+ * fallback (it would be a surprise to users who already migrated to
+ * SecretStorage). The fallback is `''`, so the input starts blank when
+ * nothing is configured.
+ *
+ * Used by `provider-section.ts` so the input's `setValue` honors the
+ * user's freshly-typed key across `tab.display()` re-renders. Without
+ * this precedence swap, every Fetch Models / Test Connection / provider
+ * dropdown change would clobber the typed value with the stale
+ * SecretStorage key from the previously-active provider.
+ *
+ * @param tempSettings - the Settings UI's in-memory buffer
+ *   (typically `tab.tempSettings`). Only `apiKey` and
+ *   `providerApiKeySecretId` are read.
+ * @param secretStorage - the live Obsidian SecretStorage, or null.
+ * @returns the trimmed key to paint into the input, or '' when nothing
+ *   is configured.
+ */
+export function resolveInitialApiKey(
+  tempSettings: { apiKey: string; providerApiKeySecretId: string },
+  secretStorage: ProviderSecretStorage | null,
+): string {
+  const pending = tempSettings.apiKey.trim();
+  if (pending.length > 0) return pending;
+  if (secretStorage === null) return '';
+  try {
+    const raw = secretStorage.getSecret(tempSettings.providerApiKeySecretId);
+    return typeof raw === 'string' ? raw.trim() : '';
+  } catch {
+    return '';
+  }
 }

--- a/src/main-commands/connection-commands.ts
+++ b/src/main-commands/connection-commands.ts
@@ -49,7 +49,7 @@ export interface ConnectionCommandsHost {
 
 /** Method signatures merged into LLMWikiPlugin via interface augmentation. */
 export interface ConnectionCommandsMethods {
-  testLLMConnection(): Promise<{ success: boolean; message: string }>;
+  testLLMConnection(pendingApiKey?: string): Promise<{ success: boolean; message: string }>;
   requireLLMReady(): boolean;
   isWikiInitialized(): Promise<boolean>;
 }
@@ -57,15 +57,21 @@ export interface ConnectionCommandsMethods {
 export const connectionCommands = {
   async testLLMConnection(
     this: ConnectionCommandsHost,
+    pendingApiKey?: string,
   ): Promise<{ success: boolean; message: string }> {
     const t = TEXTS[this.settings.language] || TEXTS.en;
 
     if (this.settings.provider === 'openai-codex' && this.codexAuthManager?.hasCredential() !== true) {
       return { success: false, message: t.codexAuthRequired };
     }
+    // v1.25.7 PATCH: accept an optional pendingApiKey so the Test
+    // Connection button can forward the in-memory typed key from
+    // tab.tempSettings.apiKey, bypassing the stale SecretStorage value.
+    // Production callers (initializeLLMClient etc.) pass undefined.
     if (providerRequiresApiKey(this.settings.provider) && !resolveProviderApiKey(
       { apiKey: this.settings.apiKey, providerApiKeySecretId: this.settings.providerApiKeySecretId },
       this.app.secretStorage,
+      pendingApiKey,
     )) {
       return { success: false, message: t.errorNoApiKey || 'API Key is not configured' };
     }
@@ -80,7 +86,7 @@ export const connectionCommands = {
     console.debug('[testLLMConnection] probe plan:', probePlan.map(p => `${p.label}=${p.model}`).join(', '));
 
     try {
-      const testClient = createLLMClient(this.settings, this.codexAuthManager ?? undefined, this.manifest.version, this.app.secretStorage);
+      const testClient = createLLMClient(this.settings, this.codexAuthManager ?? undefined, this.manifest.version, this.app.secretStorage, pendingApiKey);
 
       for (const probe of probePlan) {
         const attempted = new Set<string>();

--- a/src/ui/settings-sections/model-section.ts
+++ b/src/ui/settings-sections/model-section.ts
@@ -61,9 +61,15 @@ export function renderModelSection(tab: LLMWikiSettingTab, containerEl: HTMLElem
           // v1.25.3 #182: resolve the effective API key from SecretStorage
           // so Fetch Models works post-migration (tempSettings.apiKey is
           // normally '' — the plaintext was moved to OS keychain).
+          // v1.25.7 PATCH: Fetch Models is invoked from the Settings UI
+          // where `tempSettings.apiKey` IS the in-memory typed buffer.
+          // Pass it as `pendingKey` so the resolver honors a freshly-typed
+          // key (e.g. just switched provider + typed new key) instead of
+          // silently falling back to the stale SecretStorage value.
           const effectiveApiKey = resolveProviderApiKey(
             { apiKey: tempSettings.apiKey, providerApiKeySecretId: tempSettings.providerApiKeySecretId },
             tab.plugin.app.secretStorage,
+            tempSettings.apiKey,
           );
           const apiKey = isOllama ? 'ollama' : effectiveApiKey;
           const baseUrl = tempSettings.baseUrl?.trim() || providerConfig?.baseUrl || undefined;

--- a/src/ui/settings-sections/provider-section.ts
+++ b/src/ui/settings-sections/provider-section.ts
@@ -36,7 +36,7 @@ import { PREDEFINED_PROVIDERS } from '../../types';
 import { BEDROCK_REGIONS, BEDROCK_DEFAULT_REGION, NATIVE_PDF_PROVIDER_IDS, MAX_BATCH_DELAY_MS } from '../../constants';
 import { renderRangeSlider } from '../settings-helpers';
 import { getCodexAuthUiState } from '../openai-codex-auth-controls';
-import { ProviderSecretStore } from '../../llm-sdk/provider-secret-store';
+import { resolveInitialApiKey } from '../../llm-sdk/provider-api-key-resolver';
 
 export function renderProviderSection(tab: LLMWikiSettingTab, containerEl: HTMLElement): void {
   const { tempSettings } = tab;
@@ -106,11 +106,26 @@ export function renderProviderSection(tab: LLMWikiSettingTab, containerEl: HTMLE
     // so a user typing 30 characters does NOT trigger 30 OS keychain
     // writes — only the final value is persisted. This preserves the
     // pre-PR2 in-memory-edit-then-flush-on-save UX.
+    //
+    // v1.25.7 PATCH: respect the in-memory buffer (tempSettings.apiKey)
+    // as the FIRST source of truth. Without this precedence swap, the
+    // pending edit typed after a provider switch gets silently overwritten
+    // by the OLD SecretStorage value on every tab.display() re-render
+    // (e.g. when switching providers via the dropdown above, or after
+    // Fetch Models / Test Connection triggers display()). The previous
+    // behavior used `?? tempSettings.apiKey` as a fallback, but `??`
+    // only triggers when load() returns null — SecretStorage always has
+    // the last-flushed key, so the fallback never ran and the user's
+    // pending edit was clobbered.
     new Setting(containerEl)
       .setName(tab.getText('apiKeyName'))
       .setDesc(tab.getText('apiKeyDesc'))
       .addText(text => {
-        const initial = (new ProviderSecretStore(tab.plugin.app.secretStorage, tempSettings.providerApiKeySecretId).load() ?? tempSettings.apiKey).trim();
+        // v1.25.7 PATCH: delegate to resolveInitialApiKey so the input
+        // honors the in-memory tempSettings.apiKey buffer across re-renders
+        // instead of clobbering the user's pending edit with the stale
+        // SecretStorage value left over from the previously-active provider.
+        const initial = resolveInitialApiKey(tempSettings, tab.plugin.app.secretStorage);
         text.setPlaceholder(tab.getText('apiKeyPlaceholder'))
           .setValue(initial)
           .onChange((value) => {

--- a/src/ui/settings-sections/test-connection-section.ts
+++ b/src/ui/settings-sections/test-connection-section.ts
@@ -47,7 +47,12 @@ export function renderTestConnectionSection(tab: LLMWikiSettingTab, containerEl:
         const testSettings = { ...tab.tempSettings };
         const oldSettings = tab.plugin.settings;
         applySettings(testSettings);
-        const result = await tab.plugin.testLLMConnection();
+        // v1.25.7 PATCH: forward the in-memory typed key so testLLMConnection
+        // honors it via the resolver's pendingKey parameter (bypassing the
+        // stale SecretStorage value). See connection-commands.ts for the
+        // matching signature change. Production callers (initializeLLMClient
+        // etc.) pass undefined.
+        const result = await tab.plugin.testLLMConnection(testSettings.apiKey);
         tab.tempSettings.llmReady = result.success;
         if (!result.success) {
           // Restore live settings on test failure - do not persist broken config.


### PR DESCRIPTION
## Summary

Fixes a **regression since v1.25.3 #182** where switching LLM providers in the Settings tab silently overwrote any newly-typed API key with the old provider's SecretStorage value on every `tab.display()` re-render. Fetch Models and Test Connection fired HTTP requests with the stale key too.

## Root cause

Two orthogonal invariant violations:

1. **UI render** — `provider-section.ts:113` used `(ProviderSecretStore.load() ?? tempSettings.apiKey).trim()` as the input's initial value. The `??` operator only triggered when `load()` returned null — but SecretStorage always holds the last-flushed key, so the fallback never ran.
2. **Resolver** — `resolveProviderApiKey` read SecretStorage first, then `settings.apiKey`. It never consulted `tab.tempSettings.apiKey`, so the typed buffer was invisible to Fetch Models / Test Connection.

## Fix

- New `resolveInitialApiKey(tempSettings, secretStorage)` helper in `provider-api-key-resolver.ts`. Precedence: `tempSettings.apiKey` (in-memory buffer) > SecretStorage > `''`.
- `resolveProviderApiKey` gained optional 3rd `pendingKey?: string` parameter — when non-empty, it wins over both SecretStorage and `settings.apiKey`. Backward compatible (all 7 pre-existing 2-arg callers unchanged).
- Threaded `pendingApiKey` through 4 call sites: `testLLMConnection(pendingApiKey?)`, `createLLMClient(... pendingApiKey?)`, both factory variants, plus UI buttons in `model-section.ts` (Fetch Models) and `test-connection-section.ts` (Test Connection).

## Codex isolation verified

- Separate SecretStorage slot: `karpathywiki-openai-codex` vs `karpathywiki-provider-api-key`
- Separate store + manager classes (`CodexCredentialStore` / `CodexAuthManager` vs `ProviderSecretStore` / `resolveProviderApiKey`)
- UI gating: `isCodex` branch in `provider-section.ts:87` never renders the regular API Key input
- Zero cross-contamination risk identified

## Single-secretId design preserved

Switching providers still overwrites the same `karpathywiki-provider-api-key` slot on tab close (no per-provider slots). The fix honors the in-memory typed key until then.

## Tests

- **2566 passing / 192 files** (+19 since v1.25.6):
  - 8 `pendingKey` precedence cases in `provider-api-key-resolver.test.ts`
  - 7 `resolveInitialApiKey` precedence cases in new `settings-provider-key-switching.test.ts` (no function-mirror; calls production helpers directly)
  - 4 end-to-end scenarios
  - 2 `openai-codex-lifecycle.test.ts` mock assertions updated for new wrapper signature

## Quality gates

| Gate | Result |
|------|--------|
| ESLint | ✅ 0 errors / 0 warnings |
| TypeScript | ✅ 0 errors |
| Vitest | ✅ 2566 passed / 192 files |
| esbuild build | ✅ clean exit |
| css-lint | ✅ 0 violations |
| simplify (4-angle) | ✅ applied — helper extracted, transient field plumbing dropped, redundant guard simplified |
| code-review (5-angle) | ✅ PASS — no blocking findings |

## Files changed (this PR)

| File | Change |
|------|--------|
| `src/llm-sdk/provider-api-key-resolver.ts` | +resolveInitialApiKey + pendingKey param |
| `src/ui/settings-sections/provider-section.ts` | uses resolveInitialApiKey (Fix 1) |
| `src/ui/settings-sections/model-section.ts` | Fetch Models wires pendingKey |
| `src/ui/settings-sections/test-connection-section.ts` | Test Connection wires pendingKey |
| `src/main-commands/connection-commands.ts` | testLLMConnection signature + forwarding |
| `src/core/create-plugin-llm-client.ts` | pendingApiKey parameter added |
| `src/llm-sdk/create-llm-client.ts` | both factories accept pendingApiKey |
| `src/__tests__/llm-sdk/provider-api-key-resolver.test.ts` | +8 pendingKey precedence tests |
| `src/__tests__/ui/settings-provider-key-switching.test.ts` | NEW (11 tests) |
| `src/__tests__/root/openai-codex-lifecycle.test.ts` | 2 assertions updated |

## Files changed (docs cleanup, separate commit)

- `CLAUDE.md`, `ROADMAP.md`, `CONTRIBUTING.md` — pre-compact-prep compression pass (-213 lines net). One fact, one place; canonical sources in memory files.
- `CHANGELOG.md` — v1.25.7 PATCH entry.

## Memory

Created `feedback_provider_api_key_input_precedence.md` documenting:
- Bug pattern (any new SecretStorage-backed input must respect in-memory buffer as first source of truth)
- Fix architecture (resolver helper + signature param, no cast plumbing)
- Codex isolation verification
- Test coverage gap pattern (provider-section.ts had zero direct tests)

## User e2e

Manually tested the full scenario per the user's report:
- Provider switch (DeepSeek → MiniMax) ✅
- Type new key → click Fetch Models ✅
- Test Connection with typed key ✅
- Codex sign-in path untouched ✅
- Ollama / LM Studio no-key path unchanged ✅

Closes the user-reported regression where typing a new API key for a different provider was silently overridden by the old provider's key.