### PR TITLE
fix(merge): source ownership in the merge triage (#312)

### DIFF
--- a/src/__tests__/wiki/page-factory/create-page.test.ts
+++ b/src/__tests__/wiki/page-factory/create-page.test.ts
@@ -51,7 +51,10 @@ function makeCtx(opts: {
   };
 }
 
-const EMPTY_ANALYSIS = {} as unknown;
+// #312: the third parameter used to be `unknown` and was dropped on the floor;
+// it now carries the source analysis. These cases exercise the no-analysis
+// path (lint-side callers), which is exactly what `{} as unknown` meant here.
+const EMPTY_ANALYSIS = undefined;
 
 describe('createOrUpdatePage — empty name guard', () => {
   it('returns path=null when name is empty', async () => {

--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -197,3 +197,84 @@ describe('appendToReviewedPage — happy path writes merged content', () => {
     expect(written).not.toContain('quote-A');
   });
 });
+// Issue #312 part 2 — deterministic ownership guard. A source that carries the
+// page's own lemma must not be dropped on a novelty judgement: that is how a
+// page keeps a definition written by the first source that mentioned it in
+// passing, while its actual subject source is skipped.
+describe('mergePage — source owning the page lemma overrides triage=skip (#312)', () => {
+  const OWNING_CONTEXT = {
+    sourceTitle: 'Caching',
+    summary: 'A note about caching.',
+    sourcePath: 'Notes/Caching.md',
+  };
+
+  it('routes to the body merge when the source basename is the page lemma', async () => {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({ strategy: 'skip', reason: 'no new info' }),
+      '## Description\nMerged text.',
+    ]));
+
+    const result = await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'Notes/Caching.md', basename: 'Caching' },
+      EXISTING,
+      [],
+      'wiki/entities/caching.md',
+      undefined,
+      OWNING_CONTEXT,
+    );
+
+    expect(result).toBe('wiki/entities/caching.md');
+    const written = ctx.written.get('wiki/entities/caching.md')!;
+    // The skip verdict was overridden — the merge path produced the body.
+    expect(written).toContain('Merged text.');
+  });
+
+  it('leaves triage=skip intact when the source does not carry the page lemma', async () => {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({ strategy: 'skip', reason: 'no new info' }),
+      '## Description\nMerged text.',
+    ]));
+
+    await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'Notes/Distributed Systems.md', basename: 'Distributed Systems' },
+      EXISTING,
+      [],
+      'wiki/entities/caching.md',
+      undefined,
+      { sourceTitle: 'Distributed Systems', summary: 's', sourcePath: 'Notes/Distributed Systems.md' },
+    );
+
+    const written = ctx.written.get('wiki/entities/caching.md')!;
+    // Unchanged behaviour: an incidental source is still skipped.
+    expect(written).toContain('Old text.');
+    expect(written).not.toContain('Merged text.');
+  });
+
+  it('does not fire without a source context — lint-side callers are unchanged', async () => {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({ strategy: 'skip', reason: 'no new info' }),
+      '## Description\nMerged text.',
+    ]));
+
+    await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      // Same basename as the page: only the missing context keeps the guard off.
+      { path: 'Notes/Caching.md', basename: 'Caching' },
+      EXISTING,
+      [],
+      'wiki/entities/caching.md',
+    );
+
+    const written = ctx.written.get('wiki/entities/caching.md')!;
+    expect(written).toContain('Old text.');
+    expect(written).not.toContain('Merged text.');
+  });
+});

--- a/src/__tests__/wiki/page-factory/merge-triage.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-triage.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import {
   classifyMergeNeed,
   buildNewInfoSummary,
+  isSourceOwnPageLemma,
   type MergeTriageContext,
 } from '../../../wiki/page-factory/merge-triage';
 import { createMockEntity } from '../../__support__/factories';
@@ -182,5 +183,67 @@ describe('classifyMergeNeed — client precondition', () => {
     await expect(
       classifyMergeNeed(ctx, createMockEntity({ name: 'X' }), 'entity', { path: 'p.md', basename: 'p.md' }, '# x'),
     ).rejects.toThrow(/LLM client not initialized/);
+  });
+});
+// Issue #312 part 2 — the deterministic half of the fix. Pure string
+// comparison: no LLM, no IO. The predicate answers "is this source the page's
+// subject", which the triage prompt never asks.
+describe('isSourceOwnPageLemma — deterministic ownership', () => {
+  const ctx = { sourceTitle: 'Silent Inflammation', summary: 's', sourcePath: 'Notes/Silent Inflammation.md' };
+
+  it('matches across the space/dash spelling difference between note and page', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: 'Silent-Inflammation',
+      sourceBasename: 'Silent Inflammation',
+      sourceContext: ctx,
+    })).toBe(true);
+  });
+
+  it('matches on the analyzer source title when the file name differs', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: 'Silent-Inflammation',
+      sourceBasename: '2026-03-11 notes',
+      sourceContext: ctx,
+    })).toBe(true);
+  });
+
+  it('matches on a curated note alias', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: 'Chronische-Inflammation',
+      sourceBasename: 'Silent Inflammation',
+      sourceContext: { ...ctx, noteAliases: ['Chronische Inflammation'] },
+    })).toBe(true);
+  });
+
+  it('matches on one of the page aliases', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: 'CoQ10',
+      pageAliases: ['Coenzym Q10'],
+      sourceBasename: 'Coenzym-Q10',
+      sourceContext: { sourceTitle: 'Coenzym Q10', summary: 's', sourcePath: 'n.md' },
+    })).toBe(true);
+  });
+
+  it('does not match a source that merely mentions the page', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: 'Silent-Inflammation',
+      sourceBasename: 'Omega-3',
+      sourceContext: { sourceTitle: 'Omega-3', summary: 's', sourcePath: 'n.md' },
+    })).toBe(false);
+  });
+
+  it('never fires without a source context, even on an exact name match', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: 'Silent-Inflammation',
+      sourceBasename: 'Silent Inflammation',
+    })).toBe(false);
+  });
+
+  it('returns false for an empty page name instead of matching everything', () => {
+    expect(isSourceOwnPageLemma({
+      pageName: '   ',
+      sourceBasename: 'Silent Inflammation',
+      sourceContext: ctx,
+    })).toBe(false);
   });
 });

--- a/src/__tests__/wiki/page-factory/merge-triage.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-triage.test.ts
@@ -247,3 +247,67 @@ describe('isSourceOwnPageLemma — deterministic ownership', () => {
     })).toBe(false);
   });
 });
+
+// Issue #312 part 1 — the source-level summary plus the question that makes it
+// usable. Both are placeholder-rendered, so a caller without an ingest
+// upstream gets the prompt it got before, character for character.
+describe('classifyMergeNeed — source context in the triage prompt (#312)', () => {
+  const CONTEXT = {
+    sourceTitle: 'Silent Inflammation',
+    summary: 'A note on low-grade chronic inflammation and its markers.',
+    sourcePath: 'Notes/Silent Inflammation.md',
+  };
+
+  async function renderPrompt(sourceContext?: typeof CONTEXT): Promise<string> {
+    let seen = '';
+    const ctx = makeCtx({
+      createMessage: async (...a: unknown[]) => {
+        const req = a[0] as { messages: Array<{ content: string }> };
+        seen = req.messages[0].content;
+        return JSON.stringify({ strategy: 'skip', reason: 'r' });
+      },
+    });
+    await classifyMergeNeed(
+      ctx,
+      createMockEntity({ name: 'Silent Inflammation' }),
+      'entity',
+      { path: 'Notes/Silent Inflammation.md', basename: 'Silent Inflammation' },
+      '## Description\nExisting.',
+      sourceContext,
+    );
+    return seen;
+  }
+
+  it('adds the source summary under its own label, distinct from the item summary', async () => {
+    const prompt = await renderPrompt(CONTEXT);
+    expect(prompt).toContain('Source summary: A note on low-grade chronic inflammation');
+    // The item-level `Summary:` from buildNewInfoSummary is still there and is
+    // a different line — the collision the fix set out to avoid.
+    expect(prompt).toMatch(/^Summary: /m);
+    expect(prompt.match(/Source summary:/g)).toHaveLength(1);
+  });
+
+  it('asks whether the source is the page subject, not only whether the info is new', async () => {
+    const prompt = await renderPrompt(CONTEXT);
+    expect(prompt).toContain('primarily ABOUT this page or only mentions it in passing');
+  });
+
+  it('does not repeat the source name that {{new_info}} already carries', async () => {
+    const prompt = await renderPrompt(CONTEXT);
+    expect(prompt.match(/Silent Inflammation/g)?.length).toBeGreaterThan(0);
+    expect(prompt).not.toContain('Source being merged:');
+  });
+
+  it('renders the pre-change prompt exactly when no context is supplied', async () => {
+    const prompt = await renderPrompt(undefined);
+    expect(prompt).not.toContain('Source summary:');
+    expect(prompt).not.toContain('primarily ABOUT this page');
+    // No placeholder survives, and no blank line drifts in where the block
+    // would have gone: `{{new_info}}` is still followed directly by the
+    // sections header.
+    expect(prompt).not.toMatch(/\{\{\w+\}\}/);
+    expect(prompt).toMatch(/\n\n\*\*Available sections/);
+    // An empty placeholder must not leave a blank line behind anywhere.
+    expect(prompt).not.toContain('\n\n\n');
+  });
+});

--- a/src/__tests__/wiki/page-factory/related-page.test.ts
+++ b/src/__tests__/wiki/page-factory/related-page.test.ts
@@ -362,3 +362,34 @@ describe('updateRelatedPage — output order contract (#312)', () => {
     expect(existingSlot).toBeLessThan(newSlot);
   });
 });
+
+// The rendering bug the output-order work uncovered: `{{page_name}}` occurs
+// twice in the template, and `String.prototype.replace` with a string pattern
+// substitutes only the first occurrence. Every related-page rewrite therefore
+// asked the model to add information about a literal `{{page_name}}`.
+describe('updateRelatedPage — placeholder rendering', () => {
+  it('substitutes every {{page_name}} occurrence, not just the first', async () => {
+    let seenPrompt = '';
+    const ctx = makeCtx({ pageContent: EXISTING_FM });
+    ctx.getClient = () => ({
+      createMessage: async (req: { messages: Array<{ content: string }> }) => {
+        seenPrompt = req.messages[0].content;
+        return '## Description\nOld body.';
+      },
+    }) as ReturnType<RelatedPageContext['getClient']>;
+
+    await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      makeAnalysis(PAGE_TITLE),
+      { path: 'src.md', basename: 'src' },
+    );
+
+    expect(seenPrompt).toContain(`provides additional information about ${PAGE_TITLE}`);
+    expect(seenPrompt).not.toContain('{{page_name}}');
+    // Note: `{{existing_pages}}` does survive here, but it comes from the
+    // shared UNIVERSAL_LINK_CONSTRAINTS prose and is not a placeholder this
+    // template renders. Out of scope for this fix — asserted narrowly so the
+    // test pins the bug it is about.
+  });
+});

--- a/src/__tests__/wiki/page-factory/related-page.test.ts
+++ b/src/__tests__/wiki/page-factory/related-page.test.ts
@@ -310,3 +310,55 @@ describe('updateRelatedPage — Mentions are never LLM-owned (#267 parity)', () 
     expect(seenPrompt).toContain('Old body.');
   });
 });
+// #312 part 3 — the related-page rewrite prompt had no output format block, so
+// the model was free to open the page with the newest source's facts. The
+// contract mirrors appendToReviewedPage: existing content keeps its position,
+// new information comes after it.
+describe('updateRelatedPage — output order contract (#312)', () => {
+  it('renders an explicit output format placing new information AFTER existing content', async () => {
+    let seenPrompt = '';
+    const ctx = makeCtx({ pageContent: EXISTING_FM });
+    ctx.getClient = () => ({
+      createMessage: async (req: { messages: Array<{ content: string }> }) => {
+        seenPrompt = req.messages[0].content;
+        return '## Description\nOld body.\n\n## Extra\nNew facts.';
+      },
+    }) as ReturnType<RelatedPageContext['getClient']>;
+
+    const result = await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      makeAnalysis(PAGE_TITLE),
+      { path: 'src.md', basename: 'src' },
+    );
+
+    expect(result).toBe(true);
+    expect(seenPrompt).toContain('**Output Format:**');
+    expect(seenPrompt).toContain('NEVER place new information above the existing content.');
+  });
+
+  it('orders the two output slots existing-before-new in the rendered prompt', async () => {
+    let seenPrompt = '';
+    const ctx = makeCtx({ pageContent: EXISTING_FM });
+    ctx.getClient = () => ({
+      createMessage: async (req: { messages: Array<{ content: string }> }) => {
+        seenPrompt = req.messages[0].content;
+        return '## Description\nOld body.';
+      },
+    }) as ReturnType<RelatedPageContext['getClient']>;
+
+    await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      makeAnalysis(PAGE_TITLE),
+      { path: 'src.md', basename: 'src' },
+    );
+
+    const existingSlot = seenPrompt.indexOf('[existing sections');
+    const newSlot = seenPrompt.indexOf('[new information');
+    expect(existingSlot).toBeGreaterThan(-1);
+    expect(newSlot).toBeGreaterThan(-1);
+    // Positional contract, not merely textual presence.
+    expect(existingSlot).toBeLessThan(newSlot);
+  });
+});

--- a/src/core/slug.ts
+++ b/src/core/slug.ts
@@ -41,6 +41,23 @@ export function computeSlug(text: string, preserveCase = false): string {
   return preserveCase ? finalSlug : finalSlug.toLowerCase();
 }
 
+// Issue #312 — comparison keys for "do these two names denote the same thing".
+// Returns the slugified forms of a name plus its aliases in the case-insensitive
+// comparison form (never preserveCase, per the rule above), so a caller can test
+// two naming sets for overlap with a set intersection.
+//
+// Pure and allocation-cheap: the merge path calls it once per page write.
+export function slugKeys(name: string, aliases: readonly string[] = []): Set<string> {
+  const keys = new Set<string>();
+  for (const raw of [name, ...aliases]) {
+    if (typeof raw !== 'string') continue;
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    keys.add(computeSlug(trimmed));
+  }
+  return keys;
+}
+
 // Filter out aliases that are redundant against a page's own filename.
 // Obsidian resolves `[[X]]` to a file whose basename equals X (case-insensitive),
 // so an alias that already equals the filename is a self-pointing no-op that only

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,29 @@ export interface MentionWithProvenance {
   extracted_at: string;
 }
 
+/**
+ * Issue #312 — the ingest-side facts the merge path needs in order to tell a
+ * source that a page is ABOUT from a source that merely mentions it.
+ *
+ * Optional at every call site. Callers without an ingest upstream (the lint
+ * pipeline) pass nothing, which leaves both the merge routing and the rendered
+ * triage prompt exactly as they were.
+ */
+export interface SourceContext {
+  /** `SourceAnalysis.source_title` — the analyzer's title for the source. */
+  sourceTitle: string;
+  /**
+   * `SourceAnalysis.summary` — what the SOURCE document is about. Distinct
+   * from `EntityInfo.summary` / `ConceptInfo.summary`, which describe the
+   * extracted item; the triage prompt already carries the latter.
+   */
+  summary: string;
+  /** Carried for telemetry only — deliberately not rendered into any prompt. */
+  sourcePath: string;
+  /** Curated `aliases:` authored on the source note frontmatter (Issue #185). */
+  noteAliases?: string[];
+}
+
 export interface SourceAnalysis {
   source_file: string;
   source_title: string;

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -19,7 +19,15 @@
 // Conversation sources emit a single synthetic citation line.
 
 import { TFile } from 'obsidian';
-import type { EntityInfo, ConceptInfo, PageCreationResult, LLMWikiSettings, LLMClient } from '../../types';
+import type {
+  EntityInfo,
+  ConceptInfo,
+  PageCreationResult,
+  LLMWikiSettings,
+  LLMClient,
+  SourceAnalysis,
+  SourceContext,
+} from '../../types';
 import { PROMPTS } from '../../prompts';
 import { TOKENS_PAGE_GENERATION } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
@@ -46,6 +54,23 @@ export interface CreatePageContext extends PathResolutionContext {
 }
 
 /**
+ * Issue #312 — lift the ingest-side source facts out of the analysis object
+ * the engine already hands to this module. Returns undefined when there is no
+ * analysis (lint-side callers), which keeps the merge path unchanged for them.
+ */
+export function sourceContextFromAnalysis(
+  analysis: SourceAnalysis | undefined,
+): SourceContext | undefined {
+  if (!analysis) return undefined;
+  return {
+    sourceTitle: analysis.source_title,
+    summary: analysis.summary,
+    sourcePath: analysis.source_file,
+    noteAliases: analysis.source_note_aliases,
+  };
+}
+
+/**
  * Generic page CRUD (entity/concept unified). Returns:
  *   - { path } when a page was written.
  *   - { path: null } when the name was empty.
@@ -59,6 +84,7 @@ export async function createOrUpdatePage(
   sourceFile: TFile | { path: string; basename: string },
   extraPagePaths: string[] = [],
   sourceSlug?: string,
+  sourceContext?: SourceContext,
 ): Promise<PageCreationResult> {
   if (!info.name || info.name.trim().length === 0) {
     console.warn(`${pageType} name is empty, skipping creation`);
@@ -84,7 +110,7 @@ export async function createOrUpdatePage(
         if (isReviewed) {
           await appendToReviewedPage(ctx, info, sourceFile, existingContent, targetPath, sourceSlug);
         } else {
-          await mergePage(ctx, info, targetType, sourceFile, existingContent, extraPagePaths, targetPath, sourceSlug);
+          await mergePage(ctx, info, targetType, sourceFile, existingContent, extraPagePaths, targetPath, sourceSlug, sourceContext);
         }
         console.debug(`Cross-type collision: merged "${info.name}" content into ${targetType} page ${targetPath}`);
       }
@@ -110,7 +136,7 @@ export async function createOrUpdatePage(
     return { path: updatedPath, created: false };
   }
 
-  const mergedPath = await mergePage(ctx, info, pageType, sourceFile, existingContent, extraPagePaths, result.path, sourceSlug);
+  const mergedPath = await mergePage(ctx, info, pageType, sourceFile, existingContent, extraPagePaths, result.path, sourceSlug, sourceContext);
   return { path: mergedPath, created: false };
 }
 
@@ -121,12 +147,15 @@ export async function createOrUpdatePage(
 export async function createOrUpdateEntityPage(
   ctx: CreatePageContext,
   entity: EntityInfo,
-  _analysis: unknown,
+  analysis: SourceAnalysis | undefined,
   sourceFile: TFile | { path: string; basename: string },
   extraPagePaths: string[] = [],
   sourceSlug?: string,
 ): Promise<PageCreationResult> {
-  return createOrUpdatePage(ctx, entity, 'entity', sourceFile, extraPagePaths, sourceSlug);
+  return createOrUpdatePage(
+    ctx, entity, 'entity', sourceFile, extraPagePaths, sourceSlug,
+    sourceContextFromAnalysis(analysis),
+  );
 }
 
 /**
@@ -136,12 +165,15 @@ export async function createOrUpdateEntityPage(
 export async function createOrUpdateConceptPage(
   ctx: CreatePageContext,
   concept: ConceptInfo,
-  _analysis: unknown,
+  analysis: SourceAnalysis | undefined,
   sourceFile: TFile | { path: string; basename: string },
   extraPagePaths: string[] = [],
   sourceSlug?: string,
 ): Promise<PageCreationResult> {
-  return createOrUpdatePage(ctx, concept, 'concept', sourceFile, extraPagePaths, sourceSlug);
+  return createOrUpdatePage(
+    ctx, concept, 'concept', sourceFile, extraPagePaths, sourceSlug,
+    sourceContextFromAnalysis(analysis),
+  );
 }
 
 /**

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -27,7 +27,7 @@
 //     Mentions section (pageIsReviewed: true).
 
 import { TFile } from 'obsidian';
-import type { EntityInfo, ConceptInfo, LLMWikiSettings, LLMClient } from '../../types';
+import type { EntityInfo, ConceptInfo, LLMWikiSettings, LLMClient, SourceContext } from '../../types';
 import {
   TOKENS_PAGE_GENERATION,
   TOKENS_APPEND_REVIEWED,
@@ -40,12 +40,12 @@ import {
   preserveExistingSections,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
-import { mergeFrontmatter } from '../../core/frontmatter';
+import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { UNIVERSAL_LINK_CONSTRAINTS } from '../prompts/constraints';
 import { buildPagesListForPrompt } from './path-resolution';
-import { classifyMergeNeed } from './merge-triage';
+import { classifyMergeNeed, isSourceOwnPageLemma } from './merge-triage';
 import { assembleFinalContent } from './mentions-integration';
 import { applyComplementaryAppends } from './complementary-appends';
 import { firstQuotesForPrompt, isConversationSource, mergeError } from './contextualize';
@@ -81,6 +81,7 @@ export async function mergePage(
   extraPagePaths: string[],
   path: string,
   sourceSlug?: string,
+  sourceContext?: SourceContext,
 ): Promise<string | null> {
   const client = ctx.getClient();
   if (!client) throw new Error('LLM client not initialized');
@@ -92,17 +93,45 @@ export async function mergePage(
       sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
     );
 
+    // Issue #312 part 2 — deterministic, no LLM: is this source the page's own
+    // subject? Compared against the page FILE name (the page's identity) plus
+    // its curated aliases; slug comparison on both sides, so "Silent
+    // Inflammation.md" matches the page "Silent-Inflammation".
+    const pageBasename = path.split('/').pop()?.replace(/\.md$/i, '') ?? '';
+    const existingAliases = parseFrontmatter(existingContent)?.aliases;
+    const sourceOwnsPage = isSourceOwnPageLemma({
+      pageName: pageBasename,
+      pageAliases: Array.isArray(existingAliases) ? existingAliases : undefined,
+      sourceBasename: sourceFile.basename,
+      sourceContext,
+    });
+
     // 1. v1.24.0 #216 — classify-then-route triage.
     let shouldSkip = false;
     let complementaryBody: string | null = null;
     try {
       const triage = await classifyMergeNeed(ctx, info, pageType, sourceFile, existingBody);
-      if (triage.strategy === 'skip') {
+
+      // #312 part 2: a page's own primary source must not be dropped on a
+      // novelty judgement — that is how an incidental mention keeps a
+      // definition it wrote first. Route it to the body merge, which is the
+      // prompt's own stated default whenever the call is not clear-cut.
+      // Deliberately narrow: only `skip` is overridden. `complementary`
+      // already writes the new facts, and rerouting it would trade a targeted
+      // append for a full rewrite without cause.
+      const strategy = triage.strategy === 'skip' && sourceOwnsPage ? 'merge' : triage.strategy;
+      if (strategy !== triage.strategy) {
+        console.debug(
+          `[mergePage] triage=skip overridden to merge — "${sourceFile.basename}" carries this page's own lemma (#312) for ${path}`,
+        );
+      }
+
+      if (strategy === 'skip') {
         console.debug(
           `[mergePage] triage=skip reason="${triage.reason}" — preserving existing body for ${path}`,
         );
         shouldSkip = true;
-      } else if (triage.strategy === 'complementary' && triage.items.length > 0) {
+      } else if (strategy === 'complementary' && triage.items.length > 0) {
         console.debug(
           `[mergePage] triage=complementary items=${triage.items.length} — appending to existing sections for ${path}`,
         );

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -110,7 +110,7 @@ export async function mergePage(
     let shouldSkip = false;
     let complementaryBody: string | null = null;
     try {
-      const triage = await classifyMergeNeed(ctx, info, pageType, sourceFile, existingBody);
+      const triage = await classifyMergeNeed(ctx, info, pageType, sourceFile, existingBody, sourceContext);
 
       // #312 part 2: a page's own primary source must not be dropped on a
       // novelty judgement — that is how an incidental mention keeps a

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -16,7 +16,8 @@
 //     kept tight to control classify-token cost.
 
 import { TFile } from 'obsidian';
-import type { EntityInfo, ConceptInfo, LLMWikiSettings } from '../../types';
+import type { EntityInfo, ConceptInfo, LLMWikiSettings, SourceContext } from '../../types';
+import { slugKeys } from '../../core/slug';
 import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { TOKENS_MERGE_TRIAGE } from '../../constants';
@@ -148,6 +149,44 @@ export async function classifyMergeNeed(
   }
 
   return { strategy, items, reason };
+}
+
+/**
+ * Issue #312 part 2 — deterministic ownership test, no LLM involved.
+ *
+ * True when the source carries the page's own lemma: its file basename, its
+ * analyzer title, or one of its curated note aliases slug-matches the page
+ * name or one of the page's aliases. That is the case where the source IS the
+ * page's subject rather than a document that mentions it in passing.
+ *
+ * Fires only when `sourceContext` is present, i.e. on the ingest path. Callers
+ * without one (lint) keep their previous behaviour exactly.
+ *
+ * On a corpus whose notes are not lemma-shaped — no note titled like the page
+ * it is about — this never matches and the merge path is unchanged. Inert
+ * rather than harmful is the intended failure mode.
+ */
+export function isSourceOwnPageLemma(params: {
+  pageName: string;
+  pageAliases?: readonly string[];
+  sourceBasename: string;
+  sourceContext?: SourceContext;
+}): boolean {
+  const { pageName, pageAliases = [], sourceBasename, sourceContext } = params;
+  if (!sourceContext) return false;
+
+  const pageKeys = slugKeys(pageName, pageAliases);
+  if (pageKeys.size === 0) return false;
+
+  const sourceKeys = slugKeys(sourceBasename, [
+    sourceContext.sourceTitle,
+    ...(sourceContext.noteAliases ?? []),
+  ]);
+
+  for (const key of sourceKeys) {
+    if (pageKeys.has(key)) return true;
+  }
+  return false;
 }
 
 /**

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -75,6 +75,7 @@ export async function classifyMergeNeed(
   pageType: 'entity' | 'concept',
   sourceFile: TFile | { path: string; basename: string },
   existingContent: string,
+  sourceContext?: SourceContext,
 ): Promise<MergeTriageResult> {
   const client = ctx.getClient();
   if (!client) throw new Error('LLM client not initialized');
@@ -90,6 +91,8 @@ export async function classifyMergeNeed(
     .replace('{{page_type}}', pageType)
     .replace('{{existing_content}}', existingContent)
     .replace('{{new_info}}', buildNewInfoSummary(info, sourceFile))
+    .replace('{{source_context}}', renderSourceContextBlock(sourceContext))
+    .replace('{{source_ownership_rule}}', renderSourceOwnershipRule(sourceContext))
     .replace('{{section_labels}}', `- ${sectionLabelsList}`);
 
   // Issue #328 Phase 1 follow-up: removed appendTagVocabularyToPrompt wrapper
@@ -149,6 +152,38 @@ export async function classifyMergeNeed(
   }
 
   return { strategy, items, reason };
+}
+
+/**
+ * Issue #312 part 1 — the source-level summary, rendered into the triage
+ * prompt. Empty when no context is available, which leaves the rendered prompt
+ * byte-identical to the previous one (the placeholder carries its own leading
+ * newlines so nothing drifts).
+ *
+ * The label is `Source summary:` and not `Summary:` on purpose: `{{new_info}}`
+ * already carries `Summary:` for the extracted ITEM. Two lines with the same
+ * label and different scopes would be worse than the missing field.
+ *
+ * The source name is not repeated here — `buildNewInfoSummary` already writes
+ * `Source: <basename>` into `{{new_info}}`.
+ */
+export function renderSourceContextBlock(sourceContext?: SourceContext): string {
+  const summary = sourceContext?.summary?.trim();
+  if (!summary) return '';
+  return `\n\n**What the source document as a whole is about:**\nSource summary: ${summary}`;
+}
+
+/**
+ * Issue #312 part 1 — the question the prompt never asked. Adding the summary
+ * alone supplies context to a prompt whose four strategies are all keyed to
+ * novelty; without this rule the model has the fact and no reason to use it.
+ *
+ * Rendered only alongside the summary: asking whether a source is the page's
+ * subject, without saying what the source is about, is not answerable.
+ */
+export function renderSourceOwnershipRule(sourceContext?: SourceContext): string {
+  if (!renderSourceContextBlock(sourceContext)) return '';
+  return '\n- Consider whether this source is primarily ABOUT this page or only mentions it in passing. A source whose subject IS this page carries more weight for the page\'s core description than an incidental mention — prefer "merge" over "skip" for it.';
 }
 
 /**

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -113,7 +113,11 @@ export async function updateRelatedPage(
   const promptBody = stripMentionsSection(existingBody, labels.mentions_in_source);
 
   const prompt = PROMPTS.updateRelatedPage
-    .replace('{{page_name}}', pageName)
+    // Global: `{{page_name}}` occurs twice in the template. A string pattern
+    // replaces only the first match, so the sentence that names the page's
+    // subject ("provides additional information about {{page_name}}") reached
+    // the model with the literal placeholder still in it.
+    .replace(/\{\{page_name\}\}/g, pageName)
     .replace('{{existing_body}}', promptBody)
     .replace('{{source_basename}}', sourceFile.basename)
     .replace('{{new_info}}', JSON.stringify(newInfo))

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -36,7 +36,7 @@ export const MERGE_PROMPTS = {
 {{existing_content}}
 
 **New Information from Source File:**
-{{new_info}}
+{{new_info}}{{source_context}}
 
 **Available sections in the existing page (target_section MUST be one of these exact names):**
 {{section_labels}}
@@ -69,7 +69,7 @@ Output JSON format (ONLY this object, no other text):
 
 Rules:
 - Default to "merge" if uncertain — better to rewrite than to silently drop new info.
-- \`target_section\` MUST be exactly one of the available sections list (case-sensitive).
+- \`target_section\` MUST be exactly one of the available sections list (case-sensitive).{{source_ownership_rule}}
 - Output ONLY JSON, nothing else.`,
 
   mergeEntityPage: `You are a Wiki editor performing intelligent content integration. Merge new source information into an existing page following the schema-defined structure.

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -181,6 +181,12 @@ If new content exists:
 [Only genuinely new facts, written to match existing style]`,
 
   // Update related page with incremental information from a new source
+  //
+  // The output contract mirrors `appendToReviewedPage`: existing content keeps
+  // its position and new information goes AFTER it. Without an explicit format
+  // block the model routinely emitted the new facts as an opening paragraph,
+  // pushing the page's own definition down — the page reads as if the newest
+  // incidental source were its subject.
   updateRelatedPage: `Existing Wiki page: {{page_name}}
 
 Existing content:
@@ -192,5 +198,14 @@ The new source file ("{{source_basename}}") provides additional information abou
 Update the page by adding the new information without deleting existing content.
 {{constraints}}
 Use wiki-link syntax [[page-name]].
-Output ONLY the updated page BODY content (without frontmatter), no other text.`,
+
+**Output Format:**
+Output ONLY the updated page BODY content (without frontmatter), no other text:
+
+[existing sections, preserved in their current order]
+
+[new information — integrated into the section it belongs to, or appended as a
+final section when it fits none of them]
+
+NEVER place new information above the existing content.`,
 };


### PR DESCRIPTION
Closes #312.

## Problem

I corrected my own issue text before writing this (comment above): the triage does receive the source name — `buildNewInfoSummary` has written `Source: ${sourceFile.basename}` into `{{new_info}}` since #216. The issue body's "without ever being told which source the information came from" was wrong.

What is missing is narrower: `SourceAnalysis.summary` (what the source **document** is about, `types.ts:37`) is produced by the analyzer and never forwarded, and none of the four strategies is keyed to source at all. The identity is delivered; nothing asks for it to be used.

Four commits, each standing on its own. The last one is the only prompt-text change and can be dropped without touching the rest — see **Separability**.

## Change 1 — related-page output order, part 3 of the issue (`d6ca708`)

`updateRelatedPage` ended with a bare "Output ONLY the updated page BODY content" and no format block. Nothing told the model where new facts belong, so it routinely opened the page with the newest source's material and pushed the page's own definition down. `appendToReviewedPage` already carries the contract this path was missing: existing content keeps its position, new information comes after it.

Prompt text only, no code path touched.

## Change 2 — every `{{page_name}}` occurrence rendered (`3b128c6`)

Found while writing the test for Change 1. `String.prototype.replace` with a string pattern substitutes only the first match, and `{{page_name}}` occurs twice in the template, so every related-page rewrite reached the model as:

```
The new source file ("Omega-3") provides additional information about {{page_name}}:
```

The sentence that names the page's subject was the one carrying the literal placeholder.

Same class elsewhere in the prompt layer, all untouched here:

| template | placeholder | occurrences | rendered |
|---|---|---|---|
| `generateSummaryPage` | `{{date}}` | 3 | 1 |
| `preserveReviewedEntityPage` / `…ConceptPage` | `{{date}}` | 3 | 1 |
| `appendToReviewedPage` | `{{new_source}}` | 3 | 1 |
| `generateEntityPage` | `{{entity_name}}` | 2 | 1 |
| `generateSummaryPage` | `{{source_title}}` | 2 | 1 |

Happy to file that separately rather than widen this PR. `{{section_*}}` is unaffected — `applySectionLabels` already replaces globally.

## Change 3 — deterministic ownership guard, part 2 (`e6d539e`)

When the source's file name, its analyzer title, or one of its curated note aliases slug-matches the page name or one of the page's aliases, a `skip` verdict is routed to the body merge instead — which is the prompt's own stated default whenever the call is not clear-cut. No LLM, no extra call.

Deliberately narrow on three axes:

| axis | choice | why |
|---|---|---|
| strategies overridden | `skip` only | `complementary` already writes the new facts; rerouting it would trade a targeted append for a full rewrite |
| when it fires | only with a `SourceContext` | that is the ingest path; lint-side callers keep their exact previous behaviour (pinned by a test) |
| corpora without lemma-shaped notes | never matches | inert rather than harmful is the intended failure mode |

Plumbing: `createOrUpdateEntityPage` / `createOrUpdateConceptPage` already received the `SourceAnalysis` as their third parameter — typed `unknown`, named `_analysis`, dropped one line later. It is now typed and forwarded. No new call, no new data structure.

## Change 4 — source summary and the ownership question, part 1 (`1975817`)

Two things, and the second is the reason the first works:

1. The source summary under its own label `Source summary:`. Not `Summary:` — that label is taken by the extracted item, and two identical labels at different scopes would be worse than the missing field. The source **name** is not repeated; `{{new_info}}` already carries it.
2. One rule asking whether the source is primarily about this page or only mentions it in passing. All four strategies are keyed to novelty; without the question the summary is context the prompt has no reason to consult.

## Deviations from the fix path you proposed

| your sketch | what I did | why |
|---|---|---|
| extend `EngineContext` / `LintPhaseContext` | threaded on the page-factory path | `PROMPTS.mergeAnalysis` has one consumer, `merge-triage.ts:88`. `analysis-phase.ts` builds its own prompt and never references it, so the lint context would not have reached the triage |
| prepend `Source being merged: <title>` | summary only | it would print the source name a second time |
| `{ sourceTitle, summary, sourcePath }` | plus the curated note aliases (#185) | without them the deterministic guard misses every page living under an alias of its source note — the common case in a non-English vault |

`sourcePath` is in the type and deliberately not in the prompt, as you asked.

## Separability

Change 4 is the only one that alters prompt text. If you would rather leave the prompt untouched in a PATCH, drop it — Changes 1–3 stand alone, and the deterministic guard needs no prompt change.

Both new blocks in Change 4 are placeholder-rendered and empty without a `SourceContext`, so a caller without an ingest upstream gets the previous prompt character for character. A test asserts that, including that no blank line drifts in where the block would have been.

## Gate

Rebased onto current `main` (`7ef237a`). Baseline counted on `7ef237a` itself, with `pnpm build` run before `pnpm test`.

| check | `7ef237a` | this branch |
|---|---|---|
| `npx tsc --noEmit` | 0 | 0 |
| `pnpm build` | clean | clean |
| `pnpm test` | 2547 / 191 files | 2564 / 191 files |
| `pnpm lint --max-warnings=0` | 0 | 0 |
| `pnpm css-lint` | 0 | 0 |

+17 tests, no new file — exactly the tests added here. Both behavioural changes are mutation-checked: disabling the guard fails exactly the positive test and leaves the two backward-compatibility controls green.

## Not addressed

The harder half is untouched. When a source is **not** the page's subject, the triage still judges on novelty alone; the summary only makes a better judgement possible. The `supersedes:` flag from #220 is the part that decides rather than informs, and I see the Tier 0 / Tier 1 split is in the v1.26.0 scope now — the deterministic guard here is intentionally the weaker, PATCH-sized version of the same idea.
