### PR TITLE
fix(ingest): keep source-page tags inside the closed vocabulary

### DIFF
--- a/src/__tests__/__support__/wiki-engine-harness.ts
+++ b/src/__tests__/__support__/wiki-engine-harness.ts
@@ -14,8 +14,13 @@ import { WikiEngine } from '../../wiki/wiki-engine';
 import { parseFrontmatter } from '../../core/frontmatter';
 import { DEFAULT_SETTINGS } from './engine-context';
 
+type LLMRequest = Parameters<LLMClient['createMessage']>[0];
+
 export interface WikiEngineHarness {
   engine: WikiEngine;
+  /** Every request handed to the LLM stub, in order. Lets a test assert on the
+   *  prompt the engine built, not just on what the stub returned. */
+  llmRequests: LLMRequest[];
   /** Every path written by the engine (via onFileWrite), in order. */
   writtenPaths: string[];
   /** Every IngestReport delivered to onDone, in order. */
@@ -52,6 +57,7 @@ function mkFile(path: string): TFile {
 
 export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHarness {
   const files = new Map<string, string>(Object.entries(opts.files ?? {}));
+  const llmRequests: LLMRequest[] = [];
   const writtenPaths: string[] = [];
   const reports: IngestReport[] = [];
   const stats = { llmCalls: 0, vaultMarkdownScans: 0 };
@@ -99,8 +105,9 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
   } as unknown as App;
 
   const client: LLMClient = {
-    createMessage: async () => {
+    createMessage: async params => {
       stats.llmCalls++;
+      llmRequests.push(params);
       return opts.llmResponses?.[llmIdx++] ?? '{"entities":[],"concepts":[]}';
     },
   };
@@ -132,7 +139,7 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
     () => { /* onEnd: nothing to capture */ },
   );
 
-  return { engine, writtenPaths, reports, files, stats, startedFilenames, progressMessages };
+  return { engine, llmRequests, writtenPaths, reports, files, stats, startedFilenames, progressMessages };
 }
 
 /** True if any written path is a wiki entity/concept/source page (the #164 symptom). */

--- a/src/__tests__/wiki/wiki-engine-summary-tags.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-tags.test.ts
@@ -1,0 +1,127 @@
+// Issue #90 follow-up: the source-page `tags:` fallback must stay inside the
+// closed VALID_SOURCE_TAGS vocabulary.
+//
+// createSummaryPage feeds `{{tags}}` into the summary prompt, so these tests
+// assert on the prompt the engine builds rather than on the stubbed response.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+import { DEFAULT_SOURCE_TAG } from '../../types';
+import type { SourceAnalysis } from '../../types';
+
+const SOURCE_NOTE_PATH = 'sources/lecture-transcript.md';
+
+const PLAIN_TRANSCRIPT = `# Lecture transcript
+
+An unstructured transcript with no frontmatter at all — the normal case for
+speech-to-text output, and the case that used to leak concept names into tags.
+`;
+
+function sourceFile(): TFile {
+  return Object.assign(new TFile(), {
+    path: SOURCE_NOTE_PATH,
+    basename: 'lecture-transcript',
+    extension: 'md',
+  });
+}
+
+const SUMMARY_RESPONSE = JSON.stringify({
+  frontmatter: { type: 'source', sources: ['[[sources/self-stub]]'] },
+  body: '## Summary\n\nA lecture.',
+});
+
+function makeAnalysis(): SourceAnalysis {
+  return {
+    source_file: SOURCE_NOTE_PATH,
+    source_title: 'Lecture transcript',
+    summary: 'A lecture.',
+    entities: [],
+    concepts: [
+      { name: 'Jnana Yoga', type: 'philosophy', summary: 'path of knowledge', mentions_in_source: [] },
+      { name: 'Karma Yoga', type: 'philosophy', summary: 'path of action', mentions_in_source: [] },
+    ],
+    contradictions: [],
+    related_pages: [],
+    key_points: [],
+    created_pages: [],
+    updated_pages: [],
+  } as unknown as SourceAnalysis;
+}
+
+/**
+ * The `{{tags}}` value the engine substituted into the summary prompt.
+ *
+ * Anchored to the `source_file:` line of the source-page frontmatter template:
+ * the prompt also embeds the source note's own body (`{{content}}`), whose
+ * frontmatter can carry an unrelated `tags:` line that appears first.
+ */
+function tagsInPrompt(h: ReturnType<typeof createWikiEngineHarness>): string {
+  const request = h.llmRequests.at(-1);
+  const content = request?.messages?.[0]?.content ?? '';
+  const match = /source_file: "\[\[[^\]]*\]\]"\ntags:\s*\[(.*)\]/.exec(
+    typeof content === 'string' ? content : ''
+  );
+  expect(match, 'expected the source-page tags: line in the summary prompt').not.toBeNull();
+  return match![1].trim();
+}
+
+function harnessFor(sourceBody: string, extraFiles: Record<string, string> = {}) {
+  return createWikiEngineHarness({
+    files: { [SOURCE_NOTE_PATH]: sourceBody, ...extraFiles },
+    llmResponses: [SUMMARY_RESPONSE],
+  });
+}
+
+describe('WikiEngine.createSummaryPage — source-page tag vocabulary', () => {
+  it('falls back to the default tag instead of extracted concept names', async () => {
+    const h = harnessFor(PLAIN_TRANSCRIPT);
+
+    await h.engine.createSummaryPage(sourceFile(), makeAnalysis(), []);
+
+    const tags = tagsInPrompt(h);
+    expect(tags).toBe(DEFAULT_SOURCE_TAG);
+    expect(tags).not.toContain('Jnana Yoga');
+    expect(tags).not.toContain('Karma Yoga');
+  });
+
+  it('keeps a source-note tag that is part of the vocabulary', async () => {
+    const h = harnessFor(`---
+tags: [transcript]
+---
+
+${PLAIN_TRANSCRIPT}`);
+
+    await h.engine.createSummaryPage(sourceFile(), makeAnalysis(), []);
+
+    expect(tagsInPrompt(h)).toBe('transcript');
+  });
+
+  it('drops source-note tags outside the vocabulary', async () => {
+    const h = harnessFor(`---
+tags: [Jnana Yoga, philosophy, book]
+---
+
+${PLAIN_TRANSCRIPT}`);
+
+    await h.engine.createSummaryPage(sourceFile(), makeAnalysis(), []);
+
+    expect(tagsInPrompt(h)).toBe('book');
+  });
+
+  it('still preserves manually-set tags on an existing source page (Issue #114)', async () => {
+    const h = harnessFor(PLAIN_TRANSCRIPT, {
+      ['wiki/sources/lecture-transcript.md']: `---
+type: source
+tags: [paper]
+---
+
+Existing summary.
+`,
+    });
+
+    await h.engine.createSummaryPage(sourceFile(), makeAnalysis(), []);
+
+    expect(tagsInPrompt(h)).toBe('paper');
+  });
+});

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -12,6 +12,8 @@ import {
   IngestOptions,
   BatchRequirementsContext,
   EngineContext,
+  VALID_SOURCE_TAGS,
+  DEFAULT_SOURCE_TAG,
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { getText } from '../core/i18n';
@@ -1214,13 +1216,17 @@ export class WikiEngine {
 
     // Issue #90: inherit tags from source note frontmatter when available,
     // so the generated summary page doesn't pollute the tag vocabulary with
-    // LLM-derived concept names. Fallback to LLM-derived tags if source has none.
-    const sourceTags = extractSourceTags(content);
+    // LLM-derived concept names. Source pages use the closed VALID_SOURCE_TAGS
+    // taxonomy, so inherited tags are filtered to it and the documented default
+    // is the last resort — concept names are not a legal value here.
+    const sourceTags = extractSourceTags(content).filter(t =>
+      (VALID_SOURCE_TAGS as readonly string[]).includes(t)
+    );
     const tagsValue = existingTags
       ? existingTags.join(', ')
       : sourceTags.length > 0
         ? sourceTags.join(', ')
-        : analysis.concepts.map(c => c.name).join(', ');
+        : DEFAULT_SOURCE_TAG;
 
     const createdPagesList = plannedPaths.length > 0
       ? plannedPaths.map(p => {


### PR DESCRIPTION
## Problem

The `tags:` field of a generated source page falls back through three tiers:
tags already on the page, then the source note's frontmatter, then — until now
— every extracted concept name.

That last tier contradicts the rule the same code block documents (keeping
LLM-derived concept names out of the tag vocabulary), and it fires in the
normal case: a plain ASR transcript has no frontmatter at all.

Observed on a 9-source vault: **348 tags** written across the source pages, up
to **99 on a single page**, none of them members of `VALID_SOURCE_TAGS`. The
tag-vocabulary lint scanner flagged every page, and most values contained
spaces — so they were not valid Obsidian tags either, and the tag pane filled
with entries like `Джняна йога`. They were sticky too: tier 1 gives existing
tags priority, so re-ingesting preserved them.

## Fix

Source-page tags are a closed 7-value taxonomy (`VALID_SOURCE_TAGS`), and
anything outside it is stripped downstream regardless. So:

- tier 2 (inherited frontmatter tags) is filtered to that vocabulary;
- tier 3 falls back to `DEFAULT_SOURCE_TAG` instead of concept names.

A source whose type matters (e.g. `transcript`) declares it in its own
frontmatter — which is what tier 2 was built for.

| Source note frontmatter | Before | After |
|---|---|---|
| `tags: [transcript]` | `transcript` | `transcript` (unchanged) |
| `tags: [Джняна йога, philosophy, book]` | all three | `book` |
| no frontmatter | every extracted concept name | `other` |

Tier 1 is deliberately untouched, so manually-corrected tags on an existing
page still win (#114) — covered by a regression test.

## Tests

4 new tests in `src/__tests__/wiki/wiki-engine-summary-tags.test.ts`. Written
first: 2 of them fail on `main` for exactly the reported reason
(`'Jnana Yoga, Karma Yoga'` where `'other'` is expected), and the 2 regression
tests pass both before and after.

`{{tags}}` reaches the model through the summary prompt rather than being
written to the page directly, so `wiki-engine-harness` now records the
requests handed to the LLM stub and the tests assert on the prompt the engine
actually builds.

## Gate 1

| Check | Result |
|---|---|
| `pnpm lint` | 0 errors, 0 warnings |
| `npx tsc --noEmit` | 0 errors |
| `pnpm test` | 2570 passed / 193 files |
| `pnpm build` | clean exit |
| `pnpm css-lint` | 0 violations |

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | One `Array.filter` over a source note's tag list (single digits) against a 7-element vocabulary, once per source page. |
| Memory | ✅ | No new retained structures; the filtered array replaces the unfiltered one. |
| IO | N/A | No vault reads or writes added. |
| Network | ✅ | No additional LLM calls. |
| Token | ✅ | Slight reduction — `{{tags}}` previously carried every extracted concept name (up to 99 values observed); now at most a few vocabulary terms. |

## Notes

- **Existing polluted pages are not rewritten.** Tier 1 still prefers tags
  already present on the page, so cleanup stays the lint retag runner's job.
  Happy to add a migration if you'd prefer it in this PR.
- **CHANGELOG not touched** — there is no `Unreleased` section and the target
  version is yours to pick. Tell me where it should land and I'll add the entry.
- **READMEs not touched** — this changes generated output, not a user-facing
  feature or workflow. Say the word if you want it documented.
- #90 is referenced in the surrounding code comment (pre-existing, unchanged).
  Since that issue is closed, this PR deliberately does not use a closing
  keyword — the fix covers a tier that the original change left open.
