### PR TITLE
fix(ingest): gate translation instruction on source frontmatter language

### DIFF
--- a/src/__tests__/wiki/source-analyzer-translation-hint.test.ts
+++ b/src/__tests__/wiki/source-analyzer-translation-hint.test.ts
@@ -1,0 +1,77 @@
+// The extraction prompt asks for a `translation` field alongside each verbatim
+// quote. That only makes sense when the source and the wiki speak different
+// languages — translating a Russian quote into a Russian wiki is wasteful and
+// bloats the batch JSON toward truncation.
+//
+// The source note's frontmatter `language:` is the explicit signal; the legacy
+// `wikiLanguage !== 'en'` proxy stays in place for untagged sources.
+
+import { describe, it, expect, vi } from 'vitest';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { SourceAnalyzer } from '../../wiki/source-analyzer';
+import { TFile } from 'obsidian';
+
+const SOURCE_PATH = 'sources/lecture.md';
+const TRANSLATION_MARKER = 'TRANSLATION (cross-language wikis)';
+
+const EXTRACTION_RESPONSE = JSON.stringify({
+  source_title: 'Lecture',
+  summary: 'A lecture.',
+  entities: [{ name: 'Foo', type: 'other', summary: 'bar', mentions_in_source: [] }],
+  concepts: [],
+});
+
+/** Run one extraction and return the user prompt handed to the LLM. */
+async function promptFor(body: string, wikiLanguage: string): Promise<string> {
+  const { ctx } = createMockContext({
+    vaultFiles: { [SOURCE_PATH]: body },
+    llmResponses: [EXTRACTION_RESPONSE],
+    settings: { wikiLanguage },
+  });
+  const spy = vi.spyOn(ctx.getClient()!, 'createMessage');
+  const analyzer = new SourceAnalyzer(ctx);
+  // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+  await analyzer.analyzeSource(createMockFile(SOURCE_PATH) as unknown as TFile);
+  expect(spy).toHaveBeenCalled();
+  return spy.mock.calls[0][0].messages[0].content as string;
+}
+
+function withLanguage(language: string): string {
+  return `---\nlanguage: ${language}\n---\n\n# Лекция\n\nСодержание лекции.\n`;
+}
+
+const NO_FRONTMATTER = '# Лекция\n\nСодержание лекции.\n';
+
+describe('SourceAnalyzer — translation hint gating', () => {
+  it('omits the translation instruction when the source declares the wiki language', async () => {
+    expect(await promptFor(withLanguage('ru'), 'ru')).not.toContain(TRANSLATION_MARKER);
+  });
+
+  it('matches the language name as well as the code', async () => {
+    // wikiLanguage 'de' resolves to the display name 'Deutsch' via WIKI_LANGUAGES.
+    expect(await promptFor(withLanguage('Deutsch'), 'de')).not.toContain(TRANSLATION_MARKER);
+  });
+
+  it('ignores case and surrounding whitespace in the declared language', async () => {
+    expect(await promptFor(withLanguage('"  RU  "'), 'ru')).not.toContain(TRANSLATION_MARKER);
+  });
+
+  it('keeps the translation instruction when the source is in a different language', async () => {
+    expect(await promptFor(withLanguage('en'), 'de')).toContain(TRANSLATION_MARKER);
+  });
+
+  it('falls back to the legacy proxy for an untagged source in a non-English wiki', async () => {
+    expect(await promptFor(NO_FRONTMATTER, 'de')).toContain(TRANSLATION_MARKER);
+  });
+
+  it('falls back to the legacy proxy for an untagged source in an English wiki', async () => {
+    expect(await promptFor(NO_FRONTMATTER, 'en')).not.toContain(TRANSLATION_MARKER);
+  });
+
+  it('asks for a translation in an English wiki when the source declares a foreign language', async () => {
+    // Behaviour change: the legacy proxy suppressed the instruction for every
+    // English wiki, so quotes from a foreign source arrived untranslated. An
+    // explicit `language:` now makes the cross-language case detectable.
+    expect(await promptFor(withLanguage('ru'), 'en')).toContain(TRANSLATION_MARKER);
+  });
+});

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -190,11 +190,18 @@ export class SourceAnalyzer {
     // the generated `sources/<slug>` page (consumed there by
     // `fix-dead-link`'s slugify-normalized cross-page alias match).
     const noteFm = this.ctx.app.metadataCache
-      .getFileCache(file)?.frontmatter as { aliases?: unknown } | undefined;
+      .getFileCache(file)?.frontmatter as { aliases?: unknown; language?: unknown } | undefined;
     const rawNoteAliases = noteFm?.aliases;
     const sourceNoteAliases: string[] = Array.isArray(rawNoteAliases)
       ? rawNoteAliases.filter((a): a is string => typeof a === 'string')
       : [];
+    // Source note's frontmatter `language:` lets us skip the translation
+    // instruction when the source is already in the wiki's language (e.g. a
+    // Russian source in a Russian wiki -- translating verbatim quotes into the
+    // same language is wasteful and bloats the JSON). Absent -> legacy behavior.
+    const sourceLang = typeof noteFm?.language === 'string'
+      ? noteFm.language.trim().toLowerCase()
+      : '';
 
     console.debug('Existing Wiki pages count: — delayed until post-extraction matching');
 
@@ -312,7 +319,17 @@ export class SourceAnalyzer {
       // alongside each quote in mentions_with_provenance. The downstream
       // formatter renders: "<verbatim>" (<translation>) -- [[path|display]].
       // When source and wiki languages match, skip the translation field.
-      const translationHint = wikiLang !== 'en'
+      // When the source's own language matches the wiki language, translating
+      // its verbatim quotes back into the same language is meaningless (and
+      // bloats the JSON to the point of truncation). Prefer the explicit
+      // frontmatter `language:` signal; fall back to the legacy `!== 'en'`
+      // proxy only when the source is untagged, so cross-language wikis keep
+      // their translation behavior unchanged.
+      const wikiLangLower = wikiLang.toLowerCase();
+      const sameLanguage = sourceLang !== ''
+        && (sourceLang === wikiLangLower || sourceLang === wikiLangName.toLowerCase());
+      const crossLanguage = sourceLang !== '' ? !sameLanguage : wikiLang !== 'en';
+      const translationHint = crossLanguage
         ? `\n\nTRANSLATION (cross-language wikis): For each entry in mentions_with_provenance, ALSO add a 'translation' field containing a ${wikiLangName} translation of the quote text. The 'quote' field MUST stay verbatim in the source's original language; the translation goes in a separate 'translation' field. Example: {"quote": "Machine learning is fun", "translation": "机器学习很有趣", "source_path": "...", ...}`
         : '';
       // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer (buildSystemPrompt) always injects once.


### PR DESCRIPTION
## Problem

The extraction prompt asks the model to add a `translation` field alongside
every verbatim quote. It was gated on `wikiLanguage !== 'en'`, which is a proxy
for "this wiki is cross-language" — but it says nothing about the *source*.

Consequence: a Russian wiki ingesting a Russian transcript asked for a Russian
translation of Russian quotes. The output is meaningless, and it is not free —
the extra field is emitted per quote, inflating the batch JSON until it
truncates and gets force-halved.

## Fix

Read the source note's frontmatter `language:` and skip the translation
instruction when it matches the wiki language. When the source is untagged,
fall back to the legacy `!== 'en'` proxy, so existing cross-language wikis keep
their behaviour.

The value is matched against both the setting and its display name, so
`language: de` and `language: Deutsch` both resolve against a `de` wiki. A
custom `wikiLanguage` outside `WIKI_LANGUAGES` (e.g. `ru`) matches on the raw
value. Matching is case- and whitespace-insensitive.

| Source `language:` | Wiki language | Translation instruction |
|---|---|---|
| `ru` | `ru` | omitted (was: emitted) |
| `Deutsch` | `de` | omitted (was: emitted) |
| `en` | `de` | emitted |
| absent | `de` | emitted (legacy proxy) |
| absent | `en` | omitted (legacy proxy) |
| `ru` | `en` | emitted (was: omitted — see below) |

## Behaviour change worth calling out

An English wiki previously suppressed the instruction unconditionally, so
quotes from a foreign-language source arrived untranslated. A source that
declares `language:` now makes that cross-language case detectable, and the
instruction is emitted. Untagged sources in an English wiki are unaffected.
Happy to drop this half if you'd rather keep the change purely subtractive.

## Tests

7 new tests in `src/__tests__/wiki/source-analyzer-translation-hint.test.ts`,
asserting on the prompt handed to the LLM via the existing
`vi.spyOn(ctx.getClient()!, 'createMessage')` pattern. 4 of them fail on
`main`; the 3 legacy-behaviour tests pass both before and after.

## Gate 1

| Check | Result |
|---|---|
| `pnpm lint` | 0 errors, 0 warnings |
| `npx tsc --noEmit` | 0 errors |
| `pnpm test` | 2573 passed / 193 files |
| `pnpm build` | clean exit |
| `pnpm css-lint` | 0 violations |

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | Two string comparisons per source, once per ingest. |
| Memory | ✅ | One short string retained. |
| IO | ✅ | No new reads — `getFileCache(file)` is already called on this path for `aliases`; the same frontmatter object is reused. |
| Network | ✅ | No additional calls. Fewer halve-and-retry rounds expected, since the truncation pressure this removes is what triggers them. |
| Token | ✅ | Removes a ~90-word instruction from every extraction batch of a same-language source, and stops the model emitting a `translation` field per quote — the larger saving, since it is output. |

## Notes

- `language:` in a source note's frontmatter is the new signal. It is optional
  and absent sources keep the old behaviour, so nothing breaks for existing
  vaults — but it is undocumented. Tell me if you want it added to the READMEs
  and I'll do it in this PR.
- **CHANGELOG not touched** — no `Unreleased` section, and the target version
  is yours to pick.
