### PR TITLE
fix(llm): stop silent truncation in chat and ingest

### DIFF
--- a/src/__tests__/llm-sdk/openai-compat-sdk-client.test.ts
+++ b/src/__tests__/llm-sdk/openai-compat-sdk-client.test.ts
@@ -145,8 +145,14 @@ describe('OpenAICompatSdkClient', () => {
       });
 
       const call = mockGenerateText.mock.calls[0][0] as unknown as Record<string, unknown>;
+      // Both dialects are sent: `thinking.type` for DeepSeek/Kimi/GLM, and
+      // `chat_template_kwargs` for llama.cpp-style local servers, which ignore
+      // the former entirely. Each side ignores the field it does not know.
       expect(call.providerOptions).toEqual({
-        openaiCompatible: { thinking: { type: 'disabled' } },
+        openaiCompatible: {
+          thinking: { type: 'disabled' },
+          chat_template_kwargs: { enable_thinking: false },
+        },
       });
     });
 

--- a/src/__tests__/root/constants.test.ts
+++ b/src/__tests__/root/constants.test.ts
@@ -56,8 +56,8 @@ describe('Token budget constants (Issue #75)', () => {
     // v1.24.1 PATCH Phase 5.5.0: raised all Query-token budgets to 2000
     // so DeepSeek V3's reasoning preamble doesn't consume the entire
     // budget before the JSON output is emitted. TOKENS_LINT_ORPHAN_FIX
-    // (800) and TOKENS_QUERY_LLM_SELECT (3000) stay at their non-2000
-    // values from prior cycles.
+    // (800) stays at its non-2000 value from a prior cycle; the
+    // user-facing answer has its own budget (TOKENS_QUERY_ANSWER).
     expect(TOKENS_QUERY_PAGE_SELECT).toBe(2000);
     expect(TOKENS_QUERY_MODEL_DETECT).toBe(2000);
     expect(TOKENS_QUERY_SEED_SELECT).toBe(2000);

--- a/src/__tests__/wiki/source-analyzer-truncation-retry.test.ts
+++ b/src/__tests__/wiki/source-analyzer-truncation-retry.test.ts
@@ -46,18 +46,23 @@ interface ScriptedReply {
  * because the repair call site does not pass `onFinish`. Keeping them out of
  * the script means the script indexes extraction attempts only.
  */
-function scriptedClient(replies: ScriptedReply[]): {
+function scriptedClient(replies: ScriptedReply[], opts: { repair?: (broken: string) => string } = {}): {
   client: LLMClient;
   prompts: string[];
+  repairPrompts: string[];
 } {
   const prompts: string[] = [];
+  const repairPrompts: string[] = [];
   let idx = 0;
   let lastText = '';
   const client: LLMClient = {
     createMessage: async (params) => {
       const first = params.messages[0];
       const prompt = typeof first.content === 'string' ? first.content : '';
-      if (prompt.startsWith('Fix the following malformed JSON')) return lastText;
+      if (prompt.startsWith('Fix the following malformed JSON')) {
+        repairPrompts.push(prompt);
+        return opts.repair ? opts.repair(lastText) : lastText;
+      }
       prompts.push(prompt);
       const reply = replies[idx++];
       if (!reply) throw new Error(`unscripted extraction call #${idx}`);
@@ -66,7 +71,7 @@ function scriptedClient(replies: ScriptedReply[]): {
       return reply.text;
     },
   };
-  return { client, prompts };
+  return { client, prompts, repairPrompts };
 }
 
 function analyzerWith(client: LLMClient): SourceAnalyzer {
@@ -148,6 +153,111 @@ describe('SourceAnalyzer truncation retry (#305)', () => {
     expect(result).toBeNull();
     expect(prompts.filter(p => batchSizeOf(p) !== null)).toHaveLength(2);
     expect(warn.mock.calls.filter(c => String(c[0]).includes('halving batch size'))).toHaveLength(1);
+    warn.mockRestore();
+  });
+});
+
+/**
+ * A truncated batch that still reaches the repair path.
+ *
+ * `TRUNCATED` above stops before any closing brace, so neither the
+ * brace-count nor the greedy-regex recovery finds a candidate and `repairFn`
+ * is never consulted. A real truncated batch cuts off after several complete
+ * items, leaving closing braces behind — the greedy regex then matches up to
+ * the last one, fails to parse, and the repair call fires. That is the call
+ * this change avoids.
+ */
+const TRUNCATED_MID_ARRAY = '{"source_title": "Protein misfolding", "entities": ['
+  + '{"name": "Amyloid", "type": "other", "summary": "An aggregate", "mentions_in_source": []}, '
+  + '{"name": "Tau", "type": "other", "summary": "Aggregation occurs spontane';
+
+describe('SourceAnalyzer truncation — no futile repair call (#305 follow-up)', () => {
+  it('skips the JSON-repair call when the response was truncated', async () => {
+    // A truncated response is incomplete, not malformed: repair cannot restore
+    // content the model never emitted, and the call costs another
+    // retryCap-sized request that re-hits the same limit.
+    const { client, repairPrompts } = scriptedClient([
+      { text: TRUNCATED_MID_ARRAY, finishReason: 'length' },
+      { text: VALID, finishReason: 'stop' },
+    ]);
+
+    await run(analyzerWith(client));
+
+    expect(repairPrompts).toHaveLength(0);
+  });
+
+  it('still repairs a malformed-but-complete response', async () => {
+    // finish_reason=stop means the model finished; the JSON is genuinely
+    // broken, so the repair path must stay. parseJsonResponse attempts repair
+    // from two recovery strategies, so the count is "more than none" rather
+    // than an exact number.
+    const { client, repairPrompts } = scriptedClient([
+      { text: '{"entities": [oops]}', finishReason: 'stop' },
+    ]);
+
+    await run(analyzerWith(client));
+
+    expect(repairPrompts.length).toBeGreaterThan(0);
+  });
+
+  it('still repairs when the client reports no finish reason', async () => {
+    const { client, repairPrompts } = scriptedClient([
+      { text: '{"entities": [oops]}' },
+    ]);
+
+    await run(analyzerWith(client));
+
+    expect(repairPrompts.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * What a repair pass actually does to a truncated batch: drop the cut-off tail
+ * and close the brackets around the items that did arrive. The default stub
+ * echoes the broken text back, which models repair as unable to help — fine for
+ * asserting "repair was skipped", useless for asserting "repair salvaged it".
+ */
+function closeBrackets(broken: string): string {
+  const lastComplete = broken.lastIndexOf('}');
+  return lastComplete === -1 ? broken : broken.slice(0, lastComplete + 1) + ']}';
+}
+
+describe('SourceAnalyzer truncation — repair is the last salvage (#305 follow-up)', () => {
+  it('repairs a truncated batch once the halving budget is spent', async () => {
+    // First truncation halves. The second cannot halve again within the same
+    // batch, and without repair the parse failure reaches `if (isFirstBatch)
+    // return null` — dropping the whole source instead of the complete items
+    // the model did emit.
+    const { client, repairPrompts } = scriptedClient([
+      { text: TRUNCATED_MID_ARRAY, finishReason: 'length' },
+      { text: TRUNCATED_MID_ARRAY, finishReason: 'length' },
+    ], { repair: closeBrackets });
+
+    const result = await run(analyzerWith(client));
+
+    expect(repairPrompts.length).toBeGreaterThan(0);
+    expect(result).not.toBeNull();
+    expect(result!.entities.map(e => e.name)).toEqual(['Amyloid']);
+  });
+});
+
+describe('SourceAnalyzer truncation — retry budget resets per batch (#305 follow-up)', () => {
+  it('halves again for a later truncation once a batch has succeeded', async () => {
+    // The one-retry-per-batch budget used to latch for the whole source: the
+    // first halve anywhere meant a later truncated batch could no longer
+    // halve, and was dropped while the source finalized as "complete".
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { client } = scriptedClient([
+      { text: TRUNCATED, finishReason: 'length' },  // batch 1 truncates -> halve
+      { text: VALID, finishReason: 'stop' },        // retry succeeds -> budget resets
+      { text: TRUNCATED, finishReason: 'length' },  // batch 2 truncates -> must halve again
+      { text: VALID, finishReason: 'stop' },
+    ]);
+
+    await run(analyzerWith(client));
+
+    const halvings = warn.mock.calls.filter(c => String(c[0]).includes('halving batch size'));
+    expect(halvings.length).toBeGreaterThanOrEqual(2);
     warn.mockRestore();
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -241,13 +241,14 @@ export const TOKENS_QUERY_MODEL_DETECT = 2000;
 export const TOKENS_QUERY_PAGE_SELECT = 2000;
 
 /**
- * Token budget for query LLM selection (Layer 2/3).
+ * Output budget for the final conversational answer in the Query flow.
  *
- * v1.24.1 PATCH Phase 5.5.0: already 3000 from a prior cycle; unchanged.
- * (Earlier note incorrectly said raise to 2000 — that would have been
- * a regression. The user constraint is "only raise, never lower".)
+ * The Query flow used to reuse a 3000-token budget named for the internal
+ * page-selection step. On reasoning models the chain of thought is billed
+ * against the same budget and routinely consumes a third to a half of it, so
+ * the visible answer was cut mid-sentence.
  */
-export const TOKENS_QUERY_LLM_SELECT = 3000;
+export const TOKENS_QUERY_ANSWER = 8000;
 
 /**
  * Token budget for query suggest-save dedup check.

--- a/src/llm-sdk/finish-reason.ts
+++ b/src/llm-sdk/finish-reason.ts
@@ -7,7 +7,7 @@
 // `result.finishReason`; every client here simply dropped it on `return
 // result.text`. These helpers carry it to callers that opt in.
 
-import type { LLMFinishReason } from '../types';
+import type { LLMFinishReason, LLMFinishMeta, LLMUsage } from '../types';
 
 const KNOWN_FINISH_REASONS: readonly LLMFinishReason[] = [
   'stop',
@@ -41,9 +41,10 @@ export function normalizeFinishReason(raw: unknown): LLMFinishReason {
  * site and every mock client unchanged.
  */
 export function reportFinish(
-  onFinish: ((meta: { finishReason: LLMFinishReason }) => void) | undefined,
+  onFinish: ((meta: LLMFinishMeta) => void) | undefined,
   raw: unknown,
+  usage?: LLMUsage,
 ): void {
   if (!onFinish) return;
-  onFinish({ finishReason: normalizeFinishReason(raw) });
+  onFinish({ finishReason: normalizeFinishReason(raw), ...(usage ? { usage } : {}) });
 }

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -20,7 +20,7 @@
 
 import { type LanguageModel, APICallError } from 'ai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { LLMClient } from '../types';
+import { LLMClient, type LLMFinishReason } from '../types';
 import { obsidianFetchBridge, streamWithFallback } from '../core/obsidian-fetch-bridge';
 import { mapAiSdkError } from './openai-sdk-client';
 import {
@@ -157,7 +157,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
         ...(temperature !== undefined ? { temperature } : {}),
       });
-      reportFinish(onFinish, result.finishReason);
+      reportFinish(onFinish, result.finishReason, result.usage);
       return result.text;
     } catch (err) {
       // v1.23.0 P1.5: URL fallback for custom baseURLs.
@@ -185,7 +185,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
-        reportFinish(onFinish, result.finishReason);
+        reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
       }
 
@@ -217,7 +217,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
-        reportFinish(onFinish, result.finishReason);
+        reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
       }
 
@@ -259,6 +259,12 @@ export class OpenAICompatSdkClient implements LLMClient {
       // plugin's Custom Advanced Settings (which can pass through
       // a different providerOptions shape in v1.24.0).
       openaiOpts.thinking = { type: 'disabled' };
+      // llama.cpp's llama-server (and most local OpenAI-compatible servers
+      // serving Qwen3-family models) ignores `thinking.type` entirely — it
+      // expects chat_template_kwargs instead. Unknown fields are ignored by
+      // both dialects, so sending both is safe and makes the toggle actually
+      // work against local backends.
+      openaiOpts.chat_template_kwargs = { enable_thinking: false };
     }
 
     if (opts.repetitionPenalty !== undefined) {
@@ -281,8 +287,9 @@ export class OpenAICompatSdkClient implements LLMClient {
     enableThinking?: boolean;
     temperature?: number;
     repetition_penalty?: number;
+    onFinish?: (meta: { finishReason: LLMFinishReason }) => void;
   }): Promise<string> {
-    const { model, max_tokens, system, messages, onChunk, temperature, repetition_penalty, enableThinking } = params;
+    const { model, max_tokens, system, messages, onChunk, temperature, repetition_penalty, enableThinking, onFinish } = params;
 
     // v1.23.0 P1-7 follow-up: stream path uses streamWithFallback
     // (real streaming via window.fetch with CORS fallback to
@@ -339,6 +346,15 @@ export class OpenAICompatSdkClient implements LLMClient {
         await new Promise<void>(resolve => window.setTimeout(resolve, 0));
       }
       console.debug(`[STREAM-CHUNK] total chunks forwarded: ${chunkCount} in ${Date.now() - streamStartTime}ms`);
+
+      // Surface why generation stopped. Without this a `length` finish is
+      // indistinguishable from a normal one and the answer simply ends
+      // mid-sentence with no indication anything was cut.
+      try {
+        reportFinish(onFinish, await result.finishReason, await result.usage);
+      } catch {
+        /* finishReason unavailable on this provider — leave as unknown */
+      }
 
       // Collect reasoning content (if any) from the post-stream Promise.
       // OpenAI o-series and reasoning-capable providers populate this.

--- a/src/llm-sdk/openai-sdk-client.ts
+++ b/src/llm-sdk/openai-sdk-client.ts
@@ -151,7 +151,7 @@ export class OpenAISdkClient implements LLMClient {
         ...(temperature !== undefined ? { temperature } : {}),
         // Top-level repetition_penalty is non-standard for OpenAI; pass via providerOptions.
       });
-      reportFinish(onFinish, result.finishReason);
+      reportFinish(onFinish, result.finishReason, result.usage);
       return result.text;
     } catch (err) {
       // v1.23.0 P1.5: URL fallback for custom baseURLs (Kimi / z.ai / GLM).
@@ -179,7 +179,7 @@ export class OpenAISdkClient implements LLMClient {
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...(temperature !== undefined ? { temperature } : {}),
         });
-        reportFinish(onFinish, result.finishReason);
+        reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
       }
       throw mapAiSdkError(err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -525,6 +525,21 @@ export type LLMFinishReason =
   | 'other'
   | 'unknown';
 
+/** Token usage for a single LLM call (AI-SDK v6 shape). Any field may be
+ *  undefined when a provider omits usage from its response. */
+export interface LLMUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+/** Metadata surfaced by SDK-backed clients via `onFinish` (Issue #305 +
+ *  token usage). Additive: callers that ignore it are unaffected. */
+export interface LLMFinishMeta {
+  finishReason: LLMFinishReason;
+  usage?: LLMUsage;
+}
+
 export interface LLMClient {
   createMessage(params: {
     model: string;
@@ -551,7 +566,7 @@ export interface LLMClient {
     // so every existing caller and every mock client is unaffected. Callers
     // that need to distinguish "the model finished" from "the model ran out
     // of tokens" opt in; callers that do not, see no change.
-    onFinish?: (meta: { finishReason: LLMFinishReason }) => void;
+    onFinish?: (meta: LLMFinishMeta) => void;
   }): Promise<string>;
 
   createMessageStream?(params: {
@@ -563,6 +578,8 @@ export interface LLMClient {
     enableThinking?: boolean;
     temperature?: number;
     repetition_penalty?: number;
+    /** Issue: streamed answers were truncated silently — surface finish_reason. */
+    onFinish?: (meta: LLMFinishMeta) => void;
   }): Promise<string>;
 
   listModels?(): Promise<string[]>;

--- a/src/wiki/query-engine/QueryView-class.ts
+++ b/src/wiki/query-engine/QueryView-class.ts
@@ -22,7 +22,8 @@ import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { formatPageRefSummary } from '../../core/ppr-cascade';
 import { buildTurnIndicator, observeVisibleTurn } from '../turn-indicator';
-import { TOKENS_QUERY_LLM_SELECT, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_SHORT, NOTICE_NORMAL, NOTICE_ERROR, CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS } from '../../constants';
+import { TOKENS_QUERY_ANSWER, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_SHORT, NOTICE_NORMAL, NOTICE_ERROR, CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS } from '../../constants';
+import { capMaxTokens } from '../../core/token-cap';
 import { getSectionLabels } from '../system-prompts';
 
 import { extractThinkingPanel } from './renderers/thinking-extract';
@@ -514,7 +515,16 @@ export class QueryView extends ItemView {
         try {
           fullResponse = await this.plugin.llmClient.createMessageStream({
             model: queryModel,
-            max_tokens: TOKENS_QUERY_LLM_SELECT,
+            // Issue #75 cap applied here rather than inherited: the advanced-
+            // settings wrapper only overrides createMessage, so a streaming
+            // call would otherwise ignore maxTokensPerCall and can exceed a
+            // local server's context window.
+            max_tokens: capMaxTokens(TOKENS_QUERY_ANSWER, this.plugin.settings),
+            onFinish: (meta) => {
+              if (meta.finishReason === 'length') {
+                console.warn('[QueryView] streaming answer truncated (finish_reason=length) at max_tokens=', capMaxTokens(TOKENS_QUERY_ANSWER, this.plugin.settings));
+              }
+            },
             system: appendCustomQueryInstructions(wikiContext, this.plugin.settings.customQueryInstructions),
             messages: conversationMessages,
             onChunk: (chunk) => {
@@ -550,7 +560,12 @@ export class QueryView extends ItemView {
             try {
               fullResponse = await this.plugin.llmClient.createMessage({
                 model: queryModel,
-                max_tokens: TOKENS_QUERY_LLM_SELECT,
+                max_tokens: TOKENS_QUERY_ANSWER,
+                onFinish: (meta) => {
+                  if (meta.finishReason === 'length') {
+                    console.warn('[QueryView] non-stream-fallback answer truncated (finish_reason=length) at max_tokens=', TOKENS_QUERY_ANSWER);
+                  }
+                },
                 system: appendCustomQueryInstructions(wikiContext, this.plugin.settings.customQueryInstructions),
                 messages: conversationMessages,
                 ...(this.plugin.settings.disableThinking ? { enableThinking: false } : {}),
@@ -639,7 +654,12 @@ export class QueryView extends ItemView {
         console.debug('[QueryView] non-stream-main chat model:', queryModel);
         const response = await this.plugin.llmClient!.createMessage({
           model: queryModel,
-          max_tokens: TOKENS_QUERY_LLM_SELECT,
+          max_tokens: TOKENS_QUERY_ANSWER,
+          onFinish: (meta) => {
+            if (meta.finishReason === 'length') {
+              console.warn('[QueryView] non-stream-main answer truncated (finish_reason=length) at max_tokens=', TOKENS_QUERY_ANSWER);
+            }
+          },
           system: appendCustomQueryInstructions(wikiContext, this.plugin.settings.customQueryInstructions),
           messages: conversationMessages,
           ...(this.plugin.settings.disableThinking ? { enableThinking: false } : {}),

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -29,6 +29,7 @@ import {
   MentionWithProvenance,
   WIKI_LANGUAGES,
   LLMFinishReason,
+  LLMUsage,
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { parseJsonResponse } from '../core/json';
@@ -226,8 +227,13 @@ export class SourceAnalyzer {
     // closure so the parse-failure path and the catch path share one
     // implementation. Returns whether the caller should re-run this batch;
     // the caller owns the loop control (`batchNum--; continue;`).
+    // Whether a halve-and-retry is still available for the current batch.
+    // Gates both the retry itself and the decision to skip JSON repair on a
+    // truncated response — repair is the last salvage once halving is spent.
+    const canHalveBatch = (): boolean => !retryingBatch && currentBatchSize > limits.minBatchSize;
+
     const halveBatchAndRetry = (batchLabel: string, cause: string): boolean => {
-      if (retryingBatch || currentBatchSize <= limits.minBatchSize) return false;
+      if (!canHalveBatch()) return false;
       currentBatchSize = Math.max(limits.minBatchSize, Math.floor(currentBatchSize * 0.5));
       console.warn(`${batchLabel} Truncation detected (${cause}), halving batch size to ${currentBatchSize} and retrying`);
       retryingBatch = true;
@@ -340,7 +346,7 @@ export class SourceAnalyzer {
         // report it leave this at 'unknown', which keeps pre-#305 behavior.
         // Held in an object rather than a bare `let` so control-flow analysis
         // does not narrow it to its initializer across the callback.
-        const finish: { reason: LLMFinishReason } = { reason: 'unknown' };
+        const finish: { reason: LLMFinishReason; usage?: LLMUsage } = { reason: 'unknown' };
         const response = await client.createMessage({
           model: resolvedModel,
           max_tokens: batchMaxTokens,
@@ -349,23 +355,49 @@ export class SourceAnalyzer {
           response_format: { type: 'json_object' },
           cacheBreakpoint: staticPrefix.length,
           maxTokensPerCall: retryCap,
-          onFinish: (meta) => { finish.reason = meta.finishReason; },
+          onFinish: (meta) => { finish.reason = meta.finishReason; finish.usage = meta.usage; },
         });
 
-        console.debug(`[Batch ${batchNum + 1}] Response length:`, response.length);
+        // Surface real token usage (Issue #305 follow-up): the model reports
+        // prompt/completion tokens; logging them per batch turns truncation
+        // tuning (batch size vs max_tokens vs context window) into a
+        // measurement instead of a char-count guess.
+        const usageStr = finish.usage
+          ? ` | tokens in=${finish.usage.inputTokens ?? '?'} out=${finish.usage.outputTokens ?? '?'} (max_tokens=${batchMaxTokens})`
+          : '';
+        console.debug(`[Batch ${batchNum + 1}] Response length:`, response.length, usageStr);
         this.ctx.onProgress?.(`Analyzed batch ${batchNum + 1}, processing...`);
 
-        const analysisData = await parseJsonResponse(response, async (malformedJson: string) => {
-          const repairPrompt = `Fix the following malformed JSON. Only fix JSON syntax errors (unescaped quotes, trailing commas, missing brackets). Do NOT change any values or content. Output ONLY the fixed JSON, no other text.\n\n${malformedJson}`;
-          return await client.createMessage({
-            model: resolveModelForTask(this.ctx.settings, 'ingest'),
-            max_tokens: retryCap, // Repair may need full output if original was truncated at retryCap
-            system: await this.ctx.buildSystemPrompt('analyze'),
-            messages: [{ role: 'user', content: repairPrompt }],
-            response_format: { type: 'json_object' },
-            maxTokensPerCall: retryCap,
-          });
-        }, { silentOnEmpty: true }) as Partial<SourceAnalysis> | null;
+        // Issue #305 follow-up: on a truncated response (finish_reason=length)
+        // the JSON is *incomplete*, not malformed, and a syntax-repair pass
+        // costs another retryCap-sized call re-hitting the same limit
+        // (observed: a ~48k-token repair that itself truncates). Prefer
+        // halve-and-retry, which re-runs the batch smaller.
+        //
+        // Only skip repair while that retry is actually available. Once the
+        // halving budget is spent, repair becomes the last salvage: a truncated
+        // batch is a prefix of complete items followed by one cut-off item, and
+        // closing the brackets around the complete ones is exactly what the
+        // repair prompt asks for. Without it the parse-failure path falls to
+        // `return null` on a first batch — dropping the whole source rather
+        // than the items that did arrive.
+        //
+        // Providers that report no finish reason keep 'unknown' and the repair
+        // path regardless.
+        const repairFn = finish.reason === 'length' && canHalveBatch()
+          ? undefined
+          : async (malformedJson: string) => {
+            const repairPrompt = `Fix the following malformed JSON. Only fix JSON syntax errors (unescaped quotes, trailing commas, missing brackets). Do NOT change any values or content. Output ONLY the fixed JSON, no other text.\n\n${malformedJson}`;
+            return await client.createMessage({
+              model: resolveModelForTask(this.ctx.settings, 'ingest'),
+              max_tokens: retryCap, // Repair may need full output if original was truncated at retryCap
+              system: await this.ctx.buildSystemPrompt('analyze'),
+              messages: [{ role: 'user', content: repairPrompt }],
+              response_format: { type: 'json_object' },
+              maxTokensPerCall: retryCap,
+            });
+          };
+        const analysisData = await parseJsonResponse(response, repairFn, { silentOnEmpty: true }) as Partial<SourceAnalysis> | null;
 
         if (!analysisData) {
           // Issue #305: a truncated response is not malformed JSON, it is
@@ -385,6 +417,15 @@ export class SourceAnalyzer {
           if (isFirstBatch) return null;
           break;
         }
+
+        // Issue #305 follow-up: the one-retry-per-batch budget must reset once
+        // a batch parses successfully. Otherwise the first halve anywhere
+        // latches `retryingBatch` for the rest of the source, so a later
+        // truncation can no longer halve (halveBatchAndRetry short-circuits)
+        // and its batch is silently dropped — the source finalizes as
+        // complete while missing that batch's items. Resetting here, on the
+        // success path, gives each batch its own retry budget.
+        retryingBatch = false;
 
         const { validity, data: norm } = normalizeBatchResponse(analysisData);
 


### PR DESCRIPTION
## Problem

Reasoning models routinely hit the output cap, and both flows handled it
badly. In chat the answer was cut mid-sentence with nothing to indicate it. In
ingest the analyzer spent extra full-size calls trying to "repair" a response
that was merely incomplete, and could silently drop a batch. Reproduced
against llama-server b9205 + Qwen3.6-35B-A3B.

## Chat flow

Sibling of #305, whose finish-reason helpers were wired into
`source-analyzer.ts` only.

**Own token budget.** `TOKENS_QUERY_LLM_SELECT` (3000) was used as `max_tokens`
for the user-facing answer at all three Query call sites. On a reasoning model
the chain of thought is billed against the same budget and routinely eats a
third to a half of it. Added `TOKENS_QUERY_ANSWER = 8000`, matching
`TOKENS_PAGE_GENERATION`.

Those three sites were the *only* consumers of `TOKENS_QUERY_LLM_SELECT`, so it
is removed. Its name never matched its use: it was introduced in `7951173`
purely as a name for the literal `3000` already sitting on the answer path, and
the real selection steps have their own budgets (`TOKENS_QUERY_SEED_SELECT`,
`TOKENS_QUERY_PAGE_SELECT`, `TOKENS_QUERY_KEYWORDS`).

**Cap honoured on the streaming path.** `wrapWithAdvancedSettings` overrides
`createMessage` only — `createMessageStream` is inherited through the prototype
chain by design (v1.23.2 guard, with its own regression test). So a streaming
request ignored the Issue #75 `maxTokensPerCall` ceiling. At 3000 that rarely
showed; at the raised budget it would let a request exceed a local server's
context window (the exact HTTP 400 #75 exists to prevent). The streaming call
now applies `capMaxTokens` explicitly. Non-stream call sites are untouched —
they go through `createMessage` and are already capped.

**Truncation is observable.** No `onFinish` was passed in the Query flow, so
`finishReason: 'length'` was not observable at all. All three call sites now
pass it and log a warning, the way the ingest path already reports truncation.
`createMessageStream` gained an optional `onFinish`.

**Thinking stayed on for llama.cpp.** `enableThinking=false` mapped only to
`thinking: { type: 'disabled' }` (DeepSeek/Kimi/GLM dialect). `llama-server`
ignores that field — it expects `chat_template_kwargs: { enable_thinking: false }`.
Both dialects are now sent; each backend ignores the one it does not know.

## Ingest flow

**Token usage logging.** `LLMFinishMeta` now carries `usage`, and the openai +
openai-compatible clients forward `result.usage`. Logging real
prompt/completion tokens per batch turns truncation tuning into a measurement
instead of a guess.

**No repair call on truncation.** A truncated response is incomplete, not
malformed — repair cannot restore never-emitted content, and it re-hits the
same limit (observed: a ~48k-token repair that itself truncated). Note
`parseJsonResponse` attempts repair from *two* recovery strategies, so a
truncated batch burned up to two full `retryCap`-sized calls. Now it goes
straight to halve-and-retry. Providers reporting no finish reason keep the
repair path.

**Per-batch retry budget.** The first halve anywhere latched `retryingBatch`
for the whole source, so a later truncated batch could no longer halve and was
dropped — the source finalized as "complete" while missing those items. Reset
on the success path.

## Tests

5 new tests in `source-analyzer-truncation-retry.test.ts`, plus the updated
`chat_template_kwargs` assertion in the client test.

The skip-repair tests needed a new fixture. The existing `TRUNCATED` stops
before any closing brace, so neither recovery strategy finds a candidate and
`repairFn` is never consulted — a test written against it passes with or
without the fix. `TRUNCATED_MID_ARRAY` cuts off after several complete items,
which is what a real truncated batch looks like, and does reach the repair
path. Each new test was verified to fail on `main` for the right reason.

The existing `halves only once` test still passes and was not modified: it
scripts two truncations back-to-back, while the budget reset only fires after a
successful batch.

## Gate 1

| Check | Result |
|---|---|
| `pnpm lint` | 0 errors, 0 warnings |
| `npx tsc --noEmit` | 0 errors |
| `pnpm test` | 2570 passed / 192 files |
| `pnpm build` | clean exit |
| `pnpm css-lint` | 0 violations |

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | One enum comparison per batch; one `Math.min` per streaming request. |
| Memory | ✅ | One small `usage` object per batch, not retained. |
| IO | N/A | No vault reads or writes in scope. |
| Network | ✅ | Strictly fewer calls: up to 2 repair calls saved per truncated batch, and a batch that used to be dropped now recovers via halve. |
| Token | ⚠️ | Two directions. Ingest: down — repair calls were `retryCap`-sized. Chat: `max_tokens` 3000 → 8000 raises the *ceiling*, not the spend, since billing follows tokens actually generated; but answers previously cut at 3000 will now legitimately generate their tail, which is a real cost increase for long answers on metered providers. `maxTokensPerCall` lets a user lower it, and now does so on the streaming path too. |

## Notes

- **Removed export.** `TOKENS_QUERY_LLM_SELECT` is deleted. History: introduced
  in `7951173`, value never changed, never referenced outside those three call
  sites and one test comment, no mentions in CHANGELOG/ROADMAP. An in-flight
  branch referencing it would see a one-line conflict. Happy to keep it as
  `@deprecated` instead if you prefer.
- **Truncation is logged, not surfaced in the UI.** `console.warn`, matching
  how the ingest path reports it. That is deliberate but not symmetric: ingest
  self-heals via halve-and-retry, whereas a truncated chat answer is final and
  the user still is not told. A `Notice` would need a TEXTS key across all 10
  locales and a wording decision that is yours — happy to do it here or in a
  follow-up.
- **Type shape.** `onFinish`'s inline `{ finishReason }` becomes the named
  `LLMFinishMeta`, additively extended with `usage?`. Callers ignoring it are
  unaffected.
- **CHANGELOG not touched** — no `Unreleased` section; the target version is
  yours to pick.
