### PR TITLE
fix(settings): flush SecretStorage on every commit, not only on tab hide()

### DIFF
--- a/src/__tests__/ui/settings-codex-sections.test.ts
+++ b/src/__tests__/ui/settings-codex-sections.test.ts
@@ -84,7 +84,7 @@ describe('Codex settings section integration', () => {
     tab.plugin.wikiEngine = { updateSettings: vi.fn() } as never;
     tab.plugin.testLLMConnection = vi.fn(async () => { tab.plugin.settings.llmReady = true; return { success: true, message: 'ok' }; });
     tab.plugin.saveSettings = vi.fn(async () => { persisted.push(tab.plugin.settings.llmReady); });
-    tab.commitTempSettings = vi.fn(() => { tab.plugin.settings = { ...tab.tempSettings }; });
+    tab.commitTempSettings = vi.fn((): boolean => { tab.plugin.settings = { ...tab.tempSettings }; return true; });
     tab.syncCodexModelsFromPlugin = vi.fn();
     renderTestConnectionSection(tab, {} as HTMLElement);
     await buttonClicks[0]();

--- a/src/__tests__/ui/settings-commit-flush-api-key.test.ts
+++ b/src/__tests__/ui/settings-commit-flush-api-key.test.ts
@@ -1,0 +1,144 @@
+/**
+ * v1.25.8 HOTFIX regression test — Settings commit paths MUST flush
+ * the typed apiKey into Obsidian SecretStorage as part of the commit,
+ * not only on hide().
+ *
+ * Bug (root-cause analysis 2026-07-25): Test Connection success path
+ * ran commitTempSettings() which wiped the in-memory apiKey buffer
+ * but did NOT flush it into SecretStorage (only hide() did). The next
+ * initializeLLMClient() read SecretStorage and got the PREVIOUS
+ * provider's key, so Lint/Query/Ingest sent requests with the wrong
+ * Authorization header → 401.
+ *
+ * Fix: commitTempSettings() now flushes SecretStorage first via
+ * flushApiKey(), then wipes + spreads. Returns false on IO failure so
+ * callers skip saveSettings() (preserves typed key for retry,
+ * matching v1.25.4 #339).
+ *
+ * Tests below exercise the REAL production methods (not a mirror) per
+ * project TDD standard — shell tests via local re-implementation are
+ * explicitly banned because they pass even when production regresses.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../types';
+import { LLMWikiSettingTab } from '../../ui/settings';
+
+interface FakeStorage {
+  values: Map<string, string>;
+  getSecret: (id: string) => string | null;
+  setSecret: (id: string, value: string) => void;
+}
+
+function backend(initial?: string): FakeStorage {
+  const values = new Map<string, string>();
+  if (initial !== undefined) values.set('karpathywiki-provider-api-key', initial);
+  return {
+    values,
+    getSecret: (id) => values.get(id) ?? null,
+    setSecret: (id, value) => { values.set(id, value); },
+  };
+}
+
+function backendThrows(): FakeStorage {
+  return {
+    values: new Map(),
+    getSecret: () => null,
+    setSecret: () => { throw new Error('keychain locked'); },
+  };
+}
+
+const SECRET_ID = 'karpathywiki-provider-api-key';
+
+// Minimal Obsidian App stub (only secretStorage is touched by the
+// code under test). PluginSettingTab's constructor signature requires
+// (app, plugin); we pass throwaway objects that only expose what
+// commitTempSettings / flushApiKey actually read.
+function makeTab(
+  secretStorage: FakeStorage,
+  tempSettingsApiKey: string,
+  pluginSettingsApiKey = '',
+): {
+  tab: LLMWikiSettingTab;
+  secretStorage: FakeStorage;
+  pluginSettings: { apiKey: string };
+  tempSettings: { apiKey: string };
+} {
+  const tab = Object.create(LLMWikiSettingTab.prototype) as LLMWikiSettingTab;
+  const tempSettings = { ...DEFAULT_SETTINGS, apiKey: tempSettingsApiKey, providerApiKeySecretId: SECRET_ID };
+  const pluginSettings = { ...DEFAULT_SETTINGS, apiKey: pluginSettingsApiKey, providerApiKeySecretId: SECRET_ID };
+  // App stub — only .secretStorage is read by commitTempSettings/flushApiKey.
+  (tab as unknown as { app: unknown }).app = { secretStorage };
+  (tab as unknown as { plugin: unknown }).plugin = {
+    settings: pluginSettings,
+    initializeLLMClient: vi.fn(),
+  };
+  (tab as unknown as { tempSettings: unknown }).tempSettings = tempSettings;
+  (tab as unknown as { cascadeUnifiedModelChange: unknown }).cascadeUnifiedModelChange = vi.fn();
+  return { tab, secretStorage, pluginSettings: pluginSettings as { apiKey: string }, tempSettings: tempSettings as { apiKey: string } };
+}
+
+describe('v1.25.8 HOTFIX: commitTempSettings must flush before spread', () => {
+  it('writes typed key to SecretStorage when flush succeeds (the missing step)', () => {
+    const secretStorage = backend();
+    const { tab, pluginSettings } = makeTab(secretStorage, 'sk-minimax-new');
+    const ok = tab.commitTempSettings();
+    expect(ok).toBe(true);
+    expect(secretStorage.values.get(SECRET_ID)).toBe('sk-minimax-new');
+    expect(pluginSettings.apiKey).toBe('');
+  });
+
+  it('returns false and preserves tempSettings.apiKey when flush throws (so caller skips saveSettings)', () => {
+    const secretStorage = backendThrows();
+    const { tab, tempSettings } = makeTab(secretStorage, 'sk-user-typed');
+    const ok = tab.commitTempSettings();
+    expect(ok).toBe(false);
+    // Key preserved for retry
+    expect(tempSettings.apiKey).toBe('sk-user-typed');
+  });
+
+  it('returns true and does no SecretStorage IO when tempSettings.apiKey is empty', () => {
+    const secretStorage = backend('sk-existing-stays');
+    const { tab } = makeTab(secretStorage, '');
+    let ioCount = 0;
+    const originalSet = secretStorage.setSecret;
+    secretStorage.setSecret = (id, value) => { ioCount++; originalSet(id, value); };
+    const ok = tab.commitTempSettings();
+    expect(ok).toBe(true);
+    expect(ioCount).toBe(0);  // no needless SecretStorage write
+    expect(secretStorage.values.get(SECRET_ID)).toBe('sk-existing-stays');  // preserved
+  });
+
+  it('skips SecretStorage write for whitespace-only tempSettings.apiKey', () => {
+    const secretStorage = backend('sk-existing-stays');
+    const { tab } = makeTab(secretStorage, '   ');
+    let ioCount = 0;
+    const originalSet = secretStorage.setSecret;
+    secretStorage.setSecret = (id, value) => { ioCount++; originalSet(id, value); };
+    const ok = tab.commitTempSettings();
+    expect(ok).toBe(true);
+    expect(ioCount).toBe(0);  // don't overwrite SecretStorage with empty
+    expect(secretStorage.values.get(SECRET_ID)).toBe('sk-existing-stays');
+  });
+
+  it('end-to-end: provider switch + Test Connection → SecretStorage updated', () => {
+    // The exact bug shape:
+    // - Pre-existing SecretStorage = sk-deepseek-OLD
+    // - User typed sk-minimax-NEW in Settings tab
+    // - User clicked Test Connection → commitTempSettings runs
+    // - Pre-fix: SecretStorage still sk-deepseek-OLD (BUG)
+    // - Post-fix: SecretStorage = sk-minimax-NEW
+    const secretStorage = backend('sk-deepseek-OLD');
+    const { tab } = makeTab(secretStorage, 'sk-minimax-NEW');
+    tab.commitTempSettings();
+    expect(secretStorage.values.get(SECRET_ID)).toBe('sk-minimax-NEW');
+  });
+
+  it('end-to-end: failure path → caller skips saveSettings → SecretStorage unchanged', () => {
+    const secretStorage = backendThrows();
+    const { tab, tempSettings } = makeTab(secretStorage, 'sk-minimax-NEW');
+    const ok = tab.commitTempSettings();
+    expect(ok).toBe(false);
+    expect(tempSettings.apiKey).toBe('sk-minimax-NEW');  // preserved for retry
+  });
+});

--- a/src/ui/settings-sections/language-section.ts
+++ b/src/ui/settings-sections/language-section.ts
@@ -53,12 +53,12 @@ export function renderLanguageSection(tab: LLMWikiSettingTab, containerEl: HTMLE
     .addButton(button => button
       .setButtonText(tab.getText('saveButton'))
       .setCta()
-      .onClick(() => {
-        void (async () => {
-          tab.commitTempSettings();
-          await tab.plugin.saveSettings();
-          new Notice(tab.getText('savedNotice'), NOTICE_SHORT);
-        })();
+      .onClick(async () => {
+        // v1.25.8: skip saveSettings on flush failure so a typed key
+        // survives in tempSettings for retry (matches hide()).
+        if (!tab.commitTempSettings()) return;
+        await tab.plugin.saveSettings();
+        new Notice(tab.getText('savedNotice'), NOTICE_SHORT);
       }));
 
   // 2. Wiki Output Language: heading + dropdown + optional custom input.

--- a/src/ui/settings-sections/test-connection-section.ts
+++ b/src/ui/settings-sections/test-connection-section.ts
@@ -54,6 +54,16 @@ export function renderTestConnectionSection(tab: LLMWikiSettingTab, containerEl:
         // etc.) pass undefined.
         const result = await tab.plugin.testLLMConnection(testSettings.apiKey);
         tab.tempSettings.llmReady = result.success;
+
+        // Reset UI button + notice at one place (v1.25.8 simplify pass —
+        // previously duplicated in flush-failure early-return).
+        const resetUi = (): void => {
+          button.setButtonText(tab.getText('testButton'));
+          button.setDisabled(false);
+          tab.display();
+          new Notice(result.message, result.success ? NOTICE_NORMAL : NOTICE_ERROR);
+        };
+
         if (!result.success) {
           // Restore live settings on test failure - do not persist broken config.
           if (testSettings.provider === 'openai-codex') {
@@ -62,21 +72,41 @@ export function renderTestConnectionSection(tab: LLMWikiSettingTab, containerEl:
           }
           applySettings(oldSettings);
           await tab.plugin.saveSettings();
-        } else {
-          tab.tempSettings.thinkingControlCache = tab.plugin.settings.thinkingControlCache;
-          if (tab.plugin.settings.provider === 'openai-codex') {
-            tab.syncCodexModelsFromPlugin();
-            tab.tempSettings.model = tab.plugin.settings.model;
-            tab.tempSettings.ingestModel = tab.plugin.settings.ingestModel;
-            tab.tempSettings.lintModel = tab.plugin.settings.lintModel;
-            tab.tempSettings.queryModel = tab.plugin.settings.queryModel;
-          }
-          tab.commitTempSettings();
-          await tab.plugin.saveSettings();
+          resetUi();
+          return;
         }
-        button.setButtonText(tab.getText('testButton'));
-        button.setDisabled(false);
-        tab.display();
-        new Notice(result.message, result.success ? NOTICE_NORMAL : NOTICE_ERROR);
+
+        // Success path: sync testLLMConnection's mutated fields, then commit.
+        tab.tempSettings.thinkingControlCache = tab.plugin.settings.thinkingControlCache;
+        if (tab.plugin.settings.provider === 'openai-codex') {
+          tab.syncCodexModelsFromPlugin();
+          tab.tempSettings.model = tab.plugin.settings.model;
+          tab.tempSettings.ingestModel = tab.plugin.settings.ingestModel;
+          tab.tempSettings.lintModel = tab.plugin.settings.lintModel;
+          tab.tempSettings.queryModel = tab.plugin.settings.queryModel;
+        }
+        // v1.25.8 HOTFIX: commitTempSettings internally flushes
+        // SecretStorage. On flush failure roll back plugin.settings to
+        // oldSettings so a later saveData() can't persist the typed
+        // apiKey as plaintext (v1.25.3 #182 invariant). flushApiKey
+        // already surfaced the apiKeyMigrationFailedNotice.
+        const commitSucceeded = tab.commitTempSettings();
+        if (!commitSucceeded) {
+          // Roll back plugin.settings AND persist it: testLLMConnection
+          // already fired a fire-and-forget `void this.saveSettings()`
+          // (line 128) that captured `testSettings.apiKey` as a plaintext
+          // reference. Without an explicit overwrite, the async saveData
+          // could persist the typed key into data.json as plaintext,
+          // violating the v1.25.3 #182 invariant. flushApiKey already
+          // surfaced the apiKeyMigrationFailedNotice.
+          applySettings(oldSettings);
+          await tab.plugin.saveSettings();
+          button.setButtonText(tab.getText('testButton'));
+          button.setDisabled(false);
+          tab.display();
+          return;
+        }
+        await tab.plugin.saveSettings();
+        resetUi();
       }));
 }

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -57,28 +57,21 @@ export class LLMWikiSettingTab extends PluginSettingTab {
   // Called by hide() (auto-save) and the explicit Save button. Adding
   // a new probe-mutated field only requires extending this one helper,
   // not every save site.
-  public commitTempSettings(): void {
-    // v1.25.3 #182: never write the plaintext apiKey into data.json.
-    // The canonical value lives in Obsidian SecretStorage (OS keychain);
-    // tempSettings.apiKey is an in-memory buffer that may hold a pending
-    // value the user typed. Zero it before the merge so saveData() never
-    // persists it. The SecretStorage flush happens in flushApiKey()
-    // (called by hide() before commitTempSettings), but guard here
-    // catches any caller that invokes commitTempSettings outside hide()
-    // (language-section Save button, test-connection-section auto-save).
+  /**
+   * Flush the typed apiKey into SecretStorage, then merge
+   * `tempSettings` → `plugin.settings`. Returns false if the flush
+   * failed (caller must skip saveSettings so the typed key survives
+   * for retry — see flushApiKey for failure semantics).
+   */
+  public commitTempSettings(): boolean {
+    // Flush before wipe — see flushApiKey for failure semantics.
+    const flushSucceeded = this.flushApiKey();
+    if (!flushSucceeded) return false;
+    // Defensive: flushApiKey already clears tempSettings.apiKey on
+    // success. Belt-and-suspenders so a future caller bypassing
+    // flushApiKey can't reintroduce the v1.25.3 #182 plaintext leak.
     this.tempSettings.apiKey = '';
-    // v1.24.1 PATCH Phase 5.5.0 hotfix fix: belt-and-suspenders cascade.
-    // setFieldValue already triggers cascadeUnifiedModelChange on a
-    // dropdown/text-input edit, but there are at least 3 other write
-    // sites that mutate tempSettings.model directly (provider change →
-    // '', fetch-models auto-pick → availableModels[0], bedrock region
-    // change → ''). To guarantee unified-model edits always clear stale
-    // per-task overrides, re-run the cascade here at commit time if
-    // the unified model is non-empty.
-    //
-    // Safety: idempotent (the cascade itself skips fields already at ''),
-    // and the whitespace check matches setFieldValue's gate, so an
-    // explicit blank-edit never triggers a per-task reset.
+    // Cascade guard — see cascadeUnifiedModelChange for rationale.
     if (this.tempSettings.model.trim()) {
       this.cascadeUnifiedModelChange();
     }
@@ -87,27 +80,17 @@ export class LLMWikiSettingTab extends PluginSettingTab {
       watchedFolders: [...(this.tempSettings.watchedFolders || [])],
       thinkingControlCache: this.plugin.settings.thinkingControlCache,
     };
+    return true;
   }
 
   // Auto-save when user navigates away from settings tab
   hide(): void {
     const hasChanges = JSON.stringify(this.tempSettings) !== JSON.stringify(this.plugin.settings);
     if (hasChanges) {
-      // v1.25.3 #182: flush the in-memory apiKey edit to Obsidian
-      // SecretStorage BEFORE the data.json commit so the post-commit
-      // plugin.settings reflects the new state. This runs once per
-      // tab close — not per keystroke.
-      //
-      // v1.25.4 #339: when flushApiKey fails (Windows 10 Credential
-      // Manager locked etc.) we MUST NOT proceed to commitTempSettings,
-      // otherwise the unconditional `tempSettings.apiKey = ''` on
-      // commitTempSettings line 59 will wipe the user's freshly-typed
-      // key — re-creating the original #339 failure mode after the
-      // user retries. Skip the commit when flush fails and surface the
-      // Notice (already done in flushApiKey) so the user can edit+retry.
-      const flushSucceeded = this.flushApiKey();
-      if (!flushSucceeded) return;
-      this.commitTempSettings();
+      // commitTempSettings owns the flush; skip saveSettings on failure
+      // so the typed apiKey survives for retry (v1.25.4 #339 invariant).
+      const commitSucceeded = this.commitTempSettings();
+      if (!commitSucceeded) return;
       void this.plugin.saveSettings();
       console.debug('Settings auto-saved on tab close');
     }


### PR DESCRIPTION
## Summary

**v1.25.8 PATCH Hotfix** — 2026-07-25 user report: provider switching makes Test Connection succeed but Lint/Query/Ingest fail with 401 "Missing Authentication header".

Root cause: `commitTempSettings()` wiped the in-memory apiKey buffer without flushing it to Obsidian SecretStorage. Only `hide()` flushed. Test Connection / Language Save / other non-hide() commit paths left SecretStorage holding the **previous provider's key**. The singleton `this.llmClient` rebuilt by `initializeLLMClient()` read the stale key, so subsequent business calls sent the wrong Authorization header.

## Fix

- `commitTempSettings()` now **internally calls `flushApiKey()`** before wiping + spreading. Returns `boolean` — `false` on IO failure so the caller skips `saveSettings()` (typed key survives for retry, v1.25.4 #339 invariant).
- Two non-hide() callers (test-connection-section, language-section) consume the return the same way: skip saveSettings on false.
- Flush-failure branch also **rolls back + persists oldSettings** to prevent `testLLMConnection`'s fire-and-forget `void this.saveSettings()` from persisting the typed apiKey as plaintext (v1.25.3 #182 invariant).
- Duplicated UI button/Notice code collapsed into `resetUi()` helper; misleading double-Notice removed (flushApiKey owns the error surface).

## Tests

| File | Tests | Coverage |
|------|-------|----------|
| `settings-commit-flush-api-key.test.ts` | 6 NEW | Production method path via `Object.create(LLMWikiSettingTab.prototype)` + stubbed `app.secretStorage` — no function-mirror |
| `settings-codex-sections.test.ts` | 1 mod | Mock signature `commitTempSettings` → `(): boolean` |

## Verification

- **Before**: Switch provider, type key, Test Connection passes, Lint/Query/Ingest → 401
- **After**: Same flow → all calls succeed
- **2572/2572** tests pass (+6 new, −0 regression)
- Gate 1: lint 0/0, tsc 0, build clean, css-lint 0
- simplify (4 agents) + code-review (max effort) findings all addressed
- User e2e confirmed Hotfix/Branch

Co-Authored-By: green-dalii <654534332@qq.com>
Co-Authored-By: Claude Code <noreply@anthropic.com>