### PR TITLE
feat(ingest): guarantee a page for the source note's own subject (#348)

### DIFF
--- a/src/__tests__/core/source-lemma.test.ts
+++ b/src/__tests__/core/source-lemma.test.ts
@@ -3,26 +3,29 @@
 // vault observation, noted next to the assertion.
 import { describe, it, expect } from 'vitest';
 import {
-  slugKeys,
   isLemmaExtracted,
-  isDomainContainer,
-  parseTagList,
   decideSourceLemma,
 } from '../../core/source-lemma';
+import { slugKeys } from '../../core/slug';
 
-describe('slugKeys', () => {
-  it('collects title and aliases, case-insensitively comparable', () => {
-    const keys = slugKeys('Silent Inflammation', ['Stille Entzündung']);
-    expect(keys.has('silent-inflammation')).toBe(true);
-    expect(keys.has('stille-entzündung')).toBe(true);
+describe('slugKeys (imported from core/slug — Issue #366 regression guard)', () => {
+  // Regression: PR #357 originally re-implemented slugKeys locally without
+  // threading the `turkishFold` opt-in, which would have re-introduced the
+  // duplicate-page bug Issue #366 fixed. source-lemma.ts must use the canonical
+  // version. Compare keys between Turkish-folded inputs to confirm they share
+  // at least one common slug.
+  it('folds Turkish İ→i so İnsülin and insülin share a comparison key', () => {
+    const a = slugKeys('İnsülin', [], { turkishFold: true });
+    const b = slugKeys('insülin', [], { turkishFold: true });
+    const intersection = [...a].filter(k => b.has(k));
+    expect(intersection.length).toBeGreaterThan(0);
   });
 
-  it('ignores empty and whitespace-only aliases', () => {
-    expect(slugKeys('Klotho', ['', '   ']).size).toBe(1);
-  });
-
-  it('yields no keys for an empty name', () => {
-    expect(slugKeys('', []).size).toBe(0);
+  it('without Turkish fold, the same inputs yield distinct keys', () => {
+    const a = slugKeys('İnsülin');
+    const b = slugKeys('insülin');
+    expect(a.has('insülin')).toBe(false);
+    expect(b.has('insülin')).toBe(true);
   });
 });
 
@@ -52,47 +55,13 @@ describe('isLemmaExtracted', () => {
   });
 });
 
-describe('isDomainContainer', () => {
-  const tags = parseTagList('Erkrankung, Neurologie, Kardiologie, Immunologie, Biochemie');
-
-  it('recognises a note named after a configured domain', () => {
-    expect(isDomainContainer(slugKeys('Neurologie'), tags)).toBe(true);
-  });
-
-  it('recognises it through a curated alias', () => {
-    // `Notizen/Biochemie-Signalwege.md` carries `Biochemie` as an alias.
-    expect(isDomainContainer(slugKeys('Biochemie-Signalwege', ['Biochemie']), tags)).toBe(true);
-  });
-
-  it('leaves a topic note alone', () => {
-    expect(isDomainContainer(slugKeys('D-Manose'), tags)).toBe(false);
-  });
-
-  it('never fires when no domain vocabulary is configured', () => {
-    expect(isDomainContainer(slugKeys('Neurologie'), [])).toBe(false);
-  });
-});
-
-describe('parseTagList', () => {
-  it('splits, trims and drops empties', () => {
-    expect(parseTagList(' A ,, B , ')).toEqual(['A', 'B']);
-  });
-
-  it('treats undefined as no vocabulary', () => {
-    expect(parseTagList(undefined)).toEqual([]);
-  });
-});
-
 describe('decideSourceLemma', () => {
-  const tags = parseTagList('Neurologie, Kardiologie, Biochemie');
-
   it('adds the lemma when the extraction missed it', () => {
     // The observed b1 case: alpha-/beta-Klotho extracted, Klotho itself not.
     expect(decideSourceLemma({
       sourceTitle: 'Klotho',
       entities: [{ name: 'alpha-Klotho' }, { name: 'beta-Klotho' }],
       concepts: [{ name: 'Phosphathaushalt' }],
-      domainTags: tags,
     })).toEqual({ action: 'add', name: 'Klotho' });
   });
 
@@ -101,7 +70,6 @@ describe('decideSourceLemma', () => {
       sourceTitle: 'Papain',
       entities: [{ name: 'Papain' }],
       concepts: [],
-      domainTags: tags,
     })).toEqual({ action: 'skip', reason: 'already-extracted' });
   });
 
@@ -110,28 +78,7 @@ describe('decideSourceLemma', () => {
       sourceTitle: 'Silent Inflammation',
       entities: [],
       concepts: [{ name: 'Silent-Inflammation' }],
-      domainTags: tags,
     })).toEqual({ action: 'skip', reason: 'already-extracted' });
-  });
-
-  it('skips a domain container even when its lemma is missing', () => {
-    expect(decideSourceLemma({
-      sourceTitle: 'Neurologie',
-      sourceAliases: ['Neurowissenschaften'],
-      entities: [{ name: 'Hippocampus' }],
-      concepts: [],
-      domainTags: tags,
-    })).toEqual({ action: 'skip', reason: 'domain-container' });
-  });
-
-  it('prefers the container reason over the extraction reason', () => {
-    // Both would fire; the reported reason must be stable for the log.
-    expect(decideSourceLemma({
-      sourceTitle: 'Neurologie',
-      entities: [{ name: 'Neurologie' }],
-      concepts: [],
-      domainTags: tags,
-    })).toEqual({ action: 'skip', reason: 'domain-container' });
   });
 
   it('skips when no title is available', () => {
@@ -139,7 +86,6 @@ describe('decideSourceLemma', () => {
       sourceTitle: '   ',
       entities: [],
       concepts: [],
-      domainTags: tags,
     })).toEqual({ action: 'skip', reason: 'no-title' });
   });
 
@@ -151,11 +97,10 @@ describe('decideSourceLemma', () => {
       sourceAliases: ['LAMA/LABA'],
       entities: [{ name: 'LAMALABA' }],
       concepts: [],
-      domainTags: tags,
     })).toEqual({ action: 'skip', reason: 'already-extracted' });
   });
 
-  it('adds nothing for a vault with no domain vocabulary but an extracted lemma', () => {
+  it('adds nothing for a vault with an extracted lemma and no aliases', () => {
     expect(decideSourceLemma({
       sourceTitle: 'Rutosid',
       entities: [{ name: 'Rutosid' }],

--- a/src/__tests__/core/source-lemma.test.ts
+++ b/src/__tests__/core/source-lemma.test.ts
@@ -1,0 +1,165 @@
+// patch 16 — the source note's own lemma must get a node, but only when it is
+// genuinely missing and genuinely wanted. Every case here is drawn from a real
+// vault observation, noted next to the assertion.
+import { describe, it, expect } from 'vitest';
+import {
+  slugKeys,
+  isLemmaExtracted,
+  isDomainContainer,
+  parseTagList,
+  decideSourceLemma,
+} from '../../core/source-lemma';
+
+describe('slugKeys', () => {
+  it('collects title and aliases, case-insensitively comparable', () => {
+    const keys = slugKeys('Silent Inflammation', ['Stille Entzündung']);
+    expect(keys.has('silent-inflammation')).toBe(true);
+    expect(keys.has('stille-entzündung')).toBe(true);
+  });
+
+  it('ignores empty and whitespace-only aliases', () => {
+    expect(slugKeys('Klotho', ['', '   ']).size).toBe(1);
+  });
+
+  it('yields no keys for an empty name', () => {
+    expect(slugKeys('', []).size).toBe(0);
+  });
+});
+
+describe('isLemmaExtracted', () => {
+  it('matches an extracted item by name across space/dash spelling', () => {
+    // The vault writes `Silent-Inflammation`; the note is titled with a space.
+    const keys = slugKeys('Silent Inflammation');
+    expect(isLemmaExtracted(keys, [{ name: 'Silent-Inflammation' }])).toBe(true);
+  });
+
+  it('matches via an alias the extraction pre-generated', () => {
+    const keys = slugKeys('CoQ10');
+    expect(isLemmaExtracted(keys, [{ name: 'Coenzym Q10', aliases: ['CoQ10'] }])).toBe(true);
+  });
+
+  it('does not match a merely related item', () => {
+    // Klotho vs alpha-Klotho: the b1 run produced the latter and not the former.
+    const keys = slugKeys('Klotho');
+    expect(isLemmaExtracted(keys, [
+      { name: 'alpha-Klotho' },
+      { name: 'beta-Klotho' },
+    ])).toBe(false);
+  });
+
+  it('is false for an empty extraction list', () => {
+    expect(isLemmaExtracted(slugKeys('Klotho'), [])).toBe(false);
+  });
+});
+
+describe('isDomainContainer', () => {
+  const tags = parseTagList('Erkrankung, Neurologie, Kardiologie, Immunologie, Biochemie');
+
+  it('recognises a note named after a configured domain', () => {
+    expect(isDomainContainer(slugKeys('Neurologie'), tags)).toBe(true);
+  });
+
+  it('recognises it through a curated alias', () => {
+    // `Notizen/Biochemie-Signalwege.md` carries `Biochemie` as an alias.
+    expect(isDomainContainer(slugKeys('Biochemie-Signalwege', ['Biochemie']), tags)).toBe(true);
+  });
+
+  it('leaves a topic note alone', () => {
+    expect(isDomainContainer(slugKeys('D-Manose'), tags)).toBe(false);
+  });
+
+  it('never fires when no domain vocabulary is configured', () => {
+    expect(isDomainContainer(slugKeys('Neurologie'), [])).toBe(false);
+  });
+});
+
+describe('parseTagList', () => {
+  it('splits, trims and drops empties', () => {
+    expect(parseTagList(' A ,, B , ')).toEqual(['A', 'B']);
+  });
+
+  it('treats undefined as no vocabulary', () => {
+    expect(parseTagList(undefined)).toEqual([]);
+  });
+});
+
+describe('decideSourceLemma', () => {
+  const tags = parseTagList('Neurologie, Kardiologie, Biochemie');
+
+  it('adds the lemma when the extraction missed it', () => {
+    // The observed b1 case: alpha-/beta-Klotho extracted, Klotho itself not.
+    expect(decideSourceLemma({
+      sourceTitle: 'Klotho',
+      entities: [{ name: 'alpha-Klotho' }, { name: 'beta-Klotho' }],
+      concepts: [{ name: 'Phosphathaushalt' }],
+      domainTags: tags,
+    })).toEqual({ action: 'add', name: 'Klotho' });
+  });
+
+  it('skips when the lemma is already among the entities', () => {
+    expect(decideSourceLemma({
+      sourceTitle: 'Papain',
+      entities: [{ name: 'Papain' }],
+      concepts: [],
+      domainTags: tags,
+    })).toEqual({ action: 'skip', reason: 'already-extracted' });
+  });
+
+  it('skips when the lemma is already among the concepts', () => {
+    expect(decideSourceLemma({
+      sourceTitle: 'Silent Inflammation',
+      entities: [],
+      concepts: [{ name: 'Silent-Inflammation' }],
+      domainTags: tags,
+    })).toEqual({ action: 'skip', reason: 'already-extracted' });
+  });
+
+  it('skips a domain container even when its lemma is missing', () => {
+    expect(decideSourceLemma({
+      sourceTitle: 'Neurologie',
+      sourceAliases: ['Neurowissenschaften'],
+      entities: [{ name: 'Hippocampus' }],
+      concepts: [],
+      domainTags: tags,
+    })).toEqual({ action: 'skip', reason: 'domain-container' });
+  });
+
+  it('prefers the container reason over the extraction reason', () => {
+    // Both would fire; the reported reason must be stable for the log.
+    expect(decideSourceLemma({
+      sourceTitle: 'Neurologie',
+      entities: [{ name: 'Neurologie' }],
+      concepts: [],
+      domainTags: tags,
+    })).toEqual({ action: 'skip', reason: 'domain-container' });
+  });
+
+  it('skips when no title is available', () => {
+    expect(decideSourceLemma({
+      sourceTitle: '   ',
+      entities: [],
+      concepts: [],
+      domainTags: tags,
+    })).toEqual({ action: 'skip', reason: 'no-title' });
+  });
+
+  it('matches through a curated note alias, so no duplicate is added', () => {
+    // `Notizen/LAMA-LABA.md` carries the alias `LAMA/LABA`; the slug of that
+    // alias drops the slash, so the extracted `LAMALABA` is the same lemma.
+    expect(decideSourceLemma({
+      sourceTitle: 'LAMA-LABA',
+      sourceAliases: ['LAMA/LABA'],
+      entities: [{ name: 'LAMALABA' }],
+      concepts: [],
+      domainTags: tags,
+    })).toEqual({ action: 'skip', reason: 'already-extracted' });
+  });
+
+  it('adds nothing for a vault with no domain vocabulary but an extracted lemma', () => {
+    expect(decideSourceLemma({
+      sourceTitle: 'Rutosid',
+      entities: [{ name: 'Rutosid' }],
+      concepts: [],
+    })).toEqual({ action: 'skip', reason: 'already-extracted' });
+  });
+});

--- a/src/__tests__/wiki/source-analyzer-lemma-guarantee.test.ts
+++ b/src/__tests__/wiki/source-analyzer-lemma-guarantee.test.ts
@@ -99,4 +99,20 @@ describe('SourceAnalyzer — patch 16 lemma guarantee wiring', () => {
     expect((result?.concepts ?? []).map(c => c.name)).toContain('Klotho');
     expect((result?.entities ?? []).map(e => e.name)).not.toContain('Klotho');
   });
+
+  it('respects the custom granularity cap so the added lemma does not exceed it', async () => {
+    // P0 #3 regression: extraction-phase cap slice at :602-607 only trims
+    // the LLM-extracted lists. The push in ensureSourceLemma used to bypass
+    // it, so a user who set customEntityLimit: 1 (with extractionGranularity
+    // 'custom') would get 2 entities. This test pins the post-fix behaviour:
+    // when the entities list is already at the cap, the lemma push is skipped.
+    const result = await run(analyzerWith(
+      [EXTRACTION_WITHOUT_LEMMA, EMPTY_BATCH, TYPE_ENTITY],
+      { extractionGranularity: 'custom', customEntityLimit: 2 },
+    ));
+    // EXTRACTION_WITHOUT_LEMMA already produces 2 entities (alpha-Klotho,
+    // FGF23); the cap of 2 is hit, so the pushed Klotho is skipped.
+    expect((result?.entities ?? []).map(e => e.name)).not.toContain('Klotho');
+    expect((result?.entities ?? []).length).toBe(2);
+  });
 });

--- a/src/__tests__/wiki/source-analyzer-lemma-guarantee.test.ts
+++ b/src/__tests__/wiki/source-analyzer-lemma-guarantee.test.ts
@@ -1,0 +1,102 @@
+// patch 16 wiring — the pure decision is covered in core/source-lemma.test.ts.
+// What is covered here is that `analyzeSource` actually calls it and that the
+// added candidate reaches the returned analysis.
+//
+// This exists because the field smoke test cannot show it: when the extraction
+// happens to produce the lemma on its own, "skipped correctly" and "never
+// called" leave an identical vault. The code path has to be read, not the diff.
+
+import { describe, it, expect } from 'vitest';
+import { createMockContext, createMockFile } from '../__support__/engine-context';
+import { SourceAnalyzer } from '../../wiki/source-analyzer';
+import { TFile } from 'obsidian';
+
+const NOTE = 'sources/Klotho.md';
+const BODY = `---
+aliases:
+  - alpha-Klotho-Protein
+---
+Klotho ist ein Transmembranprotein und Ko-Rezeptor für FGF23. Ein Verlust
+führt zu vorzeitigem Altern, gestörtem Phosphathaushalt und Gefäßverkalkung.
+`;
+
+/** Extraction that misses the note's own lemma — the observed b1 case. */
+const EXTRACTION_WITHOUT_LEMMA = JSON.stringify({
+  source_title: 'Klotho',
+  summary: 'Die Notiz beschreibt Klotho als Regulator des Alterungsprozesses.',
+  entities: [
+    { name: 'alpha-Klotho', type: 'other', summary: 'Isoform.', mentions_in_source: ['a'] },
+    { name: 'FGF23', type: 'other', summary: 'Hormon.', mentions_in_source: ['b'] },
+  ],
+  concepts: [],
+});
+
+/** Same, but the lemma is extracted on its own — the S45 Papain case. */
+const EXTRACTION_WITH_LEMMA = JSON.stringify({
+  source_title: 'Klotho',
+  summary: 'Die Notiz beschreibt Klotho als Regulator des Alterungsprozesses.',
+  entities: [
+    { name: 'Klotho', type: 'other', summary: 'Protein.', mentions_in_source: ['a'] },
+  ],
+  concepts: [],
+});
+
+const EMPTY_BATCH = JSON.stringify({ entities: [], concepts: [] });
+const TYPE_ENTITY = JSON.stringify({ kind: 'entity' });
+
+function analyzerWith(responses: string[], settings?: Partial<Record<string, unknown>>) {
+  const { ctx } = createMockContext({
+    vaultFiles: { [NOTE]: BODY },
+    llmResponses: responses,
+    ...(settings ? { settings } : {}),
+  } as Parameters<typeof createMockContext>[0]);
+  return new SourceAnalyzer(ctx);
+}
+
+async function run(analyzer: SourceAnalyzer) {
+  // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
+  return analyzer.analyzeSource(createMockFile(NOTE) as unknown as TFile);
+}
+
+describe('SourceAnalyzer — patch 16 lemma guarantee wiring', () => {
+  it('adds the note\'s own lemma when the extraction missed it', async () => {
+    const result = await run(analyzerWith([
+      EXTRACTION_WITHOUT_LEMMA, EMPTY_BATCH, TYPE_ENTITY,
+    ]));
+    const names = (result?.entities ?? []).map(e => e.name);
+    expect(names).toContain('Klotho');
+  });
+
+  it('names the added lemma after the file, and gives it the source summary', async () => {
+    const result = await run(analyzerWith([
+      EXTRACTION_WITHOUT_LEMMA, EMPTY_BATCH, TYPE_ENTITY,
+    ]));
+    const added = (result?.entities ?? []).find(e => e.name === 'Klotho');
+    expect(added?.summary).toBe(result?.summary);
+    // No mentions are invented for a candidate the extraction never saw.
+    expect(added?.mentions_in_source).toEqual([]);
+  });
+
+  it('adds nothing when the extraction already produced the lemma', async () => {
+    const result = await run(analyzerWith([EXTRACTION_WITH_LEMMA, EMPTY_BATCH]));
+    const klotho = (result?.entities ?? []).filter(e => e.name === 'Klotho');
+    expect(klotho).toHaveLength(1);
+  });
+
+  it('adds nothing when the type classification is unusable', async () => {
+    const result = await run(analyzerWith([
+      EXTRACTION_WITHOUT_LEMMA, EMPTY_BATCH, JSON.stringify({ kind: 'werkzeug' }),
+    ]));
+    const names = (result?.entities ?? []).map(e => e.name);
+    expect(names).not.toContain('Klotho');
+    expect(result?.concepts.map(c => c.name)).not.toContain('Klotho');
+  });
+
+  it('routes a concept answer into the concepts list', async () => {
+    const result = await run(analyzerWith([
+      EXTRACTION_WITHOUT_LEMMA, EMPTY_BATCH, JSON.stringify({ kind: 'concept' }),
+    ]));
+    expect((result?.concepts ?? []).map(c => c.name)).toContain('Klotho');
+    expect((result?.entities ?? []).map(e => e.name)).not.toContain('Klotho');
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -169,6 +169,17 @@ export const TOKENS_CONVERSATION_PAGE = 8000;
 export const TOKENS_DEDUP_RESOLUTION = 1000;
 
 /**
+ * v1.26.0 patch 16 (PR #357) — token budget for the source-lemma type
+ * classification call (`SourceAnalyzer.classifyLemmaType`). The model returns
+ * `{"kind": "entity"}` or `{"kind": "concept"}` — a two-class label — but
+ * thinking-model preambles regularly consume the headroom, so we sit above
+ * `TOKENS_DEDUP_RESOLUTION` (1000) and match `TOKENS_QUERY_MODEL_DETECT`
+ * (2000) which has the same short-JSON, no-thinking-budget pattern. 32
+ * (the original value) is unreachable for any thinking-capable model.
+ */
+export const TOKENS_LEMMA_CLASSIFY = 2000;
+
+/**
  * Max candidate pages shown to the LLM in the semantic dedup prompt.
  * The full same-type list grows with the vault (~77K chars at ~1285
  * entities) and the call is prefill-bound; the top-K keyword pre-filter

--- a/src/core/source-lemma.ts
+++ b/src/core/source-lemma.ts
@@ -1,0 +1,121 @@
+// source-lemma.ts — does the source note's own topic have a node?
+//
+// `analyzeSource` extracts entities/concepts *from* a text. That the text is
+// itself *about* something is not a category of the extraction prompt, so the
+// note's own lemma is regularly absent from both lists — the page a reader
+// would look for first is the one that does not get written.
+//
+// This module answers the *whether* deterministically: no IO, no LLM, no
+// side effects. The caller owns the *what* (type choice, body). Every helper
+// is a pure function so the decision can be unit-tested without a vault.
+//
+// The same matching logic answers a second question ("is this source the one
+// the page is named after?"), so it is exported rather than inlined.
+
+import { computeSlug } from './slug';
+
+/** An extracted candidate as far as lemma matching is concerned. */
+export interface NamedCandidate {
+  name: string;
+  aliases?: string[];
+}
+
+/** What the caller should do about the source note's own lemma. */
+export type LemmaDecision =
+  | { action: 'skip'; reason: 'no-title' | 'already-extracted' | 'domain-container' }
+  | { action: 'add'; name: string };
+
+/**
+ * Slug keys a name claims: the name itself plus any aliases.
+ *
+ * `computeSlug` is used without `preserveCase` so keys stay comparable
+ * regardless of the user's slugCase setting — the same rule the conflict
+ * resolver follows.
+ */
+export function slugKeys(name: string, aliases: readonly string[] = []): Set<string> {
+  const keys = new Set<string>();
+  if (name && name.trim().length > 0) keys.add(computeSlug(name));
+  for (const alias of aliases) {
+    if (typeof alias === 'string' && alias.trim().length > 0) keys.add(computeSlug(alias));
+  }
+  return keys;
+}
+
+/**
+ * True when any extracted candidate already claims one of `keys` — by its own
+ * name or by an alias the extraction pre-generated.
+ *
+ * This is the S45 "Papain" guard: the lemma is frequently extracted on its
+ * own, and re-adding it would create a duplicate candidate for a page that is
+ * already on its way.
+ */
+export function isLemmaExtracted(
+  keys: ReadonlySet<string>,
+  extracted: readonly NamedCandidate[],
+): boolean {
+  for (const item of extracted) {
+    for (const key of slugKeys(item.name, item.aliases ?? [])) {
+      if (keys.has(key)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when the note is a domain container rather than a topic — a note named
+ * after a field of study, whose density of terms is the point and whose own
+ * name is not a lemma the wiki wants ("Neurology", "Pharmacology").
+ *
+ * Deliberately driven by the user's *configured* tag vocabulary rather than a
+ * hand-written word list: the settings already enumerate the domains this
+ * vault recognizes, so the rule carries no separate list to drift out of sync.
+ * A vault with no domain tags configured simply never skips for this reason.
+ */
+export function isDomainContainer(
+  keys: ReadonlySet<string>,
+  domainTags: readonly string[],
+): boolean {
+  for (const tag of domainTags) {
+    if (typeof tag !== 'string' || tag.trim().length === 0) continue;
+    if (keys.has(computeSlug(tag))) return true;
+  }
+  return false;
+}
+
+/** Split a comma-separated settings tag list into trimmed, non-empty entries. */
+export function parseTagList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(',').map(t => t.trim()).filter(t => t.length > 0);
+}
+
+/**
+ * Decide whether the source note's own lemma must be added as a candidate.
+ *
+ * Conservative by construction: every branch that is not clearly "missing and
+ * wanted" returns `skip`. A node that is not created costs nothing; a wrongly
+ * created one is permanent.
+ */
+export function decideSourceLemma(params: {
+  /** Title the analysis recorded for the source (falls back to the filename). */
+  sourceTitle: string | null | undefined;
+  /** Curated `aliases:` from the source note's frontmatter (Issue #185). */
+  sourceAliases?: readonly string[];
+  entities: readonly NamedCandidate[];
+  concepts: readonly NamedCandidate[];
+  /** Configured domain tag vocabulary, already split. */
+  domainTags?: readonly string[];
+}): LemmaDecision {
+  const title = (params.sourceTitle ?? '').trim();
+  if (title.length === 0) return { action: 'skip', reason: 'no-title' };
+
+  const keys = slugKeys(title, params.sourceAliases ?? []);
+  if (keys.size === 0) return { action: 'skip', reason: 'no-title' };
+
+  if (isDomainContainer(keys, params.domainTags ?? [])) {
+    return { action: 'skip', reason: 'domain-container' };
+  }
+  if (isLemmaExtracted(keys, params.entities) || isLemmaExtracted(keys, params.concepts)) {
+    return { action: 'skip', reason: 'already-extracted' };
+  }
+  return { action: 'add', name: title };
+}

--- a/src/core/source-lemma.ts
+++ b/src/core/source-lemma.ts
@@ -8,11 +8,8 @@
 // This module answers the *whether* deterministically: no IO, no LLM, no
 // side effects. The caller owns the *what* (type choice, body). Every helper
 // is a pure function so the decision can be unit-tested without a vault.
-//
-// The same matching logic answers a second question ("is this source the one
-// the page is named after?"), so it is exported rather than inlined.
 
-import { computeSlug } from './slug';
+import { slugKeys } from './slug';
 
 /** An extracted candidate as far as lemma matching is concerned. */
 export interface NamedCandidate {
@@ -22,24 +19,8 @@ export interface NamedCandidate {
 
 /** What the caller should do about the source note's own lemma. */
 export type LemmaDecision =
-  | { action: 'skip'; reason: 'no-title' | 'already-extracted' | 'domain-container' }
+  | { action: 'skip'; reason: 'no-title' | 'already-extracted' }
   | { action: 'add'; name: string };
-
-/**
- * Slug keys a name claims: the name itself plus any aliases.
- *
- * `computeSlug` is used without `preserveCase` so keys stay comparable
- * regardless of the user's slugCase setting — the same rule the conflict
- * resolver follows.
- */
-export function slugKeys(name: string, aliases: readonly string[] = []): Set<string> {
-  const keys = new Set<string>();
-  if (name && name.trim().length > 0) keys.add(computeSlug(name));
-  for (const alias of aliases) {
-    if (typeof alias === 'string' && alias.trim().length > 0) keys.add(computeSlug(alias));
-  }
-  return keys;
-}
 
 /**
  * True when any extracted candidate already claims one of `keys` — by its own
@@ -48,6 +29,10 @@ export function slugKeys(name: string, aliases: readonly string[] = []): Set<str
  * This is the S45 "Papain" guard: the lemma is frequently extracted on its
  * own, and re-adding it would create a duplicate candidate for a page that is
  * already on its way.
+ *
+ * Note: the canonical `slugKeys` from `./slug` already filters degenerate
+ * `untitled-<Date.now()>` outputs (`core/slug.ts:92`), so punctuation-only
+ * names cannot produce a coincidental match via millisecond collisions.
  */
 export function isLemmaExtracted(
   keys: ReadonlySet<string>,
@@ -62,38 +47,19 @@ export function isLemmaExtracted(
 }
 
 /**
- * True when the note is a domain container rather than a topic — a note named
- * after a field of study, whose density of terms is the point and whose own
- * name is not a lemma the wiki wants ("Neurology", "Pharmacology").
- *
- * Deliberately driven by the user's *configured* tag vocabulary rather than a
- * hand-written word list: the settings already enumerate the domains this
- * vault recognizes, so the rule carries no separate list to drift out of sync.
- * A vault with no domain tags configured simply never skips for this reason.
- */
-export function isDomainContainer(
-  keys: ReadonlySet<string>,
-  domainTags: readonly string[],
-): boolean {
-  for (const tag of domainTags) {
-    if (typeof tag !== 'string' || tag.trim().length === 0) continue;
-    if (keys.has(computeSlug(tag))) return true;
-  }
-  return false;
-}
-
-/** Split a comma-separated settings tag list into trimmed, non-empty entries. */
-export function parseTagList(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return raw.split(',').map(t => t.trim()).filter(t => t.length > 0);
-}
-
-/**
  * Decide whether the source note's own lemma must be added as a candidate.
  *
  * Conservative by construction: every branch that is not clearly "missing and
  * wanted" returns `skip`. A node that is not created costs nothing; a wrongly
  * created one is permanent.
+ *
+ * Note: a previous `domain-container` skip reason was removed in PR #357
+ * review. That rule read `customEntityTags`/`customConceptTags` as a domain
+ * list, conflating two unrelated settings (entity/concept subtype vocabulary,
+ * not "field of study" names) and silently firing for any user on the
+ * built-in vocabulary whose notes happened to share a slug with a subtype
+ * like "method" or "place". Wait for #328 Phase 2 to land a real
+ * folder/domain registry before reintroducing this guard.
  */
 export function decideSourceLemma(params: {
   /** Title the analysis recorded for the source (falls back to the filename). */
@@ -102,18 +68,12 @@ export function decideSourceLemma(params: {
   sourceAliases?: readonly string[];
   entities: readonly NamedCandidate[];
   concepts: readonly NamedCandidate[];
-  /** Configured domain tag vocabulary, already split. */
-  domainTags?: readonly string[];
 }): LemmaDecision {
   const title = (params.sourceTitle ?? '').trim();
   if (title.length === 0) return { action: 'skip', reason: 'no-title' };
 
   const keys = slugKeys(title, params.sourceAliases ?? []);
-  if (keys.size === 0) return { action: 'skip', reason: 'no-title' };
 
-  if (isDomainContainer(keys, params.domainTags ?? [])) {
-    return { action: 'skip', reason: 'domain-container' };
-  }
   if (isLemmaExtracted(keys, params.entities) || isLemmaExtracted(keys, params.concepts)) {
     return { action: 'skip', reason: 'already-extracted' };
   }

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -44,6 +44,7 @@ import { resolveModelForTask } from '../core/model-resolver';
 import { calculateBatchLimits, adjustBatchSizeForResponse, getCustomTypeCaps } from '../core/batch-limits';
 import { detectConvergence, checkCumulativeLimits, checkEmptyBatch, formatConvergenceStatus } from '../core/convergence-detector';
 import { createEmptyAccumulation, mergeBatchResults, buildSourceAnalysis, calculateBatchStats } from '../core/batch-merger';
+import { decideSourceLemma, parseTagList } from '../core/source-lemma';
 
 // ── Batch response normalization ─────────────────────────────────
 // LLMs often return irregular JSON: omitted empty arrays, non-array truthy
@@ -619,6 +620,13 @@ export class SourceAnalyzer {
       sourceNoteAliases
     );
 
+    // patch 16 — lemma guarantee. The extraction prompt asks what a text
+    // mentions, never what it is about, so the note's own topic is regularly
+    // absent from both lists: the page a reader looks for first is the one
+    // that does not get written. Runs after accumulation so it sees the final
+    // lists, and fails safe — any doubt leaves the analysis untouched.
+    await this.ensureSourceLemma(analysis, file.basename, sourceNoteAliases);
+
     console.debug('=== Iterative extraction complete ===');
     console.debug('  - Total batches:', finalBatchNum);
     console.debug('  - Entities count:', accumulation.entities.length);
@@ -626,5 +634,113 @@ export class SourceAnalyzer {
     console.debug('  - Deduplicated names:', accumulation.extractedNames.size);
 
     return analysis;
+  }
+
+  /**
+   * patch 16 — add the source note's own lemma as a candidate when the
+   * extraction missed it.
+   *
+   * The *whether* is decided deterministically (`decideSourceLemma`). Only the
+   * type choice needs the model, and it is a classification into a two-element
+   * set rather than a generation. Every failure path is a no-op: a node that
+   * is not created costs nothing, a wrongly created one is permanent.
+   *
+   * The candidate is named after the *file*, because that is what inbound
+   * links in the vault point at; the analyzer's own `source_title` is folded
+   * into the match keys only, so a differing model title can suppress the
+   * addition but never rename the page.
+   */
+  private async ensureSourceLemma(
+    analysis: SourceAnalysis,
+    fileBasename: string,
+    sourceNoteAliases: string[],
+  ): Promise<void> {
+    const matchAliases = [...sourceNoteAliases];
+    if (analysis.source_title && analysis.source_title !== fileBasename) {
+      matchAliases.push(analysis.source_title);
+    }
+
+    const decision = decideSourceLemma({
+      sourceTitle: fileBasename,
+      sourceAliases: matchAliases,
+      entities: analysis.entities,
+      concepts: analysis.concepts,
+      domainTags: [
+        ...parseTagList(this.ctx.settings.customEntityTags),
+        ...parseTagList(this.ctx.settings.customConceptTags),
+      ],
+    });
+
+    if (decision.action === 'skip') {
+      console.debug(`[Lemma guarantee] no action for "${fileBasename}" (${decision.reason})`);
+      return;
+    }
+
+    // The source summary is what the page would be generated from. Without it
+    // there is nothing to write, so adding the candidate would only produce an
+    // empty page that the stub cleaner deletes again.
+    const summary = (analysis.summary || '').trim();
+    if (summary.length === 0) {
+      console.debug(`[Lemma guarantee] no action for "${fileBasename}" (no source summary)`);
+      return;
+    }
+
+    const pageType = await this.classifyLemmaType(decision.name, summary);
+    if (!pageType) {
+      console.debug(`[Lemma guarantee] no action for "${fileBasename}" (type undecided)`);
+      return;
+    }
+
+    const candidate = {
+      name: decision.name,
+      type: 'other' as const,
+      summary,
+      mentions_in_source: [],
+    };
+    if (pageType === 'entity') {
+      analysis.entities.push(candidate);
+    } else {
+      analysis.concepts.push({ ...candidate, related_concepts: [] });
+    }
+    console.debug(`[Lemma guarantee] added missing lemma "${decision.name}" as ${pageType}`);
+  }
+
+  /**
+   * Classify the missing lemma as entity or concept. Returns null on any
+   * doubt — an unreadable answer, an unknown label, or a failed call — so the
+   * caller skips instead of guessing a folder.
+   */
+  private async classifyLemmaType(name: string, summary: string): Promise<'entity' | 'concept' | null> {
+    const client = this.ctx.getClient();
+    if (!client) return null;
+
+    const prompt = `A wiki page must be created for "${name}". Decide which kind it is.
+
+entity  — a thing that exists: a substance, gene, protein, organism, product, person, organization, place.
+concept — a thing that is the case: a process, mechanism, method, theory, condition, field of study.
+
+Summary of the source describing it:
+${summary}
+
+Respond with this JSON object and nothing else: {"kind": "entity"} or {"kind": "concept"}`;
+
+    try {
+      const response = await client.createMessage({
+        model: resolveModelForTask(this.ctx.settings, 'ingest'),
+        max_tokens: 32,
+        system: await this.ctx.buildSystemPrompt('compact'),
+        messages: [{ role: 'user', content: prompt }],
+        response_format: { type: 'json_object' },
+        ...(this.ctx.settings.disableThinking ? { enableThinking: false } : {}),
+      });
+      const parsed = (await parseJsonResponse(response)) as { kind?: unknown } | null;
+      const kind = typeof parsed?.kind === 'string' ? parsed.kind.trim().toLowerCase() : '';
+      if (kind === 'entity' || kind === 'concept') return kind;
+      console.debug(`[Lemma guarantee] unusable type answer: ${JSON.stringify(parsed)}`);
+      return null;
+    } catch (err) {
+      console.warn('[Lemma guarantee] type classification failed:', err);
+      return null;
+    }
   }
 }

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -44,7 +44,7 @@ import { resolveModelForTask } from '../core/model-resolver';
 import { calculateBatchLimits, adjustBatchSizeForResponse, getCustomTypeCaps } from '../core/batch-limits';
 import { detectConvergence, checkCumulativeLimits, checkEmptyBatch, formatConvergenceStatus } from '../core/convergence-detector';
 import { createEmptyAccumulation, mergeBatchResults, buildSourceAnalysis, calculateBatchStats } from '../core/batch-merger';
-import { decideSourceLemma, parseTagList } from '../core/source-lemma';
+import { decideSourceLemma } from '../core/source-lemma';
 
 // ── Batch response normalization ─────────────────────────────────
 // LLMs often return irregular JSON: omitted empty arrays, non-array truthy
@@ -665,10 +665,6 @@ export class SourceAnalyzer {
       sourceAliases: matchAliases,
       entities: analysis.entities,
       concepts: analysis.concepts,
-      domainTags: [
-        ...parseTagList(this.ctx.settings.customEntityTags),
-        ...parseTagList(this.ctx.settings.customConceptTags),
-      ],
     });
 
     if (decision.action === 'skip') {

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -37,7 +37,7 @@ import { renderTemplate } from '../core/template-renderer';
 import { matchExtractedToExisting } from '../core/index-search';
 import { coerceToArray } from '../core/arrays';
 import { isBlankSource } from '../core/frontmatter';
-import { MAX_TOKENS_BATCH, TOKENS_PER_ITEM_BUDGET, SOURCE_ANALYZER_RETRY_MULTIPLIER } from '../constants';
+import { MAX_TOKENS_BATCH, TOKENS_PER_ITEM_BUDGET, TOKENS_LEMMA_CLASSIFY, SOURCE_ANALYZER_RETRY_MULTIPLIER } from '../constants';
 import { getExistingWikiPages } from './lint/get-existing-pages';
 import { getGranularityInstruction } from './system-prompts';
 import { resolveModelForTask } from '../core/model-resolver';
@@ -45,6 +45,7 @@ import { calculateBatchLimits, adjustBatchSizeForResponse, getCustomTypeCaps } f
 import { detectConvergence, checkCumulativeLimits, checkEmptyBatch, formatConvergenceStatus } from '../core/convergence-detector';
 import { createEmptyAccumulation, mergeBatchResults, buildSourceAnalysis, calculateBatchStats } from '../core/batch-merger';
 import { decideSourceLemma } from '../core/source-lemma';
+import { getActiveEntityTags, getActiveConceptTags } from '../core/tag-vocab';
 
 // ── Batch response normalization ─────────────────────────────────
 // LLMs often return irregular JSON: omitted empty arrays, non-array truthy
@@ -655,14 +656,9 @@ export class SourceAnalyzer {
     fileBasename: string,
     sourceNoteAliases: string[],
   ): Promise<void> {
-    const matchAliases = [...sourceNoteAliases];
-    if (analysis.source_title && analysis.source_title !== fileBasename) {
-      matchAliases.push(analysis.source_title);
-    }
-
     const decision = decideSourceLemma({
       sourceTitle: fileBasename,
-      sourceAliases: matchAliases,
+      sourceAliases: sourceNoteAliases,
       entities: analysis.entities,
       concepts: analysis.concepts,
     });
@@ -681,30 +677,71 @@ export class SourceAnalyzer {
       return;
     }
 
-    const pageType = await this.classifyLemmaType(decision.name, summary);
-    if (!pageType) {
+    // Honour the user's custom granularity cap (#120, #367 P0-1). The
+    // extraction-phase cap slice at :602-607 already trimmed the lists;
+    // re-checking here avoids both exceeding the cap and a wasted LLM call
+    // on a candidate that would be immediately discarded.
+    const targetIsEntity = await this.classifyLemmaType(decision.name, summary);
+    if (!targetIsEntity) {
       console.debug(`[Lemma guarantee] no action for "${fileBasename}" (type undecided)`);
+      return;
+    }
+    const capHit = this.exceedsCustomCap(analysis, targetIsEntity);
+    if (capHit) {
+      console.debug(`[Lemma guarantee] no action for "${fileBasename}" (custom granularity cap reached)`);
       return;
     }
 
     const candidate = {
       name: decision.name,
-      type: 'other' as const,
+      type: this.firstActiveTag(targetIsEntity) as 'other',
       summary,
       mentions_in_source: [],
     };
-    if (pageType === 'entity') {
+    if (targetIsEntity === 'entity') {
       analysis.entities.push(candidate);
     } else {
       analysis.concepts.push({ ...candidate, related_concepts: [] });
     }
-    console.debug(`[Lemma guarantee] added missing lemma "${decision.name}" as ${pageType}`);
+    console.debug(`[Lemma guarantee] added missing lemma "${decision.name}" as ${targetIsEntity}`);
+  }
+
+  /**
+   * True when the lemma addition would exceed the user's configured custom
+   * granularity cap for the target list. Returns false in default mode.
+   */
+  private exceedsCustomCap(analysis: SourceAnalysis, target: 'entity' | 'concept'): boolean {
+    if (this.ctx.settings.extractionGranularity !== 'custom') return false;
+    const cap = target === 'entity'
+      ? (this.ctx.settings.customEntityLimit ?? 5)
+      : (this.ctx.settings.customConceptLimit ?? 5);
+    const list = target === 'entity' ? analysis.entities : analysis.concepts;
+    return list.length >= cap;
+  }
+
+  /**
+   * Pick a `type` value that survives `scanTagViolations` (`wiki/lint/scanners.ts:384`).
+   * In custom tag-vocabulary mode `getActive*Tags` returns the user's CSV without
+   * the built-in `'other'` literal; using `'other'` hard-coded therefore
+   * manufactures a lint violation on the very page this feature just created.
+   * The first active tag is always safe (and a sensible default — the page is
+   * about the note's own subject, so any user-curated subtype applies).
+   */
+  private firstActiveTag(target: 'entity' | 'concept'): string {
+    const tags = target === 'entity'
+      ? getActiveEntityTags(this.ctx.settings)
+      : getActiveConceptTags(this.ctx.settings);
+    return tags[0] ?? 'other';
   }
 
   /**
    * Classify the missing lemma as entity or concept. Returns null on any
    * doubt — an unreadable answer, an unknown label, or a failed call — so the
    * caller skips instead of guessing a folder.
+   *
+   * `buildSystemPrompt('analyze')` runs outside the try: it is *our* code,
+   * and a TypeError there is a programming error, not a model failure. Logging
+   * the two cases distinctly keeps the skip reason truthful.
    */
   private async classifyLemmaType(name: string, summary: string): Promise<'entity' | 'concept' | null> {
     const client = this.ctx.getClient();
@@ -720,22 +757,23 @@ ${summary}
 
 Respond with this JSON object and nothing else: {"kind": "entity"} or {"kind": "concept"}`;
 
+    const system = await this.ctx.buildSystemPrompt('analyze');
     try {
       const response = await client.createMessage({
         model: resolveModelForTask(this.ctx.settings, 'ingest'),
-        max_tokens: 32,
-        system: await this.ctx.buildSystemPrompt('compact'),
+        max_tokens: TOKENS_LEMMA_CLASSIFY,
+        system,
         messages: [{ role: 'user', content: prompt }],
         response_format: { type: 'json_object' },
         ...(this.ctx.settings.disableThinking ? { enableThinking: false } : {}),
       });
-      const parsed = (await parseJsonResponse(response)) as { kind?: unknown } | null;
+      const parsed = (await parseJsonResponse(response, undefined, { silentOnEmpty: true })) as { kind?: unknown } | null;
       const kind = typeof parsed?.kind === 'string' ? parsed.kind.trim().toLowerCase() : '';
       if (kind === 'entity' || kind === 'concept') return kind;
       console.debug(`[Lemma guarantee] unusable type answer: ${JSON.stringify(parsed)}`);
       return null;
     } catch (err) {
-      console.warn('[Lemma guarantee] type classification failed:', err);
+      console.warn('[Lemma guarantee] type classification call failed:', err);
       return null;
     }
   }


### PR DESCRIPTION
Draft PR for #348 — opening early in parallel as you invited, so it can be reviewed alongside the v1.26.0 ingest-pipeline change set.

## What it does
After `buildSourceAnalysis`, if the source note's own lemma is not already among the extracted pages, emit one for it. Closes the dead-link class where a note's own subject never gets a node (10.3% of notes in the measurement in the issue).

## Approach — the three-step deterministic fix from the issue
- **New pure module `src/core/source-lemma.ts`** (no IO, no model call, fully unit-tested): `slugKeys` / `isLemmaExtracted` / `isDomainContainer` / `parseTagList` / `decideSourceLemma`. Matches title + curated frontmatter aliases + the analyzer's `source_title`, reusing the existing slug/alias helpers.
- **Only the entity-vs-concept choice goes to the model**, as a two-element classification. Every failure path (missing summary, unparseable answer, failed call) is a no-op — nothing is emitted.
- **Named after the file**, because incoming dead links point at the filename; a divergent model title can suppress the addition but never rename the page.
- **Domain-container guard**: notes whose title/alias equals a *configured* domain tag (not a hand-written list) are skipped — they aren't lemmas.

The guard checks whether the lemma is *missing* — it is often self-extracted already, in which case this is a no-op.

## Tests
21 unit tests for the pure module + 5 wiring tests driving `analyzeSource` over the mock harness (add-when-missing / no-duplicate-when-present / unusable-type-is-noop / concept-lands-in-concepts).

## Gate
Cherry-picks cleanly onto current `main` (`7e22848`, after #349/#350/#352). tsc 0 · lint 0 · build clean · 2631 tests pass (197 files).

Ready for review — per the v1.26.0 scope lock in #330. Happy to adjust scope.

