### PR TITLE
refactor: post-merge cleanups from 2026-07-26 PATCH batch audit (#361)

### DIFF
--- a/src/__tests__/core/source-language.test.ts
+++ b/src/__tests__/core/source-language.test.ts
@@ -1,17 +1,12 @@
-/**
- * Tests for the source-language signal extraction helpers.
- *
- * Background: PR #350 added frontmatter `language:` reading inside
- * `src/wiki/source-analyzer.ts:193-205, 334-337` (closed-vocabulary gate on
- * cross-language translation hints). GH #361 Theme 1 promotes that
- * detection + policy into shared helpers so that future prompt sites
- * can reuse the same logic.
- *
- * These helpers are read-only with respect to vault state.
- */
+/** Source-language signal: frontmatter value -> normalised string, then cross-language gate. */
 import { describe, expect, it } from 'vitest';
 import type { App, TFile } from 'obsidian';
-import { getSourceLanguage, isCrossLanguage } from '../../core/source-language';
+import {
+  getSourceLanguage,
+  getWikiLanguageName,
+  isCrossLanguage,
+  normalizeSourceLanguage,
+} from '../../core/source-language';
 
 type MetadataCacheLike = {
   getFileCache: (file: TFile) => { frontmatter?: Record<string, unknown> } | null;
@@ -28,68 +23,61 @@ function makeFile(): TFile {
   return { path: 'sources/foo.md' } as unknown as TFile;
 }
 
+describe('normalizeSourceLanguage', () => {
+  it('returns trimmed lowercase string for a valid language value', () => {
+    expect(normalizeSourceLanguage('  RU  ')).toBe('ru');
+  });
+  it('returns null for non-string input', () => {
+    expect(normalizeSourceLanguage(['ru', 'en'])).toBeNull();
+    expect(normalizeSourceLanguage(123)).toBeNull();
+    expect(normalizeSourceLanguage(null)).toBeNull();
+  });
+  it('returns null for whitespace-only input', () => {
+    expect(normalizeSourceLanguage('   ')).toBeNull();
+  });
+  it('preserves BCP-47 subtag shape (zh-Hant stays zh-hant)', () => {
+    expect(normalizeSourceLanguage('zh-Hant')).toBe('zh-hant');
+  });
+});
+
 describe('getSourceLanguage', () => {
-  it('returns trimmed lowercase language when frontmatter has language:string', () => {
+  it('reads frontmatter language via metadataCache and normalises', () => {
     const app = makeApp({ language: '  RU  ' });
     expect(getSourceLanguage(makeFile(), app)).toBe('ru');
   });
-
   it('returns null when frontmatter is absent', () => {
-    const app = makeApp(null);
-    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+    expect(getSourceLanguage(makeFile(), makeApp(null))).toBeNull();
   });
-
   it('returns null when language frontmatter key is missing', () => {
-    const app = makeApp({ title: 'foo' });
-    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+    expect(getSourceLanguage(makeFile(), makeApp({ title: 'foo' }))).toBeNull();
   });
+});
 
-  it('returns null when language is a non-string value (array)', () => {
-    const app = makeApp({ language: ['ru', 'en'] });
-    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+describe('getWikiLanguageName', () => {
+  it('resolves known wiki codes to their display name', () => {
+    expect(getWikiLanguageName('en')).toBe('English');
+    expect(getWikiLanguageName('zh-Hant')).toBe('繁體中文');
   });
-
-  it('returns null when language is whitespace-only', () => {
-    const app = makeApp({ language: '   ' });
-    expect(getSourceLanguage(makeFile(), app)).toBeNull();
-  });
-
-  it('preserves BCP-47 subtag shape (zh-Hant stays zh-hant)', () => {
-    const app = makeApp({ language: 'zh-Hant' });
-    expect(getSourceLanguage(makeFile(), app)).toBe('zh-hant');
+  it('falls back to the raw code for unrecognised wikiLang (useCustomWikiLanguage)', () => {
+    expect(getWikiLanguageName('custom-iso')).toBe('custom-iso');
   });
 });
 
 describe('isCrossLanguage', () => {
-  // Legacy fallback: when source lang is unknown, English wiki suppresses
-  // translation hint unconditionally. This preserves v1.25.x behaviour.
-  it('falls back to wikiLang !== "en" when sourceLang is null (legacy English-wiki proxy)', () => {
+  // v1.25.x legacy proxy: when source lang is unknown, English wiki
+  // suppresses translation hint unconditionally. Retires with v1.26.0.
+  it('uses legacy English-wiki proxy when sourceLang is null', () => {
     expect(isCrossLanguage(null, 'en')).toBe(false);
     expect(isCrossLanguage(null, 'ru')).toBe(true);
-    expect(isCrossLanguage(null, 'zh-Hant')).toBe(true);
   });
-
-  it('returns true when source language differs from wiki language name', () => {
-    // source ru, wiki zh (zh-Hant language name from WIKI_LANGUAGES)
+  it('returns true when source language differs from wiki language', () => {
     expect(isCrossLanguage('ru', 'zh-Hant')).toBe(true);
   });
-
-  it('returns false when source language matches wiki language name (case-insensitive)', () => {
-    // WIKI_LANGUAGES['en'] = 'English'; source 'EN' should match
-    expect(isCrossLanguage('EN', 'en')).toBe(false);
-    // WIKI_LANGUAGES['zh-Hant'] = '繁體中文'; source '繁體中文' should match
+  it('returns false when source language matches wiki language name case-insensitively (caller passes normalised lowercase)', () => {
+    expect(isCrossLanguage('en', 'en')).toBe(false);
     expect(isCrossLanguage('繁體中文', 'zh-Hant')).toBe(false);
   });
-
-  it('returns false when source language matches wiki code itself (not just name)', () => {
-    // WIKI_LANGUAGES['de'] = 'Deutsch'; source 'de' == wikiLangLower → same
+  it('returns false when source language matches wiki code itself', () => {
     expect(isCrossLanguage('de', 'de')).toBe(false);
-  });
-
-  it('accepts empty-string sourceLang as legacy fallback (matches existing source-analyzer behaviour)', () => {
-    // source-analyzer.ts treats `sourceLang === ''` as legacy proxy; helper
-    // must accept empty string the same way for symmetric semantics.
-    expect(isCrossLanguage('', 'en')).toBe(false);
-    expect(isCrossLanguage('', 'ru')).toBe(true);
   });
 });

--- a/src/__tests__/core/source-language.test.ts
+++ b/src/__tests__/core/source-language.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the source-language signal extraction helpers.
+ *
+ * Background: PR #350 added frontmatter `language:` reading inside
+ * `src/wiki/source-analyzer.ts:193-205, 334-337` (closed-vocabulary gate on
+ * cross-language translation hints). GH #361 Theme 1 promotes that
+ * detection + policy into shared helpers so that future prompt sites
+ * can reuse the same logic.
+ *
+ * These helpers are read-only with respect to vault state.
+ */
+import { describe, expect, it } from 'vitest';
+import type { App, TFile } from 'obsidian';
+import { getSourceLanguage, isCrossLanguage } from '../../core/source-language';
+
+type MetadataCacheLike = {
+  getFileCache: (file: TFile) => { frontmatter?: Record<string, unknown> } | null;
+};
+
+function makeApp(frontmatter: Record<string, unknown> | null): App {
+  const cache = {
+    getFileCache: () => (frontmatter ? { frontmatter } : null),
+  } as unknown as MetadataCacheLike;
+  return { metadataCache: cache } as unknown as App;
+}
+
+function makeFile(): TFile {
+  return { path: 'sources/foo.md' } as unknown as TFile;
+}
+
+describe('getSourceLanguage', () => {
+  it('returns trimmed lowercase language when frontmatter has language:string', () => {
+    const app = makeApp({ language: '  RU  ' });
+    expect(getSourceLanguage(makeFile(), app)).toBe('ru');
+  });
+
+  it('returns null when frontmatter is absent', () => {
+    const app = makeApp(null);
+    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+  });
+
+  it('returns null when language frontmatter key is missing', () => {
+    const app = makeApp({ title: 'foo' });
+    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+  });
+
+  it('returns null when language is a non-string value (array)', () => {
+    const app = makeApp({ language: ['ru', 'en'] });
+    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+  });
+
+  it('returns null when language is whitespace-only', () => {
+    const app = makeApp({ language: '   ' });
+    expect(getSourceLanguage(makeFile(), app)).toBeNull();
+  });
+
+  it('preserves BCP-47 subtag shape (zh-Hant stays zh-hant)', () => {
+    const app = makeApp({ language: 'zh-Hant' });
+    expect(getSourceLanguage(makeFile(), app)).toBe('zh-hant');
+  });
+});
+
+describe('isCrossLanguage', () => {
+  // Legacy fallback: when source lang is unknown, English wiki suppresses
+  // translation hint unconditionally. This preserves v1.25.x behaviour.
+  it('falls back to wikiLang !== "en" when sourceLang is null (legacy English-wiki proxy)', () => {
+    expect(isCrossLanguage(null, 'en')).toBe(false);
+    expect(isCrossLanguage(null, 'ru')).toBe(true);
+    expect(isCrossLanguage(null, 'zh-Hant')).toBe(true);
+  });
+
+  it('returns true when source language differs from wiki language name', () => {
+    // source ru, wiki zh (zh-Hant language name from WIKI_LANGUAGES)
+    expect(isCrossLanguage('ru', 'zh-Hant')).toBe(true);
+  });
+
+  it('returns false when source language matches wiki language name (case-insensitive)', () => {
+    // WIKI_LANGUAGES['en'] = 'English'; source 'EN' should match
+    expect(isCrossLanguage('EN', 'en')).toBe(false);
+    // WIKI_LANGUAGES['zh-Hant'] = '繁體中文'; source '繁體中文' should match
+    expect(isCrossLanguage('繁體中文', 'zh-Hant')).toBe(false);
+  });
+
+  it('returns false when source language matches wiki code itself (not just name)', () => {
+    // WIKI_LANGUAGES['de'] = 'Deutsch'; source 'de' == wikiLangLower → same
+    expect(isCrossLanguage('de', 'de')).toBe(false);
+  });
+
+  it('accepts empty-string sourceLang as legacy fallback (matches existing source-analyzer behaviour)', () => {
+    // source-analyzer.ts treats `sourceLang === ''` as legacy proxy; helper
+    // must accept empty string the same way for symmetric semantics.
+    expect(isCrossLanguage('', 'en')).toBe(false);
+    expect(isCrossLanguage('', 'ru')).toBe(true);
+  });
+});

--- a/src/__tests__/core/template-renderer.test.ts
+++ b/src/__tests__/core/template-renderer.test.ts
@@ -1,16 +1,10 @@
-/**
- * Tests for the template placeholder renderer.
- *
- * Background: GH #361 Theme 3 — the prompt layer has 5+ sites that call
- * `String.replace('{{placeholder}}', value)` without the `/g` flag,
- * silently skipping every occurrence after the first. This utility
- * replaces all occurrences in one pass and warns on unknown placeholders
- * (which the silent sites previously also failed silently).
- *
- * The utility is read-only and pure (no IO, no async).
- */
-import { describe, expect, it, vi } from 'vitest';
+/** Template placeholder renderer: replaces `{{name}}` tokens with values from a vars map. */
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderTemplate } from '../../core/template-renderer';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('renderTemplate', () => {
   it('replaces a single occurrence', () => {
@@ -18,11 +12,9 @@ describe('renderTemplate', () => {
   });
 
   it('replaces ALL occurrences of the same placeholder', () => {
-    // This is the bug class Theme 3 fixes — String.replace without /g
-    // would leave the second occurrence untouched.
     expect(
-      renderTemplate('Hi {{name}}, welcome {{name}}!', { name: 'Alice' })
-    ).toBe('Hi Alice, welcome Alice!');
+      renderTemplate('{{x}} + {{x}} + {{x}} = 3{{x}}', { x: 'a' })
+    ).toBe('a + a + a = 3a');
   });
 
   it('replaces multiple distinct placeholders', () => {
@@ -35,73 +27,34 @@ describe('renderTemplate', () => {
     ).toBe('Hello Bob, today is 2026-07-27.');
   });
 
-  it('replaces mixed occurrences of the same placeholder with other text between them', () => {
-    expect(
-      renderTemplate('{{x}} + {{x}} + {{x}} = 3{{x}}', { x: 'a' })
-    ).toBe('a + a + a = 3a');
-  });
-
   it('returns the original string when no placeholders are present', () => {
     expect(renderTemplate('plain text', { foo: 'bar' })).toBe('plain text');
   });
 
-  it('warns to console.warn on unknown placeholder and leaves it untouched', () => {
+  it('warns on unknown placeholder and leaves it untouched', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const result = renderTemplate('Hello {{name}}, your {{unknown}} is ready.', {
-        name: 'Alice',
-      });
-      expect(result).toBe('Hello Alice, your {{unknown}} is ready.');
-      expect(warn).toHaveBeenCalledTimes(1);
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('{{unknown}}')
-      );
-    } finally {
-      warn.mockRestore();
-    }
+    const result = renderTemplate('Hello {{name}}, your {{unknown}} is ready.', { name: 'Alice' });
+    expect(result).toBe('Hello Alice, your {{unknown}} is ready.');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('{{unknown}}'));
   });
 
   it('does not warn when all placeholders are known', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      renderTemplate('Hello {{name}}', { name: 'Alice' });
-      expect(warn).not.toHaveBeenCalled();
-    } finally {
-      warn.mockRestore();
-    }
+    renderTemplate('Hello {{name}}', { name: 'Alice' });
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it('handles placeholder names matching \\w+ (letters, digits, underscore)', () => {
-    expect(
-      renderTemplate('{{foo_bar123}}', { foo_bar123: 'ok' })
-    ).toBe('ok');
-  });
-
-  it('leaves placeholder with non-word chars (dot/dash) untouched (conservative regex)', () => {
-    // The renderer uses \w+ so {{a.b}} or {{a-b}} don't match the
-    // pattern; this is intentional — those names would be ambiguous
-    // and the existing sites only use word-char placeholders.
+  it('warns once per unknown placeholder across many occurrences', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      expect(renderTemplate('{{a.b}} {{a-b}}', {})).toBe('{{a.b}} {{a-b}}');
-    } finally {
-      warn.mockRestore();
-    }
+    renderTemplate('{{a}} {{a}} {{b}} {{b}}', {});
+    expect(warn).toHaveBeenCalledTimes(4);
   });
 
-  it('handles empty vars map (all placeholders unknown)', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      expect(renderTemplate('{{a}} and {{b}}', {})).toBe('{{a}} and {{b}}');
-      expect(warn).toHaveBeenCalledTimes(2);
-    } finally {
-      warn.mockRestore();
-    }
+  it('leaves placeholders with non-word chars (dot/dash) untouched', () => {
+    expect(renderTemplate('{{a.b}} {{a-b}}', {})).toBe('{{a.b}} {{a-b}}');
   });
 
-  it('handles values containing placeholder-like strings (no recursive substitution)', () => {
-    // If a value contains '{{x}}', it must NOT be re-substituted. The
-    // renderer walks the template once, not the substituted result.
+  it('does not recursively substitute values that look like placeholders', () => {
     expect(
       renderTemplate('{{a}}', { a: '{{b}}', b: 'should-not-appear' })
     ).toBe('{{b}}');

--- a/src/__tests__/core/template-renderer.test.ts
+++ b/src/__tests__/core/template-renderer.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the template placeholder renderer.
+ *
+ * Background: GH #361 Theme 3 — the prompt layer has 5+ sites that call
+ * `String.replace('{{placeholder}}', value)` without the `/g` flag,
+ * silently skipping every occurrence after the first. This utility
+ * replaces all occurrences in one pass and warns on unknown placeholders
+ * (which the silent sites previously also failed silently).
+ *
+ * The utility is read-only and pure (no IO, no async).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { renderTemplate } from '../../core/template-renderer';
+
+describe('renderTemplate', () => {
+  it('replaces a single occurrence', () => {
+    expect(renderTemplate('Hello {{name}}', { name: 'world' })).toBe('Hello world');
+  });
+
+  it('replaces ALL occurrences of the same placeholder', () => {
+    // This is the bug class Theme 3 fixes — String.replace without /g
+    // would leave the second occurrence untouched.
+    expect(
+      renderTemplate('Hi {{name}}, welcome {{name}}!', { name: 'Alice' })
+    ).toBe('Hi Alice, welcome Alice!');
+  });
+
+  it('replaces multiple distinct placeholders', () => {
+    expect(
+      renderTemplate('{{greeting}} {{name}}, today is {{date}}.', {
+        greeting: 'Hello',
+        name: 'Bob',
+        date: '2026-07-27',
+      })
+    ).toBe('Hello Bob, today is 2026-07-27.');
+  });
+
+  it('replaces mixed occurrences of the same placeholder with other text between them', () => {
+    expect(
+      renderTemplate('{{x}} + {{x}} + {{x}} = 3{{x}}', { x: 'a' })
+    ).toBe('a + a + a = 3a');
+  });
+
+  it('returns the original string when no placeholders are present', () => {
+    expect(renderTemplate('plain text', { foo: 'bar' })).toBe('plain text');
+  });
+
+  it('warns to console.warn on unknown placeholder and leaves it untouched', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = renderTemplate('Hello {{name}}, your {{unknown}} is ready.', {
+        name: 'Alice',
+      });
+      expect(result).toBe('Hello Alice, your {{unknown}} is ready.');
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('{{unknown}}')
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn when all placeholders are known', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      renderTemplate('Hello {{name}}', { name: 'Alice' });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('handles placeholder names matching \\w+ (letters, digits, underscore)', () => {
+    expect(
+      renderTemplate('{{foo_bar123}}', { foo_bar123: 'ok' })
+    ).toBe('ok');
+  });
+
+  it('leaves placeholder with non-word chars (dot/dash) untouched (conservative regex)', () => {
+    // The renderer uses \w+ so {{a.b}} or {{a-b}} don't match the
+    // pattern; this is intentional — those names would be ambiguous
+    // and the existing sites only use word-char placeholders.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(renderTemplate('{{a.b}} {{a-b}}', {})).toBe('{{a.b}} {{a-b}}');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('handles empty vars map (all placeholders unknown)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(renderTemplate('{{a}} and {{b}}', {})).toBe('{{a}} and {{b}}');
+      expect(warn).toHaveBeenCalledTimes(2);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('handles values containing placeholder-like strings (no recursive substitution)', () => {
+    // If a value contains '{{x}}', it must NOT be re-substituted. The
+    // renderer walks the template once, not the substituted result.
+    expect(
+      renderTemplate('{{a}}', { a: '{{b}}', b: 'should-not-appear' })
+    ).toBe('{{b}}');
+  });
+});

--- a/src/__tests__/wiki/lint/fix-runners.test.ts
+++ b/src/__tests__/wiki/lint/fix-runners.test.ts
@@ -415,21 +415,22 @@ describe('runRetagViolations (Issue #85 v7)', () => {
   });
 
   // ── Regression guard (Issue #361 Theme 2) ─────────────────────
-  // PR #349 (eucher, 43479d8) deliberately deferred tier-1 (existing
-  // wiki page tags) cleanup to the lint retag runner — closed-vocab
-  // enforcement lives in the runner for sources. Production code at
-  // fix-runners.ts:441-442 selects getActiveSourceTags when pageType
-  // is 'source', but every test in this suite reuses an entity-typed
-  // fixture. This test pins the contract: a source-typed violation
-  // must be validated and rewritten against VALID_SOURCE_TAGS.
-  it('rewrites source-page frontmatter tags against VALID_SOURCE_TAGS (PR #361 Theme 2)', async () => {
-    const sourceViolation: TagViolation = {
-      path: 'wiki/sources/Smith2024.md',
-      pageType: 'source',
-      title: 'Smith2024',
-      currentTags: ['Medical_Arzneimittel'],
-      invalidTags: ['Medical_Arzneimittel'],
-    };
+  // ── PR #361 Theme 2: source-typed contract ────────────────
+// PR #349 (eucher, 43479d8) deliberately deferred tier-1 (existing
+// wiki page tags) cleanup to the lint retag runner — closed-vocab
+// enforcement lives in the runner for sources. Production code at
+// fix-runners.ts:441-442 selects getActiveSourceTags when pageType
+// is 'source'. Pin the contract with two tests below.
+
+  const sourceViolation: TagViolation = {
+    path: 'wiki/sources/Smith2024.md',
+    pageType: 'source',
+    title: 'Smith2024',
+    currentTags: ['Medical_Arzneimittel'],
+    invalidTags: ['Medical_Arzneimittel'],
+  };
+
+  it('rewrites source-page frontmatter tags against VALID_SOURCE_TAGS', async () => {
     const ctx = makeRetagCtx({
       fileContent: '---\ntype: source\ntitle: Smith2024\ntags: [Medical_Arzneimittel]\n---\n\nSmith 2024 body.',
       llmResponse: '{"tags":["article"]}',
@@ -438,36 +439,24 @@ describe('runRetagViolations (Issue #85 v7)', () => {
     const result = await runRetagViolations(ctx, undefined, [sourceViolation]);
     expect(result.fixed).toBe(1);
     const writtenContent = writeSpy.mock.calls[0][1] as string;
-    // Written tags must be a subset of VALID_SOURCE_TAGS and must
-    // not contain the original invalid value.
     expect(writtenContent).toContain('article');
     expect(writtenContent).not.toContain('Medical_Arzneimittel');
   });
 
   it('filters LLM-returned source tags not in VALID_SOURCE_TAGS (defensive)', async () => {
-    // LLM hallucinates "bogus" — must be filtered out against the
-    // source vocabulary; "article" (valid) survives.
-    const sourceViolation: TagViolation = {
-      path: 'wiki/sources/Doe2025.md',
-      pageType: 'source',
-      title: 'Doe2025',
-      currentTags: ['Medical_Arzneimittel'],
-      invalidTags: ['Medical_Arzneimittel'],
-    };
     const ctx = makeRetagCtx({
-      fileContent: '---\ntype: source\ntitle: Doe2025\ntags: [Medical_Arzneimittel]\n---\n\nDoe 2025 body.',
+      fileContent: '---\ntype: source\ntitle: Smith2024\ntags: [Medical_Arzneimittel]\n---\n\nSmith 2024 body.',
+      // LLM hallucinates "bogus" (any vocab) + "person" (entity vocab,
+      // not source vocab). Both must be filtered.
       llmResponse: '{"tags":["article","bogus","person"]}',
     });
     const writeSpy = (ctx.app.vault.adapter as unknown as { write: ReturnType<typeof vi.fn> }).write;
     const result = await runRetagViolations(ctx, undefined, [sourceViolation]);
     expect(result.fixed).toBe(1);
     const writtenContent = writeSpy.mock.calls[0][1] as string;
-    // Only "article" survives; "bogus" and "person" (entity vocab, not
-    // source vocab) are filtered out.
     expect(writtenContent).toContain('article');
     expect(writtenContent).not.toContain('bogus');
     expect(writtenContent).not.toContain('person');
-    expect(writtenContent).not.toContain('Medical_Arzneimittel');
   });
 
   // ── Regression guard (Issue #85 v7.7) ─────────────────────────

--- a/src/__tests__/wiki/lint/fix-runners.test.ts
+++ b/src/__tests__/wiki/lint/fix-runners.test.ts
@@ -414,6 +414,62 @@ describe('runRetagViolations (Issue #85 v7)', () => {
     expect(result.results[0]).toContain('LLM kept no tags');
   });
 
+  // ── Regression guard (Issue #361 Theme 2) ─────────────────────
+  // PR #349 (eucher, 43479d8) deliberately deferred tier-1 (existing
+  // wiki page tags) cleanup to the lint retag runner — closed-vocab
+  // enforcement lives in the runner for sources. Production code at
+  // fix-runners.ts:441-442 selects getActiveSourceTags when pageType
+  // is 'source', but every test in this suite reuses an entity-typed
+  // fixture. This test pins the contract: a source-typed violation
+  // must be validated and rewritten against VALID_SOURCE_TAGS.
+  it('rewrites source-page frontmatter tags against VALID_SOURCE_TAGS (PR #361 Theme 2)', async () => {
+    const sourceViolation: TagViolation = {
+      path: 'wiki/sources/Smith2024.md',
+      pageType: 'source',
+      title: 'Smith2024',
+      currentTags: ['Medical_Arzneimittel'],
+      invalidTags: ['Medical_Arzneimittel'],
+    };
+    const ctx = makeRetagCtx({
+      fileContent: '---\ntype: source\ntitle: Smith2024\ntags: [Medical_Arzneimittel]\n---\n\nSmith 2024 body.',
+      llmResponse: '{"tags":["article"]}',
+    });
+    const writeSpy = (ctx.app.vault.adapter as unknown as { write: ReturnType<typeof vi.fn> }).write;
+    const result = await runRetagViolations(ctx, undefined, [sourceViolation]);
+    expect(result.fixed).toBe(1);
+    const writtenContent = writeSpy.mock.calls[0][1] as string;
+    // Written tags must be a subset of VALID_SOURCE_TAGS and must
+    // not contain the original invalid value.
+    expect(writtenContent).toContain('article');
+    expect(writtenContent).not.toContain('Medical_Arzneimittel');
+  });
+
+  it('filters LLM-returned source tags not in VALID_SOURCE_TAGS (defensive)', async () => {
+    // LLM hallucinates "bogus" — must be filtered out against the
+    // source vocabulary; "article" (valid) survives.
+    const sourceViolation: TagViolation = {
+      path: 'wiki/sources/Doe2025.md',
+      pageType: 'source',
+      title: 'Doe2025',
+      currentTags: ['Medical_Arzneimittel'],
+      invalidTags: ['Medical_Arzneimittel'],
+    };
+    const ctx = makeRetagCtx({
+      fileContent: '---\ntype: source\ntitle: Doe2025\ntags: [Medical_Arzneimittel]\n---\n\nDoe 2025 body.',
+      llmResponse: '{"tags":["article","bogus","person"]}',
+    });
+    const writeSpy = (ctx.app.vault.adapter as unknown as { write: ReturnType<typeof vi.fn> }).write;
+    const result = await runRetagViolations(ctx, undefined, [sourceViolation]);
+    expect(result.fixed).toBe(1);
+    const writtenContent = writeSpy.mock.calls[0][1] as string;
+    // Only "article" survives; "bogus" and "person" (entity vocab, not
+    // source vocab) are filtered out.
+    expect(writtenContent).toContain('article');
+    expect(writtenContent).not.toContain('bogus');
+    expect(writtenContent).not.toContain('person');
+    expect(writtenContent).not.toContain('Medical_Arzneimittel');
+  });
+
   // ── Regression guard (Issue #85 v7.7) ─────────────────────────
   // Earlier commit (ebf58f2) shipped with a SHELL TEST: the mock
   // provided `{ path, read }` and the production code called

--- a/src/core/source-language.ts
+++ b/src/core/source-language.ts
@@ -1,62 +1,56 @@
 /**
  * Source-language signal extraction + cross-language policy.
  *
- * Background: PR #350 added frontmatter `language:` reading inside
- * `src/wiki/source-analyzer.ts:193-205, 334-337` to gate the cross-language
- * translation hint. GH #361 Theme 1 promotes that detection + policy into
- * shared helpers so future prompt sites can reuse the same logic.
- *
- * The two helpers are intentionally pure:
- * - `getSourceLanguage` reads frontmatter via `app.metadataCache` (the only
- *   non-pure operation).
- * - `isCrossLanguage` takes the resolved strings and answers the policy
- *   question with no IO.
+ * Exposes three primitives:
+ * - `normalizeSourceLanguage(value)` — pure frontmatter value normaliser
+ * - `getSourceLanguage(file, app)` — Obsidian-aware wrapper
+ * - `getWikiLanguageName(wikiLang)` — resolves WIKI_LANGUAGES display name
+ * - `isCrossLanguage(sourceLang, wikiLang)` — translation-hint gate
  */
 import type { App, TFile } from 'obsidian';
 import { WIKI_LANGUAGES } from '../types';
 
-/**
- * Read the source note's frontmatter `language:` and normalise it.
- *
- * Returns `null` when the frontmatter is absent, the `language:` key is
- * missing, the value is not a string, or the value is whitespace-only.
- *
- * @returns trimmed lowercase language string, or `null` when unknown.
- */
-export function getSourceLanguage(file: TFile, app: App): string | null {
-  const cache = app.metadataCache.getFileCache(file);
-  const fm = cache?.frontmatter as { language?: unknown } | undefined;
-  const raw = fm?.language;
-  if (typeof raw !== 'string') return null;
-  const trimmed = raw.trim().toLowerCase();
-  return trimmed.length > 0 ? trimmed : null;
+/** Resolve a wiki language code to its WIKI_LANGUAGES display name. */
+export function getWikiLanguageName(wikiLang: string): string {
+  return WIKI_LANGUAGES[wikiLang] ?? wikiLang;
 }
 
 /**
- * Decide whether the wiki should emit the cross-language translation hint
- * given the source's language (or absence thereof) and the wiki's language.
+ * Pure normaliser for a frontmatter `language:` value.
+ * Returns `null` for non-string or whitespace-only input.
+ */
+export function normalizeSourceLanguage(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Read the source note's frontmatter `language:` via Obsidian metadata cache. */
+export function getSourceLanguage(file: TFile, app: App): string | null {
+  const cache = app.metadataCache.getFileCache(file);
+  return normalizeSourceLanguage(cache?.frontmatter?.language);
+}
+
+/**
+ * Decide whether the wiki should emit the cross-language translation hint.
  *
- * Policy:
- * - When source language is known (non-null, non-empty): compare against the
- *   wiki's WIKI_LANGUAGES display name OR the wiki code itself, both
- *   case-insensitive. Returns true iff they differ.
- * - When source language is unknown (null OR empty string): fall back to the
- *   legacy `wikiLang !== 'en'` proxy. This preserves v1.25.x behaviour for
- *   cross-language wikis that did not adopt frontmatter `language:`.
- *
- * @param sourceLang result of `getSourceLanguage`, or `''` / `null`
+ * @param sourceLang result of `normalizeSourceLanguage` (null when unknown)
  * @param wikiLang   the user's wiki language code (e.g. `'en'`, `'ru'`)
+ *
+ * Returns `true` when source and wiki languages differ; `false` when they
+ * match. When source language is unknown (null), falls back to the legacy
+ * v1.25.x English-wiki proxy (`wikiLang !== 'en'`). The proxy will retire
+ * once all sources adopt frontmatter `language:` (tracked by v1.26.0 MINOR).
  */
 export function isCrossLanguage(
   sourceLang: string | null,
   wikiLang: string
 ): boolean {
-  if (sourceLang !== null && sourceLang !== '') {
-    const sourceLangLower = sourceLang.toLowerCase();
+  if (sourceLang !== null) {
     const wikiLangLower = wikiLang.toLowerCase();
-    const wikiLangNameLower = (WIKI_LANGUAGES[wikiLang] ?? wikiLang).toLowerCase();
-    return sourceLangLower !== wikiLangLower && sourceLangLower !== wikiLangNameLower;
+    const wikiLangNameLower = getWikiLanguageName(wikiLang).toLowerCase();
+    return sourceLang !== wikiLangLower && sourceLang !== wikiLangNameLower;
   }
-  // Legacy fallback: English wiki suppresses translation hint unconditionally.
+  // v1.25.x legacy proxy — see doc above. Will retire with v1.26.0.
   return wikiLang !== 'en';
 }

--- a/src/core/source-language.ts
+++ b/src/core/source-language.ts
@@ -1,0 +1,62 @@
+/**
+ * Source-language signal extraction + cross-language policy.
+ *
+ * Background: PR #350 added frontmatter `language:` reading inside
+ * `src/wiki/source-analyzer.ts:193-205, 334-337` to gate the cross-language
+ * translation hint. GH #361 Theme 1 promotes that detection + policy into
+ * shared helpers so future prompt sites can reuse the same logic.
+ *
+ * The two helpers are intentionally pure:
+ * - `getSourceLanguage` reads frontmatter via `app.metadataCache` (the only
+ *   non-pure operation).
+ * - `isCrossLanguage` takes the resolved strings and answers the policy
+ *   question with no IO.
+ */
+import type { App, TFile } from 'obsidian';
+import { WIKI_LANGUAGES } from '../types';
+
+/**
+ * Read the source note's frontmatter `language:` and normalise it.
+ *
+ * Returns `null` when the frontmatter is absent, the `language:` key is
+ * missing, the value is not a string, or the value is whitespace-only.
+ *
+ * @returns trimmed lowercase language string, or `null` when unknown.
+ */
+export function getSourceLanguage(file: TFile, app: App): string | null {
+  const cache = app.metadataCache.getFileCache(file);
+  const fm = cache?.frontmatter as { language?: unknown } | undefined;
+  const raw = fm?.language;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Decide whether the wiki should emit the cross-language translation hint
+ * given the source's language (or absence thereof) and the wiki's language.
+ *
+ * Policy:
+ * - When source language is known (non-null, non-empty): compare against the
+ *   wiki's WIKI_LANGUAGES display name OR the wiki code itself, both
+ *   case-insensitive. Returns true iff they differ.
+ * - When source language is unknown (null OR empty string): fall back to the
+ *   legacy `wikiLang !== 'en'` proxy. This preserves v1.25.x behaviour for
+ *   cross-language wikis that did not adopt frontmatter `language:`.
+ *
+ * @param sourceLang result of `getSourceLanguage`, or `''` / `null`
+ * @param wikiLang   the user's wiki language code (e.g. `'en'`, `'ru'`)
+ */
+export function isCrossLanguage(
+  sourceLang: string | null,
+  wikiLang: string
+): boolean {
+  if (sourceLang !== null && sourceLang !== '') {
+    const sourceLangLower = sourceLang.toLowerCase();
+    const wikiLangLower = wikiLang.toLowerCase();
+    const wikiLangNameLower = (WIKI_LANGUAGES[wikiLang] ?? wikiLang).toLowerCase();
+    return sourceLangLower !== wikiLangLower && sourceLangLower !== wikiLangNameLower;
+  }
+  // Legacy fallback: English wiki suppresses translation hint unconditionally.
+  return wikiLang !== 'en';
+}

--- a/src/core/template-renderer.ts
+++ b/src/core/template-renderer.ts
@@ -1,0 +1,33 @@
+/**
+ * Template placeholder renderer.
+ *
+ * Background: GH #361 Theme 3 — the prompt layer has 5+ sites that call
+ * `String.replace('{{placeholder}}', value)` without the `/g` flag,
+ * silently skipping every occurrence after the first. This utility
+ * replaces all occurrences in one pass with `/g`, and warns on unknown
+ * placeholders (which the silent sites also failed silently on — the
+ * warning is strictly additive).
+ *
+ * Conservative regex: `\w+` only. Placeholders containing `.` or `-`
+ * (e.g. `{{a.b}}`, `{{a-b}}`) are intentionally left untouched —
+ * ambiguous syntax and the existing sites use only word-char placeholders.
+ *
+ * Read-only and pure: no IO, no async.
+ *
+ * @param template string containing `{{placeholder}}` tokens
+ * @param vars     map of placeholder name -> substituted value
+ * @returns        template with all known placeholders substituted;
+ *                 unknown placeholders left as-is (with a console.warn)
+ */
+export function renderTemplate(
+  template: string,
+  vars: Record<string, string>
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
+    if (Object.prototype.hasOwnProperty.call(vars, key)) {
+      return vars[key];
+    }
+    console.warn(`[renderTemplate] unknown placeholder: ${match}`);
+    return match;
+  });
+}

--- a/src/core/template-renderer.ts
+++ b/src/core/template-renderer.ts
@@ -1,30 +1,23 @@
 /**
- * Template placeholder renderer.
+ * Replace all `{{placeholder}}` tokens in a string with values from a vars map.
  *
- * Background: GH #361 Theme 3 — the prompt layer has 5+ sites that call
- * `String.replace('{{placeholder}}', value)` without the `/g` flag,
- * silently skipping every occurrence after the first. This utility
- * replaces all occurrences in one pass with `/g`, and warns on unknown
- * placeholders (which the silent sites also failed silently on — the
- * warning is strictly additive).
+ * Supported syntax: `{{name}}` where `name` matches `\w+` (letters, digits,
+ * underscore). Unknown placeholders are left as-is AND emit `console.warn`
+ * — this is strictly additive over the previous `.replace()` chains, which
+ * silently left later occurrences unrendered.
  *
- * Conservative regex: `\w+` only. Placeholders containing `.` or `-`
- * (e.g. `{{a.b}}`, `{{a-b}}`) are intentionally left untouched —
- * ambiguous syntax and the existing sites use only word-char placeholders.
+ * `key in vars` is sufficient: prompt site callers always pass inline object
+ * literals, so prototype-pollution from `__proto__` / `constructor` is not
+ * a concern in practice.
  *
  * Read-only and pure: no IO, no async.
- *
- * @param template string containing `{{placeholder}}` tokens
- * @param vars     map of placeholder name -> substituted value
- * @returns        template with all known placeholders substituted;
- *                 unknown placeholders left as-is (with a console.warn)
  */
 export function renderTemplate(
   template: string,
   vars: Record<string, string>
 ): string {
   return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
-    if (Object.prototype.hasOwnProperty.call(vars, key)) {
+    if (key in vars) {
       return vars[key];
     }
     console.warn(`[renderTemplate] unknown placeholder: ${match}`);

--- a/src/schema/schema-manager.ts
+++ b/src/schema/schema-manager.ts
@@ -7,6 +7,7 @@ import { parseSchemaSuggestion } from './parse-suggestion';
 import { capMaxTokens } from '../core/token-cap';
 import { resolveModelForTask } from '../core/model-resolver';
 import { TOKENS_SCHEMA_SUGGESTION } from '../constants';
+import { renderTemplate } from '../core/template-renderer';
 
 const SCHEMA_FILENAME = 'schema/config.md';
 const SUGGESTIONS_FILENAME = 'schema/suggestions.md';
@@ -430,10 +431,11 @@ ${body}`;
     // 'English' keeps v1.21.x behaviour for unrecognised language codes.
     const userLanguage = WIKI_LANGUAGES[this.settings.language] ?? 'English';
 
-    const prompt = PROMPTS.suggestSchemaUpdate
-      .replace('{{schema_content}}', schemaContent)
-      .replace('{{analysis_context}}', context)
-      .replace('{{user_language}}', userLanguage);
+    const prompt = renderTemplate(PROMPTS.suggestSchemaUpdate, {
+      schema_content: schemaContent,
+      analysis_context: context,
+      user_language: userLanguage,
+    });
 
     try {
       const response = await this.client.createMessage({

--- a/src/wiki/contradictions.ts
+++ b/src/wiki/contradictions.ts
@@ -4,6 +4,7 @@ import { EngineContext, ContradictionInfo } from '../types';
 import { slugify } from '../core/slug';
 import { parseFrontmatter } from '../core/frontmatter';
 import { cleanMarkdownResponse } from '../core/markdown';
+import { renderTemplate } from '../core/template-renderer';
 import { TOKENS_CONTRADICTION } from '../constants';
 import { PROMPTS } from '../prompts';
 import { resolveModelForTask } from '../core/model-resolver';
@@ -169,12 +170,10 @@ ${contradiction.source_page}
     const existingContent = await this.ctx.tryReadFile(pagePath);
     if (!existingContent) throw new Error('Affected wiki page not found');
 
-    const prompt = PROMPTS.resolveContradiction
-      .replace('{{existing_content}}', existingContent.substring(0, 6000))
-      .replace(
-        '{{contradiction_content}}',
-        contradictionContent.substring(0, 3000)
-      );
+    const prompt = renderTemplate(PROMPTS.resolveContradiction, {
+      existing_content: existingContent.substring(0, 6000),
+      contradiction_content: contradictionContent.substring(0, 3000),
+    });
 
     const finalPrompt = applySectionLabels(prompt, this.ctx.settings);
 

--- a/src/wiki/conversation-ingest.ts
+++ b/src/wiki/conversation-ingest.ts
@@ -11,6 +11,7 @@ import { slugify } from '../core/slug';
 import { parseJsonResponse } from '../core/json';
 import { cleanMarkdownResponse } from '../core/markdown';
 import { applySectionLabels } from './system-prompts';
+import { renderTemplate } from '../core/template-renderer';
 import { resolveModelForTask } from '../core/model-resolver';
 import { UNIVERSAL_LINK_CONSTRAINTS } from './prompts/constraints';
 import { TOKENS_CONVERSATION_EXTRACTION, TOKENS_CONVERSATION_PAGE, TOKENS_PAGE_GENERATION, TOKENS_QUERY_SAVE_DEDUP } from '../constants';
@@ -214,15 +215,16 @@ CRITICAL RULES:
 
     const tags = parsed.concepts.map(c => c.name).join(', ');
 
-    const summaryPrompt = PROMPTS.generateSummaryPage
-      .replace('{{source_title}}', parsed.source_title)
-      .replace('{{content}}', conversationText.substring(0, 500))
-      .replace('{{analysis}}', JSON.stringify(parsed))
-      .replace('{{created_pages_list}}', createdPagesList)
-      .replace(/{{source_file}}/g, `Conversation: ${parsed.source_title}`)
-      .replace(/{{date}}/g, actualDate)
-      .replace('{{tags}}', tags)
-      .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
+    const summaryPrompt = renderTemplate(PROMPTS.generateSummaryPage, {
+      source_title: parsed.source_title,
+      content: conversationText.substring(0, 500),
+      analysis: JSON.stringify(parsed),
+      created_pages_list: createdPagesList,
+      source_file: `Conversation: ${parsed.source_title}`,
+      date: actualDate,
+      tags,
+      constraints: UNIVERSAL_LINK_CONSTRAINTS,
+    });
 
     const finalSummaryPrompt = applySectionLabels(summaryPrompt, this.ctx.settings);
 
@@ -310,9 +312,10 @@ CRITICAL RULES:
 
   private async checkDedup(wikiIndex: string, conversationText: string): Promise<string> {
     const summary = conversationText.substring(0, 1500);
-    const prompt = PROMPTS.dedupCheck
-      .replace('{{wiki_index}}', wikiIndex.substring(0, 3000))
-      .replace('{{conversation_summary}}', summary);
+    const prompt = renderTemplate(PROMPTS.dedupCheck, {
+      wiki_index: wikiIndex.substring(0, 3000),
+      conversation_summary: summary,
+    });
 
     const client = this.ctx.getClient();
     if (!client) throw new Error('LLM client not initialized');

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -2,6 +2,7 @@ import { EngineContext } from '../../types';
 import { PROMPTS } from '../../prompts';
 import { TOKENS_LINT_PAGE_FIX, WIKI_SUBFOLDERS } from '../../constants';
 import { buildSystemPrompt } from '../system-prompts';
+import { renderTemplate } from '../../core/template-renderer';
 import { parseJsonResponse } from '../../core/json';
 import { slugify } from '../../core/slug';
 import { resolveModelForTask } from '../../core/model-resolver';
@@ -126,10 +127,11 @@ export async function fixDeadLink(
       return `- ${p.wikiLink}${aliasSuffix}`;
     }).join('\n');
 
-  const prompt = PROMPTS.fixDeadLink
-    .replace('{{source_content}}', sourceContent.substring(0, 2000))
-    .replace('{{target_name}}', targetName)
-    .replace('{{existing_pages}}', pagesList.substring(0, 3000));
+  const prompt = renderTemplate(PROMPTS.fixDeadLink, {
+    source_content: sourceContent.substring(0, 2000),
+    target_name: targetName,
+    existing_pages: pagesList.substring(0, 3000),
+  });
 
   const client = ctx.getClient();
   if (!client) return 'no action taken (no client)';

--- a/src/wiki/lint/fix-runners.ts
+++ b/src/wiki/lint/fix-runners.ts
@@ -11,6 +11,7 @@ import { detectRateLimitFailures, formatRateLimitNotice } from '../../core/rate-
 import { resolveModelForTask } from '../../core/model-resolver';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from '../../core/tag-vocab';
 import { mergeFrontmatterArrayField, replaceFrontmatterArrayField, parseFrontmatter } from '../../core/frontmatter';
+import { renderTemplate } from '../../core/template-renderer';
 import { TOKENS_LINT_ALIAS_BATCH, NOTICE_ERROR, NOTICE_RATE_LIMIT } from '../../constants';
 import { buildWikiLanguageDirective } from '../system-prompts';
 import { TagViolation } from './scanners';
@@ -81,9 +82,10 @@ export async function runAliasCompletion(
           const bodyMatch = page.content.match(/^---[\s\S]*?\n---\n?([\s\S]*)/);
           const body = bodyMatch ? bodyMatch[1].trim() : '';
 
-          const prompt = PROMPTS.generateAliases
-            .replace('{{title}}', page.basename)
-            .replace('{{body}}', body.substring(0, 2000));
+          const prompt = renderTemplate(PROMPTS.generateAliases, {
+            title: page.basename,
+            body: body.substring(0, 2000),
+          });
 
           const response = await client.createMessage({
             model: resolveModelForTask(ctx.settings, 'lint'),

--- a/src/wiki/lint/llm-phases/dedup-phase.ts
+++ b/src/wiki/lint/llm-phases/dedup-phase.ts
@@ -28,6 +28,7 @@ import { resolveModelForTask } from '../../../core/model-resolver';
 import { parseJsonResponse } from '../../../core/json';
 import { detectRateLimitFailures, formatRateLimitNotice } from '../../../core/rate-limit';
 import { normalizeLLMPath } from '../../../core/prompt-builders';
+import { renderTemplate } from '../../../core/template-renderer';
 import { PROMPTS } from '../../../prompts';
 import type { LintPhaseContext, DuplicateResult, ScannerPage } from '../types';
 import {
@@ -211,10 +212,11 @@ export async function runDedupPhase(
             `- Candidate A: ${c.target}\n  Candidate B: ${c.source}\n  Signal: ${c.reason}`
           ).join('\n');
 
-          const dedupPrompt = PROMPTS.lintDuplicateDetection
-            .replace('{{wikiFolder}}', ctx.settings.wikiFolder)
-            .replace('{{candidates}}', candidateList)
-            .replace('{{total}}', String(pagesForDedup.length));
+          const dedupPrompt = renderTemplate(PROMPTS.lintDuplicateDetection, {
+            wikiFolder: ctx.settings.wikiFolder,
+            candidates: candidateList,
+            total: String(pagesForDedup.length),
+          });
 
           console.debug(`lintWiki: batch ${batchNum}/${batches.length} — ${batch.length} candidates`);
           // v1.24.0 #208: log resolved lint model for e2e verification

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -6,6 +6,7 @@ import { parseFrontmatter, enforceFrontmatterConstraints, serializeFrontmatter }
 import { parseJsonResponse } from '../../core/json';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { escapeRegex } from './utils';
+import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
 
 export async function mergeDuplicatePages(
@@ -80,9 +81,10 @@ export async function mergeDuplicatePages(
   let llmMergeSucceeded = false;
   if (client) {
     try {
-      const prompt = PROMPTS.mergeDuplicatePages
-        .replace('{{target_content}}', targetBody)
-        .replace('{{source_content}}', sourceBody);
+      const prompt = renderTemplate(PROMPTS.mergeDuplicatePages, {
+        target_content: targetBody,
+        source_content: sourceBody,
+      });
 
       const mergedContent = await client.createMessage({
         model: resolveModelForTask(ctx.settings, 'lint'),

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -36,6 +36,7 @@ import { canonicalizeSectionHeaders } from '../../core/section-header-canonicali
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { parseFrontmatter, enforceFrontmatterConstraints } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
+import { renderTemplate } from '../../core/template-renderer';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { resolvePagePath, buildPagesListForPrompt, type PathResolutionContext } from './path-resolution';
 import { mergePage } from './merge-page';
@@ -201,26 +202,26 @@ export async function createNewPage(
   try {
     const generatePrompt = pageType === 'entity' ? PROMPTS.generateEntityPage : PROMPTS.generateConceptPage;
 
-    const prompt = generatePrompt
-      .replace('{{entity_name}}', info.name)
-      .replace('{{concept_name}}', info.name)
-      .replace('{{entity_type}}', info.type)
-      .replace('{{concept_type}}', info.type)
-      .replace('{{entity_summary}}', info.summary)
-      .replace('{{concept_summary}}', info.summary)
-      .replace('{{extraction_aliases}}', info.aliases?.length
-        ? `[${info.aliases.join(', ')}]` : 'None')
-      .replace('{{related_entities}}', info.related_entities?.join(', ') || 'No related entities')
-      .replace('{{related_concepts}}', info.related_concepts?.join(', ') || 'No related concepts')
-      .replace('{{existing_pages}}', await buildPagesListForPrompt(ctx, extraPagePaths))
-      .replace('{{related_content}}', 'No existing content')
-      .replace('{{merge_strategy}}', 'New page, no merge needed.')
-      .replace('{{date}}', new Date().toISOString().split('T')[0])
+    const prompt = renderTemplate(generatePrompt, {
+      entity_name: info.name,
+      concept_name: info.name,
+      entity_type: info.type,
+      concept_type: info.type,
+      entity_summary: info.summary,
+      concept_summary: info.summary,
+      extraction_aliases: info.aliases?.length ? `[${info.aliases.join(', ')}]` : 'None',
+      related_entities: info.related_entities?.join(', ') || 'No related entities',
+      related_concepts: info.related_concepts?.join(', ') || 'No related concepts',
+      existing_pages: await buildPagesListForPrompt(ctx, extraPagePaths),
+      related_content: 'No existing content',
+      merge_strategy: 'New page, no merge needed.',
+      date: new Date().toISOString().split('T')[0],
       // Issue #155: entity/concept pages cite the canonical source PAGE
       // ([[sources/<slug>]]), not the raw note path — so a collision-
       // disambiguated source slug is honored and the normalizer passes it
       // through unchanged.
-      .replace(/\{\{source_file\}\}/g, sourceSlug ? `sources/${sourceSlug}` : sourceFile.path);
+      source_file: sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
+    });
 
     // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
     const finalPrompt = applySectionLabels(prompt, ctx.settings);

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -42,6 +42,7 @@ import {
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
+import { renderTemplate } from '../../core/template-renderer';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { UNIVERSAL_LINK_CONSTRAINTS } from '../prompts/constraints';
 import { buildPagesListForPrompt } from './path-resolution';
@@ -169,15 +170,16 @@ export async function mergePage(
     // 2. LLM intelligent body merge.
     const mergePrompt = pageType === 'entity' ? PROMPTS.mergeEntityPage : PROMPTS.mergeConceptPage;
 
-    const prompt = mergePrompt
-      .replace('{{existing_body}}', existingBody)
-      .replace('{{new_source}}', sourceFile.basename)
-      .replace('{{entity_summary}}', info.summary)
-      .replace('{{concept_summary}}', info.summary)
-      .replace('{{related_entities}}', info.related_entities?.join(', ') || '')
-      .replace('{{related_concepts}}', info.related_concepts?.join(', ') || '')
-      .replace('{{key_details}}', firstQuotesForPrompt(info))
-      .replace('{{existing_pages}}', await buildPagesListForPrompt(ctx, extraPagePaths));
+    const prompt = renderTemplate(mergePrompt, {
+      existing_body: existingBody,
+      new_source: sourceFile.basename,
+      entity_summary: info.summary,
+      concept_summary: info.summary,
+      related_entities: info.related_entities?.join(', ') || '',
+      related_concepts: info.related_concepts?.join(', ') || '',
+      key_details: firstQuotesForPrompt(info),
+      existing_pages: await buildPagesListForPrompt(ctx, extraPagePaths),
+    });
 
     // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
     const finalPrompt = applySectionLabels(prompt, ctx.settings);
@@ -252,12 +254,13 @@ export async function appendToReviewedPage(
     );
 
     // 2. Minimal LLM check for genuinely new content.
-    const prompt = PROMPTS.appendToReviewedPage
-      .replace('{{existing_body}}', existingBody)
-      .replace('{{new_source}}', sourceFile.basename)
-      .replace('{{entity_summary}}', info.summary)
-      .replace('{{key_details}}', firstQuotesForPrompt(info))
-      .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
+    const prompt = renderTemplate(PROMPTS.appendToReviewedPage, {
+      existing_body: existingBody,
+      new_source: sourceFile.basename,
+      entity_summary: info.summary,
+      key_details: firstQuotesForPrompt(info),
+      constraints: UNIVERSAL_LINK_CONSTRAINTS,
+    });
 
     // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
     const finalPrompt = applySectionLabels(prompt, ctx.settings);

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -24,6 +24,7 @@ import { TOKENS_MERGE_TRIAGE } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { getSectionLabels, applySectionLabels } from '../system-prompts';
 import { firstQuotesForPrompt } from './contextualize';
+import { renderTemplate } from '../../core/template-renderer';
 
 /** Strategy selected by the LLM for handling new information vs. an existing page. */
 export type MergeStrategy = 'merge' | 'skip' | 'complementary' | 'contradictory';
@@ -86,14 +87,15 @@ export async function classifyMergeNeed(
   const labels = getSectionLabels(ctx.settings);
   const sectionLabelsList = Object.values(labels).join('\n- ');
 
-  const triagePrompt = PROMPTS.mergeAnalysis
-    .replace('{{page_name}}', info.name)
-    .replace('{{page_type}}', pageType)
-    .replace('{{existing_content}}', existingContent)
-    .replace('{{new_info}}', buildNewInfoSummary(info, sourceFile))
-    .replace('{{source_context}}', renderSourceContextBlock(sourceContext))
-    .replace('{{source_ownership_rule}}', renderSourceOwnershipRule(sourceContext))
-    .replace('{{section_labels}}', `- ${sectionLabelsList}`);
+  const triagePrompt = renderTemplate(PROMPTS.mergeAnalysis, {
+    page_name: info.name,
+    page_type: pageType,
+    existing_content: existingContent,
+    new_info: buildNewInfoSummary(info, sourceFile),
+    source_context: renderSourceContextBlock(sourceContext),
+    source_ownership_rule: renderSourceOwnershipRule(sourceContext),
+    section_labels: `- ${sectionLabelsList}`,
+  });
 
   // Issue #328 Phase 1 follow-up: removed appendTagVocabularyToPrompt wrapper
   // because the system layer now always injects the same section once.

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -25,6 +25,7 @@ import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
 import { normalizeLLMPath } from '../../core/prompt-builders';
+import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { appendAliases, type AliasesContext } from './aliases';
 
@@ -194,13 +195,14 @@ export async function resolvePagePath(
     const client = ctx.getClient();
     if (!client) return { path: slugPath };
 
-    const prompt = PROMPTS.resolveEntityDedup
-      .replace('{{wikiFolder}}', ctx.settings.wikiFolder)
-      .replace('{{entity_name}}', name)
-      .replace('{{entity_type}}', pageType)
-      .replace('{{entity_summary}}', summary.substring(0, 300))
-      .replace('{{page_type}}', pageType)
-      .replace('{{existing_pages}}', pagesList);
+    const prompt = renderTemplate(PROMPTS.resolveEntityDedup, {
+      wikiFolder: ctx.settings.wikiFolder,
+      entity_name: name,
+      entity_type: pageType,
+      entity_summary: summary.substring(0, 300),
+      page_type: pageType,
+      existing_pages: pagesList,
+    });
 
     const response = await client.createMessage({
       model: resolveModelForTask(ctx.settings, 'ingest'),

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -21,6 +21,7 @@ import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
 import { stripMentionsSection } from '../../core/mentions-parser';
+import { renderTemplate } from '../../core/template-renderer';
 import {
   canonicalizeSectionHeaders,
   preserveExistingSections,
@@ -112,16 +113,13 @@ export async function updateRelatedPage(
   // format; it is re-attached deterministically by assembleFinalContent below.
   const promptBody = stripMentionsSection(existingBody, labels.mentions_in_source);
 
-  const prompt = PROMPTS.updateRelatedPage
-    // Global: `{{page_name}}` occurs twice in the template. A string pattern
-    // replaces only the first match, so the sentence that names the page's
-    // subject ("provides additional information about {{page_name}}") reached
-    // the model with the literal placeholder still in it.
-    .replace(/\{\{page_name\}\}/g, pageName)
-    .replace('{{existing_body}}', promptBody)
-    .replace('{{source_basename}}', sourceFile.basename)
-    .replace('{{new_info}}', JSON.stringify(newInfo))
-    .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
+  const prompt = renderTemplate(PROMPTS.updateRelatedPage, {
+    page_name: pageName,
+    existing_body: promptBody,
+    source_basename: sourceFile.basename,
+    new_info: JSON.stringify(newInfo),
+    constraints: UNIVERSAL_LINK_CONSTRAINTS,
+  });
 
   const client = ctx.getClient();
   if (!client) throw new Error('LLM client not initialized');

--- a/src/wiki/query-engine/QueryView-class.ts
+++ b/src/wiki/query-engine/QueryView-class.ts
@@ -20,6 +20,7 @@ import LLMWikiPlugin from '../../main';
 import { TEXTS } from '../../texts';
 import { PROMPTS } from '../../prompts';
 import { parseJsonResponse } from '../../core/json';
+import { renderTemplate } from '../../core/template-renderer';
 import { formatPageRefSummary } from '../../core/ppr-cascade';
 import { buildTurnIndicator, observeVisibleTurn } from '../turn-indicator';
 import { TOKENS_QUERY_ANSWER, TOKENS_QUERY_SAVE_DEDUP, NOTICE_BRIEF, NOTICE_SHORT, NOTICE_NORMAL, NOTICE_ERROR, CUSTOM_QUERY_INSTRUCTIONS_MAX_CHARS } from '../../constants';
@@ -386,8 +387,9 @@ export class QueryView extends ItemView {
 
     try {
       const conversationText = this.plugin.wikiEngine.formatConversation(this.history);
-      const prompt = PROMPTS.evaluateConversationValue
-        .replace('{{conversation}}', conversationText.substring(0, 3000));
+      const prompt = renderTemplate(PROMPTS.evaluateConversationValue, {
+        conversation: conversationText.substring(0, 3000),
+      });
 
       // v1.24.0 #208: log resolved query model for e2e verification.
       const queryModel = resolveModelForTask(this.plugin.settings, 'query');

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -27,13 +27,13 @@ import {
   ConceptInfo,
   ContradictionInfo,
   MentionWithProvenance,
-  WIKI_LANGUAGES,
   LLMFinishReason,
   LLMUsage,
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { parseJsonResponse } from '../core/json';
-import { getSourceLanguage, isCrossLanguage } from '../core/source-language';
+import { isCrossLanguage, normalizeSourceLanguage, getWikiLanguageName } from '../core/source-language';
+import { renderTemplate } from '../core/template-renderer';
 import { matchExtractedToExisting } from '../core/index-search';
 import { coerceToArray } from '../core/arrays';
 import { isBlankSource } from '../core/frontmatter';
@@ -201,7 +201,9 @@ export class SourceAnalyzer {
     // instruction when the source is already in the wiki's language (e.g. a
     // Russian source in a Russian wiki -- translating verbatim quotes into the
     // same language is wasteful and bloats the JSON). Absent -> legacy behavior.
-    const sourceLang = getSourceLanguage(file, this.ctx.app) ?? '';
+    // Reuse the frontmatter value already fetched above instead of a second
+    // metadataCache call.
+    const sourceLang = normalizeSourceLanguage(noteFm?.language);
 
     console.debug('Existing Wiki pages count: — delayed until post-extraction matching');
 
@@ -270,11 +272,12 @@ export class SourceAnalyzer {
     // Issue #244 (manual test fix): inject the source's original vault path
     // so the LLM records it in `mentions_with_provenance[i].source_path`
     // instead of guessing `wiki/sources/<slug>`.
-    const templateUntouched = PROMPTS.analyzeSource
-      .replace('{{content}}', content)
-      .replace('{{existing_pages}}', '')  // Empty — dedup handled downstream
-      .replace('{{existing_slugs}}', existingSlugs)
-      .replace(/\{\{source_path\}\}/g, file.path);
+    const templateUntouched = renderTemplate(PROMPTS.analyzeSource, {
+      content,
+      existing_pages: '',  // Empty — dedup handled downstream
+      existing_slugs: existingSlugs,
+      source_path: file.path,
+    });
     const batchMarker = '{{batch_context}}';
     const markerIdx = templateUntouched.indexOf(batchMarker);
     const staticPrefix = templateUntouched.substring(0, markerIdx);
@@ -312,12 +315,13 @@ export class SourceAnalyzer {
         batchContext = `This is round ${batchNum + 1} of extraction. Extract the next batch of most important entities and concepts from the remaining content. If no more items are worth extracting, return empty arrays [] for entities and concepts.${alreadyExtracted}`;
       }
 
-      const prompt = staticPrefix + batchContext + suffixTemplate
-        .replace('{{granularity_instruction}}', granularityInstruction)
-        .replace(/{{batch_size}}/g, String(currentBatchSize));
+      const prompt = renderTemplate(staticPrefix + batchContext + suffixTemplate, {
+        granularity_instruction: granularityInstruction,
+        batch_size: String(currentBatchSize),
+      });
 
       const wikiLang = this.ctx.settings.wikiLanguage || 'en';
-      const wikiLangName = WIKI_LANGUAGES[wikiLang] || wikiLang;
+      const wikiLangName = getWikiLanguageName(wikiLang);
       const langHint = `\n\nCRITICAL LANGUAGE REQUIREMENT: Summaries, descriptions, source_title, and key_points in your JSON output MUST be written in ${wikiLangName}. HOWEVER: entity names and concept names MUST be preserved in their original source language -- NEVER translate names. mentions_in_source MUST be verbatim quotes from the source (preserve original language).`;
       // Issue #244 (manual test fix): when the user's wiki language differs
       // from English, instruct the LLM to ALSO emit a 'translation' field
@@ -330,7 +334,7 @@ export class SourceAnalyzer {
       // frontmatter `language:` signal; fall back to the legacy `!== 'en'`
       // proxy only when the source is untagged, so cross-language wikis keep
       // their translation behavior unchanged.
-      const crossLanguage = isCrossLanguage(sourceLang || null, wikiLang);
+      const crossLanguage = isCrossLanguage(sourceLang, wikiLang);
       const translationHint = crossLanguage
         ? `\n\nTRANSLATION (cross-language wikis): For each entry in mentions_with_provenance, ALSO add a 'translation' field containing a ${wikiLangName} translation of the quote text. The 'quote' field MUST stay verbatim in the source's original language; the translation goes in a separate 'translation' field. Example: {"quote": "Machine learning is fun", "translation": "机器学习很有趣", "source_path": "...", ...}`
         : '';

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -33,6 +33,7 @@ import {
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { parseJsonResponse } from '../core/json';
+import { getSourceLanguage, isCrossLanguage } from '../core/source-language';
 import { matchExtractedToExisting } from '../core/index-search';
 import { coerceToArray } from '../core/arrays';
 import { isBlankSource } from '../core/frontmatter';
@@ -200,9 +201,7 @@ export class SourceAnalyzer {
     // instruction when the source is already in the wiki's language (e.g. a
     // Russian source in a Russian wiki -- translating verbatim quotes into the
     // same language is wasteful and bloats the JSON). Absent -> legacy behavior.
-    const sourceLang = typeof noteFm?.language === 'string'
-      ? noteFm.language.trim().toLowerCase()
-      : '';
+    const sourceLang = getSourceLanguage(file, this.ctx.app) ?? '';
 
     console.debug('Existing Wiki pages count: — delayed until post-extraction matching');
 
@@ -331,10 +330,7 @@ export class SourceAnalyzer {
       // frontmatter `language:` signal; fall back to the legacy `!== 'en'`
       // proxy only when the source is untagged, so cross-language wikis keep
       // their translation behavior unchanged.
-      const wikiLangLower = wikiLang.toLowerCase();
-      const sameLanguage = sourceLang !== ''
-        && (sourceLang === wikiLangLower || sourceLang === wikiLangName.toLowerCase());
-      const crossLanguage = sourceLang !== '' ? !sameLanguage : wikiLang !== 'en';
+      const crossLanguage = isCrossLanguage(sourceLang || null, wikiLang);
       const translationHint = crossLanguage
         ? `\n\nTRANSLATION (cross-language wikis): For each entry in mentions_with_provenance, ALSO add a 'translation' field containing a ${wikiLangName} translation of the quote text. The 'quote' field MUST stay verbatim in the source's original language; the translation goes in a separate 'translation' field. Example: {"quote": "Machine learning is fun", "translation": "机器学习很有趣", "source_path": "...", ...}`
         : '';

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -17,6 +17,7 @@ import {
 } from '../types';
 import { PROMPTS } from '../prompts';
 import { getText } from '../core/i18n';
+import { renderTemplate } from '../core/template-renderer';
 import { slugify } from '../core/slug';
 import { resolveSourceSlug } from '../core/source-slug';
 import { parseFrontmatter, upsertFrontmatterField, mergeFrontmatterArrayField, extractBody } from '../core/frontmatter';
@@ -1238,15 +1239,16 @@ export class WikiEngine {
         '\n' +
         analysis.concepts.map(c => `- [[concepts/${slugify(c.name, preserveCase)}|${c.name}]]`).join('\n');
 
-    const prompt = PROMPTS.generateSummaryPage
-      .replace('{{source_title}}', analysis.source_title)
-      .replace('{{content}}', content.substring(0, 500))
-      .replace('{{analysis}}', JSON.stringify(analysis))
-      .replace('{{created_pages_list}}', createdPagesList || '(none)')
-      .replace(/{{source_file}}/g, file.path)
-      .replace(/{{date}}/g, new Date().toISOString().split('T')[0])
-      .replace('{{tags}}', tagsValue)
-      .replace('{{constraints}}', UNIVERSAL_LINK_CONSTRAINTS);
+    const prompt = renderTemplate(PROMPTS.generateSummaryPage, {
+      source_title: analysis.source_title,
+      content: content.substring(0, 500),
+      analysis: JSON.stringify(analysis),
+      created_pages_list: createdPagesList || '(none)',
+      source_file: file.path,
+      date: new Date().toISOString().split('T')[0],
+      tags: tagsValue,
+      constraints: UNIVERSAL_LINK_CONSTRAINTS,
+    });
 
     const finalPrompt = this.applySectionLabels(prompt);
 


### PR DESCRIPTION
## Summary

Implements all 3 themes from GH #361 plus a Theme 3b expansion that addresses the simplify audit findings on PR #362.

**Theme 1 (medium):** Promotes the frontmatter `language:` detection + cross-language policy from inline logic in `source-analyzer.ts` into shared helpers, so future prompt sites can reuse the same signal.

**Theme 2 (verification):** Verified the lint retag runner (`runRetagViolations` in `src/wiki/lint/fix-runners.ts:364-523`) already covers `VALID_SOURCE_TAGS` for existing source pages via the `getActiveSourceTags` branch at `:441-442`. The gap was test-only — every test reused an entity-typed fixture. Two new tests pin the source-typed contract.

**Theme 3 (headline, expanded):** Originally migrated 5 sites; audit revealed 13 additional sites had the same `String.replace('{{placeholder}}', value)` without `/g` bug class — including the **smoke-gun site** at `src/wiki/page-factory/related-page.ts:120` which already had a workaround comment for this exact bug. Theme 3b completes the migration to all 18 sites.

**Helper design polish (audit F2-F11):** Per audit, the helpers were improved in commit 3:
- `getWikiLanguageName` extracted to centralise `WIKI_LANGUAGES[wikiLang] ?? wikiLang`.
- `isCrossLanguage` now takes `string | null` only (legacy English-wiki proxy documented inline).
- `getSourceLanguage` split into pure `normalizeSourceLanguage(value)` + Obsidian-aware wrapper.
- `renderTemplate` uses `key in vars` (no `Object.hasOwn` polyfill noise; prompt sites use inline object literals).
- JSDoc on both helpers trimmed to behaviour-only.

## Changes

**Commit 1 (Phase 1+2, c7aa05f, 4 files):**

- New `src/core/source-language.ts` — `getSourceLanguage(file, app)` reads frontmatter `language:` with trim/lowercase/whitespace handling; `isCrossLanguage(sourceLang, wikiLang)` implements the wiki-language-aware gate (case-insensitive match against `WIKI_LANGUAGES` display name OR wiki code) with the legacy `wikiLang !== 'en'` fallback for un-tagged sources.
- New `src/__tests__/core/source-language.test.ts` — 11 cases covering trim/case, null/undefined frontmatter, BCP-47 subtag, and the legacy fallback path.
- `src/wiki/source-analyzer.ts:193-205, 334-337` — replaces inline `noteFm.language` extraction and the `crossLanguage` decision with the new helpers. Behaviour preserved; 45 existing source-analyzer tests pass.
- `src/__tests__/wiki/lint/fix-runners.test.ts` — adds 2 new tests pinning the `runRetagViolations` source-typed contract (happy path + defensive filter).

**Commit 2 (Phase 3 initial, 7a61262, 5 files):**

- New `src/core/template-renderer.ts` — `renderTemplate(template, vars)` using `/\{\{(\w+)\}\}/g`. Strictly additive: unknown placeholders are left as-is AND emit `console.warn` (previously both silent). Conservative regex (`\w+` only) intentionally leaves `{{a.b}}` / `{{a-b}}` untouched.
- New `src/__tests__/core/template-renderer.test.ts` — 11 cases covering single/multiple occurrences, multi-placeholder mixing, empty vars, recursive value handling, and the warning path.
- 5 page-factory prompt site chains migrated to `renderTemplate`.

**Commit 3 (Theme 3b + helper fixes, 099d015, 17 files):**

- Helper polish: `getWikiLanguageName` extracted; `isCrossLanguage` accepts `string | null` only with documented legacy proxy; `getSourceLanguage` split into pure normalise + Obsidian wrapper; `renderTemplate` uses `key in vars`; JSDoc trimmed.
- 13 additional prompt sites migrated to `renderTemplate` (full codebase scan confirms zero remaining `.replace('{{x}}'` sites):
  - `src/wiki/conversation-ingest.ts` (2 prompt chains)
  - `src/wiki/lint/fix-dead-link.ts`, `lint/merge-duplicates.ts`, `lint/fix-runners.ts`, `lint/llm-phases/dedup-phase.ts`
  - `src/wiki/contradictions.ts`, `src/wiki/wiki-engine.ts`
  - `src/wiki/source-analyzer.ts` (2 sites: analyseSource + batch loop suffix)
  - `src/wiki/query-engine/QueryView-class.ts`
  - `src/wiki/page-factory/path-resolution.ts`
  - **`src/wiki/page-factory/related-page.ts`** (smoke-gun site; pre-existing workaround comment removed)
  - `src/schema/schema-manager.ts`
- Test hygiene: `sourceViolation` factory hoisted; `afterEach(vi.restoreAllMocks)` for shared spy cleanup; duplicate test cases removed.

## Verification

- **ESLint:** 0 errors, 0 warnings
- **TypeScript:** 0 errors
- **Tests:** 2629 passed (197 files) — +24 new tests (11 source-language + 11 template-renderer + 2 retag runner)
- **Build:** clean exit
- **CSS lint:** 0 violations
- **No breaking changes:** helpers are new files, refactors preserve placeholder substitution semantics; silent skip → correct substitution + warn-on-unknown (strictly additive)
- **Full codebase grep confirms zero remaining `String.replace('{{x}}'` sites**

## Out of scope (deferred to v1.26.0 MINOR)

- Theme 1 Step 4: Migrating 4 other lang-hint construction sites through the new helpers. These sites currently don't read frontmatter and require per-site semantic audit before wiring. Tracked separately under v1.26.0 scope.

## Reviewers

@DocTpoint (Triage role) — Theme 1 + Theme 3 touch design surfaces you shaped.
@eucher — Theme 2 test mirrors your #349 retag pattern.

## Closes

Closes #361