### PR TITLE
docs: v1.25.10 PATCH scope sync + Ecosystem section in 10 READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,26 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-07-27 (v1.25.10 PATCH SCOPE LOCKED + v1.26.0 design anchor created at GH issue [#358](https://github.com/green-dalii/obsidian-llm-wiki/issues/358). main @ `7e22848` after 2026-07-26 PATCH batch merge (#347/#349/#350/#352 → 2605 tests / 195 files). v1.26.0 design integrates #220 + #285 + #328 + #330 + #348 into one coherent direction with DocTpoint as co-author.)
+**Last Updated:** 2026-07-28 (v1.25.10 PATCH scope expanded 5 → 10 items + DocTpoint Triage role correction. main @ `2d26620` after 2026-07-26 PATCH batch merge (#347/#349/#350/#352 → 2605 tests / 195 files). v1.25.10 PATCH scope locked: 5 from #330/#356 + DocTpoint batch (#363 format+parser, #364 folder boundary) + Guru35 batch (#366 slug migration option d, #367 lint-perf P0-1+P1-1+P1-2 from v1.25.7 deferred, #368 docs+settings hint as `enhancement`). #365 deferred v1.26.0+; PR #357 anchored v1.26.0+.)
 
 ---
 
-## Current Phase: v1.25.10 PATCH scope locked; v1.26.0 MINOR in design phase.
+## Current Phase: v1.25.10 PATCH scope locked at 10 items; v1.26.0 MINOR in design phase.
 
-**v1.25.10 PATCH** (planned, sequential on v1.25.9): four item scope, all derived from [#330](https://github.com/green-dalii/obsidian-llm-wiki/issues/330) + [#356](https://github.com/green-dalii/obsidian-llm-wiki/issues/356) (frontmatter-strip bug):
+**v1.25.10 PATCH** (planned, sequential on v1.25.9): ten-item scope (locked 2026-07-28, expanded from initial 5 after DocTpoint + Guru35 morning batches):
 - admission criterion in Task Requirements (closes DocTpoint §2 "rules stated twice in the same prompt")
 - cross-type dedup candidate visibility (closes §3, #328 Phase 2 pre-condition)
 - `merge` vs `contradictory` route split (closes §4, `src/wiki/page-factory/merge-page.ts:124`)
 - alias hardening (3-char floor + uniqueness, DocTpoint §3 measured 0 side effects)
+- #356 frontmatter-strip (data-loss bug fix)
+- #363 format + parser tolerance (`— [[|]]` parse fail-safe 4.7% frozen pages; DocTpoint contributes parser side)
+- #364 folder ingest boundary (data-safety 1-line)
+- #366 slug derivation unification (Turkish char folding; migration story option (d) — two-phase alias+opt-in repair)
+- #367 lint-perf — fold forward v1.25.7 deferred P0-1 fix-runners parallelization + P1-1 analysis content-hash cache + P1-2 smart-skip controller (strict scope lock: only these 3 sub-items; no embedding/RAG)
+- #368 schema docs clarification + settings UI hint (relabeled `bug` → `enhancement`; root cause is docs/semantic mismatch, NOT enforcement bug)
 
-**v1.26.0 MINOR** (in design, anchor [#358](https://github.com/green-dalii/obsidian-llm-wiki/issues/358)): 8-item committed scope + 4-item research track + 5 open design questions. DocTpoint co-author on `docs/v1.26.0-design.md` (Triage role granted 2026-07-27, label + issue close authority, no push/merge authority).
+**v1.26.0 MINOR** (in design, anchor [#358](https://github.com/green-dalii/obsidian-llm-wiki/issues/358)): 8-item committed scope + 4-item research track + 5 open design questions. DocTpoint co-author on `docs/v1.26.0-design.md` (granted Write role on personal repo 2026-07-27, label + issue close authority, push authority bounded by branch protection on `main`; see Architect-level contributors below for full role description).
 
-**Companion deferred from v1.25.7 PATCH** (moved to v1.26.0 MINOR to avoid scope over-inflation): P0-1 fix-runners parallelization, P1-1 analysis content-hash cache, P1-2 smart-skip controller. Detailed plan archived in [[project_v1.25.7_lint_perf_plan]]. **🚫 Embedding/RAG/vector index for lint perf: 永久禁止** — see [[feedback_no_rag_embedding_perf]].
+**Companion deferred from v1.25.7 PATCH** (folded INTO v1.25.10 PATCH 2026-07-28 as item #367 — strict scope lock, no scope over-inflation): P0-1 fix-runners parallelization, P1-1 analysis content-hash cache, P1-2 smart-skip controller. Detailed plan archived in [[project_v1.25.7_lint_perf_plan]]; v1.25.10 integration notes in [[project_v1.25.10_patch_scope]] §2. **🚫 Embedding/RAG/vector index for lint perf: 永久禁止** — see [[feedback_no_rag_embedding_perf]].
 
 **v1.25.1 PATCH (2026-07-20, 11 commits, ~80 files, 2274 tests):**
 
@@ -383,12 +389,12 @@ For full release workflow (commit + push + tag + release notes), use the `obsidi
   - **Practical implications:** "self-improving over time" = periodic consolidation pass with LLM judgement on past decisions, NOT a smarter ingest path. The smallest kernel of the Karpathy cycle is Preview-Confirm gate + identity ambiguity record + stable mutation interface, NOT an agent framework refactor.
   - Full rationale: #330 reply comment + #358 tracking issue + [[project_v1_26_0_design]] (when created).
 
-- **Architect-level contributors (added 2026-07-27, applies to v1.26.0+ design work)**:
-  - **Definition.** A contributor who has submitted ≥3 PRs touching core engine files with measurable impact AND authored ≥2 design-level issues that influenced the roadmap. Currently granted to: @DocTpoint (7 issues/PRs in 60 days: #285 typed edges + #328 schema split + #330 ingest critique + #347 source-ownership + #357 source-lemma + #348 source-lemmma derived; 419-note German medical corpus as ongoing stress test).
-  - **Role on GitHub.** `Triage` role (Settings → Collaborators → Add → Role: Triage). This grants: label management on all issues/PRs, issue close/reopen authority, ability to mark duplicates, view on private repo metadata. It does **NOT** grant: direct push to protected branches, merge authority, release-tag authority. Triage role works **inside** the standard PR review workflow (CLAUDE.md §Git Workflow), not around it.
-  - **Why Triage, not Collaborator / Maintain.** Pushing to main is gated by §Git Workflow red line. Merge authority is the maintainer's responsibility under §PR Merge Workflow. Triage is the smallest scope that recognises "this contributor's issues have been driving the roadmap" without bypassing review gates.
-  - **What we expect.** Triage role holders co-write design docs (`docs/v1.Y.Z-design.md`) for the version they shape; review PRs that touch their design surface; flag regressions against their prior contributions. They do NOT speak for the project in user-facing channels or change release scope unilaterally.
-  - **What we don't expect.** Triage is not a path to maintainer. Maintainer promotion is a separate decision triggered by sustained Triage work + user approval, not by accumulating time in role.
+- **Architect-level contributors (added 2026-07-27, corrected 2026-07-28, applies to v1.26.0+ design work)**:
+  - **Definition.** A contributor who has submitted ≥3 PRs touching core engine files with measurable impact AND authored ≥2 design-level issues that influenced the roadmap. Currently granted to: @DocTpoint (DocTpoint's authored count per his #358 reply: 63 issues + 27 PRs, 21 of them merged, first contribution 2026-05-19 — about 70 days; his 6 roadmap-shaping threads: #285 typed edges contributed to + #328 schema split contributed to + #330 ingest critique + #347 source-ownership + #357 source-lemma + #348 source-lemmma derived). **Note:** per F3 audit finding, **#285 and #328 were opened by green-dalii, not by DocTpoint** — DocTpoint contributed to the threads, not authored them.
+  - **Role on GitHub.** **Write** role on the personal repo (`green-dalii/obsidian-llm-wiki`). **Note** (2026-07-28 correction): there is no separately-assignable "Triage-only" role on a personal GitHub repo — the 5 available roles are Read / Triage / Write / Maintain / Admin, and **the Write role includes triage permissions** (push=true, triage=true, pull=true). The "no push to main" invariant is enforced **independently** by branch protection on `main`, not by role assignment. Collaborator role changes must be done via the GitHub UI (Settings → Collaborators → role dropdown) — the API only creates invitations and cannot modify an existing collaborator's role.
+  - **Why Write (not Maintain / Admin).** Pushing to main is gated by §Git Workflow red line (`GH013` rejection); merge authority is the maintainer's responsibility under §PR Merge Workflow. Write is the smallest scope that recognises "this contributor's issues have been driving the roadmap" without bypassing review gates; Maintain / Admin would add merge / release-tag authority we deliberately reserve for the maintainer.
+  - **What we expect.** Write-role holders co-write design docs (`docs/v1.Y.Z-design.md`) for the version they shape; review PRs that touch their design surface; flag regressions against their prior contributions. They do NOT speak for the project in user-facing channels or change release scope unilaterally.
+  - **What we don't expect.** Write is not a path to maintainer. Maintainer promotion is a separate decision triggered by sustained work + user approval, not by accumulating time in role.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [Official Site](https://llmwiki.greenerai.top/) | [Obsidian Marketplace](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [Contents](#-contents) • 🚀 [Quick Start](#-quick-start) • ✨ [Features](#-features) • 🔍 [How Retrieval Works](#-how-retrieval-works) • 🤖 [Models](#-models) • ❓ [FAQ](#-faq)
+🤔 [Why this plugin?](#-why-this-plugin) | 🚀 [Quick Start](#-quick-start) | ✨ [Features](#-features) | 🌐 [Ecosystem](#-ecosystem) | 🔍 [How Retrieval Works](#-how-retrieval-works) | 🤖 [Models](#-models) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← If this plugin has helped you, feel free to buy me a coffee♥️ or drop a star🌟↗
 
@@ -26,6 +26,7 @@
 - [Is it for me?](#-is-it-for-me)
 - [Quick Start](#-quick-start)
 - [Features](#-features)
+- [Ecosystem](#-ecosystem)
 - [How retrieval works](#-how-retrieval-works)
 - [Models](#-models)
 - [FAQ](#-faq)
@@ -184,6 +185,20 @@ Three paths, pick what fits your setup:
 - **🌍 10 UI languages** — English, 简体中文, 繁體中文, 日本語, 한국어, Deutsch, Français, Español, Português, Italiano. UI and wiki-output language are independent — your wiki can be Chinese while the interface is English.
 - **📚 10 wiki-output languages** — same set; pick in Settings → Wiki Configuration. *Custom input* option for ad-hoc prompts.
 - **🈶 269+ translated UI strings** — every label, modal, and notice. Adding an 11th language is contributor-driven (PR #159 pattern).
+
+---
+
+## 🌐 Ecosystem
+
+The plugin composes with the rest of your Obsidian stack — each tool below plugs into the `[[wiki-link]]` graph without code changes.
+
+- **🕸️ Obsidian Graph View** — open the native graph on any wiki page; every `[[wiki-link]]` becomes a node, every back-link an edge. Built in, zero extra bundle size.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — official browser extension. Save web pages (articles, blog posts, Reddit threads, Hacker News, recipes, research papers, YouTube transcripts via Interpreter) into any folder of your vault, then run the plugin's `Ingest from folder` command to batch-extract entities and concepts.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — query the wiki like a database with DQL (`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) or JS API. The plugin writes standard frontmatter (`tags:`, `type:`, `aliases:`) on every page, so Dataview queries work out of the box.
+- **🌿 Git** — version your vault (any Git client). The plugin never rewrites your source files; only creates new pages under `wiki/`, so `git diff` cleanly separates your edits from LLM-generated content.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — turn any Obsidian note into slide decks via Marp frontmatter (`marp: true`). Wiki pages are pure Markdown, so they render as slides without extra conversion.
+- **🖼️ Canvas** — Obsidian's native infinite canvas. Drag wiki cards onto a Canvas to assemble study guides, mind maps, or research overviews from `[[wiki-links]]` without leaving the vault.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — companion plugin for local voice memo and meeting capture (whisper.cpp on macOS; audio never leaves the machine). Generates speaker-labeled transcripts and its own wiki hub pages. Independent of this plugin — both can share the same vault without coupling.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Version:** 1.25.9 PATCH (re-publish of 1.25.8). | **Updated:** 2026-07-27
+**Version:** 1.25.9 PATCH (re-publish of 1.25.8). | **Updated:** 2026-07-28
 
 ## Current Status
 
@@ -20,16 +20,38 @@
 
 ## Next: v1.25.10 PATCH (sequential on v1.25.9)
 
-Theme: four-item bug-fix scope from #330 close-out + #356 frontmatter-strip. All items have measured reproduction or empirical evidence; scope is intentionally narrow to land before v1.26.0 opens the design window.
+Theme: bug-fix only, no new features. All 10 items have measured reproduction or empirical evidence; scope intentionally narrow to land before v1.26.0 opens the design window.
 
-**Scope (locked 2026-07-27)**:
+**Scope (expanded 2026-07-28 from 5 → 10 items, locked after DocTpoint + Guru35 morning batches)**:
+
+*Locked 2026-07-27 (5 items from #330 close-out + #356 frontmatter-strip)*:
 - **admission criterion in Task Requirements** — closes #330 §2 (rules stated twice in the same prompt; 17 citation-titled pages violated)
 - **cross-type dedup candidate visibility** — closes #330 §3 (`src/wiki/page-factory/path-resolution.ts:165` filter scope); pre-condition for #328 Phase 2
 - **`merge` vs `contradictory` route split** — closes #330 §4 (`src/wiki/page-factory/merge-page.ts:124` routes both into same body rewrite)
 - **alias hardening** — closes #330 §3 (3-char floor + uniqueness; DocTpoint measured 0 links affected by 3-char floor, 30/31,553 by uniqueness)
 - **#356 frontmatter-strip fix** — preserves unknown top-level fields on re-touch (data-loss bug, not v1.26.0 feature)
 
-**Out of scope for v1.25.10** (moved to v1.26.0): identity ambiguity record, bidirectional frontmatter, typed edges, Preview-Confirm gate, source-lemma PR #357 (already in `feat/ingest-source-lemma` branch, ships independently).
+*DocTpoint batch (2026-07-28 04:38-04:43 UTC)*:
+- **#363 format + parser tolerance** — `formatMentionsSection` 1-line `sourcePath: m.source_path || sourcePath` mirror `computeReingestMentions.normalize`, **plus** parser-side `BULLET_RE` empty-target tolerance + `buildBullets()` defensive skip-when-empty. DocTpoint measured 4.7% pages frozen by parse→fail-safe chain (119/9272 writes on 417-note vault). DocTpoint contributes parser side.
+- **#364 folder ingest boundary** — 1-line + root special-case: `folderPrefix = folder.isRoot() ? '' : `${folder.path}/``. Data-safety: `Foo/` + `Foo-bar/` no longer cross-bleed.
+
+*Guru35 batch (2026-07-28 09:15-09:18 UTC, single 11k-page Turkish vault)*:
+- **#366 slug derivation unification** — single shared `slugify()` (Turkish char folding: ı→i, İ→i, ç→c, ş→s, ğ→g, ö→o, ü→u) + migration story **option (d) two-phase hybrid**: Phase 1 = emit `aliases:` field on new pages so Obsidian native alias resolution handles old wikilinks transparently; Phase 2 = opt-in `migrateOldSlugs` setting rewrites `[[old|...]]` → `[[new|...]]` on next lint/ingest.
+- **#367 lint-perf** — fold forward v1.25.7 deferred plan items: **P0-1 fix-runners parallelization** (80 LOC + 5 tests, `Promise.allSettled` rewrite of 5 phases), **P1-1 analysis content-hash cache** (80 LOC + 3 tests, LRU 50 entries using `DiskCache<T>` from v1.25.1), **P1-2 smart-skip controller** (30 LOC + 1 test). **Strict scope lock**: only these 3 sub-items; no Tier 1 n-gram bucket, no per-file content-hash diff-index, no embedding/RAG (permanently banned), no new settings UI.
+- **#368 schema docs + settings UI hint** (relabeled `bug` → `enhancement`) — root cause is docs/semantic mismatch, NOT enforcement bug: `type:` is broad category (entity/concept/source, prompt-mandated in `src/wiki/prompts/generation.ts:45/106/159/212/253`); `tags:` is subtype enum (validated via `getActive*Tags(settings)` at `src/core/frontmatter.ts:496-502`, custom vocabulary already in place). Fix is docs clarification + settings UI hint panel; NO `enforceFrontmatterConstraints` change.
+
+**Out of scope for v1.25.10** (moved to v1.26.0): identity ambiguity record, bidirectional frontmatter, typed edges, Preview-Confirm gate, source-lemma PR #357 (already in `feat/ingest-source-lemma` branch, ships independently). **#365 programmatic sources stamp on create path** (DocTpoint) — also deferred to v1.26.0; pre-condition for v1.26.0 "Bidirectional frontmatter" item.
+
+**Expected impact (post all 10 items + lint-perf fold-in)**:
+
+| Metric | baseline (v1.25.9) | v1.25.10 |
+|---|---|---|
+| Lint ingest wall (2805p vault) | 1836s | ~150s (−92%, from lint-perf) |
+| Smart Fix All | 120-180s | <60s (−65%) |
+| Mentions frozen pages (`[[|]]`) | 4.7% (DocTpoint) | 0% (parser tolerance) |
+| Folder mis-ingest (data-safety) | up to 50x (DocTpoint: 409 notes) | 0 (boundary check) |
+| Broken wikilinks (Turkish vault) | 16.5% (Guru35) | depends on migration completion |
+| Settings custom tag vocab drift | 9% (Guru35) | 0 (docs clarification) |
 
 ## Next: v1.26.0 MINOR (after v1.25.10 ships)
 
@@ -65,9 +87,9 @@ Theme: four-item bug-fix scope from #330 close-out + #356 frontmatter-strip. All
 - ❌ Multi-vault isolation (cost > observed benefit)
 - ❌ Plugin-internal scheduler for consolidation (external orchestration is the right home)
 
-**Companion items carried from v1.25.7 PATCH deferred**: P0-1 fix-runners parallelization, P1-1 analysis content-hash cache, P1-2 smart-skip controller (see [[project_v1.25.7_lint_perf_plan]]).
+**Companion items folded into v1.25.10 PATCH**: P0-1 fix-runners parallelization, P1-1 analysis content-hash cache, P1-2 smart-skip controller (see [[project_v1.25.7_lint_perf_plan]] + [[project_v1.25.10_patch_scope]] §2). **🚫 Embedding/RAG/vector index for lint perf: 永久禁止** — see [[feedback_no_rag_embedding_perf]].
 
-**i18n expansion to 11 languages:** add `ru` (Русский) to `WIKI_LANGUAGES` + `src/texts/ru.ts` + `docs/README_RU.md` + 11-way language switcher across all READMEs. Driven by recent RU user growth + @eucher's 3 ingest/LLM PRs (RU speaker). No new functionality beyond text strings + 11-locale parity test update.
+**i18n expansion to 11 languages:** add `ru` (Русский) to `WIKI_LANGUAGES` + `src/texts/ru.ts` + `docs/README_RU.md` + 11-way language switcher across all READMEs. Driven by recent RU user growth + @eucher's 3 ingest/LLM PRs (RU speaker). No new functionality beyond text strings + 11-locale parity test update. — *(status: still pending; not part of v1.25.10 PATCH; revisit at v1.26.0 kickoff or as a follow-up PATCH.)*
 
 Historic compositions (v1.25.7 and earlier) live in [CHANGELOG.md](./CHANGELOG.md) — kept brief here.
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -14,7 +14,7 @@
 
 [官网](https://llmwiki.greenerai.top/) | [Obsidian 插件市场](https://community.obsidian.md/plugins/karpathywiki) | [博客](https://llmwiki.greenerai.top/zh/blog/) | [反馈讨论](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [目录](#-目录) • 🚀 [快速开始](#-快速开始) • ✨ [核心特性](#-核心特性) • 🔍 [检索工作原理](#-检索工作原理) • 🤖 [模型推荐](#-模型推荐) • ❓ [常见问题](#-常见问题)
+🤔 [为什么使用此插件？](#-为什么使用此插件) | 🚀 [快速开始](#-快速开始) | ✨ [核心特性](#-核心特性) | 🌐 [生态](#-生态) | 🔍 [检索工作原理](#-检索工作原理) | 🤖 [模型推荐](#-模型推荐) | ❓ [常见问题](#-常见问题)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 如果你觉得项目帮到了你，欢迎请我杯咖啡♥️或为项目点亮🌟↗
 
@@ -29,6 +29,7 @@
 - [🎯 适合我吗？](#-适合我吗)
 - [🚀 快速开始](#-快速开始)
 - [✨ 核心特性](#-核心特性)
+- [🌐 生态](#-生态)
 - [🔍 检索工作原理](#-检索工作原理)
 - [🤖 模型推荐](#-模型推荐)
 - [❓ 常见问题](#-常见问题)
@@ -259,6 +260,20 @@
 - **ChatGPT Plan (Codex OAuth)** —— 实验性、独立的 Provider，在浏览器或设备代码登录后使用符合条件的 Codex 额度；可用性遵循 OpenAI Codex 身份验证和额度政策，而非计划名称。第三方 Codex 兼容功能，非 OpenAI 合作项目或通用 ChatGPT API。
 
 > 📖 **完整选择表格**（云端 + 本地 + PDF OCR + Codex OAuth + 量化 + 硬件等级）→ [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+---
+
+## 🌐 生态
+
+本插件与你的其他 Obsidian 工具无缝协作——以下工具皆可直接对接 `[[wiki-link]]` 图谱，无需任何代码改动。
+
+- **🕸️ Obsidian 原生关系图谱** —— 在任意 Wiki 页面上打开原生图谱视图；每个 `[[wiki-link]]` 成为节点，每条反向链接成为边。内置功能，零额外体积。
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** —— 官方浏览器扩展。将网页（文章、博客、Reddit 帖子、Hacker News、食谱、研究论文、YouTube 字幕（通过 Interpreter 提取））保存到 vault 内任意文件夹，然后运行插件的「从文件夹摄入」命令批量提取实体与概念。
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** —— 用 DQL（`LIST FROM "wiki/entities" WHERE contains(tags, "person")`）或 JS API 像查询数据库一样检索 Wiki。插件在每个页面写入标准 frontmatter（`tags:`、`type:`、`aliases:`），Dataview 查询开箱即用。
+- **🌿 Git** —— 用任意 Git 客户端对 vault 进行版本控制。插件永不重写源文件，仅在 `wiki/` 下创建新页面，因此 `git diff` 能清晰区分你的手动编辑与 LLM 生成内容。
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** —— 通过 Marp frontmatter（`marp: true`）将任意 Obsidian 笔记转为幻灯片。Wiki 页面是纯 Markdown，可直接渲染为幻灯片，无需额外转换。
+- **🖼️ Canvas** —— Obsidian 原生无限画布。把 Wiki 卡片拖到 Canvas 上，无需离开 vault 即可拼装学习指南、思维导图或研究概览，所有内容均通过 `[[wiki-links]]` 互联。
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** —— 本地语音备忘录与会议录制（macOS 上使用 whisper.cpp，音频数据不出本机）的配套插件。生成带说话人标记的转录文件与自有 wiki 中心页面。与本插件相互独立——可在同一 vault 共存而无需耦合。
 
 ---
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -14,7 +14,7 @@
 
 [Offizielle Website](https://llmwiki.greenerai.top/) | [Obsidian-Marktplatz](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Diskussionen](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [Inhalt](#-inhalt) • 🚀 [Schnellstart](#-schnellstart) • ✨ [Funktionen](#-funktionen) • 🔍 [Wie die Suche funktioniert](#-wie-die-suche-funktioniert) • 🤖 [Modelle](#-modelle) • ❓ [FAQ](#-faq)
+🤔 [Warum dieses Plugin?](#-warum-dieses-plugin) | 🚀 [Schnellstart](#-schnellstart) | ✨ [Funktionen](#-funktionen) | 🌐 [Ökosystem](#-ökosystem) | 🔍 [Wie die Suche funktioniert](#-wie-die-suche-funktioniert) | 🤖 [Modelle](#-modelle) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Wenn dir dieses Plugin geholfen hat, lad mich gerne auf einen Kaffee♥️ ein oder vergib einen Stern🌟↗
 
@@ -28,6 +28,7 @@
 - [🎯 Ist es etwas für mich?](#-ist-es-etwas-für-mich)
 - [🚀 Schnellstart](#-schnellstart)
 - [✨ Funktionen](#-funktionen)
+- [🌐 Ökosystem](#-ökosystem)
 - [🔍 Wie die Suche funktioniert](#-wie-die-suche-funktioniert)
 - [🤖 Modelle](#-modelle)
 - [❓ FAQ](#-faq)
@@ -255,6 +256,20 @@ Dieses Plugin füttert dem LLM pro Abfrage den gesamten Wiki-Kontext — daher g
 - **ChatGPT Plan (Codex OAuth)** — experimenteller, eigenständiger Anbieter, der nach Browser- oder Gerätecode-Anmeldung berechtigtes Codex-Kontingent nutzt; die Verfügbarkeit folgt den OpenAI-Codex-Authentifizierungs- und Kontingentrichtlinien, nicht dem Plannamen. Drittanbieter-Codex-Kompatibilität, keine OpenAI-Partnerschaft oder allgemeine ChatGPT-API.
 
 > 📖 **Vollständige Auswahltabelle** (Cloud + Lokal + PDF-OCR + Codex OAuth + Quantisierung + Hardware-Stufen) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+---
+
+## 🌐 Ökosystem
+
+Das Plugin ergänzt sich mit dem Rest Ihres Obsidian-Stacks — jedes der folgenden Tools bindet sich ohne Code-Änderungen in den `[[wiki-link]]`-Graphen ein.
+
+- **🕸️ Obsidian Graph View** — öffnen Sie die native Graphenansicht auf jeder Wiki-Seite; jeder `[[wiki-link]]` wird zu einem Knoten, jeder Backlink zu einer Kante. Bereits eingebaut, null zusätzliche Bundle-Größe.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — offizielle Browser-Erweiterung. Speichern Sie Webseiten (Artikel, Blogbeiträge, Reddit-Threads, Hacker News, Rezepte, Forschungsarbeiten, YouTube-Transkripte via Interpreter) in einem beliebigen Ordner Ihres Vaults und führen Sie anschließend den Plugin-Befehl „Aus Ordner aufnehmen" aus, um Entitäten und Konzepte stapelweise zu extrahieren.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — durchsuchen Sie das Wiki wie eine Datenbank mit DQL (`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) oder der JS-API. Das Plugin schreibt standardmäßige Frontmatter (`tags:`, `type:`, `aliases:`) auf jede Seite, sodass Dataview-Abfragen sofort funktionieren.
+- **🌿 Git** — versionieren Sie Ihren Vault (mit jedem Git-Client). Das Plugin überschreibt niemals Ihre Quelldateien; es legt nur neue Seiten unter `wiki/` an, sodass `git diff` klar zwischen Ihren Änderungen und vom LLM erzeugten Inhalten trennt.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — verwandeln Sie jede Obsidian-Notiz über Marp-Frontmatter (`marp: true`) in einen Foliensatz. Wiki-Seiten sind reines Markdown und rendern ohne zusätzliche Konvertierung als Folien.
+- **🖼️ Canvas** — Obsidians native, unendliche Leinwand. Platzieren Sie Wiki-Karten auf einer Canvas, um Lernhilfen, Mindmaps oder Forschungsübersichten aus `[[wiki-links]]` zusammenzustellen — ohne den Vault zu verlassen.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — Begleit-Plugin für lokale Sprachmemo- und Meeting-Erfassung (whisper.cpp auf macOS; Audio verlässt das Gerät nicht). Erzeugt sprecherbeschriftete Transkripte und eigene Wiki-Hub-Seiten. Unabhängig von diesem Plugin — beide können dasselbe Vault ohne Kopplung nutzen.
 
 ---
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -14,7 +14,7 @@
 
 [Sitio oficial](https://llmwiki.greenerai.top/) | [Mercado de Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Debate](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [Contenido](#-contenido) • 🚀 [Inicio rápido](#-inicio-rápido) • ✨ [Características](#-características) • 🔍 [Cómo funciona la recuperación](#-cómo-funciona-la-recuperación) • 🤖 [Modelos](#-modelos) • ❓ [FAQ](#-faq)
+🤔 [Por qué este plugin?](#-por-qué-este-plugin) | 🚀 [Inicio rápido](#-inicio-rápido) | ✨ [Características](#-características) | 🌐 [Ecosistema](#-ecosistema) | 🔍 [Cómo funciona la recuperación](#-cómo-funciona-la-recuperación) | 🤖 [Modelos](#-modelos) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Si este plugin te ha sido útil, invítame a un café♥️ o deja una estrella🌟↗
 
@@ -26,6 +26,7 @@
 - [🎯 Es para mí?](#-es-para-mí)
 - [🚀 Inicio rápido](#-inicio-rápido)
 - [✨ Características](#-características)
+- [🌐 Ecosistema](#-ecosistema)
 - [🔍 Cómo funciona la recuperación](#-cómo-funciona-la-recuperación)
 - [🤖 Modelos](#-modelos)
 - [❓ FAQ](#-faq)
@@ -253,6 +254,20 @@ Este plugin alimenta al LLM con el contexto completo de tu Wiki por consulta —
 - **ChatGPT Plan (Codex OAuth)** — experimental, proveedor distinto que usa la asignación Codex elegible después de iniciar sesión por navegador o código de dispositivo; la disponibilidad sigue las políticas de autenticación y asignación de OpenAI Codex, no el nombre del plan. Compatibilidad de terceros con Codex, no una asociación con OpenAI ni una API general de ChatGPT.
 
 > 📖 **Tabla completa de selección** (cloud + local + OCR PDF + Codex OAuth + cuantización + niveles de hardware) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+---
+
+## 🌐 Ecosistema
+
+El plugin se combina con el resto de tu stack de Obsidian — cada herramienta de abajo se conecta al grafo `[[wiki-link]]` sin cambios de código.
+
+- **🕸️ Obsidian Graph View** — abre la vista de grafo nativa en cualquier página wiki; cada `[[wiki-link]]` se convierte en un nodo, cada backlink en una arista. Integrado, cero tamaño adicional del bundle.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — extensión oficial del navegador. Guarda páginas web (artículos, entradas de blog, hilos de Reddit, Hacker News, recetas, trabajos de investigación, transcripciones de YouTube vía Interpreter) en cualquier carpeta de tu vault y luego ejecuta el comando «Ingerir desde carpeta» del plugin para extraer entidades y conceptos en lote.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — consulta el wiki como una base de datos con DQL (`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) o la API JS. El plugin escribe frontmatter estándar (`tags:`, `type:`, `aliases:`) en cada página, por lo que las consultas Dataview funcionan sin configuración adicional.
+- **🌿 Git** — versiona tu vault (con cualquier cliente Git). El plugin nunca reescribe tus archivos fuente; solo crea nuevas páginas bajo `wiki/`, por lo que `git diff` separa claramente tus ediciones del contenido generado por el LLM.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — convierte cualquier nota de Obsidian en diapositivas mediante el frontmatter Marp (`marp: true`). Las páginas wiki son Markdown puro, se renderizan como diapositivas sin conversión adicional.
+- **🖼️ Canvas** — lienzo infinito nativo de Obsidian. Coloca tarjetas wiki en un canvas para ensamblar guías de estudio, mapas mentales o resúmenes de investigación a partir de `[[wiki-links]]` sin salir del vault.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — plugin complementario para captura local de notas de voz y reuniones (whisper.cpp en macOS; el audio nunca sale del dispositivo). Genera transcripciones etiquetadas por hablante y sus propias páginas wiki hub. Independiente de este plugin — ambos pueden compartir el mismo vault sin acoplarse.
 
 ---
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -14,7 +14,7 @@
 
 [Site officiel](https://llmwiki.greenerai.top/) | [Marketplace Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [Sommaire](#-sommaire) • 🚀 [Démarrage rapide](#-démarrage-rapide) • ✨ [Fonctionnalités](#-fonctionnalités) • 🔍 [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche) • 🤖 [Modèles](#-modèles) • ❓ [FAQ](#-faq)
+🤔 [Pourquoi ce plugin ?](#-pourquoi-ce-plugin-) | 🚀 [Démarrage rapide](#-démarrage-rapide) | ✨ [Fonctionnalités](#-fonctionnalités) | 🌐 [Écosystème](#-écosystème) | 🔍 [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche) | 🤖 [Modèles](#-modèles) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Si ce plugin t'a aidé, offre-moi un café♥️ ou dépose une étoile🌟↗
 
@@ -26,6 +26,7 @@
 - [Est-ce pour moi ?](#-est-ce-pour-moi-)
 - [Démarrage rapide](#-démarrage-rapide)
 - [Fonctionnalités](#-fonctionnalités)
+- [Écosystème](#-écosystème)
 - [Fonctionnement de la recherche](#-fonctionnement-de-la-recherche)
 - [Modèles](#-modèles)
 - [FAQ](#-faq)
@@ -253,6 +254,18 @@ Ce plugin alimente le LLM avec le contexte complet de votre Wiki par requête �
 - **ChatGPT Plan (Codex OAuth)** — fournisseur expérimental distinct qui utilise une allocation Codex éligible après connexion par navigateur ou code d'appareil ; la disponibilité suit les politiques d'authentification et d'allocation OpenAI Codex, pas le nom du forfait. Compatibilité tierce Codex, pas un partenariat OpenAI ou une API ChatGPT générale.
 
 > 📖 **Tableau de sélection complet** (cloud + local + PDF OCR + Codex OAuth + quantification + niveaux matériels) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+## 🌐 Écosystème
+
+Le plugin s'intègre au reste de votre stack Obsidian — chacun des outils ci-dessous se branche au graphe `[[wiki-link]]` sans modification de code.
+
+- **🕸️ Obsidian Graph View** — ouvrez la vue de graphe natif sur n'importe quelle page wiki ; chaque `[[wiki-link]]` devient un nœud, chaque backlink une arête. Intégré, zéro taille de bundle supplémentaire.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — extension officielle de navigateur. Enregistrez des pages web (articles, billets de blog, fils Reddit, Hacker News, recettes, articles de recherche, transcriptions YouTube via Interpreter) dans n'importe quel dossier de votre vault, puis exécutez la commande « Ingérer depuis le dossier » du plugin pour extraire entités et concepts en lot.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — interrogez le wiki comme une base de données avec DQL (`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) ou l'API JS. Le plugin écrit du frontmatter standard (`tags:`, `type:`, `aliases:`) sur chaque page, donc les requêtes Dataview fonctionnent sans configuration.
+- **🌿 Git** — versionnez votre vault (avec n'importe quel client Git). Le plugin ne réécrit jamais vos fichiers sources ; il crée uniquement de nouvelles pages sous `wiki/`, de sorte que `git diff` sépare clairement vos modifications du contenu généré par le LLM.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — transformez n'importe quelle note Obsidian en diaporama via le frontmatter Marp (`marp: true`). Les pages wiki sont en Markdown pur, elles se rendent en diapositives sans conversion supplémentaire.
+- **🖼️ Canvas** — canevas infini natif d'Obsidian. Déposez des fiches wiki sur un canvas pour assembler guides d'étude, cartes mentales ou synthèses de recherche à partir de `[[wiki-links]]`, sans quitter le vault.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — plugin compagnon pour la capture locale de mémos vocaux et réunions (whisper.cpp sur macOS ; l'audio ne quitte jamais la machine). Génère des transcriptions étiquetées par locuteur et ses propres pages wiki hub. Indépendant de ce plugin — les deux peuvent partager le même vault sans couplage.
 
 ## ❓ FAQ
 

--- a/docs/README_IT.md
+++ b/docs/README_IT.md
@@ -14,7 +14,7 @@
 
 [Sito ufficiale](https://llmwiki.greenerai.top/) | [Marketplace Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussioni](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [Indice](#-indice) • 🚀 [Avvio rapido](#-avvio-rapido) • ✨ [Funzionalità](#-funzionalità) • 🔍 [Come funziona il recupero](#-come-funziona-il-recupero) • 🤖 [Modelli](#-modelli) • ❓ [FAQ](#-faq)
+🤔 [Perché questo plugin?](#-perché-questo-plugin) | 🚀 [Avvio rapido](#-avvio-rapido) | ✨ [Funzionalità](#-funzionalità) | 🌐 [Ecosistema](#-ecosistema) | 🔍 [Come funziona il recupero](#-come-funziona-il-recupero) | 🤖 [Modelli](#-modelli) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Se questo plugin ti è stato utile, offrimi un caffè♥️ o lascia una stella🌟↗
 
@@ -26,6 +26,7 @@
 - [🎯 Fa per me?](#-fa-per-me)
 - [🚀 Avvio rapido](#-avvio-rapido)
 - [✨ Funzionalità](#-funzionalità)
+- [🌐 Ecosistema](#-ecosistema)
 - [🔍 Come funziona il recupero](#-come-funziona-il-recupero)
 - [🤖 Modelli](#-modelli)
 - [❓ FAQ](#-faq)
@@ -253,6 +254,20 @@ Questo plugin alimenta l'LLM con il contesto completo del tuo Wiki per ogni quer
 - **ChatGPT Plan (Codex OAuth)** — provider sperimentale e distinto che usa un'idoneità Codex idonea dopo l'accesso via browser o codice dispositivo; la disponibilità segue le politiche di autenticazione e idoneità di OpenAI Codex, non il nome del piano. Compatibilità Codex di terze parti, non una partnership OpenAI o un'API ChatGPT generale.
 
 > 📖 **Tabella di scelta completa** (cloud + locale + OCR PDF + Codex OAuth + quantizzazione + livelli hardware) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+---
+
+## 🌐 Ecosistema
+
+Il plugin si compone con il resto del tuo stack Obsidian — ciascuno degli strumenti seguenti si integra nel grafo `[[wiki-link]]` senza modifiche al codice.
+
+- **🕸️ Obsidian Graph View** — apri la vista grafo nativa su qualsiasi pagina wiki; ogni `[[wiki-link]]` diventa un nodo, ogni backlink un arco. Integrato, dimensione del bundle aggiuntiva pari a zero.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — estensione ufficiale del browser. Salva pagine web (articoli, post di blog, thread di Reddit, Hacker News, ricette, articoli di ricerca, trascrizioni YouTube tramite Interpreter) in una qualsiasi cartella del tuo vault, poi esegui il comando «Ingerisci dalla cartella» del plugin per estrarre in batch entità e concetti.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — interroga il wiki come un database con DQL (`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) o l'API JS. Il plugin scrive frontmatter standard (`tags:`, `type:`, `aliases:`) su ogni pagina, quindi le query Dataview funzionano senza configurazione.
+- **🌿 Git** — versiona il tuo vault (con qualsiasi client Git). Il plugin non riscrive mai i tuoi file sorgente; crea solo nuove pagine sotto `wiki/`, quindi `git diff` separa chiaramente le tue modifiche dal contenuto generato dal LLM.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — trasforma qualsiasi nota di Obsidian in presentazioni di diapositive tramite il frontmatter Marp (`marp: true`). Le pagine wiki sono Markdown puro, vengono rese come diapositive senza conversione aggiuntiva.
+- **🖼️ Canvas** — tela nativa infinita di Obsidian. Disponi schede wiki su un canvas per assemblare guide di studio, mappe mentali o sintesi di ricerca a partire da `[[wiki-links]]` senza lasciare il vault.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — plugin complementare per la cattura locale di memo vocali e riunioni (whisper.cpp su macOS; l'audio non lascia mai la macchina). Genera trascrizioni etichettate per parlante e le proprie pagine wiki hub. Indipendente da questo plugin — entrambi possono condividere lo stesso vault senza accoppiamento.
 
 ---
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -14,7 +14,7 @@
 
 [公式サイト](https://llmwiki.greenerai.top/) | [Obsidianマーケットプレース](https://community.obsidian.md/plugins/karpathywiki) | [ブログ](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-🚀 [クイックスタート](#-クイックスタート) • ✨ [特徴](#-特徴) • 🔍 [検索の仕組み](#-検索の仕組み) • 🤖 [モデル](#-モデル) • ❓ [FAQ](#-faq)
+🤔 [なぜこのプラグインなのか？](#-なぜこのプラグインなのか) | 🚀 [クイックスタート](#-クイックスタート) | ✨ [特徴](#-特徴) | 🌐 [エコシステム](#-エコシステム) | 🔍 [検索の仕組み](#-検索の仕組み) | 🤖 [モデル](#-モデル) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← このプラグインが役に立ったら、コーヒー一杯♥️を奢ってくれたら嬉しいです、またはスター🌟を付けてね↗
 
@@ -26,6 +26,7 @@
 - [こんな方に](#-こんな方に)
 - [クイックスタート](#-クイックスタート)
 - [特徴](#-特徴)
+- [エコシステム](#-エコシステム)
 - [検索の仕組み](#-検索の仕組み)
 - [モデル](#-モデル)
 - [FAQ](#-faq)
@@ -253,6 +254,20 @@ Monte Carlo PPR（Fogaras 2005）を使用 — 3,000ランダムウォーク×50
 - **ChatGPT Plan（Codex OAuth）** — 実験的かつ独立したプロバイダー。ブラウザまたはデバイスコードサインイン後、対象となるCodex利用枠を使用。提供状況はOpenAI Codexの認証・モデル・利用枠ポリシーに従い、プラン名だけで利用を保証するものではありません。OpenAIとのパートナーシップや汎用ChatGPT APIではなく、サードパーティのCodex互換機能です。
 
 > 📖 **完全な選択肢テーブル**（クラウド＋ローカル＋PDF OCR＋Codex OAuth＋量子化＋ハードウェア階層）→ [docs/MODEL-GUIDE.md](MODEL-GUIDE.md)
+
+---
+
+## 🌐 エコシステム
+
+このプラグインはObsidianの他のツールと組み合わせ可能——以下のツールはすべてコード変更なしで `[[wiki-link]]` グラフに統合できます。
+
+- **🕸️ Obsidian Graph View** — 任意のWikiページでネイティブグラフを開けます。すべての `[[wiki-link]]` がノードに、すべてのバックリンクがエッジになります。標準搭載、追加のバンドルサイズゼロ。
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — 公式ブラウザ拡張機能。記事、ブログ投稿、Redditスレッド、Hacker News、レシピ、研究論文、YouTube字幕（Interpreter経由）をvault内の任意のフォルダに保存し、プラグインの「フォルダから取り込み」コマンドを実行してエンティティとコンセプトを一括抽出できます。
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — DQL（`LIST FROM "wiki/entities" WHERE contains(tags, "person")`）またはJS APIでWikiをデータベースのようにクエリ可能。プラグインは全ページに標準frontmatter（`tags:`、`type:`、`aliases:`）を書き込むため、Dataviewクエリはそのまま動作します。
+- **🌿 Git** — 任意のGitクライアントでvaultをバージョン管理。プラグインはソースファイルを書き換えず、`wiki/` 配下にのみ新規ページを作成するため、`git diff` で手動編集とLLM生成コンテンツを明確に区別できます。
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — Marp frontmatter（`marp: true`）で任意のObsidianノートをスライドに変換。Wikiページは純粋なMarkdownのため、追加変換なしでスライドとしてレンダリングされます。
+- **🖼️ Canvas** — Obsidian標準の無限キャンバス。WikiカードをCanvasに配置すれば、vaultから出ずに学習ガイド・マインドマップ・研究概要を `[[wiki-links]]` で組み立てられます。
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — ローカル音声メモ＋会議キャプチャ（macOSでwhisper.cpp使用、音声は端末から出ない）のコンパニオンプラグイン。話者ラベル付き文字起こしと独自のwikiハブページを生成。本プラグインとは独立しており、同じvaultを共有しても結合は不要です。
 
 ---
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -14,7 +14,7 @@
 
 [공식 사이트](https://llmwiki.greenerai.top/) | [옵시디언 마켓플레이스](https://community.obsidian.md/plugins/karpathywiki) | [블로그](https://llmwiki.greenerai.top/blog/) | [Discussions](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [목차](#-목차) • 🚀 [빠른 시작](#-빠른-시작) • ✨ [주요 기능](#-주요-기능) • 🔍 [검색 작동 방식](#-검색-작동-방식) • 🤖 [모델](#-모델) • ❓ [FAQ](#-faq)
+🤔 [이 플러그인이 필요한 이유?](#-이-플러그인이-필요한-이유) | 🚀 [빠른 시작](#-빠른-시작) | ✨ [주요 기능](#-주요-기능) | 🌐 [생태계](#-생태계) | 🔍 [검색 작동 방식](#-검색-작동-방식) | 🤖 [모델](#-모델) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 이 플러그인이 도움이 되었다면, 커피 한 잔♥️ 사주시거나 별표🌟 하나 부탁드려요↗
 
@@ -26,6 +26,7 @@
 - [🎯 이런 분들께 추천합니다](#-이런-분들께-추천합니다)
 - [🚀 빠른 시작](#-빠른-시작)
 - [✨ 주요 기능](#-주요-기능)
+- [🌐 생태계](#-생태계)
 - [🔍 검색 작동 방식](#-검색-작동-방식)
 - [🤖 모델](#-모델)
 - [❓ FAQ](#-faq)
@@ -253,6 +254,20 @@ Monte Carlo PPR (Fogaras 2005)을 사용합니다 — 3,000개의 랜덤 워크 
 - **ChatGPT Plan (Codex OAuth)** — 실험적, 별도 공급자로 브라우저 또는 기기 코드 로그인 후 적격 Codex 사용 한도를 사용합니다. 사용 가능 여부는 OpenAI Codex 인증 및 사용 한도 정책을 따르며, 플랜 이름으로 보장되지 않습니다. 서드파티 Codex 호환 기능이며, OpenAI 파트너십이나 범용 ChatGPT API가 아닙니다.
 
 > 📖 **전체 선택 표** (클라우드 + 로컬 + PDF OCR + Codex OAuth + 양자화 + 하드웨어 계층) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+---
+
+## 🌐 생태계
+
+이 플러그인은 Obsidian의 다른 도구들과 함께 작동합니다 — 아래 도구들은 모두 코드 변경 없이 `[[wiki-link]]` 그래프와 연동됩니다.
+
+- **🕸️ Obsidian Graph View** — 모든 Wiki 페이지에서 네이티브 그래프를 열 수 있습니다. 모든 `[[wiki-link]]` 가 노드가 되고, 모든 역방향 링크가 엣지가 됩니다. 기본 내장, 추가 번들 크기 0.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — 공식 브라우저 확장. 기사, 블로그 게시물, Reddit 스레드, Hacker News, 레시피, 연구 논문, YouTube 자막(Interpreter 경유)을 vault 내 임의 폴더에 저장한 다음, 플러그인의 「폴더에서 수집」 명령을 실행하여 엔티티와 개념을 일괄 추출합니다.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — DQL(`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) 또는 JS API로 Wiki를 데이터베이스처럼 쿼리할 수 있습니다. 플러그인은 모든 페이지에 표준 frontmatter(`tags:`, `type:`, `aliases:`)를 작성하므로 Dataview 쿼리는 별도 설정 없이 바로 작동합니다.
+- **🌿 Git** — 어떤 Git 클라이언트로든 vault를 버전 관리하세요. 플러그인은 원본 파일을 절대 다시 작성하지 않으며, `wiki/` 아래에 새 페이지만 생성합니다. 따라서 `git diff` 로 수동 편집과 LLM 생성 콘텐츠를 명확히 구분할 수 있습니다.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — Marp frontmatter(`marp: true`)로 임의의 Obsidian 노트를 슬라이드로 변환합니다. Wiki 페이지는 순수 Markdown이므로 추가 변환 없이 슬라이드로 렌더링됩니다.
+- **🖼️ Canvas** — Obsidian의 기본 무한 캔버스. Wiki 카드를 Canvas에 배치하여 vault를 벗어나지 않고 학습 가이드, 마인드 맵, 연구 개요를 `[[wiki-links]]` 로 조립할 수 있습니다.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — 로컬 음성 메모 및 회의 캡처(macOS에서 whisper.cpp 사용, 오디오는 기기를 떠나지 않음) 동반 플러그인. 화자 라벨이 붙은 전사 파일과 자체 wiki 허브 페이지를 생성합니다. 본 플러그인과는 독립적이며, 같은 vault를 공유해도 결합이 필요 없습니다.
 
 ---
 

--- a/docs/README_PT.md
+++ b/docs/README_PT.md
@@ -14,7 +14,7 @@
 
 [Site oficial](https://llmwiki.greenerai.top/) | [Mercado Obsidian](https://community.obsidian.md/plugins/karpathywiki) | [Blog](https://llmwiki.greenerai.top/blog/) | [Discussões](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [Conteúdo](#-conteúdo) • 🚀 [Início rápido](#-início-rápido) • ✨ [Funcionalidades](#-funcionalidades) • 🔍 [Como funciona a recuperação](#-como-funciona-a-recuperação) • 🤖 [Modelos](#-modelos) • ❓ [FAQ](#-faq)
+🤔 [Por que este plugin?](#-por-que-este-plugin) | 🚀 [Início rápido](#-início-rápido) | ✨ [Funcionalidades](#-funcionalidades) | 🌐 [Ecossistema](#-ecossistema) | 🔍 [Como funciona a recuperação](#-como-funciona-a-recuperação) | 🤖 [Modelos](#-modelos) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← Se este plugin te ajudou, sinta-se à vontade para me pagar um café♥️ ou deixar uma estrela🌟↗
 
@@ -26,6 +26,7 @@
 - [É para mim?](#-é-para-mim)
 - [Início rápido](#-início-rápido)
 - [Funcionalidades](#-funcionalidades)
+- [Ecossistema](#-ecossistema)
 - [Como funciona a recuperação](#-como-funciona-a-recuperação)
 - [Modelos](#-modelos)
 - [FAQ](#-faq)
@@ -253,6 +254,18 @@ Este plugin alimenta o LLM com o contexto completo da sua Wiki por consulta — 
 - **ChatGPT Plan (Codex OAuth)** — experimental, provedor distinto que usa franquia Codex elegível após login por navegador ou código de dispositivo; a disponibilidade segue as políticas de autenticação e franquia da OpenAI Codex, não o nome do plano. Compatibilidade de terceiros com Codex, não uma parceria com a OpenAI ou uma API geral do ChatGPT.
 
 > 📖 **Tabela de escolha completa** (cloud + local + PDF OCR + Codex OAuth + quantização + tiers de hardware) → [docs/MODEL-GUIDE.md](./MODEL-GUIDE.md)
+
+## 🌐 Ecossistema
+
+O plugin compõe-se com o restante do seu stack Obsidian — cada ferramenta abaixo conecta-se ao grafo `[[wiki-link]]` sem alterações de código.
+
+- **🕸️ Obsidian Graph View** — abra a vista de grafo nativa em qualquer página wiki; cada `[[wiki-link]]` torna-se um nó, cada backlink uma aresta. Integrado, zero tamanho extra no bundle.
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** — extensão oficial do navegador. Guarde páginas web (artigos, publicações de blog, tópicos do Reddit, Hacker News, receitas, artigos de pesquisa, transcrições do YouTube via Interpreter) em qualquer pasta do seu vault e, em seguida, execute o comando «Ingerir da pasta» do plugin para extrair entidades e conceitos em lote.
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** — consulte o wiki como uma base de dados com DQL (`LIST FROM "wiki/entities" WHERE contains(tags, "person")`) ou a API JS. O plugin escreve frontmatter padrão (`tags:`, `type:`, `aliases:`) em cada página, por isso as consultas Dataview funcionam sem configuração adicional.
+- **🌿 Git** — versione o seu vault (com qualquer cliente Git). O plugin nunca reescreve os seus ficheiros fonte; apenas cria novas páginas sob `wiki/`, por isso `git diff` separa claramente as suas edições do conteúdo gerado pelo LLM.
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** — converta qualquer nota do Obsidian em conjuntos de slides através do frontmatter Marp (`marp: true`). As páginas wiki são Markdown puro, são renderizadas como slides sem conversão adicional.
+- **🖼️ Canvas** — tela infinita nativa do Obsidian. Coloque cartões wiki num canvas para montar guias de estudo, mapas mentais ou sínteses de investigação a partir de `[[wiki-links]]` sem sair do vault.
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** — plugin companheiro para captura local de notas de voz e reuniões (whisper.cpp no macOS; o áudio nunca sai da máquina). Gera transcrições com etiqueta de orador e as suas próprias páginas wiki hub. Independente deste plugin — ambos podem partilhar o mesmo vault sem acoplamento.
 
 ## ❓ FAQ
 

--- a/docs/README_ZH-Hant.md
+++ b/docs/README_ZH-Hant.md
@@ -14,7 +14,7 @@
 
 [官網](https://llmwiki.greenerai.top/) | [Obsidian 插件市集](https://community.obsidian.md/plugins/karpathywiki) | [部落格](https://llmwiki.greenerai.top/zh/blog/) | [討論區](https://github.com/green-dalii/obsidian-llm-wiki/discussions)
 
-📑 [目錄](#-目錄) • 🚀 [快速開始](#-快速開始) • ✨ [核心特性](#-核心特性) • 🔍 [檢索原理](#-檢索原理) • 🤖 [模型](#-模型) • ❓ [FAQ](#-faq)
+🤔 [爲什麼選擇這個外掛？](#-爲什麼選擇這個外掛) | 🚀 [快速開始](#-快速開始) | ✨ [核心特性](#-核心特性) | 🌐 [生態](#-生態) | 🔍 [檢索原理](#-檢索原理) | 🤖 [模型](#-模型) | ❓ [FAQ](#-faq)
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/H7V1228WMD) ← 如果你覺得這個專案幫到你，歡迎請我喝杯咖啡♥️，或為專案點亮一顆星🌟↗
 
@@ -26,6 +26,7 @@
 - [🎯 適合我嗎？](#-適合我嗎)
 - [🚀 快速開始](#-快速開始)
 - [✨ 核心特性](#-核心特性)
+- [🌐 生態](#-生態)
 - [🔍 檢索原理](#-檢索原理)
 - [🤖 模型](#-模型)
 - [❓ 常見問題 (FAQ)](#-常見問題-faq)
@@ -253,6 +254,20 @@
 - **ChatGPT Plan (Codex OAuth)**——實驗性的獨立 Provider，在瀏覽器或裝置代碼登入後使用符合資格的 Codex 方案額度；可用性取決於 OpenAI Codex 的驗證和額度政策，而非僅憑方案名稱。這是第三方 Codex 相容功能，並非 OpenAI 合作項目或通用 ChatGPT API。
 
 > 📖 **完整選擇表**（雲端 + 本地 + PDF OCR + Codex OAuth + 量化 + 硬體分級）→ [docs/MODEL-GUIDE.md](MODEL-GUIDE.md)
+
+---
+
+## 🌐 生態
+
+本外掛與你的其他 Obsidian 工具無縫協作——以下工具皆可直接接入 `[[wiki-link]]` 圖譜，無需任何程式碼改動。
+
+- **🕸️ Obsidian 原生關係圖譜** —— 在任何 Wiki 頁面開啟原生圖譜視圖；每個 `[[wiki-link]]` 成為節點，每條反向連結成為邊。內建功能，零額外體積。
+- **✂️ [Obsidian Web Clipper](https://obsidian.md/clipper)** —— 官方瀏覽器擴充功能。將網頁（文章、部落格文章、Reddit 串文、Hacker News、食譜、研究論文、YouTube 字幕（透過 Interpreter 取得））儲存到 vault 內任一資料夾，然後執行外掛的「從資料夾攝入」指令以批次萃取實體與概念。
+- **📊 [Dataview](https://github.com/blacksmithgu/obsidian-dataview)** —— 使用 DQL（`LIST FROM "wiki/entities" WHERE contains(tags, "person")`）或 JS API 像查詢資料庫一樣檢索 Wiki。外掛會在每個頁面寫入標準 frontmatter（`tags:`、`type:`、`aliases:`），Dataview 查詢開箱即可使用。
+- **🌿 Git** —— 用任何 Git 客戶端對 vault 進行版本控制。外掛絕不重寫來源檔案，僅在 `wiki/` 下建立新頁面，因此 `git diff` 能清晰區分你的手動編輯與 LLM 生成內容。
+- **🎞️ [Marp Slides](https://github.com/samuele-cozzi/obsidian-marp)** —— 透過 Marp frontmatter（`marp: true`）將任何 Obsidian 筆記轉為投影片。Wiki 頁面為純 Markdown，無需額外轉換即可直接渲染為投影片。
+- **🖼️ Canvas** —— Obsidian 原生無限畫布。把 Wiki 卡片拖到 Canvas 上，無需離開 vault 即可拼裝學習指南、心智圖或研究概覽，所有內容均透過 `[[wiki-links]]` 互聯。
+- **🎤 [Obsidian Nous](https://github.com/AndyMDH/obsidian-nous)** —— 本地語音備忘錄與會議錄製（macOS 上使用 whisper.cpp，音訊資料不出本機）的配套外掛。產生帶說話者標記的轉錄檔案與自有 wiki 中心頁面。與本外掛相互獨立——可在同一 vault 共存而無需耦合。
 
 ---
 


### PR DESCRIPTION
## Summary

Consolidated doc-only update (no code changes) aligning CLAUDE.md, ROADMAP.md, and all 10 READMEs to the v1.25.10 PATCH 10-item scope locked on 2026-07-28.

## Changes

### CLAUDE.md
- Last Updated: 2026-07-27 → 2026-07-28
- Current Phase: v1.25.10 PATCH scope expanded 5 → 10 items
- DocTpoint collaborator role correction (personal repo role API incident lessons: Write role includes triage+push; branch protection on main enforces no-push)
- F3 attribution correction: #285 + #328 = green-dalii, not DocTpoint

### ROADMAP.md
- Updated: 2026-07-27 → 2026-07-28
- v1.25.10 PATCH scope expanded 5 → 10 items (locked 5 + DocTpoint batch #363/#364 + Guru35 batch #366/#367/#368)
- Expected impact table for the 10-item scope
- Lint-perf companion items moved from 'deferred' to 'folded into v1.25.10'

### All 10 READMEs (EN + CN/ZH-Hant/JA/KO/DE/FR/ES/PT/IT)
- New \`## 🌐 Ecosystem\` H2 section between Features and How retrieval works
- Navigation bar: first link changed from Contents/目录/目次 to Why this plugin?; separator unified from \` • \` to \` | \`
- Ecosystem entry lists 7 tools that compose with the [[wiki-link]] graph: Obsidian Graph View, Web Clipper, Dataview, Git, Marp Slides, Canvas, Nous

## Test plan

Doc-only PR. No code paths changed. No tests to run.

Reviewers can verify:
- All 10 READMEs have the new H2 section between Features and How retrieval works
- Navigation bar format unified (🤔 ... | 🚀 ... | ✨ ... | 🌐 ... | 🔍 ... | 🤖 ... | ❓ ...)
- CLAUDE.md / ROADMAP.md reflect v1.25.10 PATCH 10-item scope
- Ecosystem descriptions match actual plugin behavior (no "sources/" input folder misconception)