### PR TITLE
fix(ingest): scope folder ingest on the folder boundary (#364)

### DIFF
--- a/src/__tests__/core/folder-scope.test.ts
+++ b/src/__tests__/core/folder-scope.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { folderScopePrefix, isInFolderScope } from '../../core/folder-scope';
+
+describe('folderScopePrefix', () => {
+  it('anchors a folder path on a trailing slash', () => {
+    expect(folderScopePrefix('Notizen', false)).toBe('Notizen/');
+    expect(folderScopePrefix('a/b', false)).toBe('a/b/');
+  });
+
+  it('returns an empty prefix for the vault root', () => {
+    expect(folderScopePrefix('/', true)).toBe('');
+    expect(folderScopePrefix('', true)).toBe('');
+  });
+
+  it('does not double the separator on an already-trailing slash', () => {
+    expect(folderScopePrefix('Notizen/', false)).toBe('Notizen/');
+    expect(folderScopePrefix('Notizen//', false)).toBe('Notizen/');
+  });
+
+  it('treats an empty non-root path as unscoped rather than emitting a bare slash', () => {
+    expect(folderScopePrefix('', false)).toBe('');
+  });
+});
+
+describe('isInFolderScope', () => {
+  it('matches true descendants at any depth', () => {
+    expect(isInFolderScope('Notizen/a.md', 'Notizen', false)).toBe(true);
+    expect(isInFolderScope('Notizen/sub/deep/a.md', 'Notizen', false)).toBe(true);
+  });
+
+  // Issue #364, the reported case.
+  it('does not match a sibling folder sharing a name prefix', () => {
+    expect(isInFolderScope('Notizen-temp/a.md', 'Notizen', false)).toBe(false);
+    expect(isInFolderScope('Notizen2/a.md', 'Notizen', false)).toBe(false);
+  });
+
+  // Same root cause, second symptom: an unanchored prefix also swallows a
+  // file that merely starts with the folder's name.
+  it('does not match a file sitting beside the folder', () => {
+    expect(isInFolderScope('Notizen.md', 'Notizen', false)).toBe(false);
+  });
+
+  it('does not match the folder itself', () => {
+    expect(isInFolderScope('Notizen', 'Notizen', false)).toBe(false);
+  });
+
+  it('scopes nested folders without leaking into name-prefixed neighbours', () => {
+    expect(isInFolderScope('a/b/x.md', 'a/b', false)).toBe(true);
+    expect(isInFolderScope('a/bc/x.md', 'a/b', false)).toBe(false);
+  });
+
+  it('accepts every path at the vault root', () => {
+    expect(isInFolderScope('a.md', '/', true)).toBe(true);
+    expect(isInFolderScope('deep/nested/a.md', '/', true)).toBe(true);
+  });
+
+  it('is unaffected by the folder name appearing later in the path', () => {
+    expect(isInFolderScope('Archiv/Notizen/a.md', 'Notizen', false)).toBe(false);
+  });
+});

--- a/src/core/folder-scope.ts
+++ b/src/core/folder-scope.ts
@@ -1,0 +1,39 @@
+// Issue #364 — folder-boundary scoping for "ingest a folder".
+//
+// A bare `path.startsWith(folder.path)` treats a folder path as a plain string
+// prefix, which is not the same as "is a descendant of this folder". Two things
+// leak through:
+//
+//   * sibling folders sharing a name prefix — picking "Notizen" also matches
+//     "Notizen-temp/x.md", because "Notizen-temp/x.md".startsWith("Notizen")
+//   * a file sitting next to the folder — "Notizen.md" also matches "Notizen"
+//
+// Anchoring on a trailing slash makes the comparison mean what the caller
+// intends. The vault root is the one folder with no prefix: every path is a
+// descendant of it, and its own `path` is "/" rather than "".
+//
+// Pure and IO-free so the boundary rule can be unit-tested without an Obsidian
+// vault — the call site only supplies two primitives.
+
+/**
+ * The string prefix every descendant of a folder shares.
+ * Returns '' for the vault root, so `startsWith` accepts every path.
+ */
+export function folderScopePrefix(folderPath: string, isRoot: boolean): string {
+  if (isRoot) return '';
+  const trimmed = folderPath.replace(/\/+$/, '');
+  if (trimmed.length === 0) return '';
+  return `${trimmed}/`;
+}
+
+/**
+ * True when `filePath` names a file inside the given folder, at any depth.
+ * A folder is not a descendant of itself.
+ */
+export function isInFolderScope(
+  filePath: string,
+  folderPath: string,
+  isRoot: boolean
+): boolean {
+  return filePath.startsWith(folderScopePrefix(folderPath, isRoot));
+}

--- a/src/main-commands/ingest-commands.ts
+++ b/src/main-commands/ingest-commands.ts
@@ -24,6 +24,7 @@ import type { BatchProgress } from '../core/status-bar';
 import { TEXTS } from '../texts';
 import { getText } from '../core/i18n';
 import { slugify } from '../core/slug';
+import { isInFolderScope } from '../core/folder-scope';
 import { parseFrontmatter } from '../core/frontmatter';
 import { COMPATIBLE_SOURCE_EXTENSIONS, NOTICE_NORMAL, NOTICE_ERROR } from '../constants';
 import { FileSuggestModal, FolderSuggestModal, MultiFileSuggestModal, IngestReportModal } from '../ui/modals';
@@ -132,8 +133,11 @@ export const ingestCommands = {
 
     new FolderSuggestModal(this.app, this.settings.wikiFolder, (folder) => {
       const allowedExts: readonly string[] = COMPATIBLE_SOURCE_EXTENSIONS;
+      // Issue #364: scope on the folder boundary, not on a bare string prefix.
+      // See core/folder-scope.ts for the two cases a bare startsWith leaks.
       const files = this.app.vault.getFiles()
-        .filter(f => f.path.startsWith(folder.path) && allowedExts.includes(f.extension.toLowerCase()));
+        .filter(f => isInFolderScope(f.path, folder.path, folder.isRoot())
+          && allowedExts.includes(f.extension.toLowerCase()));
 
       if (files.length === 0) {
         const msg = TEXTS[this.settings.language].selectFolderNoMdFiles.replace('{path}', folder.path);


### PR DESCRIPTION
## Problem

`selectFolderToIngest` filtered candidates with `f.path.startsWith(folder.path)`. That is a string-prefix test, not a descendant test, and two things leak through it:

| Picked folder | Also swept in | Why |
|---|---|---|
| `Notizen` | `Notizen-temp/x.md` | sibling folder sharing a name prefix |
| `Notizen` | `Notizen.md` | a file sitting beside the folder |

The first is the reported case. The second falls out of the same root cause and is fixed by the same change.

## Change

Anchor the comparison on a trailing slash. The vault root keeps an empty prefix, so every path remains a descendant of it.

The rule lives in `src/core/folder-scope.ts` as a pure, IO-free helper rather than inline at the call site, because `selectFolderToIngest` opens a modal and cannot be unit-tested without an Obsidian vault. The helper takes two primitives, so the boundary cases are testable directly. This mirrors the shape used elsewhere in `core/` for decision rules.

## Tests

11 new tests in `src/__tests__/core/folder-scope.test.ts` — 4 on the prefix derivation, 7 on the predicate.

**Mutation-checked rather than only green:** removing the anchoring fails exactly 6 of them — both prefix cases, sibling folder, neighbouring file, the folder itself, and nested name-prefixed neighbours. The 5 controls stay green: root handling, true descendants at depth, empty path, and the folder name appearing later in a path.

## Related call sites — deliberately not in this PR

The same unanchored comparison appears in seven other places. I am not touching them here, because this is a PATCH cycle and they split into two different failure directions that deserve their own issue:

| Site | Direction | Consequence with `wikiFolder: "wiki"` |
|---|---|---|
| `wiki/lint/delete-empty-stubs.ts:10` | over-include | a vault folder `wiki-archive` enters the **stub deleter** |
| `wiki/lint/get-existing-pages.ts:12` | over-include | counted as wiki pages |
| `wiki/lint/phases/preparation.ts:23` | over-include | counted as wiki pages |
| `schema/auto-maintain.ts:407` | over-include | scanned by Phase 2 quick-fixes |
| `core/orphan-matcher.ts:81` | over-include | treated as a wiki path |
| `ui/modals/suggest-modals.ts:29` | over-exclude | user's `wiki-archive` notes vanish from the ingest picker |
| `ui/modals/MultiFileSuggestModal-class.ts:101` | over-exclude | same, multi-file picker |

Four other sites already anchor correctly (`ensure-welcome-note.ts:179`, `prompt-builders.ts:126`, `auto-maintain.ts:550`, `lint/scanners.ts:268`), so the codebase is inconsistent rather than uniformly wrong. Happy to open that as a separate issue if you want it tracked.

## Gate

Baseline counted on `2d26620` itself, with `pnpm build` before `pnpm test`.

| | baseline | this branch |
|---|---|---|
| `tsc --noEmit` | 0 | 0 |
| `pnpm lint --max-warnings=0` | 0 | 0 |
| `pnpm css-lint` | 0 | 0 |
| `pnpm build` | clean | clean |
| `pnpm test` | 2629 / 197 | 2640 / 198 |

+11 tests / +1 file — exactly the new ones.

Closes #364.
