### PR TITLE
fix(mentions): tolerate an empty or absent citation target (#363)

### DIFF
--- a/src/__tests__/core/mentions-formatter-roundtrip.test.ts
+++ b/src/__tests__/core/mentions-formatter-roundtrip.test.ts
@@ -301,3 +301,117 @@ describe('#289 — legacy grouped-blockquote Mentions sections', () => {
     ]);
   });
 });
+
+// ─── #363: citation with no resolvable target ────────────────────────────
+//
+// An empty wikilink `[[|]]` reached pages through `formatMentionsSection`
+// taking a blank `source_path` straight from the model. It reads as cosmetic
+// and is not: `BULLET_RE` required a non-empty target, so the line failed to
+// parse, `computeReingestMentions` returned `preserveRaw`, the #267 fail-safe
+// fired, and the page stopped accumulating quotes on every later ingest.
+// Measured on a 417-note corpus (9272 writes): 119 frozen pages, 104 of the
+// 144 unparseable lines were empty backlinks.
+//
+// The two halves below are one fix, not two: the formatter stops writing an
+// empty target (it emits the quote without a citation), and the parser accepts
+// both that shape and the `[[|]]` already sitting in vaults. Shipping only the
+// formatter half would trade one unparseable shape for another.
+
+describe('#363 — empty and absent citations', () => {
+  const frozen = [
+    `## ${LABEL}`,
+    '',
+    '- "ein eingefrorener Beleg" — [[|]]',
+    '- "mit Übersetzung" (with translation) — [[|]]',
+  ].join('\n');
+
+  it('parses a bullet whose citation target is empty', () => {
+    const r = parseMentionsSection(frozen, LABEL);
+    expect(r.found).toBe(true);
+    expect(r.fullyParsed).toBe(true); // the fail-safe no longer fires
+    expect(r.mentions.map(m => m.quote)).toEqual(['ein eingefrorener Beleg', 'mit Übersetzung']);
+    expect(r.mentions.map(m => m.source_path)).toEqual(['', '']);
+    expect(r.mentions[1].translation).toBe('with translation');
+  });
+
+  it('parses a bullet that carries no citation at all', () => {
+    const body = [`## ${LABEL}`, '', '- "a quote with no source"'].join('\n');
+    const r = parseMentionsSection(body, LABEL);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions).toEqual([mention({ quote: 'a quote with no source', source_path: '' })]);
+  });
+
+  it('[control] a real target is still required to be recovered verbatim', () => {
+    const r = parseMentionsSection([`## ${LABEL}`, '', '- "q" — [[notes/A|A]]'].join('\n'), LABEL);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions[0].source_path).toBe('notes/A');
+  });
+
+  it('[control] genuinely unstructurable lines still fail safe', () => {
+    const body = [
+      `## ${LABEL}`,
+      '',
+      '- "a real quote" — [[|]]',
+      '- a freehand note that is not a quote at all',
+    ].join('\n');
+    const r = parseMentionsSection(body, LABEL);
+    expect(r.fullyParsed).toBe(false);
+    expect(r.raw).toContain('freehand note');
+  });
+
+  it('the formatter emits no wikilink when the source path is blank', () => {
+    const section = formatMentionsSection([mention({ quote: 'q', source_path: '' })], '', LABEL);
+    expect(section).toContain('- "q"');
+    expect(section).not.toContain('[[');
+  });
+
+  it('the formatter emits no wikilink in conversation mode without a path', () => {
+    const section = formatMentionsSection([], '', LABEL, {
+      conversationMode: true,
+      conversationLabel: 'Conversation: X',
+    });
+    expect(section).toContain('- (Conversation: X)');
+    expect(section).not.toContain('[[');
+  });
+
+  it('a citation-less bullet round-trips through the parser', () => {
+    const section = formatMentionsSection([mention({ quote: 'orphan', source_path: '' })], '', LABEL);
+    const r = parseMentionsSection(section, LABEL);
+    expect(r.fullyParsed).toBe(true);
+    expect(r.mentions).toEqual([mention({ quote: 'orphan', source_path: '' })]);
+  });
+
+  it('fills a blank source from the source being merged, and keeps it blank without one', () => {
+    const withDefault = computeReingestMentions(frozen, [], LABEL, 'sources/Aktuell.md');
+    expect(withDefault.preserveRaw).toBeNull();
+    expect(withDefault.mentions.map(m => m.source_path)).toEqual(['sources/Aktuell', 'sources/Aktuell']);
+
+    const withoutDefault = computeReingestMentions(frozen, [], LABEL);
+    expect(withoutDefault.preserveRaw).toBeNull();
+    expect(withoutDefault.mentions.map(m => m.source_path)).toEqual(['', '']);
+  });
+
+  it('[invariance] a frozen page merging a new source keeps its quotes AND heals the links', () => {
+    const existingBody = ['# Klotho', '', '## Summary', 'A frozen page.', '', frozen].join('\n');
+    const { mentions: unioned, preserveRaw } = computeReingestMentions(
+      existingBody,
+      [mention({ quote: 'neuer Beleg', source_path: 'sources/Neu.md' })],
+      LABEL,
+      'sources/Aktuell.md',
+    );
+    expect(preserveRaw).toBeNull();
+
+    const merged = injectMentionsSection(existingBody, unioned, 'sources/Aktuell.md', { sectionLabel: LABEL });
+    expect(merged).toContain('ein eingefrorener Beleg');
+    expect(merged).toContain('mit Übersetzung');
+    expect(merged).toContain('neuer Beleg');
+    expect(merged).not.toContain('[[|]]');
+    expect((merged.match(/## Mentions in Source/g) || []).length).toBe(1);
+
+    // And the page is now in a shape that parses on its own — the freeze is
+    // gone for good, not just for this pass.
+    const reparsed = parseMentionsSection(merged, LABEL);
+    expect(reparsed.fullyParsed).toBe(true);
+    expect(reparsed.mentions).toHaveLength(3);
+  });
+});

--- a/src/core/mentions-formatter.ts
+++ b/src/core/mentions-formatter.ts
@@ -61,10 +61,10 @@ export function formatMentionsSection(
   // Issue #244 manual-test fix: conversation ingest does not extract verbatim
   // Mentions; the page-factory synthesizes one "from <conversation>" citation.
   if (options.conversationMode) {
-    const leftPath = sourcePath.replace(/\.md$/, '');
-    const displayName = leftPath.split('/').pop() || leftPath;
+    const leftPath = (sourcePath ?? '').replace(/\.md$/, '');
     const label = options.conversationLabel?.trim() || 'this conversation';
-    return [`## ${sectionLabel}`, '', `- (${label}) — [[${leftPath}|${displayName}]]`].join('\n');
+    // Same rule as the quote bullets: no path ⇒ no link, never `[[|]]` (#363).
+    return [`## ${sectionLabel}`, '', `- (${label})${renderCitation(leftPath)}`].join('\n');
   }
 
   if (!mentions || mentions.length === 0) return '';
@@ -106,6 +106,24 @@ export function formatMentionsSection(
 
 // ─── helpers ───────────────────────────────────────────────────────────
 
+/**
+ * Issue #363 — render the trailing citation, or nothing when there is no path.
+ *
+ * `[[|]]` is not a weak link, it is an unresolvable one: Obsidian collapses
+ * every occurrence into a single nameless graph node and refuses to open it.
+ * A blank path can arrive legitimately — the auto-provenance builder writes
+ * `source_path: ''` for the page-factory to fill at write time — so the
+ * formatter must be unable to express an empty target rather than trust every
+ * producer upstream of it to be non-blank. The quote is still emitted; the
+ * parser accepts the citation-less shape and the next merge fills the
+ * attribution back in from the source being ingested.
+ */
+function renderCitation(leftPath: string): string {
+  if (!leftPath) return '';
+  const displayName = leftPath.split('/').pop() || leftPath;
+  return ` — [[${leftPath}|${displayName}]]`;
+}
+
 function isStructured(m: unknown[]): boolean {
   return m.length > 0 && typeof m[0] === 'object' && m[0] !== null && 'quote' in m[0];
 }
@@ -142,23 +160,23 @@ function buildBullets(
   const bullets: string[] = [];
   let used = 0;
   for (const e of entries) {
-    const leftPath = e.sourcePath.replace(/\.md$/, '');
-    const displayName = leftPath.split('/').pop() || leftPath;
+    const leftPath = (e.sourcePath ?? '').replace(/\.md$/, '');
     // Half-width parentheses regardless of locale (per design decision).
     // Translation is rendered ONLY when present — single-language wikis skip it.
     const quotePart = e.translation?.trim()
       ? `"${e.quote}" (${e.translation})`
       : `"${e.quote}"`;
-    const line = `- ${quotePart} — [[${leftPath}|${displayName}]]`;
+    const citation = renderCitation(leftPath);
+    const line = `- ${quotePart}${citation}`;
     if (used + line.length + 1 > maxChars) {
       if (used === 0) {
         // First quote already exceeds budget — emit a truncated head.
-        const overhead = ` — [[${leftPath}|${displayName}]]`.length + 3;
+        const overhead = citation.length + 3;
         const head = Math.max(0, maxChars - overhead);
         const truncated = e.translation?.trim()
           ? `"${e.quote.substring(0, head)}..." (${e.translation})`
           : `"${e.quote.substring(0, head)}..."`;
-        bullets.push(`- ${truncated} — [[${leftPath}|${displayName}]]`);
+        bullets.push(`- ${truncated}${citation}`);
       }
       break;
     }

--- a/src/core/mentions-parser.ts
+++ b/src/core/mentions-parser.ts
@@ -94,7 +94,23 @@ function findSection(
 //   - "quote" (translation) — [[leftPath|display]]
 // Half-width parentheses, em-dash separator (U+2014). Anything that does not
 // match is treated as a hand-edit and flips `fullyParsed` to false.
-const BULLET_RE = /^-\s+"([\s\S]+)"(?:\s+\(([^)]*)\))?\s+—\s+\[\[([^\]|]+)\|[^\]]*\]\]\s*$/;
+//
+// Issue #363 — the citation is optional and its target may be empty:
+//   - "quote" — [[|]]   written by builds whose `formatMentionsSection` took a
+//                       blank `source_path` straight from the model
+//   - "quote"           what the formatter emits now when no source path is
+//                       known (an empty target is not representable, see
+//                       `mentions-formatter.ts`)
+// Requiring a non-empty target froze both shapes out of the parser: the line
+// failed, `computeReingestMentions` returned `preserveRaw`, the #267 fail-safe
+// fired, and the page never accumulated another quote — on every subsequent
+// ingest, not once. Both shapes now parse with an empty `source_path`, which
+// `computeReingestMentions` fills from `defaultSourcePath`, so the page repairs
+// itself the next time it merges. That attribution is an inference, not a
+// recovery: an empty target carries no source, so the quote is attributed to
+// the source being merged. It is the same rule the legacy shape already uses
+// for a quote under a group header, and strictly more than `[[|]]` conveyed.
+const BULLET_RE = /^-\s+"([\s\S]+)"(?:\s+\(([^)]*)\))?(?:\s+—\s+\[\[([^\]|]*)\|[^\]]*\]\])?\s*$/;
 
 // Issue #289 — the pre-#244 shape, grouped by source under a blockquote header:
 //   > **Source: [[sources/X|X]]**
@@ -168,7 +184,9 @@ export function parseMentionsSection(body: string, sectionLabel: string): Parsed
       mentions.push({
         quote,
         ...(translation && translation.trim() ? { translation: translation.trim() } : {}),
-        source_path: leftPath,
+        // Absent citation (group undefined) and empty target (`[[|]]`) are the
+        // same state: no source on the line. #363.
+        source_path: leftPath ?? '',
         source_slug: '',
         extracted_at: '',
       });


### PR DESCRIPTION
Closes the parser half of #363, as scoped in ROADMAP v1.25.10 ("DocTpoint contributes parser side"). The formatter one-liner on your side (`sourcePath: m.source_path || sourcePath`) is deliberately **not** in this PR.

### Why this is not cosmetic

`BULLET_RE` required a non-empty link target. A line ending in `— [[|]]` therefore fails to parse, `computeReingestMentions` returns `preserveRaw`, the #267 fail-safe fires, and the mentions merge for that page is skipped. Not once — on every later ingest. The page never accumulates another quote.

So repairing the producer stops new pages from being poisoned, but it does not release the pages that already carry a `[[|]]`. This PR makes the reader tolerant, which is how the other two failure shapes in this section were handled before: the garbled header (`canonicalizeSectionHeaders`, `c4e47ba`) and the legacy grouped blockquote (#289).

### The two halves are one fix

* **Formatter:** an empty target is no longer expressible. A blank `source_path` is a legitimate state — the auto-provenance builder writes `source_path: ''` for the page-factory to fill at write time — so the quote is emitted **without** a citation instead of with a link that points nowhere. Same rule applied in conversation mode.
* **Parser:** accepts both that citation-less shape and the `[[|]]` already sitting in vaults, recovering an empty `source_path`. `computeReingestMentions` fills it from `defaultSourcePath`, so the page repairs itself on its next merge.

Shipping only the formatter half would trade one unparseable shape for another: the citation-less bullet would itself fail `BULLET_RE` and freeze the page.

**One judgment call, stated plainly.** Filling the blank from the source being merged is an *inference*, not a recovery — an empty target carries no attribution, so the quote is attributed to the source currently ingesting. That is the same rule #289 already applies to a quote under a group header, and it is strictly more than `[[|]]` conveyed. If you would rather leave such quotes unattributed, the change is one line in `computeReingestMentions` and I will follow your call.

### Measured on my corpus, re-measured today

The 4.7 % (119/2586 pages) I reported in the thread came from the full-corpus run of 9272 writes. **On today's vault the same probe gives 23 frozen pages (0.9 %), of which this patch releases 22.** The difference is repair passes run since that measurement, not a correction to it — the two numbers measure different vault states.

The one page that stays frozen is a quote reflowed across two lines. That is a genuine hand-edit and the fail-safe should keep holding it.

| | pages |
|---|---|
| with a Mentions section | 2586 |
| frozen, current parser | 23 (0.9 %) |
| frozen, this PR | 1 |
| released | 22 |

Probe self-checked against six fixtures with known answers before the corpus numbers were taken.

### Gate

`tsc --noEmit` 0 · `lint --max-warnings=0` 0 · `css-lint` 0 · `build` clean · **tests 2638 / 197 files against a self-counted baseline of 2629 / 197 on `0c9b0b6` = +9, exactly the new ones** (`pnpm build` before `pnpm test`).

Mutation-checked, both halves separately: reverting the parser tolerance fails exactly 5 tests and leaves the 4 controls green; reverting the formatter guard fails exactly 2. Under the formatter mutation alone the round-trip test still passes — which is the interlock above, visible as a test result.

### Not in scope

The other line-level failure I reported in that thread — nested parentheses inside the gloss group, `\(([^)]*)\)` forbidding an inner paren — is untouched here. It no longer occurs anywhere in my current corpus, so I have no live measurement that would justify widening the regex in a PATCH. Happy to open a separate issue if you want it tracked.
