### PR TITLE
fix(scope): anchor the wikiFolder prefix checks (Closes #383)

### DIFF
--- a/src/__tests__/__support__/setup.ts
+++ b/src/__tests__/__support__/setup.ts
@@ -138,9 +138,15 @@ vi.mock('obsidian', () => ({
     loadData() { return Promise.resolve({}); }
     saveData() { return Promise.resolve(); }
   },
-  // Suggest modals (stubbed — used in settings.ts FolderSuggestModal)
+  // Suggest modals (stubbed — used in settings.ts FolderSuggestModal).
+  // The real FuzzySuggestModal takes the app in its constructor and exposes it
+  // as `this.app`; subclasses read `this.app.vault` in getItems(). The stub has
+  // to do the same or those methods cannot be exercised at all.
   FuzzySuggestModal: class {
-    constructor() {}
+    app: unknown;
+    constructor(app: unknown) {
+      this.app = app;
+    }
     open() {}
     close() {}
     onOpen() {}

--- a/src/__tests__/wiki/wiki-folder-boundary.test.ts
+++ b/src/__tests__/wiki/wiki-folder-boundary.test.ts
@@ -1,0 +1,289 @@
+// Issue #383 — regression tests for the unanchored `wikiFolder` prefix checks.
+//
+// `path.startsWith(wikiFolder)` is a string test, not a containment test. With
+// `wikiFolder: "wiki"` two kinds of foreign path pass it:
+//
+//   * a sibling folder sharing the name prefix — "wiki-archive/note.md"
+//   * a file sitting beside the folder          — "wiki.md"
+//
+// The call sites leak in both directions, so every case below is asserted
+// twice, once per leak shape:
+//
+//   * INCLUDING too much — lint, startup fixes and the page listing treat
+//     foreign notes as wiki pages (deleteEmptyStubs then deletes them).
+//   * EXCLUDING too much — the ingest pickers subtract those same foreign
+//     notes from the candidate set, so the user cannot select their own files.
+//
+// The helper itself (`isInFolderScope`) is covered in
+// `__tests__/core/folder-scope.test.ts`; these tests pin the CALL SITES, which
+// is where the bug lived.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TFile, TFolder } from 'obsidian'; // mocked in __support__/setup.ts
+
+import { deleteEmptyStubs } from '../../wiki/lint/delete-empty-stubs';
+import { getExistingWikiPages } from '../../wiki/lint/get-existing-pages';
+import { runPreparationPhase } from '../../wiki/lint/phases/preparation';
+import { FileSuggestModal, FolderSuggestModal } from '../../ui/modals/suggest-modals';
+import { AutoMaintainManager } from '../../schema/auto-maintain';
+import { createMockContext } from '../__support__/engine-context';
+import type { LintPhaseContext } from '../../wiki/lint/types';
+import type { LLMWikiSettings } from '../../types';
+import type { WikiEngine } from '../../wiki/wiki-engine';
+
+const WIKI = 'wiki';
+
+/** A real wiki page — the control. Every fix must keep this one in scope. */
+const REAL_PAGE = 'wiki/entities/Real.md';
+/** Leak 1: sibling folder sharing the name prefix. */
+const SIBLING_FOLDER_FILE = 'wiki-archive/Old.md';
+/** Leak 2: a file sitting beside the folder. */
+const NEIGHBOUR_FILE = 'wiki.md';
+
+/** Short enough to count as an empty stub (< MIN_SUBSTANTIVE_CHARS). */
+const EMPTY_STUB = '---\ntitle: X\n---\n\nTBD\n';
+
+/** A `sources:` entry with the `.md` extension — what Phase 2 normalizes. */
+const POLLUTED = '---\nsources:\n  - "[[sources/Foo.md]]"\n---\n\nBody text.\n';
+
+describe('#383 — deleteEmptyStubs stays inside the wiki folder', () => {
+  async function runWith(files: Record<string, string>): Promise<string[]> {
+    const { ctx } = createMockContext({ vaultFiles: files });
+    const deleted: string[] = [];
+    ctx.deleteFile = async (path: string) => { deleted.push(path); };
+    await deleteEmptyStubs(ctx, WIKI);
+    return deleted;
+  }
+
+  it('still deletes an empty stub inside the wiki folder', async () => {
+    expect(await runWith({ [REAL_PAGE]: EMPTY_STUB })).toEqual([REAL_PAGE]);
+  });
+
+  // The sharpest case in the issue: this path is unanchored AND deleting.
+  it('does not delete an empty note in a sibling folder', async () => {
+    const deleted = await runWith({
+      [REAL_PAGE]: EMPTY_STUB,
+      [SIBLING_FOLDER_FILE]: EMPTY_STUB,
+    });
+    expect(deleted).not.toContain(SIBLING_FOLDER_FILE);
+    expect(deleted).toEqual([REAL_PAGE]);
+  });
+
+  it('does not delete an empty note sitting beside the wiki folder', async () => {
+    const deleted = await runWith({
+      [REAL_PAGE]: EMPTY_STUB,
+      [NEIGHBOUR_FILE]: EMPTY_STUB,
+    });
+    expect(deleted).not.toContain(NEIGHBOUR_FILE);
+    expect(deleted).toEqual([REAL_PAGE]);
+  });
+});
+
+describe('#383 — getExistingWikiPages stays inside the wiki folder', () => {
+  it('reports the wiki page and neither foreign note', async () => {
+    const { ctx } = createMockContext({
+      vaultFiles: {
+        [REAL_PAGE]: '# Real\n\nBody',
+        [SIBLING_FOLDER_FILE]: '# Old\n\nBody',
+        [NEIGHBOUR_FILE]: '# Neighbour\n\nBody',
+      },
+    });
+
+    const pages = await getExistingWikiPages(ctx.app, WIKI);
+    const paths = pages.map(p => p.path);
+
+    expect(paths).toEqual([REAL_PAGE]);
+    expect(paths).not.toContain(SIBLING_FOLDER_FILE);
+    expect(paths).not.toContain(NEIGHBOUR_FILE);
+  });
+});
+
+describe('#383 — the lint preparation phase stays inside the wiki folder', () => {
+  function makeContext(files: Record<string, string>): LintPhaseContext {
+    const tfiles = Object.keys(files).map(path => ({
+      path,
+      basename: path.split('/').pop()?.replace('.md', '') || '',
+    }));
+    return {
+      app: {
+        vault: {
+          getMarkdownFiles: () => tfiles,
+          read: async (file: { path: string }) => files[file.path] ?? '',
+          getAbstractFileByPath: () => null,
+          process: async (file: { path: string }, fn: (data: string) => string) => {
+            files[file.path] = fn(files[file.path] ?? '');
+            return files[file.path];
+          },
+        },
+      } as unknown as LintPhaseContext['app'],
+      settings: { wikiFolder: WIKI, language: 'en', slugCase: 'lower' } as LLMWikiSettings,
+      llmClient: () => null,
+      wikiEngine: { updateStatusBar: () => {} } as unknown as LintPhaseContext['wikiEngine'],
+      checkCancelled: () => {},
+      stageNotice: null,
+      totalPages: 0,
+      buildSystemPrompt: async () => undefined,
+    };
+  }
+
+  it('collects the wiki page and neither foreign note', async () => {
+    const ctx = makeContext({
+      [REAL_PAGE]: '# Real\n\nBody',
+      [SIBLING_FOLDER_FILE]: '# Old\n\nBody',
+      [NEIGHBOUR_FILE]: '# Neighbour\n\nBody',
+    });
+
+    const result = await runPreparationPhase(ctx);
+    const paths = result.wikiFiles.map(f => f.path);
+
+    expect(paths).toEqual([REAL_PAGE]);
+  });
+});
+
+describe('#383 — startup quick fixes (Phase 2) only rewrite wiki files', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('normalizes sources in the wiki page and writes to neither foreign note', async () => {
+    const files: Record<string, string> = {
+      [REAL_PAGE]: POLLUTED,
+      [SIBLING_FOLDER_FILE]: POLLUTED,
+      [NEIGHBOUR_FILE]: POLLUTED,
+    };
+    const written: string[] = [];
+
+    const app = {
+      vault: {
+        getMarkdownFiles: () => Object.keys(files).map(path => ({
+          path,
+          basename: path.split('/').pop()?.replace('.md', '') || '',
+          stat: { size: files[path].length, mtime: 1 },
+        })),
+        read: async (file: { path: string }) => files[file.path] ?? '',
+        process: async (file: { path: string }, fn: (data: string) => string) => {
+          written.push(file.path);
+          files[file.path] = fn(files[file.path] ?? '');
+          return files[file.path];
+        },
+        // Phase 1 only reports on the folder structure; present is enough.
+        getAbstractFileByPath: (path: string) => ({ path }),
+      },
+    };
+
+    const settings = {
+      wikiFolder: WIKI,
+      language: 'en',
+      slugCase: 'lower',
+      startupCheckNoticeLevel: 'silent',
+    } as unknown as LLMWikiSettings;
+
+    const wikiEngine = {
+      getExistingWikiPages: async () => [],
+      tryReadFile: async () => null,
+      createOrUpdateFile: async () => {},
+    } as unknown as WikiEngine;
+
+    const mgr = new AutoMaintainManager(
+      app as unknown as ConstructorParameters<typeof AutoMaintainManager>[0],
+      settings,
+      wikiEngine,
+      { llmClient: null } as unknown as ConstructorParameters<typeof AutoMaintainManager>[3],
+    );
+
+    const run = mgr.runStartupCheck();
+    await vi.advanceTimersByTimeAsync(3000);
+    await run;
+
+    // The wiki page was polluted, so it was rewritten...
+    expect(written).toContain(REAL_PAGE);
+    // ...and the two foreign notes were left alone, equally polluted or not.
+    expect(written).not.toContain(SIBLING_FOLDER_FILE);
+    expect(written).not.toContain(NEIGHBOUR_FILE);
+    expect(files[SIBLING_FOLDER_FILE]).toBe(POLLUTED);
+    expect(files[NEIGHBOUR_FILE]).toBe(POLLUTED);
+  });
+});
+
+// The pickers subtract the wiki folder from the vault, so here the SAME
+// unanchored prefix takes the user's own notes away instead of swallowing
+// them — the second leak direction.
+describe('#383 — the source picker offers the user their own notes', () => {
+  function fileEntry(path: string) {
+    return Object.assign(new TFile(), {
+      path,
+      basename: path.split('/').pop()?.replace('.md', '') || '',
+      extension: 'md',
+    });
+  }
+
+  function makeApp(paths: string[]) {
+    return {
+      vault: {
+        configDir: '.obsidian',
+        getFiles: () => paths.map(fileEntry),
+      },
+    };
+  }
+
+  it('keeps wiki pages out but leaves both foreign notes selectable', () => {
+    const app = makeApp([REAL_PAGE, SIBLING_FOLDER_FILE, NEIGHBOUR_FILE, '.obsidian/plugins/x.md']);
+    const modal = new FileSuggestModal(
+      app as unknown as ConstructorParameters<typeof FileSuggestModal>[0],
+      WIKI,
+      () => {},
+    );
+
+    const offered = modal.getItems().map(f => f.path);
+
+    expect(offered).toContain(SIBLING_FOLDER_FILE);
+    expect(offered).toContain(NEIGHBOUR_FILE);
+    expect(offered).not.toContain(REAL_PAGE);
+    expect(offered).not.toContain('.obsidian/plugins/x.md');
+  });
+});
+
+// NOTE — MultiFileSuggestModal's candidate filter (the two-pane picker) is the
+// one call site without a test here. Its filter line is character-identical to
+// FileSuggestModal.getItems above, but it lives inside `onOpen()`, which builds
+// the modal DOM; driving it needs the jsdom environment, and under jsdom the
+// `obsidian` module does not resolve (`server.deps.inline` only covers the node
+// environment). Rewiring the test setup for that is out of scope for a fix on
+// this deadline.
+
+describe('#383 — the folder picker offers sibling folders, not the wiki folder', () => {
+  function folderEntry(path: string, children: TFolder[] = []): TFolder {
+    return Object.assign(new TFolder(), {
+      path,
+      name: path.split('/').pop() || path,
+      children,
+    });
+  }
+
+  it('offers the sibling folder while still hiding the wiki folder and its children', () => {
+    const wikiEntities = folderEntry('wiki/entities');
+    const wikiFolder = folderEntry('wiki', [wikiEntities]);
+    const archive = folderEntry('wiki-archive');
+    const root = folderEntry('/', [wikiFolder, archive]);
+
+    const app = {
+      vault: {
+        configDir: '.obsidian',
+        getRoot: () => root,
+      },
+    };
+
+    const modal = new FolderSuggestModal(
+      app as unknown as ConstructorParameters<typeof FolderSuggestModal>[0],
+      WIKI,
+      () => {},
+    );
+
+    const offered = modal.getItems().map(f => f.path);
+
+    expect(offered).toContain('wiki-archive');
+    // The folder itself is not a descendant of itself — without the explicit
+    // identity check, anchoring would have put it back into the picker.
+    expect(offered).not.toContain('wiki');
+    expect(offered).not.toContain('wiki/entities');
+  });
+});

--- a/src/core/orphan-matcher.test.ts
+++ b/src/core/orphan-matcher.test.ts
@@ -195,11 +195,24 @@ describe('Orphan Matcher — Pure Functions', () => {
       expect(result).toBe('wiki/entities/page.md');
     });
 
-    it('handles paths starting with wiki folder name', () => {
-      // If path starts with wiki folder name (not full path), it's treated as full
-      const result = normalizeOrphanPagePath('wiki-concepts/page.md', 'wiki');
-      // startsWith('wiki') is true, so treated as full path
-      expect(result).toBe('wiki-concepts/page.md');
+    // Issue #383 — INVERTED. This test used to assert the unanchored
+    // behaviour ("startsWith('wiki') is true, so treated as full path"),
+    // which is the bug: a relative page whose first segment merely starts
+    // with the folder's name never received its prefix, and the resulting
+    // link pointed at a path that does not exist.
+    it('prefixes a relative path whose first segment starts with the folder name', () => {
+      expect(normalizeOrphanPagePath('wiki-concepts/page.md', 'wiki'))
+        .toBe('wiki/wiki-concepts/page.md');
+    });
+
+    it('prefixes a relative file sitting beside the wiki folder', () => {
+      expect(normalizeOrphanPagePath('wikipedia.md', 'wiki'))
+        .toBe('wiki/wikipedia.md');
+    });
+
+    it('still leaves a genuinely absolute path untouched', () => {
+      expect(normalizeOrphanPagePath('wiki/concepts/page.md', 'wiki'))
+        .toBe('wiki/concepts/page.md');
     });
 
     it('handles root-level paths', () => {

--- a/src/core/orphan-matcher.ts
+++ b/src/core/orphan-matcher.ts
@@ -78,7 +78,12 @@ export function normalizeOrphanPagePath(
   pagePath: string,
   wikiFolder: string
 ): string {
-  return pagePath.startsWith(wikiFolder)
+  // Issue #383: this one asks "is the path already absolute?", so it keeps the
+  // plain prefix form rather than isInFolderScope — but the prefix has to be
+  // anchored all the same. Unanchored, a relative page whose name merely starts
+  // with the folder's name ("wikipedia.md" under wikiFolder "wiki") was taken
+  // for an absolute path and never got its prefix, producing a dead link.
+  return pagePath.startsWith(`${wikiFolder}/`)
     ? pagePath
     : `${wikiFolder}/${pagePath}`;
 }

--- a/src/schema/auto-maintain.ts
+++ b/src/schema/auto-maintain.ts
@@ -6,6 +6,7 @@ import { LLMWikiSettings } from '../types';
 import { WikiEngine } from '../wiki/wiki-engine';
 import { TEXTS } from '../texts';
 import { fixPollutedSources, scanPollutedSources } from '../core/sources-normalizer';
+import { isInFolderScope } from '../core/folder-scope';
 import { findIncompletePages, cleanIncompletePages } from '../core/incomplete-page-cleaner';
 import { needsLogHeaderMigration, migrateLogHeader } from '../core/log-header';
 import { ensureWelcomeNote, type EnsureResult, type VaultAdapter } from '../core/ensure-welcome-note';
@@ -403,8 +404,11 @@ export class AutoMaintainManager {
     let sourcesFilesScanned = 0;
     let sourcesFilesPolluted = 0;
     try {
+      // Issue #383: anchored — this phase WRITES (vault.process below), so an
+      // unanchored prefix would rewrite files in a sibling folder
+      // ("wiki-archive/") or beside the wiki ("wiki.md") on every startup.
       const wikiFiles = this.app.vault.getMarkdownFiles()
-        .filter(f => f.path.startsWith(wikiFolder));
+        .filter(f => isInFolderScope(f.path, wikiFolder, false));
       console.debug(`[QuickFixes] Phase 2: scanning ${wikiFiles.length} files in "${wikiFolder}"`);
       const sourcesPreserveCase = this.settings.slugCase === 'preserve';
       for (const file of wikiFiles) {

--- a/src/ui/modals/MultiFileSuggestModal-class.ts
+++ b/src/ui/modals/MultiFileSuggestModal-class.ts
@@ -23,6 +23,7 @@ import { getText } from '../../core/i18n';
 import { buildFolderTree, type TreeNode } from '../../core/build-folder-tree';
 import type { IngestQueue } from '../../core/ingest-queue';
 import { COMPATIBLE_SOURCE_EXTENSIONS } from '../../constants';
+import { isInFolderScope } from '../../core/folder-scope';
 
 export class MultiFileSuggestModal extends Modal {
   /** The shared ingest queue. Modal reads + subscribes; never owns
@@ -97,8 +98,12 @@ export class MultiFileSuggestModal extends Modal {
     // close every <details> and force the user to re-expand
     // folders (the bug v2 fixes). v1.25.0 PR2: include PDFs.
     const compatibleExts: readonly string[] = COMPATIBLE_SOURCE_EXTENSIONS;
+    // Issue #383: anchored — unanchored, the two-pane picker silently dropped
+    // the user's own notes whose path merely starts with the wiki folder's
+    // name ("wiki-archive/note.md", "wiki.md").
     const available = this.app.vault.getFiles()
-      .filter(f => !f.path.startsWith(this.wikiFolder) && !f.path.startsWith(this.app.vault.configDir))
+      .filter(f => !isInFolderScope(f.path, this.wikiFolder, false)
+                && !f.path.startsWith(this.app.vault.configDir))
       .filter(f => compatibleExts.includes(f.extension.toLowerCase()))
       .sort((a, b) => a.path.localeCompare(b.path));
     this.treeRoots = buildFolderTree(available);

--- a/src/ui/modals/suggest-modals.ts
+++ b/src/ui/modals/suggest-modals.ts
@@ -6,6 +6,7 @@
 
 import { App, TFile, TFolder, FuzzySuggestModal } from 'obsidian';
 import { COMPATIBLE_SOURCE_EXTENSIONS } from '../../constants';
+import { isInFolderScope } from '../../core/folder-scope';
 
 const isCompatibleSource = (f: TFile): boolean =>
   (COMPATIBLE_SOURCE_EXTENSIONS as readonly string[]).includes(f.extension.toLowerCase());
@@ -24,9 +25,13 @@ export class FileSuggestModal extends FuzzySuggestModal<TFile> {
     // v1.25.0 PR2: include PDFs in the source picker (PDFs are a first-class
     // source format). Filter by compatible extension + exclude wiki/config
     // directories, mirroring the legacy markdown-only behavior.
+    // Issue #383: the exclusion is anchored. Unanchored it hid the user's own
+    // notes from the source picker whenever their path merely started with the
+    // wiki folder's name ("wiki-archive/note.md", "wiki.md").
     return this.app.vault.getFiles()
       .filter(f => isCompatibleSource(f))
-      .filter(f => !f.path.startsWith(this.wikiFolder) && !f.path.startsWith(this.app.vault.configDir));
+      .filter(f => !isInFolderScope(f.path, this.wikiFolder, false)
+                && !f.path.startsWith(this.app.vault.configDir));
   }
 
   getItemText(file: TFile): string {
@@ -52,8 +57,15 @@ export class FolderSuggestModal extends FuzzySuggestModal<TFolder> {
     const folders: TFolder[] = [];
     const root = this.app.vault.getRoot();
 
+    // Issue #383: anchored, but note the shape — the set to exclude here is the
+    // wiki folder ITSELF plus its descendants, and `isInFolderScope` answers
+    // "descendant of", which a folder is not of itself. Dropping the identity
+    // check would put the wiki folder back into the picker.
+    const isWikiScope = (path: string): boolean =>
+      path === this.wikiFolder || isInFolderScope(path, this.wikiFolder, false);
+
     const collect = (folder: TFolder) => {
-      if (!folder.path.startsWith(this.app.vault.configDir) && !folder.path.startsWith(this.wikiFolder)) {
+      if (!folder.path.startsWith(this.app.vault.configDir) && !isWikiScope(folder.path)) {
         folders.push(folder);
       }
       for (const child of folder.children) {

--- a/src/wiki/lint/delete-empty-stubs.ts
+++ b/src/wiki/lint/delete-empty-stubs.ts
@@ -1,13 +1,18 @@
 import { EngineContext } from '../../types';
 import { parseFrontmatter } from '../../core/frontmatter';
+import { isInFolderScope } from '../../core/folder-scope';
 import { isPageEmpty } from './utils';
 
 export async function deleteEmptyStubs(
   ctx: EngineContext,
   wikiFolder: string
 ): Promise<{ deleted: number; failed: number; errors: string[] }> {
+  // Issue #383: the scope test runs FIRST and this path deletes. An
+  // unanchored `startsWith` also matches a sibling folder ("wiki-archive/")
+  // and a neighbouring file ("wiki.md"); the exclusions below only shrink an
+  // already-wrong set. Anchor before anything is considered for deletion.
   const files = ctx.app.vault.getMarkdownFiles()
-    .filter(f => f.path.startsWith(wikiFolder) &&
+    .filter(f => isInFolderScope(f.path, wikiFolder, false) &&
                  !f.path.endsWith('/index.md') &&
                  !f.path.includes('/schema/') &&
                  !f.path.includes('/sources/') &&

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -1,5 +1,6 @@
 import { App } from 'obsidian';
 import { parseFrontmatter } from '../../core/frontmatter';
+import { isInFolderScope } from '../../core/folder-scope';
 
 export async function getExistingWikiPages(
   app: App,
@@ -7,9 +8,11 @@ export async function getExistingWikiPages(
 ): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; ctime?: number }>> {
   const wikiFiles = app.vault
     .getMarkdownFiles()
+    // Issue #383: anchored so a sibling folder ("wiki-archive/") and a
+    // neighbouring file ("wiki.md") are not reported as wiki pages.
     .filter(
       f =>
-        f.path.startsWith(wikiFolder) &&
+        isInFolderScope(f.path, wikiFolder, false) &&
         !f.path.includes('index.md') &&
         !f.path.includes('log.md') &&
         !f.path.includes('/schema/') &&

--- a/src/wiki/lint/phases/preparation.ts
+++ b/src/wiki/lint/phases/preparation.ts
@@ -3,6 +3,7 @@ import { getText } from '../../../core/i18n';
 import { fixDoubleNestedWikiLinks } from '../utils';
 import { scanPollutedSources, fixPollutedSources } from '../../../core/sources-normalizer';
 import { parseFrontmatter } from '../../../core/frontmatter';
+import { isInFolderScope } from '../../../core/folder-scope';
 import { LINT_PREP_BATCH_READ } from '../../../constants';
 import { LintPhaseContext, ScannerPage } from '../types';
 
@@ -19,8 +20,11 @@ export interface PreparationResult {
 export async function runPreparationPhase(
   ctx: LintPhaseContext,
 ): Promise<PreparationResult> {
+  // Issue #383: anchored so lint does not pull a sibling folder
+  // ("wiki-archive/") or a neighbouring file ("wiki.md") into the page set
+  // every later phase operates on.
   const wikiFiles = ctx.app.vault.getMarkdownFiles()
-    .filter(f => f.path.startsWith(ctx.settings.wikiFolder) &&
+    .filter(f => isInFolderScope(f.path, ctx.settings.wikiFolder, false) &&
                  !f.path.includes('index.md') &&
                  !f.path.includes('log.md') &&
                  !f.path.includes('/schema/') &&


### PR DESCRIPTION
Closes #383.

Thanks for cross-checking every line in the issue — the fix follows exactly the form you confirmed, with three deviations I want to flag rather than bury.

## What changed

Six sites move to `isInFolderScope(path, wikiFolder, false)` (the helper from #364), and `orphan-matcher.ts` gets the anchored plain prefix:

| file | direction of the leak |
|---|---|
| `wiki/lint/delete-empty-stubs.ts` | included too much — **and deletes** |
| `wiki/lint/get-existing-pages.ts` | included too much |
| `wiki/lint/phases/preparation.ts` | included too much |
| `schema/auto-maintain.ts` (startup Phase 2) | included too much — **and writes** |
| `ui/modals/suggest-modals.ts` (file + folder picker) | excluded too much |
| `ui/modals/MultiFileSuggestModal-class.ts` | excluded too much |
| `core/orphan-matcher.ts` | produced a link to a path that does not exist |

## Three things that are not mechanical

**1. `FolderSuggestModal` needed an identity check on top of the anchoring.** The set to exclude there is the wiki folder *itself* plus its descendants, and `isInFolderScope` answers "descendant of" — which a folder is not of itself. A plain substitution would have anchored the boundary correctly and, in the same move, put the wiki folder back into the folder picker. It now reads `path === wikiFolder || isInFolderScope(...)`.

**2. `orphan-matcher.ts` keeps the plain prefix form**, as you suggested. The question there is "is this path already absolute?", not "is it in scope", and a scope-shaped predicate would misname it. Only the anchor was missing.

**3. An existing test asserted the bug and had to be inverted.** `orphan-matcher.test.ts` contained:

```ts
it('handles paths starting with wiki folder name', () => {
  const result = normalizeOrphanPagePath('wiki-concepts/page.md', 'wiki');
  // startsWith('wiki') is true, so treated as full path
  expect(result).toBe('wiki-concepts/page.md');
});
```

That is the unanchored behaviour written down as intent. It now asserts `wiki/wiki-concepts/page.md`, with a comment recording that it was inverted and why. Worth a second look from you, since inverting a green test is the one change in this PR that a reviewer cannot verify by reading the diff alone.

## Tests

New `src/__tests__/wiki/wiki-folder-boundary.test.ts`, one regression per call site. `folder-scope.test.ts` already covers the helper, so these pin the call sites — which is where the bug lived. Every case asserts **both** leak shapes, sibling folder (`wiki-archive/Old.md`) and neighbouring file (`wiki.md`), and keeps a real wiki page as the control so the fix cannot pass by simply excluding everything.

I verified the tests actually catch the bug: with the source changes stashed and the tests in place, all nine fail; restored, all pass.

Two notes on the test setup:

- `__support__/setup.ts`: the `FuzzySuggestModal` stub did not assign `this.app`, unlike the real base class, so subclass `getItems()` threw on `this.app.vault` and could not be tested at all. The stub now takes the app in its constructor.
- **One call site has no test**: `MultiFileSuggestModal`. Its filter line is character-identical to the tested `FileSuggestModal.getItems`, but it sits inside `onOpen()`, which builds the modal DOM. Driving that needs the jsdom environment, and under jsdom the `obsidian` import does not resolve — `server.deps.inline` in `vitest.config.ts` only takes effect in the node environment. Rewiring that felt out of scope for a fix on this timeline; happy to do it separately if you want the coverage.

## An eighth site with the same shape — and why anchoring is the wrong fix there

`wiki/lint/merge-duplicates.ts:168` carries the same unanchored form:

```ts
const allWikiFiles = ctx.app.vault.getMarkdownFiles().filter(
  f => f.path.startsWith(wikiFolder) && f.path !== sourcePath
);
```

It is not in #383, and it should not be folded into this PR — but not because the boundary is fine there. It is because anchoring alone would make it *worse*.

`mergeDuplicates` deletes the source page at the end (`deleteFile(sourcePath)`, line 182). Every link that is not rewritten therefore points at a file that no longer exists. So the defect at this site is the mirror image of the seven: the rewrite is scoped **too narrowly**, not too widely. Notes outside the wiki folder never get their links carried over and are left with dead links. The unanchored prefix happens to catch an arbitrary subset of them — exactly those whose path starts with the folder's name — which is neither wiki-only nor vault-wide.

Anchoring that line in isolation would make the scope coherent and take the accidental rescue away, turning those links dead for real.

A proper fix has a second axis, too: the search term is `[[entities/Foo]]`, the wiki-relative form. A link written outside the wiki folder usually carries a different shape (full path, or just the title), so even a vault-wide sweep with only this one form would still miss most of them.

Both axes together are a scope decision about the merge path, not a boundary repair, so I would rather raise it as its own issue than attach it to a fix you want landed before the v1.26.0 hardening. Say the word and I will write it up.

For a comparable reason I left the neighbouring `configDir` prefix checks alone, though they have the identical shape.

## Gate

Built on current `main` (`29e2402`). `pnpm lint --max-warnings=0`, `npx tsc --noEmit`, `pnpm test`, `pnpm build`, `pnpm css-lint` — all clean. Test suite: 207 files / 2772 tests, up from 206 / 2762 on the base.
