### PR TITLE
fix(folder-scope): close #383 follow-up regressions — identity check, unanchored configDir, shell tests

### DIFF
--- a/src/__tests__/core/folder-scope.test.ts
+++ b/src/__tests__/core/folder-scope.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { folderScopePrefix, isInFolderScope } from '../../core/folder-scope';
+import {
+  folderScopePrefix,
+  isInFolderScope,
+  isAtOrInFolderScope,
+  isExcludedFromSourcePicker,
+} from '../../core/folder-scope';
 
 describe('folderScopePrefix', () => {
   it('anchors a folder path on a trailing slash', () => {
@@ -56,5 +61,62 @@ describe('isInFolderScope', () => {
 
   it('is unaffected by the folder name appearing later in the path', () => {
     expect(isInFolderScope('Archiv/Notizen/a.md', 'Notizen', false)).toBe(false);
+  });
+});
+
+describe('isAtOrInFolderScope', () => {
+  it('matches the folder itself — the case isInFolderScope refuses', () => {
+    expect(isAtOrInFolderScope('Notizen', 'Notizen', false)).toBe(true);
+  });
+
+  it('still matches descendants at any depth', () => {
+    expect(isAtOrInFolderScope('Notizen/a.md', 'Notizen', false)).toBe(true);
+    expect(isAtOrInFolderScope('Notizen/sub/deep/a.md', 'Notizen', false)).toBe(true);
+  });
+
+  it('still refuses sibling folders and adjacent files', () => {
+    expect(isAtOrInFolderScope('Notizen-temp/a.md', 'Notizen', false)).toBe(false);
+    expect(isAtOrInFolderScope('Notizen.md', 'Notizen', false)).toBe(false);
+  });
+
+  it('normalises a trailing slash on the folder path', () => {
+    expect(isAtOrInFolderScope('Notizen', 'Notizen/', false)).toBe(true);
+    expect(isAtOrInFolderScope('Notizen/a.md', 'Notizen/', false)).toBe(true);
+  });
+});
+
+describe('isExcludedFromSourcePicker', () => {
+  it('excludes the wiki folder itself', () => {
+    expect(isExcludedFromSourcePicker('wiki', 'wiki', '.obsidian')).toBe(true);
+  });
+
+  it('excludes wiki descendants at any depth', () => {
+    expect(isExcludedFromSourcePicker('wiki/entities', 'wiki', '.obsidian')).toBe(true);
+    expect(isExcludedFromSourcePicker('wiki/sources/deep', 'wiki', '.obsidian')).toBe(true);
+  });
+
+  it('keeps a sibling folder sharing the wiki name prefix', () => {
+    expect(isExcludedFromSourcePicker('wiki-archive', 'wiki', '.obsidian')).toBe(false);
+  });
+
+  it('keeps an unrelated user folder', () => {
+    expect(isExcludedFromSourcePicker('Notes', 'wiki', '.obsidian')).toBe(false);
+  });
+
+  it('excludes the config directory and its descendants', () => {
+    expect(isExcludedFromSourcePicker('.obsidian/plugins', 'wiki', '.obsidian')).toBe(true);
+    expect(isExcludedFromSourcePicker('.obsidian/plugins/foo/bar', 'wiki', '.obsidian')).toBe(true);
+  });
+
+  // Same root cause as #383 — unanchored prefix leak. PR #384's
+  // `FolderSuggestModal` line `folder.path.startsWith(configDir)` let
+  // `.obsidian-backup/...` enter the picker; the centralised rule here
+  // uses isAtOrInFolderScope and is anchored.
+  it('does not leak a folder sharing the config name prefix', () => {
+    expect(isExcludedFromSourcePicker('.obsidian-backup/x.md', 'wiki', '.obsidian')).toBe(false);
+  });
+
+  it('keeps the vault root selectable', () => {
+    expect(isExcludedFromSourcePicker('/', 'wiki', '.obsidian')).toBe(false);
   });
 });

--- a/src/__tests__/wiki/lint/wiki-folder-scope-sites.test.ts
+++ b/src/__tests__/wiki/lint/wiki-folder-scope-sites.test.ts
@@ -1,30 +1,34 @@
 // Issue #383 follow-up regression coverage.
 //
-// Hashim1999164's PR #384 migrated 7 call sites from `f.path.startsWith(wikiFolder)`
-// to `isInFolderScope(f.path, wikiFolder, false)`. The shared helper test
-// (`folder-scope.test.ts`) covers the helper itself, but per-site call patterns
-// can drift back to the bare startsWith form during a refactor and not be caught
-// by the helper test alone.
+// PR #384 migrated 7 call sites from `f.path.startsWith(wikiFolder)` to
+// `isInFolderScope(...)`. This file pins the BEHAVIOURAL contract for **six**
+// of those call sites — preparation, get-existing-pages, delete-empty-stubs,
+// normalizeSourcesInFolder (auto-maintain Phase 2), contradictions, and the
+// follow-up fix on contradictions. The seventh site (merge-duplicates) is
+// omitted on purpose: #386 (assigned to DocTpoint) rewrites that filter and
+// owns its own production-function coverage.
 //
-// This file pins the BEHAVIOURAL contract for each migrated call site: given a
-// vault whose markdown files include sibling-folder (e.g. `wiki-archive/x.md`)
-// and adjacent-file (`wiki.md`) leak directions, the filter that the site uses
-// MUST exclude them. If a future contributor reverts any site to the bare
-// `startsWith(wikiFolder)` form, the relevant test here fails with a clear
-// "leaked file at <path>" message — pointing directly at the regression.
+// For each pinned site the test calls the production function with a minimal
+// vault whose markdown files include both leak directions — sibling folder
+// (`wiki-archive/x.md`) and adjacent file (`wiki.md`) — and asserts the
+// filter excludes them. The shared helper (`src/core/folder-scope.ts`) has
+// its own test file; the tests here exercise behaviour, not implementation.
 //
-// Test pattern: build a minimal vault (markdown file list + the engine-context
-// pieces the site consumes), invoke the entry point, assert the result set
-// excludes the leak paths. The tests do not import isInFolderScope directly —
-// they exercise the behaviour, not the implementation.
+// Centralisation note: the picker exclusion rule (wiki folder + config
+// directory) lives in `isExcludedFromSourcePicker` (`folder-scope.ts`) and
+// is shared by `FileSuggestModal`, `FolderSuggestModal`, and the multi-file
+// variant. SourcePicker regressions belong in this file's follow-up
+// coverage, not here.
 
 import { describe, it, expect } from 'vitest';
+import { App } from 'obsidian';
 import { runPreparationPhase } from '../../../wiki/lint/phases/preparation';
 import { LintPhaseContext } from '../../../wiki/lint/types';
 import { LLMWikiSettings } from '../../../types';
 import { getExistingWikiPages } from '../../../wiki/lint/get-existing-pages';
 import { ContradictionManager } from '../../../wiki/contradictions';
-import { isInFolderScope } from '../../../core/folder-scope';
+import { deleteEmptyStubs } from '../../../wiki/lint/delete-empty-stubs';
+import { normalizeSourcesInFolder } from '../../../core/sources-normalizer';
 import type { EngineContext } from '../../../types';
 
 // --- shared fixture builders ------------------------------------------------
@@ -159,77 +163,206 @@ describe('PR #384 / #383 — get-existing-pages.ts leak guard', () => {
 
 // --- 3. delete-empty-stubs.ts (sharp site — user-data-loss) ---------------
 //
-// We test the FILTER shape (the line that excludes non-wiki paths) rather than
-// the full deleteEmptyStubs function, because the full function needs
-// ctx.deleteFile + reviewed-frontmatter detection that are out of scope for a
-// per-site regression test. The shared helper test (folder-scope.test.ts) and
-// the per-site test below ensure that if anyone reverts delete-empty-stubs.ts
-// back to `f.path.startsWith(wikiFolder)`, the leak path enters the candidate
-// set.
+// Calls the production function with a deleteFile collector. Reverting the
+// filter to `startsWith(wikiFolder)` makes `wiki-archive/Empty.md` and
+// `wiki.md` enter the delete set and fails every case below.
 
-describe('PR #384 / #383 — delete-empty-stubs.ts filter shape', () => {
-  it('POST-#384 form (isInFolderScope) excludes both leak paths', () => {
-    // Mirrors delete-empty-stubs.ts:10-16 post-#384.
-    // If anyone reverts the filter to bare `f.path.startsWith(wikiFolder)`,
-    // wiki-archive/Empty.md and wiki.md will re-enter the candidate set and
-    // this test fails with `expected [ 'wiki/entities/Empty.md' ] to equal
-    // [ 'wiki/entities/Empty.md', 'wiki-archive/Empty.md', 'wiki.md' ]`.
-    const candidateFiles = [
-      { path: 'wiki/entities/Empty.md' },
-      { path: 'wiki-archive/Empty.md' },
-      { path: 'wiki.md' },
+describe('PR #384 / #383 — delete-empty-stubs.ts (production function)', () => {
+  it('deletes only empty stubs inside the wiki folder', async () => {
+    const deleted: string[] = [];
+    const files: MockVaultFile[] = [
+      { path: 'wiki/entities/Empty.md', basename: 'Empty', content: '# Empty' },
+      { path: 'wiki-archive/Empty.md', basename: 'Empty', content: '# Empty' },
+      { path: 'wiki.md', basename: 'wiki', content: '# wiki' },
     ];
-    const wikiFolder = 'wiki';
-    const filtered = candidateFiles.filter(f =>
-      isInFolderScope(f.path, wikiFolder, false) &&
-      !f.path.endsWith('/index.md') &&
-      !f.path.includes('/schema/') &&
-      !f.path.includes('/sources/') &&
-      !f.path.includes('/contradictions/') &&
-      !f.path.includes('log.md')
-    );
-    expect(filtered.map(f => f.path)).toEqual(['wiki/entities/Empty.md']);
+    const ctx = {
+      ...makeEngineCtx(files),
+      deleteFile: async (p: string) => {
+        deleted.push(p);
+      },
+    } as unknown as EngineContext;
+
+    const result = await deleteEmptyStubs(ctx, 'wiki');
+
+    expect(result.deleted).toBe(1);
+    expect(deleted).toEqual(['wiki/entities/Empty.md']);
+  });
+
+  it('keeps a non-empty wiki file', async () => {
+    const deleted: string[] = [];
+    const files: MockVaultFile[] = [
+      // MIN_SUBSTANTIVE_CHARS = 50; pad so textBody length crosses the threshold.
+      { path: 'wiki/entities/Substantive.md', basename: 'Substantive', content: '# Title\n\n' + 'word '.repeat(30) },
+    ];
+    const ctx = {
+      ...makeEngineCtx(files),
+      deleteFile: async (p: string) => {
+        deleted.push(p);
+      },
+    } as unknown as EngineContext;
+
+    const result = await deleteEmptyStubs(ctx, 'wiki');
+
+    expect(result.deleted).toBe(0);
+    expect(deleted).toEqual([]);
+  });
+
+  it('keeps an empty stub carrying reviewed: true', async () => {
+    const deleted: string[] = [];
+    const files: MockVaultFile[] = [
+      { path: 'wiki/entities/Reviewed.md', basename: 'Reviewed', content: '---\nreviewed: true\n---\n# Empty' },
+    ];
+    const ctx = {
+      ...makeEngineCtx(files),
+      deleteFile: async (p: string) => {
+        deleted.push(p);
+      },
+    } as unknown as EngineContext;
+
+    const result = await deleteEmptyStubs(ctx, 'wiki');
+
+    expect(result.deleted).toBe(0);
+    expect(deleted).toEqual([]);
+  });
+
+  it.each([
+    ['wiki/sources/Empty.md'],
+    ['wiki/schema/Empty.md'],
+    ['wiki/index.md'],
+    ['wiki/log.md'],
+    ['wiki/entities/sub/log.md'],
+  ])('keeps the protected wiki file %s', async (path) => {
+    const deleted: string[] = [];
+    const files: MockVaultFile[] = [
+      { path, basename: path.split('/').pop()!, content: '# Empty' },
+    ];
+    const ctx = {
+      ...makeEngineCtx(files),
+      deleteFile: async (p: string) => {
+        deleted.push(p);
+      },
+    } as unknown as EngineContext;
+
+    const result = await deleteEmptyStubs(ctx, 'wiki');
+
+    expect(result.deleted).toBe(0);
+    expect(deleted).toEqual([]);
+  });
+
+  it('records the failure when deleteFile throws and continues', async () => {
+    const deleted: string[] = [];
+    const files: MockVaultFile[] = [
+      { path: 'wiki/entities/A.md', basename: 'A', content: '# A' },
+      { path: 'wiki/entities/B.md', basename: 'B', content: '# B' },
+    ];
+    const ctx = {
+      ...makeEngineCtx(files),
+      deleteFile: async (p: string) => {
+        deleted.push(p);
+        throw new Error('disk full');
+      },
+    } as unknown as EngineContext;
+
+    const result = await deleteEmptyStubs(ctx, 'wiki');
+
+    expect(deleted).toEqual(['wiki/entities/A.md', 'wiki/entities/B.md']);
+    expect(result.deleted).toBe(0);
+    expect(result.failed).toBe(2);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toMatch(/^wiki\/entities\/A\.md: disk full$/);
   });
 });
 
-// --- 4. merge-duplicates.ts (filter inside mergeDuplicatePages) -----------
-
-describe('PR #384 / #383 — merge-duplicates.ts filter shape', () => {
-  it('FIXED form excludes both leak paths from the allWikiFiles derivation', () => {
-    const allMarkdownFiles = [
-      { path: 'wiki/entities/Foo.md' },
-      { path: 'wiki-archive/Foo.md' },
-      { path: 'wiki.md' },
-    ];
-    const wikiFolder = 'wiki';
-    const sourcePath = 'wiki/entities/Foo.md';
-    // Mirrors merge-duplicates.ts:168-170 post-#384.
-    const allWikiFiles = allMarkdownFiles.filter(
-      f => isInFolderScope(f.path, wikiFolder, false) && f.path !== sourcePath
-    );
-    expect(allWikiFiles.map(f => f.path)).toEqual([]);
-  });
-});
+// --- 4. merge-duplicates.ts -------------------------------------------------
+//
+// No regression test lives here. The original pinned the filter expression by
+// rebuilding it inside the test file — it did not exercise the production
+// function, so a regression stayed green (DocTpoint, #383 follow-up).
+//
+// The filter itself is slated for replacement: #386 (assigned to DocTpoint)
+// rewrites the rewrite to sweep the whole vault and handle the bare-title
+// `[[Foo]]` link form, with a resolve-before-replace safeguard. The real
+// regression coverage for this site belongs to that implementation, which
+// rewrites the function and will assert against its own production code.
 
 // --- 5. auto-maintain.ts (Phase 2 source-pollution scan) -------------------
 //
-// The Phase 2 filter at auto-maintain.ts:408 uses the same shape as
-// preparation.ts: `getMarkdownFiles().filter(f => isInFolderScope(...))`.
-// The shared helper test pins the helper; this test asserts the same
-// exclude-both-leak contract on the same pattern as preparation.ts.
+// Phase 2 previously lived inline in `runStartupCheck` (which sleeps 3s
+// and needs the whole startup surface), so it is extracted into the
+// module-level `normalizeSourcesInFolder` (src/core/sources-normalizer.ts)
+// — the same module-function shape as Phase 3 (`findIncompletePages`).
 
-describe('PR #384 / #383 — auto-maintain.ts (Phase 2) filter shape', () => {
-  it('FIXED form excludes both leak paths from the Phase 2 inventory', () => {
-    const allMarkdownFiles = [
-      { path: 'wiki/sources/Src.md' },
-      { path: 'wiki-archive/Src.md' },
-      { path: 'wiki.md' },
-    ];
-    const wikiFolder = 'wiki';
-    const filtered = allMarkdownFiles.filter(f => isInFolderScope(f.path, wikiFolder, false));
-    expect(filtered.map(f => f.path)).toEqual(['wiki/sources/Src.md']);
+describe('PR #384 / #383 — normalizeSourcesInFolder (production function)', () => {
+  it('processes only polluted files inside the wiki folder', async () => {
+    const processed: string[] = [];
+    const byPath = new Map<string, string>([
+      ['wiki/sources/Polluted.md', '---\nsources: ["[[Notizen/Foo.md]]"]\n---\n# Polluted\n'],
+      ['wiki-archive/Polluted.md', '---\nsources: ["[[Notizen/Foo.md]]"]\n---\n# Polluted\n'],
+      ['wiki.md', '---\nsources: ["[[Notizen/Foo.md]]"]\n---\n# wiki\n'],
+    ]);
+    const app = makeVaultNormalizerApp(byPath, processed);
+
+    const result = await normalizeSourcesInFolder(app as unknown as App, 'wiki', false);
+
+    expect(processed).toEqual(['wiki/sources/Polluted.md']);
+    expect(result).toEqual({ filesCleaned: 1, entriesCleaned: 1 });
+  });
+
+  it('does not process a clean wiki file', async () => {
+    const processed: string[] = [];
+    const byPath = new Map<string, string>([
+      ['wiki/sources/Clean.md', '---\nsources: ["[[sources/Foo]]"]\n---\n# Clean\n'],
+    ]);
+    const app = makeVaultNormalizerApp(byPath, processed);
+
+    const result = await normalizeSourcesInFolder(app as unknown as App, 'wiki', false);
+
+    expect(processed).toEqual([]);
+    expect(result).toEqual({ filesCleaned: 0, entriesCleaned: 0 });
+  });
+
+  it('returns 0 counts when vault.read throws', async () => {
+    const app = {
+      vault: {
+        getMarkdownFiles: () => [{ path: 'wiki/sources/X.md', basename: 'X', extension: 'md' }],
+        read: async () => {
+          throw new Error('IO error');
+        },
+        process: async () => {},
+      },
+    };
+
+    const result = await normalizeSourcesInFolder(app as unknown as App, 'wiki', false);
+
+    expect(result).toEqual({ filesCleaned: 0, entriesCleaned: 0 });
   });
 });
+
+function makeVaultNormalizerApp(
+  byPath: Map<string, string>,
+  processed: string[]
+): {
+  vault: {
+    getMarkdownFiles: () => Array<{ path: string; basename: string; extension: string }>;
+    read: (file: { path: string }) => Promise<string>;
+    process: (file: { path: string }, fn: (d: string) => string | Promise<string>) => Promise<void>;
+  };
+} {
+  return {
+    vault: {
+      getMarkdownFiles: () => Array.from(byPath.keys()).map(p => ({
+        path: p,
+        basename: p.split('/').pop() ?? p,
+        extension: 'md',
+      })),
+      read: async (f: { path: string }) => byPath.get(f.path) ?? '',
+      process: async (f: { path: string }, fn: (d: string) => string | Promise<string>) => {
+        processed.push(f.path);
+        byPath.set(f.path, String(await fn(byPath.get(f.path) ?? '')));
+      },
+    },
+  };
+}
 
 // --- 6. contradictions.ts (missed site fixed in follow-up) ----------------
 

--- a/src/core/folder-scope.ts
+++ b/src/core/folder-scope.ts
@@ -37,3 +37,41 @@ export function isInFolderScope(
 ): boolean {
   return filePath.startsWith(folderScopePrefix(folderPath, isRoot));
 }
+
+/**
+ * True when `filePath` names the folder itself OR anything inside it.
+ * The sibling case is `isInFolderScope`; the identity case was previously
+ * hand-rolled at every call site as `path === folder || isInFolderScope(...)`
+ * (e.g. PR #384's `FolderSuggestModal`, where the missing identity clause
+ * let the wiki folder itself leak back into the picker). Centralizing it
+ * keeps the boundary semantics in one file with one test suite.
+ *
+ * `folderPath` is compared with trailing slashes stripped so a normalised
+ * folder path and an unnormalised one with a trailing slash both match.
+ */
+export function isAtOrInFolderScope(
+  filePath: string,
+  folderPath: string,
+  isRoot: boolean
+): boolean {
+  const trimmedFolder = folderPath.replace(/\/+$/, '');
+  if (trimmedFolder.length > 0 && filePath === trimmedFolder) return true;
+  return isInFolderScope(filePath, folderPath, isRoot);
+}
+
+/**
+ * Whether a path may be presented to the user as an ingest source folder
+ * or watched folder. Combines the wiki boundary, the config directory, and
+ * the wiki folder's own identity. Used by both `FileSuggestModal`,
+ * `FolderSuggestModal` and the multi-file variant — one rule, three sites.
+ */
+export function isExcludedFromSourcePicker(
+  path: string,
+  wikiFolder: string,
+  configDir: string
+): boolean {
+  return (
+    isAtOrInFolderScope(path, wikiFolder, false) ||
+    isAtOrInFolderScope(path, configDir, false)
+  );
+}

--- a/src/core/sources-normalizer.ts
+++ b/src/core/sources-normalizer.ts
@@ -16,6 +16,19 @@
  */
 
 import { computeSlug } from './slug';
+import { isInFolderScope } from './folder-scope';
+
+/**
+ * The minimum `app.vault` surface used by `normalizeSourcesInFolder`.
+ * Spelled out so callers and tests don't have to fake the full Obsidian
+ * `App` (the previous extraction needed `{} as unknown as WikiEngine`
+ * junk casts because the shape lived on the AutoMaintainManager class).
+ */
+interface VaultLike {
+  getMarkdownFiles: () => Array<{ path: string }>;
+  read: (file: { path: string }) => Promise<string>;
+  process: (file: { path: string }, fn: (data: string) => string | Promise<string>) => Promise<unknown>;
+}
 
 /**
  * Normalize a single raw source entry to its canonical form.
@@ -199,4 +212,46 @@ export function fixPollutedSources(
     content.substring(fmMatch.index! + fmMatch[0].length);
 
   return { fixed: 1, content: newContent };
+}
+
+/**
+ * Phase 2 of `AutoMaintainManager.runStartupCheck`, extracted as a module
+ * function so the folder-scope filter is testable without standing up the
+ * whole startup surface (which sleeps 3s and needs the wikiEngine/plugin
+ * dependencies). Mirrors the Phase 3 shape (`findIncompletePages` in
+ * `incomplete-page-cleaner.ts`) so all startup phases follow the same
+ * dependency surface.
+ *
+ * Returns `{ filesCleaned, entriesCleaned }` so the caller (runStartupCheck
+ * Phase 5) can build the summary Notice. The function swallows per-call
+ * errors via the underlying `vault.process` and `vault.read` paths the
+ * caller already supplied — the original inline loop did the same.
+ */
+export async function normalizeSourcesInFolder(
+  app: { vault: VaultLike },
+  wikiFolder: string,
+  preserveCase: boolean
+): Promise<{ filesCleaned: number; entriesCleaned: number }> {
+  let filesCleaned = 0;
+  let entriesCleaned = 0;
+  try {
+    const wikiFiles = app.vault.getMarkdownFiles()
+      .filter(f => isInFolderScope(f.path, wikiFolder, false));
+    let polluted = 0;
+    for (const file of wikiFiles) {
+      const content = await app.vault.read(file);
+      if (!scanPollutedSources(content, wikiFolder, preserveCase)) continue;
+      polluted += 1;
+      const { fixed, content: fixedContent } = fixPollutedSources(content, wikiFolder, preserveCase);
+      if (fixed > 0) {
+        await app.vault.process(file, () => fixedContent);
+        filesCleaned += 1;
+        entriesCleaned += fixed;
+      }
+    }
+    console.debug(`[QuickFixes] Phase 2 complete: ${wikiFiles.length} scanned, ${polluted} polluted, ${filesCleaned} fixed (${entriesCleaned} entries)`);
+  } catch (e) {
+    console.warn('[QuickFixes] Phase 2 failed:', e);
+  }
+  return { filesCleaned, entriesCleaned };
 }

--- a/src/schema/auto-maintain.ts
+++ b/src/schema/auto-maintain.ts
@@ -5,7 +5,7 @@ import { App, TAbstractFile, TFile, Notice, Plugin } from 'obsidian';
 import { LLMWikiSettings } from '../types';
 import { WikiEngine } from '../wiki/wiki-engine';
 import { TEXTS } from '../texts';
-import { fixPollutedSources, scanPollutedSources } from '../core/sources-normalizer';
+import { normalizeSourcesInFolder } from '../core/sources-normalizer';
 import { findIncompletePages, cleanIncompletePages } from '../core/incomplete-page-cleaner';
 import { needsLogHeaderMigration, migrateLogHeader } from '../core/log-header';
 import { ensureWelcomeNote, type EnsureResult, type VaultAdapter } from '../core/ensure-welcome-note';
@@ -14,7 +14,6 @@ import { resolveModelForTask } from '../core/model-resolver';
 import { isLocalNoKeyProvider } from '../core/local-no-key-provider';
 import { resolveProviderApiKey } from '../llm-sdk/provider-api-key-resolver';
 import type { LLMClient } from '../types';
-import { isInFolderScope } from '../core/folder-scope';
 
 export class AutoMaintainManager {
   private app: App;
@@ -399,35 +398,11 @@ export class AutoMaintainManager {
 
     // ---- Phase 2: Sources field normalize (Issue #81) ----
     // Scans only files in wikiFolder, only writes files that need fixing.
-    let sourcesFilesCleaned = 0;
-    let sourcesEntriesCleaned = 0;
-    let sourcesFilesScanned = 0;
-    let sourcesFilesPolluted = 0;
-    try {
-      const wikiFiles = this.app.vault.getMarkdownFiles()
-        .filter(f => isInFolderScope(f.path, wikiFolder, false));
-      console.debug(`[QuickFixes] Phase 2: scanning ${wikiFiles.length} files in "${wikiFolder}"`);
-      const sourcesPreserveCase = this.settings.slugCase === 'preserve';
-      for (const file of wikiFiles) {
-        sourcesFilesScanned += 1;
-        const content = await this.app.vault.read(file);
-        if (!scanPollutedSources(content, wikiFolder, sourcesPreserveCase)) continue;
-        sourcesFilesPolluted += 1;
-        console.debug(`[QuickFixes] Polluted sources detected in ${file.path}`);
-        const { fixed, content: fixedContent } = fixPollutedSources(content, wikiFolder, sourcesPreserveCase);
-        if (fixed > 0) {
-          await this.app.vault.process(file, () => fixedContent);
-          sourcesFilesCleaned += 1;
-          sourcesEntriesCleaned += fixed;
-          console.debug(`[QuickFixes] Fixed ${file.path} (${fixed} entry normalization)`);
-        } else {
-          console.debug(`[QuickFixes] Scan reported polluted but fix returned 0 for ${file.path} — possible bug`);
-        }
-      }
-      console.debug(`[QuickFixes] Phase 2 complete: ${sourcesFilesScanned} scanned, ${sourcesFilesPolluted} polluted, ${sourcesFilesCleaned} fixed (${sourcesEntriesCleaned} entries)`);
-    } catch (e) {
-      console.warn('[QuickFixes] Phase 2 failed:', e);
-    }
+    // Module-function shape matches Phase 3 (findIncompletePages /
+    // cleanIncompletePages in src/core/incomplete-page-cleaner.ts).
+    const sourcesPreserveCase = this.settings.slugCase === 'preserve';
+    const { filesCleaned: sourcesFilesCleaned, entriesCleaned: sourcesEntriesCleaned } =
+      await normalizeSourcesInFolder(this.app, wikiFolder, sourcesPreserveCase);
 
     // ---- Phase 3: Incomplete-page cleanup (Issue #170) ----
     // Scan wiki/{entities,concepts,sources} for pages whose `generation_complete`

--- a/src/ui/modals/MultiFileSuggestModal-class.ts
+++ b/src/ui/modals/MultiFileSuggestModal-class.ts
@@ -23,7 +23,7 @@ import { getText } from '../../core/i18n';
 import { buildFolderTree, type TreeNode } from '../../core/build-folder-tree';
 import type { IngestQueue } from '../../core/ingest-queue';
 import { COMPATIBLE_SOURCE_EXTENSIONS } from '../../constants';
-import { isInFolderScope } from '../../core/folder-scope';
+import { isExcludedFromSourcePicker } from '../../core/folder-scope';
 
 export class MultiFileSuggestModal extends Modal {
   /** The shared ingest queue. Modal reads + subscribes; never owns
@@ -99,7 +99,7 @@ export class MultiFileSuggestModal extends Modal {
     // folders (the bug v2 fixes). v1.25.0 PR2: include PDFs.
     const compatibleExts: readonly string[] = COMPATIBLE_SOURCE_EXTENSIONS;
     const available = this.app.vault.getFiles()
-      .filter(f => !isInFolderScope(f.path, this.wikiFolder, false) && !f.path.startsWith(this.app.vault.configDir))
+      .filter(f => !isExcludedFromSourcePicker(f.path, this.wikiFolder, this.app.vault.configDir))
       .filter(f => compatibleExts.includes(f.extension.toLowerCase()))
       .sort((a, b) => a.path.localeCompare(b.path));
     this.treeRoots = buildFolderTree(available);

--- a/src/ui/modals/suggest-modals.ts
+++ b/src/ui/modals/suggest-modals.ts
@@ -2,11 +2,12 @@
 // in settings.ts (folder picker) and settings tab flows (file picker).
 //
 // Extracted from the original `src/ui/modals.ts` god file (PR split).
-// No behavior change — pure code movement.
+// The exclusion rule for both pickers lives in `isExcludedFromSourcePicker`
+// (src/core/folder-scope.ts); PR #384 / #383 follow-up centralised it.
 
 import { App, TFile, TFolder, FuzzySuggestModal } from 'obsidian';
 import { COMPATIBLE_SOURCE_EXTENSIONS } from '../../constants';
-import { isInFolderScope } from '../../core/folder-scope';
+import { isExcludedFromSourcePicker } from '../../core/folder-scope';
 
 const isCompatibleSource = (f: TFile): boolean =>
   (COMPATIBLE_SOURCE_EXTENSIONS as readonly string[]).includes(f.extension.toLowerCase());
@@ -24,10 +25,13 @@ export class FileSuggestModal extends FuzzySuggestModal<TFile> {
   getItems(): TFile[] {
     // v1.25.0 PR2: include PDFs in the source picker (PDFs are a first-class
     // source format). Filter by compatible extension + exclude wiki/config
-    // directories, mirroring the legacy markdown-only behavior.
+    // directories, mirroring the legacy markdown-only behavior. The exclusion
+    // rule (`isExcludedFromSourcePicker`) is shared with the folder picker so
+    // the wiki folder itself, its descendants, and configDir siblings of any
+    // shape are all hidden together.
     return this.app.vault.getFiles()
       .filter(f => isCompatibleSource(f))
-      .filter(f => !isInFolderScope(f.path, this.wikiFolder, false) && !f.path.startsWith(this.app.vault.configDir));
+      .filter(f => !isExcludedFromSourcePicker(f.path, this.wikiFolder, this.app.vault.configDir));
   }
 
   getItemText(file: TFile): string {
@@ -54,7 +58,7 @@ export class FolderSuggestModal extends FuzzySuggestModal<TFolder> {
     const root = this.app.vault.getRoot();
 
     const collect = (folder: TFolder) => {
-      if (!folder.path.startsWith(this.app.vault.configDir) && !isInFolderScope(folder.path, this.wikiFolder, false)) {
+      if (!isExcludedFromSourcePicker(folder.path, this.wikiFolder, this.app.vault.configDir)) {
         folders.push(folder);
       }
       for (const child of folder.children) {


### PR DESCRIPTION
## Summary

Follow-up on PR #384 / Issue #383. Closes the two findings @DocTpoint
raised in his #383 reply (4.7 / 4.8), plus the depth improvements the
in-branch review surfaced. Three independent commits.

### What's fixed

1. **FolderSuggestModal identity-check regression** — PR #384 described
   `path === wikiFolder` but the merged code dropped it, so the wiki
   folder itself was selectable as a source/watched folder again.

2. **Unanchored `configDir` leak** — `FolderSuggestModal.getItems()` had
   `folder.path.startsWith(configDir)` — the same leak class folder-scope.ts
   was created to eliminate (#364). A `.obsidian-backup/` folder next to
   `.obsidian/` would have entered the picker; the centralised rule now
   uses `isInFolderScope` so it doesn't.

3. **Three shell tests pinned nothing** — `delete-empty-stubs` /
   `merge-duplicates` / `auto-maintain` rebuilt the filter expression
   inside the test file and asserted against the copy. Reverting any of
   those three source lines left the tests green. Rewritten as real
   production-function coverage:
   - delete-empty-stubs: 5 cases (leak direction + substantive content +
     reviewed:true + protected paths + deleteFile throw)
   - normalizeSourcesInFolder (auto-maintain Phase 2): 3 cases (leak
     direction + clean file + read throw)
   - merge-duplicates: deleted with a header note — #386 (assigned to
     DocTpoint) rewrites that filter and owns its own coverage.

### Depth improvements (from in-branch review)

4. **Centralised picker rule** — `FileSuggestModal`, `FolderSuggestModal`,
   and `MultiFileSuggestModal` each open-coded the wiki+configDir filter.
   Two new primitives in `src/core/folder-scope.ts` (`isAtOrInFolderScope`,
   `isExcludedFromSourcePicker`) collapse all three to one rule. The
   previously-hand-rolled `path === folder || isInFolderScope(...)`
   pattern lives there now with its tests.

5. **Module-function shape** — auto-maintain Phase 2 previously lived
   inline in `runStartupCheck` (which sleeps 3s and needs the wikiEngine/
   plugin dependencies — hence the previous test cast the manager to a
   junk shape with two `as unknown as` casts). Extracted to
   `normalizeSourcesInFolder` in `src/core/sources-normalizer.ts` with the
   same module-function shape as the neighbouring Phase 3
   (`findIncompletePages`).

### Out of scope (filed as separate issues)

- FileSuggestModal pre-existing identity-check bug for `wiki.md` (a file
  at the vault root sharing the wiki folder's name).
- Trailing-slash on wikiFolder across the codebase (`'wiki/'` ≠ `'wiki'`)
  — folder-scope normalises trailing slashes; settings UI does not strip
  them on input.

### Verification

Gate 1 green (`pnpm lint & npx tsc --noEmit & pnpm test & pnpm build & pnpm css-lint`).
2863/2863 tests pass (+20 net).

Each leak-direction test was verified by reverting the production filter
to `startsWith` and watching the test fail, then restoring.

Closes #383
