### PR TITLE
fix(merge): retarget links vault-wide and in every link form before the delete

### DIFF
--- a/src/__tests__/__support__/link-vault.ts
+++ b/src/__tests__/__support__/link-vault.ts
@@ -1,0 +1,134 @@
+// A vault fake with the two things `src/core/link-retarget.ts` depends on and
+// the production mock context does not model: a link cache with positions, and
+// a linkpath resolver.
+//
+// The resolver deliberately mirrors Obsidian's own behaviour, because the
+// safeguard under test ("only rewrite links that actually resolve to the page
+// being deleted") is only meaningful against a realistic resolver:
+//
+//   * a linkpath may be a full path, a partial path, or a bare basename
+//   * frontmatter aliases are NOT consulted — Obsidian's resolver reads its
+//     file lookup, not aliases, so a bare link matching only an alias does not
+//     resolve
+//   * when several files match, the one in the linking file's own folder wins,
+//     then the shortest path
+//
+// Links inside fenced code blocks are not reported, which is also what the real
+// metadata cache does — a quoted `[[Foo]]` in documentation is not a link.
+
+export interface FakeReference {
+  link: string;
+  original: string;
+  position: { start: { offset: number }; end: { offset: number } };
+}
+
+export interface FakeLinkVault {
+  vault: {
+    getMarkdownFiles(): Array<{ path: string }>;
+    process(file: { path: string }, fn: (data: string) => string): Promise<string>;
+  };
+  metadataCache: {
+    getFileCache(file: { path: string }): { links?: FakeReference[]; embeds?: FakeReference[] } | null;
+    getFirstLinkpathDest(linkpath: string, sourcePath: string): { path: string } | null;
+  };
+  read(path: string): string;
+  write(path: string, content: string): void;
+  /** Paths whose content was handed to `vault.process`, in call order. */
+  processed: string[];
+}
+
+const FENCE = /^\s*(```|~~~)/;
+
+function fencedLineRanges(content: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let offset = 0;
+  let openedAt: number | null = null;
+  for (const line of content.split('\n')) {
+    if (FENCE.test(line)) {
+      if (openedAt === null) openedAt = offset;
+      else {
+        ranges.push([openedAt, offset + line.length]);
+        openedAt = null;
+      }
+    }
+    offset += line.length + 1;
+  }
+  if (openedAt !== null) ranges.push([openedAt, content.length]);
+  return ranges;
+}
+
+function scanReferences(content: string): { links: FakeReference[]; embeds: FakeReference[] } {
+  const fenced = fencedLineRanges(content);
+  const inFence = (offset: number): boolean =>
+    fenced.some(([start, end]) => offset >= start && offset < end);
+
+  const links: FakeReference[] = [];
+  const embeds: FakeReference[] = [];
+  const pattern = /(!?)\[\[([^\][]+)\]\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(content)) !== null) {
+    if (inFence(match.index)) continue;
+    const inner = match[2];
+    const pipe = inner.indexOf('|');
+    const link = pipe >= 0 ? inner.slice(0, pipe) : inner;
+    const reference: FakeReference = {
+      link,
+      original: match[0],
+      position: {
+        start: { offset: match.index },
+        end: { offset: match.index + match[0].length },
+      },
+    };
+    (match[1] === '!' ? embeds : links).push(reference);
+  }
+  return { links, embeds };
+}
+
+export function createFakeLinkVault(initial: Record<string, string>): FakeLinkVault {
+  const files = new Map<string, string>(Object.entries(initial));
+  const processed: string[] = [];
+
+  const resolve = (linkpath: string, sourcePath: string): { path: string } | null => {
+    const wanted = linkpath.replace(/\.md$/, '');
+    const sourceFolder = sourcePath.slice(0, sourcePath.lastIndexOf('/') + 1);
+    const matches = [...files.keys()].filter(path => {
+      const withoutExt = path.replace(/\.md$/, '');
+      if (withoutExt === wanted) return true;
+      if (withoutExt.endsWith(`/${wanted}`)) return true;
+      return false;
+    });
+    if (matches.length === 0) return null;
+    matches.sort((a, b) => {
+      const exact = (p: string): number => (p.replace(/\.md$/, '') === wanted ? 0 : 1);
+      if (exact(a) !== exact(b)) return exact(a) - exact(b);
+      const local = (p: string): number => (p.startsWith(sourceFolder) ? 0 : 1);
+      if (local(a) !== local(b)) return local(a) - local(b);
+      if (a.length !== b.length) return a.length - b.length;
+      return a.localeCompare(b);
+    });
+    return { path: matches[0] };
+  };
+
+  return {
+    vault: {
+      getMarkdownFiles: () => [...files.keys()].map(path => ({ path })),
+      process: async (file, fn) => {
+        processed.push(file.path);
+        const next = fn(files.get(file.path) ?? '');
+        files.set(file.path, next);
+        return next;
+      },
+    },
+    metadataCache: {
+      getFileCache: file => {
+        const content = files.get(file.path);
+        if (content === undefined) return null;
+        return scanReferences(content);
+      },
+      getFirstLinkpathDest: resolve,
+    },
+    read: path => files.get(path) ?? '',
+    write: (path, content) => { files.set(path, content); },
+    processed,
+  };
+}

--- a/src/__tests__/core/link-retarget.test.ts
+++ b/src/__tests__/core/link-retarget.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { retargetLinksToPage } from '../../core/link-retarget';
+import { createFakeLinkVault } from '../__support__/link-vault';
+
+const FROM = 'wiki/entities/Osteopontin-2.md';
+const TO = 'wiki/entities/Osteopontin.md';
+
+describe('retargetLinksToPage', () => {
+  it('rewrites a bare-title link in a note outside the wiki folder', async () => {
+    // The measured case: 1762 of 1762 incoming links from user notes were
+    // written bare, and the previous rewrite visited wiki files only.
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Knochenstoffwechsel.md': 'See [[Osteopontin-2]] for the marker.\n',
+    });
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe('See [[Osteopontin]] for the marker.\n');
+    expect(result).toEqual({ filesChanged: 1, linksRewritten: 1, stale: 0 });
+  });
+
+  it('leaves a same-named page elsewhere in the vault alone', async () => {
+    // Resolve-before-replace: a bare `[[Osteopontin-2]]` next to the note's own
+    // Osteopontin-2 addresses that file, not the wiki page being merged. A
+    // string match would bend this link to a page it never referenced.
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Osteopontin-2.md': '# My own note\n',
+      'Notizen/Knochenstoffwechsel.md': 'See [[Osteopontin-2]].\n',
+    });
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe('See [[Osteopontin-2]].\n');
+    expect(result).toEqual({ filesChanged: 0, linksRewritten: 0, stale: 0 });
+    expect(fake.processed).toEqual([]);
+  });
+
+  it('keeps the link shape: a folder-prefixed link stays folder-prefixed', async () => {
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'wiki/concepts/Knochenumbau.md': 'Regulated by [[entities/Osteopontin-2]].\n',
+      'Notizen/Knochenstoffwechsel.md': 'See [[Osteopontin-2]].\n',
+    });
+
+    await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('wiki/concepts/Knochenumbau.md')).toBe('Regulated by [[entities/Osteopontin]].\n');
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe('See [[Osteopontin]].\n');
+  });
+
+  it('preserves display text, subpath and the embed marker', async () => {
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Knochenstoffwechsel.md':
+        'A [[Osteopontin-2|OPN]] and a section [[Osteopontin-2#Funktion]].\n' +
+        '![[Osteopontin-2#Funktion|OPN]]\n',
+    });
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe(
+      'A [[Osteopontin|OPN]] and a section [[Osteopontin#Funktion]].\n' +
+      '![[Osteopontin#Funktion|OPN]]\n'
+    );
+    expect(result.linksRewritten).toBe(3);
+  });
+
+  it('does not touch a link quoted inside a code block', async () => {
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Plugin-Notizen.md': 'Example:\n\n```\n[[Osteopontin-2]]\n```\n',
+    });
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('Notizen/Plugin-Notizen.md')).toContain('[[Osteopontin-2]]');
+    expect(result.linksRewritten).toBe(0);
+  });
+
+  it('skips the page being deleted and files without references', async () => {
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n\nSee [[Osteopontin-2]] and [[Osteopontin]].\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Unrelated.md': 'No links here.\n',
+    });
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read(FROM)).toContain('[[Osteopontin-2]]');
+    expect(fake.processed).toEqual([]);
+    expect(result).toEqual({ filesChanged: 0, linksRewritten: 0, stale: 0 });
+  });
+
+  it('reports a link it could not rewrite instead of splicing on a stale offset', async () => {
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Knochenstoffwechsel.md': 'See [[Osteopontin-2]].\n',
+    });
+    // The cache is read first; the file then changes underneath, as it would if
+    // the user edited the note between indexing and the merge.
+    const cache = fake.metadataCache.getFileCache;
+    fake.metadataCache.getFileCache = file => {
+      const result = cache({ path: file.path });
+      if (file.path === 'Notizen/Knochenstoffwechsel.md') {
+        fake.write(file.path, 'Rewritten by hand. See [[Osteopontin-2]].\n');
+      }
+      return result;
+    };
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe('Rewritten by hand. See [[Osteopontin-2]].\n');
+    expect(result).toEqual({ filesChanged: 0, linksRewritten: 0, stale: 1 });
+  });
+
+  it('rewrites several links in one file in a single write', async () => {
+    const fake = createFakeLinkVault({
+      [FROM]: '# Osteopontin-2\n',
+      [TO]: '# Osteopontin\n',
+      'Notizen/Knochenstoffwechsel.md': '[[Osteopontin-2]] und [[Osteopontin-2|OPN]] und [[Osteopontin-2]].\n',
+    });
+
+    const result = await retargetLinksToPage(fake, FROM, TO);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe(
+      '[[Osteopontin]] und [[Osteopontin|OPN]] und [[Osteopontin]].\n'
+    );
+    expect(result).toEqual({ filesChanged: 1, linksRewritten: 3, stale: 0 });
+    expect(fake.processed).toEqual(['Notizen/Knochenstoffwechsel.md']);
+  });
+
+  it('is a no-op when source and target are the same page', async () => {
+    const fake = createFakeLinkVault({
+      [TO]: '# Osteopontin\n',
+      'Notizen/Knochenstoffwechsel.md': 'See [[Osteopontin]].\n',
+    });
+
+    const result = await retargetLinksToPage(fake, TO, TO);
+
+    expect(result).toEqual({ filesChanged: 0, linksRewritten: 0, stale: 0 });
+    expect(fake.processed).toEqual([]);
+  });
+});

--- a/src/__tests__/wiki/lint/merge-duplicates-link-retarget.test.ts
+++ b/src/__tests__/wiki/lint/merge-duplicates-link-retarget.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { mergeDuplicatePages } from '../../../wiki/lint/merge-duplicates';
+import { createFakeLinkVault } from '../../__support__/link-vault';
+import type { EngineContext } from '../../../types';
+
+// Issue #386 at the call site. PR #389 deliberately left the merge-duplicates
+// site without leak-direction coverage because this issue replaces the filter
+// outright — this is that coverage.
+//
+// The LLM client is absent on purpose: `mergeDuplicatePages` falls back to its
+// programmatic merge, which is the path that matters for the link rewrite.
+
+const TARGET = 'wiki/entities/Osteopontin.md';
+const SOURCE = 'wiki/entities/Osteopontin-2.md';
+
+function makeCtx(files: Record<string, string>) {
+  const fake = createFakeLinkVault(files);
+  const deleted: string[] = [];
+  const ctx = {
+    app: { vault: fake.vault, metadataCache: fake.metadataCache },
+    settings: { wikiFolder: 'wiki', language: 'en' },
+    getClient: () => null,
+    tryReadFile: async (path: string) => (files[path] === undefined ? fake.read(path) || null : fake.read(path)),
+    createOrUpdateFile: async (path: string, content: string) => { fake.write(path, content); },
+    deleteFile: async (path: string) => { deleted.push(path); },
+    getSchemaContext: async () => undefined,
+  } as unknown as EngineContext;
+  return { ctx, fake, deleted };
+}
+
+describe('mergeDuplicatePages — link retargeting (#386)', () => {
+  it('retargets a bare-title link in a user note outside the wiki folder', async () => {
+    const { ctx, fake, deleted } = makeCtx({
+      [TARGET]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin\n\nBone marker.\n',
+      [SOURCE]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin-2\n\nAlso a bone marker.\n',
+      'Notizen/Knochenstoffwechsel.md': 'Reguliert durch [[Osteopontin-2]].\n',
+      'wiki/concepts/Knochenumbau.md': 'Reguliert durch [[entities/Osteopontin-2]].\n',
+    });
+
+    const summary = await mergeDuplicatePages(ctx, TARGET, SOURCE);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe('Reguliert durch [[Osteopontin]].\n');
+    expect(fake.read('wiki/concepts/Knochenumbau.md')).toBe('Reguliert durch [[entities/Osteopontin]].\n');
+    expect(deleted).toEqual([SOURCE]);
+    expect(summary).toContain('2 links retargeted in 2 files');
+  });
+
+  it('does not write into a note whose links point elsewhere', async () => {
+    const { ctx, fake } = makeCtx({
+      [TARGET]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin\n\nBone marker.\n',
+      [SOURCE]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin-2\n\nAlso a bone marker.\n',
+      'Notizen/Osteopontin-2.md': '# My own note\n',
+      'Notizen/Knochenstoffwechsel.md': 'Siehe [[Osteopontin-2]].\n',
+    });
+
+    const summary = await mergeDuplicatePages(ctx, TARGET, SOURCE);
+
+    expect(fake.read('Notizen/Knochenstoffwechsel.md')).toBe('Siehe [[Osteopontin-2]].\n');
+    expect(fake.processed).toEqual([]);
+    expect(summary).toBe('merged entities/Osteopontin-2 → entities/Osteopontin');
+  });
+});

--- a/src/core/link-retarget.ts
+++ b/src/core/link-retarget.ts
@@ -1,0 +1,210 @@
+// Issue #386 — retarget every link that points at a page before that page is
+// deleted.
+//
+// `mergeDuplicatePages` merges a duplicate into its target and then deletes the
+// duplicate. Every link still pointing at the deleted page is dead from that
+// moment on, and the deletion is what makes it unfindable afterwards: no scan
+// can report a reference to a file that no longer exists.
+//
+// The rewrite this replaces looked only inside the wiki folder, and searched
+// only for the wiki-relative form (`[[entities/Foo]]`). Measured on a vault
+// with 2824 wiki pages and 473 notes outside the wiki: of the links pointing
+// from outside into the wiki, 1762 (across 340 notes) were written as a bare
+// title `[[Foo]]` and none carried a folder prefix — the bare form is what
+// Obsidian's own autocomplete inserts. Widening the radius without widening
+// the link form would therefore have changed nothing at all.
+//
+// Two properties this module is built around:
+//
+//   * Resolve before replacing. A bare `[[Foo]]` is not evidence that this
+//     page is meant: another note named `Foo` elsewhere in the vault owns that
+//     link. Every candidate is resolved through the same resolver the app uses
+//     (`getFirstLinkpathDest`, which is source-file relative), and only a link
+//     that actually lands on the page being deleted is touched. Frontmatter
+//     aliases are deliberately NOT consulted, because Obsidian's resolver does
+//     not consult them either — a bare link matching only an alias does not
+//     resolve today, and pretending otherwise here would rewrite links that
+//     were never pointing at this page.
+//
+//   * Write surgically. Foreign notes are the user's own files. Replacements
+//     are applied at the offsets the metadata cache reports, so nothing else
+//     in the file is reformatted, and links inside code blocks are left alone
+//     because the cache does not report them as links. This is also why the
+//     write goes through `vault.process` rather than the wiki's own write gate
+//     (`createOrUpdateFile`), which normalizes `sources:` frontmatter and
+//     corrects link pollution on every write — appropriate for a generated
+//     wiki page, not for someone's own note.
+//
+// The module is deliberately free of wiki vocabulary (no `wikiFolder`, no page
+// types) so the same primitive serves a rename or a redirect feature later.
+
+/** The subset of `TFile` this module needs. */
+export interface RetargetFile {
+  path: string;
+}
+
+/** The subset of `Reference` (link and embed cache entries) this module needs. */
+export interface RetargetReference {
+  /** Link destination as written, including any `#subpath`. */
+  link: string;
+  /** The reference exactly as it appears in the document, e.g. `[[a/b|c]]`. */
+  original: string;
+  position: { start: { offset: number }; end: { offset: number } };
+}
+
+/** The subset of `MetadataCache` this module needs. */
+export interface RetargetMetadataCache {
+  getFileCache(file: RetargetFile): {
+    links?: RetargetReference[];
+    embeds?: RetargetReference[];
+  } | null;
+  getFirstLinkpathDest(linkpath: string, sourcePath: string): RetargetFile | null;
+}
+
+/** The subset of `Vault` this module needs. */
+export interface RetargetVault {
+  getMarkdownFiles(): RetargetFile[];
+  process(file: RetargetFile, fn: (data: string) => string): Promise<string>;
+}
+
+export interface RetargetDeps {
+  vault: RetargetVault;
+  metadataCache: RetargetMetadataCache;
+}
+
+export interface RetargetResult {
+  /** Files whose content was rewritten. */
+  filesChanged: number;
+  /** Individual references rewritten. */
+  linksRewritten: number;
+  /**
+   * References that resolved to the page but could not be rewritten because
+   * the file on disk no longer matched the cached position. Non-zero means
+   * those links are about to go dead — the caller should surface it.
+   */
+  stale: number;
+}
+
+/**
+ * Every linkpath under which `filePath` is addressable, shortest first:
+ * `Foo`, `entities/Foo`, `wiki/entities/Foo`. Which of them actually resolves
+ * to this file depends on the linking file and is decided by the resolver.
+ */
+function addressableForms(filePath: string): string[] {
+  const withoutExt = filePath.replace(/\.md$/, '');
+  const segments = withoutExt.split('/');
+  const forms: string[] = [];
+  for (let i = segments.length - 1; i >= 0; i--) {
+    forms.push(segments.slice(i).join('/'));
+  }
+  return forms;
+}
+
+/**
+ * Pick the linkpath to write for a link that lived in `fromFile` and pointed at
+ * the page now being replaced by `toPath`.
+ *
+ * Preference order is *shape first*: a link written with two segments is
+ * rewritten with two segments where that resolves. The wiki writes its own
+ * internal links folder-prefixed and a user note writes bare titles; a rewrite
+ * that silently converted between the two would be a second, unasked-for change
+ * to the file. Only when the original's shape does not resolve does this fall
+ * back to the shortest form that does, and finally to the full path, which
+ * always resolves.
+ */
+function chooseLinkpath(
+  metadataCache: RetargetMetadataCache,
+  linkingFilePath: string,
+  originalLinkpath: string,
+  toPath: string
+): string {
+  const forms = addressableForms(toPath);
+  const resolvesToTarget = (candidate: string): boolean =>
+    metadataCache.getFirstLinkpathDest(candidate, linkingFilePath)?.path === toPath;
+
+  const originalDepth = originalLinkpath.split('/').length;
+  const sameShape = forms.find(f => f.split('/').length === originalDepth);
+  if (sameShape && resolvesToTarget(sameShape)) return sameShape;
+
+  const shortestResolving = forms.find(resolvesToTarget);
+  if (shortestResolving) return shortestResolving;
+
+  return forms[forms.length - 1];
+}
+
+/**
+ * Rewrite every link in the vault that resolves to `fromPath` so it points at
+ * `toPath` instead. Call this BEFORE deleting `fromPath` — resolution depends
+ * on the file still existing.
+ *
+ * `fromPath` itself is skipped: its own links are about to disappear with it.
+ */
+export async function retargetLinksToPage(
+  deps: RetargetDeps,
+  fromPath: string,
+  toPath: string
+): Promise<RetargetResult> {
+  const result: RetargetResult = { filesChanged: 0, linksRewritten: 0, stale: 0 };
+  if (fromPath === toPath) return result;
+
+  for (const file of deps.vault.getMarkdownFiles()) {
+    if (file.path === fromPath) continue;
+
+    const cache = deps.metadataCache.getFileCache(file);
+    const references = [...(cache?.links ?? []), ...(cache?.embeds ?? [])];
+    if (references.length === 0) continue;
+
+    const edits: Array<{ start: number; end: number; original: string; replacement: string }> = [];
+    for (const ref of references) {
+      const hashIndex = ref.link.indexOf('#');
+      const linkpath = hashIndex >= 0 ? ref.link.slice(0, hashIndex) : ref.link;
+      const subpath = hashIndex >= 0 ? ref.link.slice(hashIndex) : '';
+      // `[[#Heading]]` addresses the current file and has no linkpath.
+      if (!linkpath) continue;
+
+      const dest = deps.metadataCache.getFirstLinkpathDest(linkpath, file.path);
+      if (!dest || dest.path !== fromPath) continue;
+
+      const newLinkpath = chooseLinkpath(deps.metadataCache, file.path, linkpath, toPath);
+      // Rebuild from `original` so display text (`|…`), the embed marker (`!`)
+      // and the subpath survive verbatim; only the destination changes.
+      const replacement = ref.original.replace(`[[${ref.link}`, `[[${newLinkpath}${subpath}`);
+      if (replacement === ref.original) continue;
+
+      edits.push({
+        start: ref.position.start.offset,
+        end: ref.position.end.offset,
+        original: ref.original,
+        replacement,
+      });
+    }
+    if (edits.length === 0) continue;
+
+    let applied = 0;
+    let stale = 0;
+    await deps.vault.process(file, data => {
+      let next = data;
+      // Descending, so an earlier edit's offsets stay valid.
+      for (const edit of [...edits].sort((a, b) => b.start - a.start)) {
+        // The cache can lag the file. Splicing on a stale offset would corrupt
+        // the note, so a position that no longer holds what the cache promised
+        // is reported instead of guessed at.
+        if (next.slice(edit.start, edit.end) !== edit.original) {
+          stale++;
+          continue;
+        }
+        next = next.slice(0, edit.start) + edit.replacement + next.slice(edit.end);
+        applied++;
+      }
+      return next;
+    });
+
+    result.stale += stale;
+    if (applied > 0) {
+      result.filesChanged++;
+      result.linksRewritten += applied;
+    }
+  }
+
+  return result;
+}

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -5,10 +5,9 @@ import { buildSystemPrompt } from '../system-prompts';
 import { parseFrontmatter, enforceFrontmatterConstraints, serializeFrontmatter } from '../../core/frontmatter';
 import { parseJsonResponse } from '../../core/json';
 import { cleanMarkdownResponse } from '../../core/markdown';
-import { escapeRegex } from './utils';
 import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
-import { isInFolderScope } from '../../core/folder-scope';
+import { retargetLinksToPage } from '../../core/link-retarget';
 
 export async function mergeDuplicatePages(
   ctx: EngineContext,
@@ -161,25 +160,25 @@ export async function mergeDuplicatePages(
   const enforced = enforceFrontmatterConstraints(newContent, pageType, ctx.settings);
   await ctx.createOrUpdateFile(targetPath, enforced);
 
-  // Rewrite wiki-links: all references to sourcePath -> targetPath
+  // Issue #386: retarget every link that resolves to the source page, vault-wide
+  // and in every link form, BEFORE the page is deleted. The previous rewrite
+  // visited only files inside the wiki folder and searched only for the
+  // wiki-relative form, so an ordinary user note linking `[[Foo]]` kept a link
+  // into nothing — and after the delete that reference is no longer findable.
   const wikiFolder = ctx.settings.wikiFolder;
   const sourceRel = sourcePath.replace(wikiFolder + '/', '').replace('.md', '');
   const targetRel = targetPath.replace(wikiFolder + '/', '').replace('.md', '');
-  const allWikiFiles = ctx.app.vault.getMarkdownFiles().filter(
-    f => isInFolderScope(f.path, wikiFolder, false) && f.path !== sourcePath
-  );
-  for (const file of allWikiFiles) {
-    const content = await ctx.app.vault.read(file);
-    if (content.includes(`[[${sourceRel}]]`) || content.includes(`[[${sourceRel}|`)) {
-      const updated = content
-        .replace(new RegExp(`\\[\\[${escapeRegex(sourceRel)}\\]\\]`, 'g'), `[[${targetRel}]]`)
-        .replace(new RegExp(`\\[\\[${escapeRegex(sourceRel)}\\|`, 'g'), `[[${targetRel}|`);
-      if (updated !== content) {
-        await ctx.createOrUpdateFile(file.path, updated);
-      }
-    }
+  const retargeted = await retargetLinksToPage(ctx.app, sourcePath, targetPath);
+  if (retargeted.stale > 0) {
+    console.warn(
+      `mergeDuplicatePages: ${retargeted.stale} link(s) to ${sourceRel} could not be retargeted ` +
+      `(file changed since it was indexed) and will be dead after the merge`
+    );
   }
 
   await ctx.deleteFile(sourcePath);
-  return `merged ${sourceRel} → ${targetRel}`;
+  const linkNote = retargeted.linksRewritten > 0
+    ? ` (${retargeted.linksRewritten} link${retargeted.linksRewritten === 1 ? '' : 's'} retargeted in ${retargeted.filesChanged} file${retargeted.filesChanged === 1 ? '' : 's'})`
+    : '';
+  return `merged ${sourceRel} → ${targetRel}${linkNote}`;
 }


### PR DESCRIPTION
Closes #386 — option A as picked in the issue, with the resolve-before-replace safeguard, and as a separate testable function rather than inlined in `mergeDuplicatePages`.

## What changed

New `src/core/link-retarget.ts` with one exported function, `retargetLinksToPage(deps, fromPath, toPath)`. `mergeDuplicatePages` calls it immediately before `ctx.deleteFile(sourcePath)`; the old in-place loop is gone.

The module carries no wiki vocabulary — no `wikiFolder`, no page types, no lint context — so the same primitive is what a rename or redirect feature would call.

## The safeguard is the app's own resolver, not a string match

Every candidate goes through `metadataCache.getFirstLinkpathDest(linkpath, linkingFile.path)`, and only a link that actually lands on the page being deleted is touched. A bare `[[Foo]]` in a note that sits next to the user's own `Foo.md` resolves to that note and is left alone.

One thing I checked before building, because it decides whether this bug exists at all: the merge adds the source page's title to the target's `aliases`, so it would be reasonable to assume a bare `[[Foo-2]]` survives the deletion by resolving through the alias. It does not. Obsidian's resolver reads its file lookup and never consults frontmatter aliases — that is why community plugins exist that monkey-patch `getFirstLinkpathDest` to add exactly this ([forum report on 1.12.7](https://forum.obsidian.md/t/wikilink-resolution-does-not-honor-frontmatter-aliases-1-12-7/113902), [Alias Linker](https://community.obsidian.md/plugins/alias-linker)). The alias is good for the suggester, not for resolution. The same fact is why this module must not consult aliases either: doing so would rewrite links that were never pointing at the page.

## Two decisions worth your eye

**1. Foreign notes are written through `vault.process`, not `createOrUpdateFile`.** The wiki's write gate normalizes the `sources:` frontmatter field and auto-corrects link pollution on every write. That is right for a generated wiki page and wrong for someone's own note — the plugin should change the one link it came for and nothing else. Edits are applied at the offsets the metadata cache reports, after verifying the text at that offset still matches what the cache promised; a note that changed since indexing is counted as `stale` and reported rather than spliced blind. Links quoted inside code blocks are untouched, since the cache does not report them as links.

**2. The rewrite keeps the link's shape.** A folder-prefixed `[[entities/Foo-2]]` inside the wiki becomes `[[entities/Foo]]`, a bare `[[Foo-2]]` in a user note becomes `[[Foo]]`. The candidate forms are generated from the target path (`Foo`, `entities/Foo`, `wiki/entities/Foo`) and each is verified to resolve back to the target from that particular file, preferring the original's depth. Rewriting everything to the shortest resolving form would have been simpler, but it would convert a wiki page's link convention as a side effect of a merge, and it would fight `correctRelatedLinkPrefixes`.

## Not in this PR

`stale` currently surfaces as a `console.warn`. If you would rather have it in the lint report as a finding, say so and I will wire it — it is the one case where the merge knowingly leaves a dead link behind, so it arguably belongs on screen.

The sweep is one pass over the markdown file list per merged pair, using in-memory cache lookups. On a lint run merging many pairs that is O(pairs × files) cache hits; measurable but not hot. If you want it batched across a whole lint run, that is a different shape and I would rather do it as a follow-up than fold it in here.

## Verification

Gate 1 measured against `69f3357`, both sides on this machine rather than quoted:

| | base | branch |
|---|---|---|
| `pnpm lint --max-warnings=0` | 0/0 | 0/0 |
| `npx tsc --noEmit` | clean | clean |
| `pnpm test` | 2863 / 212 files | 2874 / 214 files |
| `pnpm build` | — | clean, production |
| `pnpm css-lint` | — | 0 |

11 new tests: 9 on the primitive (bare-title case, resolve-before-replace, shape preservation, display text / subpath / embed marker, code block, stale offsets, self-skip, several links in one write, no-op) and 2 at the merge site — the latter being the leak-direction coverage PR #389 deliberately left to this issue.

Each of the three load-bearing tests was verified by mutating the production code: removing the resolve guard, removing the shape preference, and removing the stale check each fail exactly their own test and nothing else.
