### PR TITLE
fix(frontmatter): take created: from the caller, never from the content

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -235,11 +235,16 @@ describe('enforceFrontmatterConstraints', () => {
     expect(result).not.toContain('tags: [other]');
   });
 
-  it('preserves created but forces updated to today', () => {
-    const input = '---\ntype: entity\ncreated: 2026-01-01\nupdated: 2026-05-18\n---\n\nBody';
-    const result = enforceFrontmatterConstraints(input, 'entity');
+  it('preserves the caller-supplied created but forces updated to today', () => {
+    // Issue #388: the prior value arrives as an argument. The `created:` line
+    // in the content is the model's, and is not what gets written.
+    const input = '---\ntype: entity\ncreated: 2024-11-03\nupdated: 2026-05-18\n---\n\nBody';
+    const result = enforceFrontmatterConstraints(input, 'entity', undefined, {
+      preserveCreated: '2026-01-01',
+    });
     const today = new Date().toISOString().split('T')[0];
     expect(result).toContain('created: 2026-01-01');
+    expect(result).not.toContain('created: 2024-11-03');
     expect(result).toContain(`updated: ${today}`);
     expect(result).not.toContain('updated: 2026-05-18');
   });
@@ -282,9 +287,11 @@ describe('enforceFrontmatterConstraints', () => {
     expect(result).not.toContain('tags: [other]');
   });
 
-  it('preserves existing created but forces updated to today', () => {
-    const input = '---\ntype: entity\ncreated: 2025-03-20\nupdated: 2024-12-01\n---\n\nBody';
-    const result = enforceFrontmatterConstraints(input, 'entity');
+  it('preserves the caller-supplied created on a page that already has one', () => {
+    const input = '---\ntype: entity\ncreated: 2024-12-01\nupdated: 2024-12-01\n---\n\nBody';
+    const result = enforceFrontmatterConstraints(input, 'entity', undefined, {
+      preserveCreated: '2025-03-20',
+    });
     const today = new Date().toISOString().split('T')[0];
     expect(result).toContain('created: 2025-03-20');
     expect(result).toContain(`updated: ${today}`);
@@ -297,6 +304,48 @@ describe('enforceFrontmatterConstraints', () => {
     const today = new Date().toISOString().split('T')[0];
     expect(result).toContain(`created: ${today}`);
     expect(result).toContain(`updated: ${today}`);
+  });
+
+  // ── Issue #388: `created:` provenance ────────────────────────────
+
+  it('ignores a created date the caller did not supply', () => {
+    // The generation paths hand this function the model's own reply. Without a
+    // prior file there is nothing to preserve, and a date found in that reply
+    // is invented by construction.
+    const input = '---\ntype: entity\ncreated: 2024-11-03\n---\n\nBody';
+    const result = enforceFrontmatterConstraints(input, 'entity');
+    const today = new Date().toISOString().split('T')[0];
+    expect(result).toContain(`created: ${today}`);
+    expect(result).not.toContain('2024-11-03');
+  });
+
+  it('ignores a caller value that is not an ISO date', () => {
+    const input = '---\ntype: entity\n---\n\nBody';
+    const today = new Date().toISOString().split('T')[0];
+    for (const bogus of ['gestern', '2025-13-99x', '', '   ']) {
+      const result = enforceFrontmatterConstraints(input, 'entity', undefined, {
+        preserveCreated: bogus,
+      });
+      expect(result).toContain(`created: ${today}`);
+    }
+  });
+
+  it('reviewed-guard: keeps the caller-supplied created instead of stamping today', () => {
+    // The reviewed branch returns early and previously forced `created` to
+    // today unconditionally, so a reviewed page lost its real creation date on
+    // every pass. With the value supplied it survives; without one the branch
+    // behaves as before.
+    const input = '---\ntype: entity\nreviewed: true\ncreated: 2024-11-03\nupdated: 2020-01-01\n---\n\nBody';
+    const today = new Date().toISOString().split('T')[0];
+
+    const withValue = enforceFrontmatterConstraints(input, 'entity', undefined, {
+      preserveCreated: '2026-01-05',
+    });
+    expect(withValue).toContain('created: 2026-01-05');
+    expect(withValue).toContain(`updated: ${today}`);
+
+    const withoutValue = enforceFrontmatterConstraints(input, 'entity');
+    expect(withoutValue).toContain(`created: ${today}`);
   });
 });
 

--- a/src/__tests__/wiki/lint/fill-empty-page-created.test.ts
+++ b/src/__tests__/wiki/lint/fill-empty-page-created.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { fillEmptyPage } from '../../../wiki/lint/fill-empty-page';
+import type { EngineContext } from '../../../types';
+
+// Issue #388 at the fill path. Unlike page creation, a real page exists here —
+// so the model's `created:` does not invent a date, it overwrites a true one.
+
+const PAGE = 'wiki/entities/Osteopontin.md';
+const ON_DISK =
+  '---\ntype: entity\ncreated: 2026-07-30\nupdated: 2026-07-30\ntags: [other]\n---\n\n# Osteopontin\n';
+
+function makeCtx(llmReply: string) {
+  const files = new Map<string, string>([[PAGE, ON_DISK]]);
+  const ctx = {
+    app: { vault: { getMarkdownFiles: () => [] } },
+    settings: { wikiFolder: 'wiki', wikiLanguage: 'en', language: 'en', disableThinking: false },
+    getClient: () => ({ createMessage: async () => llmReply }),
+    tryReadFile: async (path: string) => files.get(path) ?? null,
+    createOrUpdateFile: async (path: string, content: string) => { files.set(path, content); },
+    getSchemaContext: async () => undefined,
+    getSectionLabels: () => ({ section_description: 'Description' }),
+  } as unknown as EngineContext;
+  return { ctx, files };
+}
+
+describe('fillEmptyPage — created: provenance (Issue #388)', () => {
+  it('keeps the date from the file on disk when the model writes another one', async () => {
+    const { ctx, files } = makeCtx(
+      '---\ntype: entity\ncreated: 2024-11-03\nupdated: 2024-11-03\ntags: [other]\n---\n\n' +
+      '## Description\n\nOsteopontin is a phosphoprotein of the bone matrix and a marker ' +
+      'of vascular calcification, discussed here at enough length to clear the substantive ' +
+      'content threshold that the fill path applies before writing.\n'
+    );
+
+    await fillEmptyPage(ctx, PAGE);
+
+    const written = files.get(PAGE)!;
+    const today = new Date().toISOString().split('T')[0];
+    expect(written).toContain('created: 2026-07-30');
+    expect(written).not.toContain('2024-11-03');
+    expect(written).toContain(`updated: ${today}`);
+  });
+});

--- a/src/__tests__/wiki/page-factory/create-page.test.ts
+++ b/src/__tests__/wiki/page-factory/create-page.test.ts
@@ -429,3 +429,26 @@ Body.`;
     expect(sourcesLines.length).toBe(1);
   });
 });
+
+describe('createNewPage — created: provenance (Issue #388)', () => {
+  it('stamps today even when the model writes a date of its own', async () => {
+    // The rule the prompt states ("created: … NEVER LLM-generated") is only as
+    // good as the code behind it: on this path no prior file exists, so a date
+    // in the model's reply cannot be anything but invented.
+    const ctx = makeCtx({
+      llmResponse: '---\ntype: entity\ncreated: 2024-11-03\nupdated: 2024-11-03\ntags: [other]\n---\n\n## Description\nBody.',
+    });
+    await createNewPage(
+      ctx,
+      createMockEntity({ name: 'X' }),
+      'entity',
+      { path: 'notes/article.md', basename: 'article.md' },
+      [],
+      'wiki/entities/X.md',
+    );
+    const written = ctx.written.get('wiki/entities/X.md')!;
+    const today = new Date().toISOString().split('T')[0];
+    expect(written).toContain(`created: ${today}`);
+    expect(written).not.toContain('2024-11-03');
+  });
+});

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -529,10 +529,35 @@ export function preserveFrontmatterReviewTag(originalContent: string, newContent
   return newContent;
 }
 
+/**
+ * Issue #388: the creation date the caller knows to be real, read from the
+ * file that already exists on disk. `created:` is documented as programmatic
+ * and NEVER LLM-generated (`schema-manager.ts:190`), but this function cannot
+ * see where its input string came from — on the page-creation and empty-page-
+ * fill paths that string is the model's own reply, so a `created:` value
+ * found in it is the model's invention, not history.
+ *
+ * The rule is therefore: the prior value arrives as an argument or not at all.
+ * A caller that has no prior file (page creation) passes nothing and gets
+ * today; a caller that does (fill, merge) passes what it read.
+ */
+export interface FrontmatterDateOptions {
+  /** `YYYY-MM-DD` from the existing file. Anything else is ignored. */
+  preserveCreated?: string;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function resolveCreated(options: FrontmatterDateOptions | undefined, today: string): string {
+  const candidate = options?.preserveCreated?.trim();
+  return candidate && ISO_DATE.test(candidate) ? candidate : today;
+}
+
 export function enforceFrontmatterConstraints(
   content: string,
   pageType: 'entity' | 'concept' | 'source',
-  settings?: LLMWikiSettings
+  settings?: LLMWikiSettings,
+  options?: FrontmatterDateOptions
 ): string {
   if (!content.startsWith('---')) return content;
 
@@ -543,8 +568,9 @@ export function enforceFrontmatterConstraints(
 
   if (/^reviewed:\s*true\s*$/m.test(fmText)) {
     const today = new Date().toISOString().split('T')[0];
+    const created = resolveCreated(options, today);
     return content
-      .replace(/^created:\s*\d{4}-\d{2}-\d{2}\s*$/m, `created: ${today}`)
+      .replace(/^created:\s*\d{4}-\d{2}-\d{2}\s*$/m, `created: ${created}`)
       .replace(/^updated:\s*\d{4}-\d{2}-\d{2}\s*$/m, `updated: ${today}`);
   }
 
@@ -558,14 +584,15 @@ export function enforceFrontmatterConstraints(
   let foundTags = false;
   let foundAliases = false;
   let collectedAliases: string[] = [];
-  let createdValue = '';
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trim();
     if (!line) continue;
 
     if (line.startsWith('created:')) {
-      createdValue = line.substring(8).trim();
+      // Dropped on purpose — see FrontmatterDateOptions. Whatever stands here
+      // is only as trustworthy as the string this function was handed, and on
+      // the generation paths that string is the model's reply.
       continue;
     }
     if (line.startsWith('updated:')) {
@@ -650,7 +677,7 @@ export function enforceFrontmatterConstraints(
   const frontmatter = serializeFrontmatter(
     {
       type: foundType ? pageType : undefined,
-      created: createdValue || today,
+      created: resolveCreated(options, today),
       updated: today,
       tags: dedupedTags,
       aliases: (foundAliases || collectedAliases.length > 0) ? collectedAliases : undefined,

--- a/src/wiki/lint/fill-empty-page.ts
+++ b/src/wiki/lint/fill-empty-page.ts
@@ -6,7 +6,7 @@ import {
   applySectionLabels,
   getGranularityFixLimits,
 } from '../system-prompts';
-import { enforceFrontmatterConstraints } from '../../core/frontmatter';
+import { enforceFrontmatterConstraints, parseFrontmatter } from '../../core/frontmatter';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { resolveModelForTask } from '../../core/model-resolver';
 import {
@@ -93,7 +93,12 @@ export async function fillEmptyPage(
   const dateStr = new Date().toISOString().split('T')[0];
   const withDates = normalizeFrontmatterDates(stubFree, dateStr);
   const pageTypeSingular = pageType === WIKI_SUBFOLDERS.entities ? 'entity' : pageType === WIKI_SUBFOLDERS.concepts ? 'concept' : 'source';
-  const enforced = enforceFrontmatterConstraints(withDates, pageTypeSingular, ctx.settings);
+  // Issue #388: the page being filled already exists, so its real creation date
+  // is on disk. `withDates` is the model's reply and its `created:` line, if it
+  // wrote one, is a transcription at best.
+  const enforced = enforceFrontmatterConstraints(withDates, pageTypeSingular, ctx.settings, {
+    preserveCreated: parseFrontmatter(content)?.created,
+  });
 
   await ctx.createOrUpdateFile(pagePath, enforced);
 

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -157,7 +157,12 @@ export async function mergeDuplicatePages(
       ? 'concept'
       : 'source';
 
-  const enforced = enforceFrontmatterConstraints(newContent, pageType, ctx.settings);
+  // Issue #388: `newContent` was serialized from `targetFm` a few lines up, but
+  // the caller is the one that read the target page — pass the date explicitly
+  // rather than relying on it surviving a round trip through the serializer.
+  const enforced = enforceFrontmatterConstraints(newContent, pageType, ctx.settings, {
+    preserveCreated: targetFm?.created,
+  });
   await ctx.createOrUpdateFile(targetPath, enforced);
 
   // Issue #386: retarget every link that resolves to the source page, vault-wide

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -236,6 +236,9 @@ export async function createNewPage(
 
     const cleanedContent = cleanMarkdownResponse(pageContent);
     // Issue #85: pass settings so custom tag vocabulary is honored.
+    // Issue #388: no `preserveCreated` — this page is being created, so there is
+    // no prior file and no real creation date to preserve. Anything `created:`
+    // in the model's reply says about the past is invented by construction.
     const enforcedContent = enforceFrontmatterConstraints(cleanedContent, pageType, ctx.settings);
     const labels = getSectionLabels(ctx.settings);
     // Re-assert the known section labels before the link corrector runs, so a


### PR DESCRIPTION
Closes #388

Rebased onto current main (now includes #392's vault-wide link retarget).

$(cat <<'EOF'
DocTpoint's original description with one addition for the rebased context.

The provenance is now explicit instead of inferred from the string. A fourth
optional argument carries the prior value, and the content's own created: line
is dropped unconditionally:

- create-page passes nothing - there is no prior file
- fill-empty-page passes the value parsed from the page on disk
- merge-duplicates passes targetFm.created, the value it already read

A caller value that is not an ISO date is ignored, so a corrupted file cannot
propagate its frontmatter into a rewrite.

This also fixes the reviewed-page branch, which returned early and stamped
created: today unconditionally - a reviewed page lost its real creation date
on every pass.

Gate 1 (rebased against current main, including #392): lint 0/0, tsc clean,
2895 / 215 tests passed, build clean, css-lint 0.

Single-line touchpoint with #392: src/wiki/lint/merge-duplicates.ts reads
enforceFrontmatterConstraints's new fourth argument; the rest of #392's
vault-wide link retarget is orthogonal.
EOF
)