### PR TITLE
docs: align Batch 1 plan to rev 2 — dual-key bucket only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,22 @@
 # LLM Wiki Plugin Project Development Standards
 
-**Last Updated:** 2026-08-02 (v1.26.0 MINOR re-scoped on main @ `a253078`, release deferred pending 5-batch P0+P1 work). v1.25.11 PATCH RELEASED. User decision (2026-08-02): include P0+P1 hardening before tag v1.26.0.
+**Last Updated:** 2026-08-03 (v1.26.0 MINOR re-scoped on main @ `429d956`, release deferred pending 5-batch P0+P1 work; Russian i18n MERGED via PR #397; Batch 1 rev 2 simplified to 方案 1 dual-key bucket per ROI analysis). v1.25.11 PATCH RELEASED. User decision (2026-08-02): include P0+P1 hardening before tag v1.26.0.
 
 ---
 
 ## Current Phase: v1.26.0 MINOR RE-SCOPED on main (release deferred pending 5-batch P0+P1 work); v1.25.11 PATCH RELEASED
 
-**v1.26.0 P0+P1 final scope** (user-revised 2026-08-02, 5 batches):
+**v1.26.0 P0+P1 final scope** (user-revised 2026-08-02, 5 batches; **Batch 1 rev 2 simplified 2026-08-03**):
 
 | Batch | Item | Issue | Type | Effort |
 |---|---|---|---|---|
-| 1 | Streaming/bucketed dedup refactor | #382 item 3 | P1 (prerequisite) | 1 week |
+| **1** (in progress) | **Dual-key bucketed dedup** (tp-prefix + lh-link-hash buckets) | #382 item 3 | P1 (prerequisite) | **0.8 week** |
 | 2 | Cross-type dedup candidate set expansion | #382 item 1 | P0 | 1.5-2 weeks |
 | 3 | P1-1/P1-2 wire-or-delete decision (delete recommended) | #382 item 4 | P1 | 0.2 week |
 | 4 | dead-code-as-docs policy (CLAUDE.md + pre-release-gate check) | #382 item 5 | P1 (governance) | 0.3 week |
 | 5 | Settings-owned enum-as-section-value (CVSS-style controlled vocab) | #358 item 8 / #328 §2 | design | 0.5 week |
 
-**Estimated total:** ~3.5-4 weeks focused work before v1.26.0 MINOR ships.
+**Estimated total:** ~3.3-3.8 weeks focused work before v1.26.0 MINOR ships.
 
 **Deferred to v1.27.0+ (per user decision 2026-08-02):** #317 (schema.md changes ignored), #326 (defer to canonical pages outside wikiFolder), #306, #295, #184.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,23 +2,25 @@
 
 > Feature planning and improvement proposals
 
-**Version:** v1.26.0 MINOR — re-scoped on main @ `a253078` (2026-08-02), release deferred. v1.25.11 PATCH RELEASED. | **Updated:** 2026-08-02
+**Version:** v1.26.0 MINOR — re-scoped on main @ `429d956` (2026-08-03), release deferred. Russian i18n MERGED. v1.25.11 PATCH RELEASED. | **Updated:** 2026-08-03
 
 ## Current Status
 
-**v1.26.0 — RE-SCOPED on 2026-08-02; release deferred pending P0+P1 hardening work.** User decision (2026-08-02): "不立即发版，需要再把高优先级的P0+P1纳入开发后，再发布1.26.0". Main @ `a253078` already contains the v1.26.0 user-visible surface (headless CLI `pnpm llm-wiki` + DocTpoint #357 source-lemma + DocTpoint #386 vault-wide link retarget + DocTpoint #388 `created:` provenance + #383 folder-boundary follow-up + PR #395 lint dedup thresholds) plus the re-scope means the following P0+P1 work must ship before tagging v1.26.0:
+**v1.26.0 — RE-SCOPED on 2026-08-02; release deferred pending P0+P1 hardening work.** User decision (2026-08-02): "不立即发版，需要再把高优先级的P0+P1纳入开发后，再发布1.26.0". Main @ `429d956` already contains the v1.26.0 user-visible surface (headless CLI `pnpm llm-wiki` + DocTpoint #357 source-lemma + DocTpoint #386 vault-wide link retarget + DocTpoint #388 `created:` provenance + #383 folder-boundary follow-up + PR #395 lint dedup thresholds + **Russian i18n (PR #397)**) plus the re-scope means the following P0+P1 work must ship before tagging v1.26.0:
 
-**v1.26.0 P0+P1 final scope** (in execution order; user-revised 2026-08-02 — #317 and #326 deferred to v1.27.0+):
+**v1.26.0 P0+P1 final scope** (in execution order; user-revised 2026-08-02 — #317 and #326 deferred to v1.27.0+; **Batch 1 rev 2 simplified 2026-08-03** to 方案 1 dual-key bucket only, abandoning方案 4 spillover + 方案 7 hub bridge per ROI analysis):
 
 | Bucket | Item | Issue | Type | Effort |
 |---|---|---|---|---|
-| Batch 1 | Streaming/bucketed dedup refactor (precondition for cross-type dedup) | #382 item 3 | P1 (prerequisite) | 1 week |
+| **Batch 1** (in progress, branch `feat/v1.26.0-batch-1-dedup-streaming`) | **Dual-key bucketed dedup** (tp-prefix + lh-link-hash buckets) | #382 item 3 | P1 (prerequisite) | **0.8 week** |
 | Batch 2 | Cross-type dedup candidate set expansion | #382 item 1 | P0 | 1.5-2 weeks |
 | Batch 3 | P1-1/P1-2 wire-or-delete decision (delete recommended, see #382 item 4) | #382 item 4 | P1 | 0.2 week |
 | Batch 4 | dead-code-as-docs policy (CLAUDE.md + pre-release-gate check) | #382 item 5 | P1 (governance) | 0.3 week |
 | Batch 5 | Settings-owned enum-as-section-value (CVSS-style controlled vocab) | #358 item 8 / #328 §2 | design | 0.5 week |
 
-**Estimated total: ~3.5-4 weeks of focused work before v1.26.0 MINOR ships.**
+**Estimated total: ~3.3-3.8 weeks of focused work before v1.26.0 MINOR ships.**
+
+**Batch 1 plan reference**: see `~/.claude/projects/-Users-greener-project-obsidian-llm-wiki/memory/project_v1_26_0_batch_1_dedup_streaming.md` (rev 2, 2026-08-03). 5 independent commits: (1) extract bucket constants → (2) `partitionPagesMultiBucket` pure helper → (3) integrate multi-bucket into `generateDuplicateCandidates` → (4) `checkCancelled` at bucket boundary in dedup-phase → (5) e2e recall + memory profile. Expected recall ≥ 95% (旧版 80-90%,方案 1 单独 97-98%); memory peak O(N² candidates) → O(B² per bucket).
 
 **Deferred to v1.27.0+ (per user decision 2026-08-02)**:
 
@@ -57,8 +59,14 @@
 - `62701c9` fix(merge): retarget links vault-wide and in every form before the delete (PR #392, DocTpoint, Closes #386)
 - `cd734b9` fix(frontmatter): take created: from the caller, never from the content (DocTpoint, Closes #388)
 - `a253078` Merge pull request #396 from `green-dalii/fix/388-created-provenance` (DocTpoint's commit via rebase; see ROADMAP §Process note)
+- `9422dd8` docs: re-scope v1.26.0 MINOR — 5-batch P0+P1 work + Russian i18n before tag
+- `ba09997` feat(i18n): register Russian locale + full UI translation (667 keys)
+- `ebca969` feat(i18n): add Russian section labels for wiki output system prompts
+- `292873f` test(i18n): pin Russian locale wiring + README switcher count
+- `cc7ad5d` docs(i18n): add Russian to all 10 README dropdowns + full README_RU translation
+- `429d956` Merge pull request #397 from `green-dalii/feat/v1.26.0-russian-i18n`
 
-*Stats*: 2863 tests / 213 files at PR #395 merge → **2895 tests / 215 files** after DocTpoint PR #392 + PR #396 (note: PR #396 closed but the underlying fix commit `cd734b9` is on main, contribution attributed via issue #388 and #393 design thread).
+*Stats*: 2863 tests / 213 files at PR #395 merge → **2895 tests / 215 files** after DocTpoint PR #392 + PR #396 → **2904 tests / 215 files** after Russian i18n PR #397 (note: PR #396 closed but the underlying fix commit `cd734b9` is on main, contribution attributed via issue #388 and #393 design thread).
 
 *Why MINOR not PATCH*: the CLI ships as a fresh user-visible tool (`pnpm llm-wiki` script, npm bin, subcommand dispatch, complete flag surface) — that is the canonical SemVer trigger for MINOR, not PATCH. The planned `v1.25.12` slot stays unused; the patch slot is not retroactively filled. Version numbers need not be consecutive.
 


### PR DESCRIPTION
## Summary

Simplify v1.26.0 Batch 1 (streaming/bucketed dedup refactor) from rev 1 (single-key bucket + spillover + hub bridge) to rev 2 (dual-key bucket only).

## User decision (2026-08-03)

- Adopt the **dual-key bucket** strategy (title-prefix + link-hash) as the sole Batch 1 approach
- Drop the spillover neighbour-bucket pass and the hub bridge pass
- Rationale: dual-key bucket is the ROI inflection point (+20 LOC, +12 percentage points recall). The other two passes are diminishing returns (+70 LOC, +2 percentage points recall) — and the hub bridge pass solves a non-existent problem, since the sharedLinks signal only inspects outgoing wiki-links, not incoming ones

## Changes

- `CLAUDE.md` — Batch 1 row updated (1 week → 0.8 week, dual-key bucket description, mark in progress)
- `ROADMAP.md` — Version line + Current Status + scope table + Batch 1 plan reference + test count (2895 → 2904 from Russian i18n PR #397)
- Total v1.26.0 P0+P1 estimate: ~3.5-4 weeks → ~3.3-3.8 weeks

## Invariants

- Doc-only change; no code paths modified
- main HEAD remains protected
- PR #395 (lint dedup thresholds) stays the prerequisite foundation for Batch 1
- All other v1.26.0 batches unchanged

Refs #382 (item 3)