### PR TITLE
fix(#399): duplicate `sources:` frontmatter key on stub-created concept pages

### DIFF
--- a/src/__tests__/wiki/lint/fix-dead-link.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link.test.ts
@@ -52,9 +52,12 @@ describe('fixDeadLink stub construction (#197 — honest placeholders)', () => {
         wikiFolder: 'wiki',
         referringPageRel: 'entities/SomeSource',
       });
-      // sources array points at the referring page — better than nothing, and
-      // the placeholder text explicitly notes this is not a real source yet.
-      expect(out).toContain('sources: ["[[entities/SomeSource]]"]');
+      // sources points at the referring page — better than nothing, and the
+      // placeholder text explicitly notes this is not a real source yet.
+      // Emitted as block-style so the v1.25.11 provenance-stamp writer in
+      // create-page.ts merges into it instead of appending a duplicate
+      // top-level `sources:` key. See issue #399.
+      expect(out).toContain('sources:\n  - [[entities/SomeSource]]');
     });
 
     it('produces a concept-shaped stub when stubType is concept', () => {

--- a/src/__tests__/wiki/lint/fix-dead-link.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link.test.ts
@@ -57,7 +57,11 @@ describe('fixDeadLink stub construction (#197 — honest placeholders)', () => {
       // Emitted as block-style so the v1.25.11 provenance-stamp writer in
       // create-page.ts merges into it instead of appending a duplicate
       // top-level `sources:` key. See issue #399.
-      expect(out).toContain('sources:\n  - [[entities/SomeSource]]');
+      //
+      // PR #405 review: wikilink value MUST be double-quoted. Bare
+      // `- [[value]]` YAML-parses as a nested flow sequence, not a string,
+      // breaking Obsidian's Properties panel + backlinks + graph edges.
+      expect(out).toContain('sources:\n  - "[[entities/SomeSource]]"');
     });
 
     it('produces a concept-shaped stub when stubType is concept', () => {

--- a/src/__tests__/wiki/page-factory/append-source-slug.test.ts
+++ b/src/__tests__/wiki/page-factory/append-source-slug.test.ts
@@ -1,0 +1,95 @@
+// Coverage for the #399 fix in appendSourceSlugToFrontmatter — the
+// v1.25.11 provenance stamp previously inserted a duplicate block-style
+// `sources:` key when the existing key was flow-style, producing invalid
+// YAML. The fix detects flow-style and merges into it (re-emitting as
+// block-style canonical shape).
+
+import { describe, it, expect } from 'vitest';
+import { appendSourceSlugToFrontmatter } from '../../../wiki/page-factory/create-page';
+
+describe('appendSourceSlugToFrontmatter (#399)', () => {
+  it('merges into an existing FLOW-style sources key (single entry) — re-emits as block-style, no duplicate key', () => {
+    const before = [
+      '---',
+      'type: concept',
+      'sources: ["[[sources/Existing]]"]',
+      'tags: [term]',
+      '---',
+      '',
+      '# Title',
+      '',
+    ].join('\n');
+    const out = appendSourceSlugToFrontmatter(before, 'New-Source_abcdef');
+    // Exactly ONE sources: key
+    const sourcesKeys = out.split('\n').filter(l => /^sources:/.test(l));
+    expect(sourcesKeys.length).toBe(1);
+    // Block-style with both entries preserved, in insertion order
+    expect(out).toContain('sources:\n  - [[sources/Existing]]\n  - [[sources/New-Source_abcdef]]');
+  });
+
+  it('merges into an existing FLOW-style sources key (multiple entries)', () => {
+    const before = [
+      '---',
+      'type: concept',
+      'sources: ["[[sources/A]]", "[[sources/B]]"]',
+      'tags: [term]',
+      '---',
+      '',
+      '# Title',
+      '',
+    ].join('\n');
+    const out = appendSourceSlugToFrontmatter(before, 'C');
+    const sourcesKeys = out.split('\n').filter(l => /^sources:/.test(l));
+    expect(sourcesKeys.length).toBe(1);
+    expect(out).toContain('sources:\n  - [[sources/A]]\n  - [[sources/B]]\n  - [[sources/C]]');
+  });
+
+  it('is idempotent when the new source is already present in flow-style', () => {
+    const before = [
+      '---',
+      'type: concept',
+      'sources: ["[[sources/Existing]]"]',
+      'tags: [term]',
+      '---',
+      '',
+      '# Title',
+      '',
+    ].join('\n');
+    const out = appendSourceSlugToFrontmatter(before, 'Existing');
+    // Unchanged
+    expect(out).toBe(before);
+  });
+
+  it('still handles the block-style existing sources key (regression guard)', () => {
+    const before = [
+      '---',
+      'type: concept',
+      'sources:',
+      '  - [[sources/Existing]]',
+      'tags: [term]',
+      '---',
+      '',
+      '# Title',
+      '',
+    ].join('\n');
+    const out = appendSourceSlugToFrontmatter(before, 'New');
+    const sourcesKeys = out.split('\n').filter(l => /^sources:/.test(l));
+    expect(sourcesKeys.length).toBe(1);
+    expect(out).toContain('sources:\n  - [[sources/Existing]]\n  - [[sources/New]]');
+  });
+
+  it('inserts a fresh block-style sources: when the key is absent', () => {
+    const before = [
+      '---',
+      'type: concept',
+      'tags: [term]',
+      '---',
+      '',
+      '# Title',
+      '',
+    ].join('\n');
+    const out = appendSourceSlugToFrontmatter(before, 'First');
+    expect(out).toContain('sources:\n  - [[sources/First]]');
+    expect(out).toContain('tags: [term]');
+  });
+});

--- a/src/__tests__/wiki/page-factory/append-source-slug.test.ts
+++ b/src/__tests__/wiki/page-factory/append-source-slug.test.ts
@@ -180,4 +180,108 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
       ]);
     });
   });
+
+  // PR #405 review — @DocTpoint notes A and B.
+  //
+  // A. "Flow heals, block doesn't": the block-append branch previously
+  //    only spliced one new line, so a v1.25.11-stamped file (with bare
+  //    `- [[x]]` continuation entries) ended up with a correct new entry
+  //    next to a broken bare one. The block branch now re-emits the whole
+  //    block from a Set, normalizing legacy entries on touch.
+  //
+  // B. The quote-tolerant dedup path had no test feeding legacy unquoted
+  //    block input.
+  //
+  // These cases feed the exact shape a real v1.25.11 vault carries today
+  // and assert both the healing behavior AND idempotency against it.
+  describe('PR #405 note A/B: legacy bare block-style entries heal on touch', () => {
+    it('bare entries get re-emitted as quoted when a new entry is appended', () => {
+      const before = [
+        '---',
+        'type: concept',
+        'sources:',
+        '  - [[sources/Existing]]',  // legacy bare
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'New');
+      // Both entries end up quoted — the old one heals.
+      expect(out).toContain('sources:\n  - "[[sources/Existing]]"\n  - "[[sources/New]]"');
+      // No bare `- [[x]]` continuation lines survive.
+      expect(out).not.toMatch(/^\s*-\s+\[\[/m);
+      // Parser-shape guard: sources is a flat string array, both entries strings.
+      const parsed = parseFrontmatter(out);
+      expect(parsed.sources).toEqual([
+        '[[sources/Existing]]',
+        '[[sources/New]]',
+      ]);
+    });
+
+    it('bare + quoted mixed continuation lines heal on touch (no duplication)', () => {
+      // The exact shape a v1.25.11 vault could carry: an old bare entry
+      // plus a newer quoted one, from two separate provenance stamps.
+      const before = [
+        '---',
+        'type: concept',
+        'sources:',
+        '  - [[sources/OldBare]]',
+        '  - "[[sources/NewerQuoted]]"',
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'ThirdEntry');
+      expect(out).toContain(
+        'sources:\n  - "[[sources/OldBare]]"\n  - "[[sources/NewerQuoted]]"\n  - "[[sources/ThirdEntry]]"',
+      );
+      const parsed = parseFrontmatter(out);
+      expect(parsed.sources).toEqual([
+        '[[sources/OldBare]]',
+        '[[sources/NewerQuoted]]',
+        '[[sources/ThirdEntry]]',
+      ]);
+    });
+
+    it('is idempotent against a legacy bare entry (dedup strips quotes on both sides)', () => {
+      const before = [
+        '---',
+        'type: concept',
+        'sources:',
+        '  - [[sources/Existing]]',  // legacy bare
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      // Try to stamp the same source again — should be a no-op.
+      const out = appendSourceSlugToFrontmatter(before, 'Existing');
+      expect(out).toBe(before);
+    });
+
+    it('is idempotent against a legacy bare entry when the new stamp uses the target slug', () => {
+      // Same as above but the "new" stamp uses the same slug the legacy
+      // entry pointed to — proves the strip-both dedup catches it before
+      // we go re-emit the block.
+      const before = [
+        '---',
+        'type: concept',
+        'sources:',
+        '  - [[sources/Alpha]]',
+        '  - [[sources/Beta]]',
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'Beta');
+      expect(out).toBe(before);
+    });
+  });
 });

--- a/src/__tests__/wiki/page-factory/append-source-slug.test.ts
+++ b/src/__tests__/wiki/page-factory/append-source-slug.test.ts
@@ -3,9 +3,25 @@
 // `sources:` key when the existing key was flow-style, producing invalid
 // YAML. The fix detects flow-style and merges into it (re-emitting as
 // block-style canonical shape).
+//
+// PR #405 review update: block-style entries MUST be double-quoted
+// (`  - "[[value]]"`), not bare (`  - [[value]]`). The bare form is
+// YAML-parsed as a NESTED flow sequence, not a string, which breaks
+// Obsidian's Properties panel + backlinks + graph edges. The tests
+// below assert the quoted output AND parse the resulting frontmatter
+// with a real YAML parser (yaml, YAML 1.2 — same spec as js-yaml which
+// Obsidian uses under the hood) to guarantee `sources` is `string[]`.
 
 import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { appendSourceSlugToFrontmatter } from '../../../wiki/page-factory/create-page';
+
+/** Extract the first `---`-delimited frontmatter block and YAML-parse it. */
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const m = content.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!m) throw new Error('no frontmatter block found');
+  return parseYaml(m[1]) as Record<string, unknown>;
+}
 
 describe('appendSourceSlugToFrontmatter (#399)', () => {
   it('merges into an existing FLOW-style sources key (single entry) — re-emits as block-style, no duplicate key', () => {
@@ -23,8 +39,8 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
     // Exactly ONE sources: key
     const sourcesKeys = out.split('\n').filter(l => /^sources:/.test(l));
     expect(sourcesKeys.length).toBe(1);
-    // Block-style with both entries preserved, in insertion order
-    expect(out).toContain('sources:\n  - [[sources/Existing]]\n  - [[sources/New-Source_abcdef]]');
+    // Block-style with both entries preserved, in insertion order — QUOTED (see PR #405)
+    expect(out).toContain('sources:\n  - "[[sources/Existing]]"\n  - "[[sources/New-Source_abcdef]]"');
   });
 
   it('merges into an existing FLOW-style sources key (multiple entries)', () => {
@@ -41,7 +57,7 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
     const out = appendSourceSlugToFrontmatter(before, 'C');
     const sourcesKeys = out.split('\n').filter(l => /^sources:/.test(l));
     expect(sourcesKeys.length).toBe(1);
-    expect(out).toContain('sources:\n  - [[sources/A]]\n  - [[sources/B]]\n  - [[sources/C]]');
+    expect(out).toContain('sources:\n  - "[[sources/A]]"\n  - "[[sources/B]]"\n  - "[[sources/C]]"');
   });
 
   it('is idempotent when the new source is already present in flow-style', () => {
@@ -65,7 +81,7 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
       '---',
       'type: concept',
       'sources:',
-      '  - [[sources/Existing]]',
+      '  - "[[sources/Existing]]"',
       'tags: [term]',
       '---',
       '',
@@ -75,7 +91,7 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
     const out = appendSourceSlugToFrontmatter(before, 'New');
     const sourcesKeys = out.split('\n').filter(l => /^sources:/.test(l));
     expect(sourcesKeys.length).toBe(1);
-    expect(out).toContain('sources:\n  - [[sources/Existing]]\n  - [[sources/New]]');
+    expect(out).toContain('sources:\n  - "[[sources/Existing]]"\n  - "[[sources/New]]"');
   });
 
   it('inserts a fresh block-style sources: when the key is absent', () => {
@@ -89,7 +105,79 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
       '',
     ].join('\n');
     const out = appendSourceSlugToFrontmatter(before, 'First');
-    expect(out).toContain('sources:\n  - [[sources/First]]');
+    expect(out).toContain('sources:\n  - "[[sources/First]]"');
     expect(out).toContain('tags: [term]');
+  });
+
+  // PR #405 review — parser-shape regression guard.
+  //
+  // The string `contains` assertions above would silently pass even if the
+  // emitted format were unquoted (`- [[value]]`), which YAML parses as a
+  // nested flow sequence instead of a string and breaks user-visible output
+  // in Obsidian's Properties panel. These tests parse the resulting
+  // frontmatter with a real YAML parser and assert `sources` is a flat
+  // string array — the shape Obsidian's property-type detection needs.
+  describe('PR #405: parser-shape guard — sources must be string[], not nested array', () => {
+    it('flow → block merge produces sources parseable as string[]', () => {
+      const before = [
+        '---',
+        'type: concept',
+        'sources: ["[[sources/Existing]]"]',
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'New');
+      const parsed = parseFrontmatter(out);
+      const sources = parsed.sources;
+      expect(Array.isArray(sources)).toBe(true);
+      // Every entry must be a plain string containing the wikilink literal.
+      // A nested-array bug would surface here as `[["sources/Existing"]]`.
+      for (const entry of sources as unknown[]) {
+        expect(typeof entry).toBe('string');
+        expect(entry as string).toMatch(/^\[\[sources\/.+\]\]$/);
+      }
+      expect(sources).toEqual([
+        '[[sources/Existing]]',
+        '[[sources/New]]',
+      ]);
+    });
+
+    it('fresh insertion produces sources parseable as string[]', () => {
+      const before = [
+        '---',
+        'type: concept',
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'First');
+      const parsed = parseFrontmatter(out);
+      expect(parsed.sources).toEqual(['[[sources/First]]']);
+    });
+
+    it('block-style merge stays parseable as string[]', () => {
+      const before = [
+        '---',
+        'type: concept',
+        'sources:',
+        '  - "[[sources/Existing]]"',
+        'tags: [term]',
+        '---',
+        '',
+        '# Title',
+        '',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'New');
+      const parsed = parseFrontmatter(out);
+      expect(parsed.sources).toEqual([
+        '[[sources/Existing]]',
+        '[[sources/New]]',
+      ]);
+    });
   });
 });

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -75,7 +75,13 @@ export function buildStubContent(params: StubContentParams): string {
   // only detects `^sources:\s*$`) merges into it instead of inserting
   // a duplicate top-level `sources:` key. Duplicate keys are invalid
   // YAML and break Obsidian's Properties render. See issue #399.
-  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - [[${referringPageRel}]]\ntags: [${defaultTag}]\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
+  //
+  // Wikilink value MUST be double-quoted. Unquoted `- [[x]]` is parsed
+  // by YAML 1.2 as a nested flow sequence `[["x"]]` — not a string —
+  // which makes Obsidian's Properties panel drop the property type and
+  // the value becomes literal text (no link chip, no backlink, no graph
+  // edge). Match `yamlStringify()` in src/core/frontmatter.ts (line 104).
+  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - "[[${referringPageRel}]]"\ntags: [${defaultTag}]\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
 }
 
 /**

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -70,7 +70,12 @@ export function buildStubContent(params: StubContentParams): string {
   const { title, stubType, referringPageRel } = params;
   const today = new Date().toISOString().split('T')[0];
   const defaultTag = stubType === 'entity' ? 'other' : 'term';
-  return `---\ntype: ${stubType}\ncreated: ${today}\nsources: ["[[${referringPageRel}]]"]\ntags: [${defaultTag}]\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
+  // Emit `sources:` as block-style so the v1.25.11 provenance-stamp
+  // writer in create-page.ts's `appendSourceSlugToFrontmatter` (which
+  // only detects `^sources:\s*$`) merges into it instead of inserting
+  // a duplicate top-level `sources:` key. Duplicate keys are invalid
+  // YAML and break Obsidian's Properties render. See issue #399.
+  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - [[${referringPageRel}]]\ntags: [${defaultTag}]\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
 }
 
 /**

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -333,7 +333,10 @@ export async function createNewPage(
  * `[[]]` wrapper); we add both to keep the wire format identical to
  * what `merge-page.ts:95` would have produced.
  */
-function appendSourceSlugToFrontmatter(content: string, sourceSlug: string): string {
+// Exported for direct unit-test coverage of the flow-style detection path
+// added for #399. Not part of the plugin's public API — call sites live in
+// createOrUpdatePage / createNewPage above.
+export function appendSourceSlugToFrontmatter(content: string, sourceSlug: string): string {
   if (!content.startsWith('---')) return content;
   const fmEnd = content.indexOf('\n---\n', 3);
   if (fmEnd === -1) return content;
@@ -342,6 +345,34 @@ function appendSourceSlugToFrontmatter(content: string, sourceSlug: string): str
   const sourceEntry = `[[sources/${sourceSlug}]]`;
 
   const lines = fmText.split('\n');
+
+  // First, handle inline flow-style `sources: ["[[...]]", ...]`. Prior to
+  // this fix, we only matched the block-style form `^sources:\s*$`, so a
+  // flow-style existing key would fall through to the "no sources yet"
+  // branch and get a NEW block-style key inserted — producing two
+  // top-level `sources:` keys, which is invalid YAML and breaks the
+  // Properties panel. See #399. Detect the flow-style form, extract its
+  // wikilink entries, add the new one if absent, then re-emit as
+  // block-style (canonical shape used elsewhere in the plugin).
+  const flowIdx = lines.findIndex(l => /^sources:\s*\[.*\]\s*$/.test(l));
+  if (flowIdx !== -1) {
+    const flowMatch = lines[flowIdx].match(/^sources:\s*\[(.*)\]\s*$/);
+    const entries: string[] = [];
+    if (flowMatch && flowMatch[1].trim().length > 0) {
+      const linkPattern = /\[\[([^\]]+)\]\]/g;
+      let m;
+      while ((m = linkPattern.exec(flowMatch[1])) !== null) {
+        entries.push(m[1]);
+      }
+    }
+    const targetLink = sourceEntry.slice(2, -2);
+    if (entries.includes(targetLink)) return content;
+    entries.push(targetLink);
+    const blockLines = ['sources:', ...entries.map(e => `  - [[${e}]]`)];
+    lines.splice(flowIdx, 1, ...blockLines);
+    return `---\n${lines.join('\n')}\n---\n${body}`;
+  }
+
   const sourcesIdx = lines.findIndex(l => /^sources:\s*$/.test(l));
   if (sourcesIdx === -1) {
     // No existing `sources:` key — insert one. Anchor on `tags:` so the

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -368,7 +368,11 @@ export function appendSourceSlugToFrontmatter(content: string, sourceSlug: strin
     const targetLink = sourceEntry.slice(2, -2);
     if (entries.includes(targetLink)) return content;
     entries.push(targetLink);
-    const blockLines = ['sources:', ...entries.map(e => `  - [[${e}]]`)];
+    // Double-quote wikilink values. Unquoted `- [[x]]` YAML-parses as a
+    // nested flow sequence (not a string), which breaks Obsidian's Properties
+    // panel + backlinks + graph edges. Match `yamlStringify()` in
+    // src/core/frontmatter.ts (line 104). See PR #405 review.
+    const blockLines = ['sources:', ...entries.map(e => `  - "[[${e}]]"`)];
     lines.splice(flowIdx, 1, ...blockLines);
     return `---\n${lines.join('\n')}\n---\n${body}`;
   }
@@ -379,18 +383,29 @@ export function appendSourceSlugToFrontmatter(content: string, sourceSlug: strin
     // block order (type / created / updated / sources / tags / aliases /
     // reviewed) matches the canonical layout produced by
     // `enforceFrontmatterConstraints` + `serializeFrontmatter`.
+    //
+    // Double-quote the wikilink value — bare `- [[x]]` YAML-parses as a
+    // nested flow sequence (not a string). See PR #405 review.
     const tagsIdx = lines.findIndex(l => /^tags:\s*$/.test(l));
     const insertAt = tagsIdx === -1 ? lines.length : tagsIdx;
-    lines.splice(insertAt, 0, `sources:\n  - ${sourceEntry}`);
+    lines.splice(insertAt, 0, `sources:\n  - "${sourceEntry}"`);
   } else {
     // Existing `sources:` block — append the new entry if not already
     // present. Scan only indented continuation lines (same semantics
-    // as `mergeFrontmatter`'s Set dedup, lines 484-490).
+    // as `mergeFrontmatter`'s Set dedup, lines 484-490). Continuation
+    // lines may be quoted (`- "[[x]]"` canonical) or bare (`- [[x]]`
+    // legacy) — strip both to check.
     const existing = new Set<string>();
     for (let i = sourcesIdx + 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (!line.startsWith('- ')) break;
-      const entry = line.substring(2).trim();
+      let entry = line.substring(2).trim();
+      // Strip surrounding quotes if present so `- "[[x]]"` and `- [[x]]`
+      // are treated as the same entry.
+      if ((entry.startsWith('"') && entry.endsWith('"')) ||
+          (entry.startsWith("'") && entry.endsWith("'"))) {
+        entry = entry.slice(1, -1);
+      }
       if (entry.startsWith('[[') && entry.endsWith(']]')) {
         existing.add(entry.slice(2, -2).trim());
       }
@@ -403,7 +418,8 @@ export function appendSourceSlugToFrontmatter(content: string, sourceSlug: strin
     while (insertAt < lines.length && lines[insertAt].trim().startsWith('- ')) {
       insertAt++;
     }
-    lines.splice(insertAt, 0, `  - ${sourceEntry}`);
+    // Quoted (see comment above).
+    lines.splice(insertAt, 0, `  - "${sourceEntry}"`);
   }
   return `---\n${lines.join('\n')}\n---\n${body}`;
 }

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -390,36 +390,44 @@ export function appendSourceSlugToFrontmatter(content: string, sourceSlug: strin
     const insertAt = tagsIdx === -1 ? lines.length : tagsIdx;
     lines.splice(insertAt, 0, `sources:\n  - "${sourceEntry}"`);
   } else {
-    // Existing `sources:` block — append the new entry if not already
-    // present. Scan only indented continuation lines (same semantics
-    // as `mergeFrontmatter`'s Set dedup, lines 484-490). Continuation
-    // lines may be quoted (`- "[[x]]"` canonical) or bare (`- [[x]]`
-    // legacy) — strip both to check.
-    const existing = new Set<string>();
+    // Existing `sources:` block — collect continuation entries, append
+    // the new one if not already present, and re-emit the WHOLE block
+    // in canonical quoted form. This "block heals" behavior means a
+    // legacy v1.25.11-stamped file (with bare `- [[x]]` entries) gets
+    // normalized to `- "[[x]]"` the next time we stamp it, matching
+    // the healing behavior the flow→block branch already has. See PR
+    // #405 review note A from @DocTpoint.
+    //
+    // Continuation lines may be quoted (`- "[[x]]"` canonical) or
+    // bare (`- [[x]]` legacy) — strip surrounding quotes when reading,
+    // always emit quoted when writing.
+    const entries: string[] = [];
+    const seen = new Set<string>();
+    let contEnd = sourcesIdx + 1;
     for (let i = sourcesIdx + 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (!line.startsWith('- ')) break;
+      contEnd = i + 1;
       let entry = line.substring(2).trim();
-      // Strip surrounding quotes if present so `- "[[x]]"` and `- [[x]]`
-      // are treated as the same entry.
       if ((entry.startsWith('"') && entry.endsWith('"')) ||
           (entry.startsWith("'") && entry.endsWith("'"))) {
         entry = entry.slice(1, -1);
       }
       if (entry.startsWith('[[') && entry.endsWith(']]')) {
-        existing.add(entry.slice(2, -2).trim());
+        const inner = entry.slice(2, -2).trim();
+        if (!seen.has(inner)) {
+          seen.add(inner);
+          entries.push(inner);
+        }
       }
     }
-    if (existing.has(sourceEntry.slice(2, -2))) return content;
-    // Find the first non-`sources:` continuation line — that's where we
-    // append. If no continuation lines exist yet, insert immediately
-    // after the `sources:` key.
-    let insertAt = sourcesIdx + 1;
-    while (insertAt < lines.length && lines[insertAt].trim().startsWith('- ')) {
-      insertAt++;
-    }
-    // Quoted (see comment above).
-    lines.splice(insertAt, 0, `  - "${sourceEntry}"`);
+    const targetInner = sourceEntry.slice(2, -2);
+    if (seen.has(targetInner)) return content;
+    entries.push(targetInner);
+    // Splice out the old (bare + new) continuation lines and replace
+    // with the canonical quoted form for all entries.
+    const newContinuation = entries.map(e => `  - "[[${e}]]"`);
+    lines.splice(sourcesIdx + 1, contEnd - (sourcesIdx + 1), ...newContinuation);
   }
   return `---\n${lines.join('\n')}\n---\n${body}`;
 }


### PR DESCRIPTION
Fixes #399.

Two-sided fix so the hole stays closed even if a future writer emits inline flow-style `sources:` again:

## 1. `buildStubContent` (src/wiki/lint/fix-dead-link.ts)

Emit `sources:` as block-style instead of inline flow-style:

```diff
- sources: ["[[${referringPageRel}]]"]
+ sources:
+   - [[${referringPageRel}]]
```

Stops the specific collision that shipped in v1.25.11.

## 2. `appendSourceSlugToFrontmatter` (src/wiki/page-factory/create-page.ts)

Detect inline flow-style `sources:` BEFORE falling through to the insert branch. When flow-style is found, parse its wikilink entries, add the new slug if absent, and re-emit as block-style (canonical shape).

This is the durability piece @DocTpoint flagged in the issue thread — any future inline writer no longer reopens the hole. The function is now exported (was previously module-private) so it can be unit-tested directly; still not part of the plugin's public API surface.

## Test coverage

- Updated the existing `fix-dead-link.test.ts` assertion to match the new block-style stub template.
- New `append-source-slug.test.ts` with 5 cases:
  1. Merges into single flow-style entry — re-emits block-style, exactly one `sources:` key.
  2. Merges into multiple flow-style entries.
  3. Idempotent when the new slug is already present.
  4. Regression guard: block-style existing key still merged into (not duplicated).
  5. Baseline: absent `sources:` key still inserted correctly.

All 2924 tests pass (up from 2919; +5 new).

## Repair for already-affected users

Users on v1.25.11 who already accumulated duplicate keys will keep seeing broken Properties render until the files are repaired. A short Python script that merges the two keys into one block-style list is at the top of #399 — I ran it against 132 affected files in my own vault (out of 321 flagged). Happy to add a bundled cleanup command (`Repair duplicate sources: keys` in the plugin's lint menu) if you'd like — say the word and I'll add it in this PR or a follow-up.

## Environment

- Plugin fork: `borthwick/obsidian-llm-wiki` @ `fix/399-duplicate-sources-key`
- Plugin: karpathywiki v1.25.11
- Obsidian: 1.13.4 (macOS)
- Node: v24.13.0

Generated with Claude Code.