### PR TITLE
fix(cli): give each run its own bundle

### DIFF
--- a/tools/llm-wiki-cli/run-llm-wiki.mjs
+++ b/tools/llm-wiki-cli/run-llm-wiki.mjs
@@ -10,11 +10,46 @@
 import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import * as nodePath from 'node:path';
+import { readdir, rm } from 'node:fs/promises';
 
 const CLI_DIR = nodePath.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = nodePath.resolve(CLI_DIR, '../..');
-const BUNDLE_PATH = nodePath.join(CLI_DIR, '.build', 'llm-wiki-cli.mjs');
+// Per-process, because several runs may overlap and esbuild writes the bundle
+// in place: a second builder truncating the file while the first is importing
+// it fails the import — usually `SyntaxError: Unexpected end of input`, and
+// occasionally `main is not a function` when the truncation happens to leave
+// valid syntax. Measured on the shared path: 14 of 60 concurrent runs failed.
+const BUNDLE_DIR = nodePath.join(CLI_DIR, '.build');
+const BUNDLE_PATH = nodePath.join(BUNDLE_DIR, `llm-wiki-cli.${process.pid}.mjs`);
 const OBSIDIAN_SHIM = nodePath.join(CLI_DIR, 'src', 'obsidian.ts');
+
+/**
+ * Bundles left behind by runs that died between the build and the import — a
+ * per-process name means nothing overwrites them, so without this they
+ * accumulate at 11 MB each. A file is only removed when its process is gone:
+ * `kill(pid, 0)` throws for a dead pid and succeeds for a live one, so a
+ * concurrent run's bundle is never pulled out from under it.
+ */
+async function sweepStaleBundles() {
+  let names;
+  try {
+    names = await readdir(BUNDLE_DIR);
+  } catch {
+    return; // first run: the directory is esbuild's to create
+  }
+  for (const name of names) {
+    const pid = Number(/^llm-wiki-cli\.(\d+)\.mjs$/.exec(name)?.[1]);
+    if (!pid || pid === process.pid) continue;
+    try {
+      process.kill(pid, 0);
+      continue; // alive — its bundle is in use
+    } catch {
+      await rm(nodePath.join(BUNDLE_DIR, name), { force: true });
+    }
+  }
+}
+
+await sweepStaleBundles();
 
 const require = createRequire(nodePath.join(PLUGIN_ROOT, 'package.json'));
 const esbuild = require('esbuild');
@@ -45,6 +80,10 @@ await esbuild.build({
 });
 
 const { main } = await import(pathToFileURL(BUNDLE_PATH).href);
+// Node keeps the loaded module, so removing the file now is safe — the stack
+// traces and the inline sourcemap survive it. A run killed before this line
+// leaves its bundle behind; the sweep above collects it on the next run.
+await rm(BUNDLE_PATH, { force: true });
 
 try {
   await main(process.argv.slice(2));


### PR DESCRIPTION
Two runs of the CLI at once are one esbuild truncating the bundle while the
other imports it. Measured on `main` (2a42241), 60 `ingest --help` runs in
three waves of four — no LLM involved, the build is the whole of it:

| bundle path | outcome |
|---|---|
| shared (current) | 14 of 60 failed: 13 × `SyntaxError: Unexpected end of input`, 1 × `main is not a function` |
| per-process | 20 of 20 clean, `.build/` empty afterwards |

The bundle is now named after the process and deleted after the import — Node
keeps the loaded module, and stack traces and the inline sourcemap survive it.

A per-process name means nothing overwrites the bundle of a run that died
between the build and the import, so each such run would strand 11 MB. Stale
bundles are swept at startup, and only those whose process is gone
(`kill(pid, 0)` succeeds for a live one), so a concurrent run's bundle is never
pulled out from under it.
