### PR TITLE
fix(#419): re-assert the page's own H1 after an LLM body rewrite

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeSectionHeaders,
   classifyHeader,
   preserveExistingSections,
+  reassertH1,
 } from '../../core/section-header-canonicalizer';
 
 describe('canonicalizeSectionHeaders (deterministic repair of LLM-garbled section headers)', () => {
@@ -215,5 +216,36 @@ describe('preserveExistingSections (re-assert schema sections the LLM dropped)',
     // Hallucinated Mentions gone — assembleFinalContent will add the real one.
     expect(out).not.toContain('## Erwähnungen in der Quelle');
     expect(out).not.toContain('- lost quote');
+  });
+});
+
+// #419 — the title line sits inside the rewrite window while no layer owns it.
+// `preserveExistingSections` guards `##` blocks only (its own test above pins
+// that), so a reply that starts at the first `##` silently drops the H1.
+describe('reassertH1 (the title is not the model\'s call)', () => {
+  it('prepends the page\'s own H1 when the rewrite dropped it', () => {
+    const existing = '# Silent Inflammation\n\nLead.\n\n## Beschreibung\nAlt';
+    const rewrite = '## Beschreibung\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe('# Silent Inflammation\n\n## Beschreibung\nNeu');
+  });
+
+  it('restores the previous title when the rewrite returned a different one', () => {
+    const existing = '# Sulforaphan\n\n## Beschreibung\nAlt';
+    const rewrite = '# Sulforaphan-Dosierung\n\n## Beschreibung\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe('# Sulforaphan\n\n## Beschreibung\nNeu');
+  });
+
+  it('is a no-op when the rewrite kept the title', () => {
+    const body = '# Sulforaphan\n\n## Beschreibung\nText';
+    expect(reassertH1(body, body)).toBe(body);
+  });
+
+  // The file name is a lossy slug of the title, so a synthesized `# <file name>`
+  // would flatten punctuation on every page that has a title the slug cannot
+  // reproduce. Nothing is invented: a page that never had an H1 keeps none.
+  it('invents no title when the page never had one', () => {
+    const existing = '## Beschreibung\nAlt';
+    const rewrite = '## Beschreibung\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe(rewrite);
   });
 });

--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -248,4 +248,26 @@ describe('reassertH1 (the title is not the model\'s call)', () => {
     const rewrite = '## Beschreibung\nNeu';
     expect(reassertH1(existing, rewrite)).toBe(rewrite);
   });
+
+  // The restore is spliced in at the match position, not handed to
+  // `String.replace` as a replacement string — which would read `$$` as one `$`
+  // and `$&` as the title it just matched, mutating exactly the punctuation this
+  // function exists to keep.
+  it('restores a title containing `$` escapes verbatim', () => {
+    const existing = '# Kosten $$500 und $& im Titel\n\n## Beschreibung\nAlt';
+    const rewrite = '# Kosten\n\n## Beschreibung\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe(
+      '# Kosten $$500 und $& im Titel\n\n## Beschreibung\nNeu',
+    );
+  });
+
+  // ...and at the match POSITION, so a line that merely quotes the title earlier
+  // in the body is not mistaken for the H1.
+  it('changes the H1 only, not an earlier line quoting it mid-line', () => {
+    const existing = '# Sulforaphan\n\n## Beschreibung\nAlt';
+    const rewrite = 'Siehe # Sulforaphan-Dosierung im Anhang.\n# Sulforaphan-Dosierung\n\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe(
+      'Siehe # Sulforaphan-Dosierung im Anhang.\n# Sulforaphan\n\nNeu',
+    );
+  });
 });

--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -278,3 +278,29 @@ describe('mergePage — source owning the page lemma overrides triage=skip (#312
     expect(written).not.toContain('Merged text.');
   });
 });
+
+// #419 — end-to-end on this call site: triage routes to the full body merge,
+// the model returns a body starting at the first `##`, and the written page
+// must still carry its title.
+describe('mergePage — H1 survives a rewrite that omits it', () => {
+  it('writes the page\'s own title back when the merged body has none', async () => {
+    const withTitle = `---\ntitle: Caching\n---\n\n# Caching (HTTP), a title the file name cannot reproduce\n\n## Description\nOld text.\n`;
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({ strategy: 'merge', reason: 'rewrite' }),
+      '## Description\nMerged body.',
+    ]));
+    const result = await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'new.md', basename: 'new.md' },
+      withTitle,
+      [],
+      'wiki/entities/caching.md',
+    );
+    expect(result).toBe('wiki/entities/caching.md');
+    const written = ctx.written.get('wiki/entities/caching.md')!;
+    expect(written).toContain('# Caching (HTTP), a title the file name cannot reproduce');
+    expect(written).toContain('Merged body.');
+  });
+});

--- a/src/__tests__/wiki/page-factory/related-page.test.ts
+++ b/src/__tests__/wiki/page-factory/related-page.test.ts
@@ -393,3 +393,27 @@ describe('updateRelatedPage — placeholder rendering', () => {
     // test pins the bug it is about.
   });
 });
+
+// #419 — end-to-end on this call site: the model returns a body that starts at
+// the first `##`, and the written page must still carry its title.
+describe('updateRelatedPage — H1 survives a rewrite that omits it', () => {
+  it('writes the page\'s own title back when the reply has none', async () => {
+    const withTitle = `---\ncreated: 2026-07-10\nupdated: 2026-07-10\nsources:\n  - "[[existing]]"\ntags: []\n---\n\n# X — a title the file name cannot reproduce\n\n## Description\nOld body.\n`;
+    const ctx = makeCtx({ pageContent: withTitle, llmResponse: '## Description\nNew body.' });
+
+    const result = await updateRelatedPage(
+      ctx,
+      PAGE_TITLE,
+      makeAnalysis(PAGE_TITLE),
+      { path: 'src.md', basename: 'src' },
+    );
+
+    expect(result).toBe(true);
+    const written = ctx.written.get(PAGE_PATH) ?? '';
+    expect(written).toContain('# X — a title the file name cannot reproduce');
+    expect(written).toContain('New body.');
+    // Restored, not merely retained somewhere: the title leads the body.
+    const body = written.split('---').slice(2).join('---');
+    expect(body.trimStart().startsWith('# X —')).toBe(true);
+  });
+});

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -247,12 +247,20 @@ export function preserveExistingSections(
  * Pure, no LLM, O(lines).
  */
 export function reassertH1(existingBody: string, rewrite: string): string {
-  const previous = existingBody.match(/^# .*/m)?.[0];
+  const previous = /^# .*/m.exec(existingBody)?.[0];
   if (previous === undefined) return rewrite;
 
-  const current = rewrite.match(/^# .*/m)?.[0];
-  if (current === previous) return rewrite;
-  if (current !== undefined) return rewrite.replace(current, previous);
+  const current = /^# .*/m.exec(rewrite);
+  if (current === null) return `${previous}\n\n${rewrite.replace(/^\s+/, '')}`;
+  if (current[0] === previous) return rewrite;
 
-  return `${previous}\n\n${rewrite.replace(/^\s+/, '')}`;
+  // Splice at the match position instead of `replace(current[0], previous)`: a
+  // string replacement interprets `$` escapes in the title it inserts (`# Kosten
+  // $$500` would arrive as `# Kosten $500`, `$&` as the whole matched title), and
+  // it substitutes the first occurrence ANYWHERE in the body — a preceding line
+  // quoting the title mid-line takes the restore while the real H1 keeps the
+  // model's version.
+  const head = rewrite.slice(0, current.index);
+  const tail = rewrite.slice(current.index + current[0].length);
+  return `${head}${previous}${tail}`;
 }

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -219,3 +219,40 @@ export function preserveExistingSections(
   if (restored.length === 0) return strippedRewrite;
   return `${strippedRewrite.replace(/\s+$/, '')}\n\n${restored.join('\n\n')}\n`;
 }
+
+/**
+ * Re-assert the page's H1 after an LLM body rewrite (#419).
+ *
+ * `preserveExistingSections` above guards `##` blocks only — its contract, and
+ * its tests, deliberately ignore the title line. On the merge and related-page
+ * paths the model is handed the whole body and asked to return the whole body,
+ * so the H1 is inside the rewrite window while no layer owns it: when the reply
+ * comes back starting at `## Beschreibung`, the title is simply gone.
+ *
+ * The restored title is the page's OWN previous H1, not one synthesized from the
+ * file name. A page's file name is a slug of its title and is lossy — of 1930
+ * pages carrying an H1 in a 2416-page vault, 677 (35%) have a title the file name
+ * cannot reproduce (`Harvard-T-H-Chan-School-of-Public-Health` vs `Harvard T.H.
+ * Chan School of Public Health`, `Lungu-et-al-2021` vs `Lungu et al. (2021)`).
+ * Rebuilding the H1 from the file name would repair the pages that lost one and
+ * quietly flatten the punctuation of every page that did not.
+ *
+ * For the same reason this never invents a title: a page that had no H1 before
+ * the rewrite keeps none. 486 pages in that vault have no H1, and minting them
+ * on the next merge is a mass mutation, not a repair.
+ *
+ * A rewrite that returns a DIFFERENT H1 is overwritten with the previous one.
+ * The page's identity is not the model's call — the same reasoning that makes
+ * `correctRelatedLinkPrefixes` re-type a link folder rather than trust the copy.
+ * Pure, no LLM, O(lines).
+ */
+export function reassertH1(existingBody: string, rewrite: string): string {
+  const previous = existingBody.match(/^# .*/m)?.[0];
+  if (previous === undefined) return rewrite;
+
+  const current = rewrite.match(/^# .*/m)?.[0];
+  if (current === previous) return rewrite;
+  if (current !== undefined) return rewrite.replace(current, previous);
+
+  return `${previous}\n\n${rewrite.replace(/^\s+/, '')}`;
+}

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -38,6 +38,7 @@ import { cleanMarkdownResponse } from '../../core/markdown';
 import {
   canonicalizeSectionHeaders,
   preserveExistingSections,
+  reassertH1,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
@@ -233,6 +234,11 @@ export async function mergePage(
       Object.values(labels),
       labels.mentions_in_source,
     );
+
+    // #419: the guard above owns `##` blocks only, so the title line falls
+    // between the layers — the model is asked for the whole body and the reply
+    // routinely starts at the first `##`. Restore the page's own H1.
+    const titledBody = reassertH1(existingBody, guardedBody);
     await ctx.createOrUpdateFile(
       path,
       await assembleFinalContent(
@@ -246,7 +252,7 @@ export async function mergePage(
         contradictedSourcePath
           ? appendContradictedByMarker(frontmatter, contradictedSourcePath)
           : frontmatter,
-        guardedBody,
+        titledBody,
         info,
         sourceFile,
         existingBody,

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -25,6 +25,7 @@ import { renderTemplate } from '../../core/template-renderer';
 import {
   canonicalizeSectionHeaders,
   preserveExistingSections,
+  reassertH1,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { getSectionLabels } from '../system-prompts';
@@ -159,6 +160,11 @@ export async function updateRelatedPage(
     labels.mentions_in_source,
   );
 
+  // #419: the guard above owns `##` blocks only, so the title line falls
+  // between the layers — the model is asked for the whole body and the reply
+  // routinely starts at the first `##`. Restore the page's own H1.
+  const titledBody = reassertH1(promptBody, guardedBody);
+
   // 2. Assemble: programmatic frontmatter + LLM body + Mentions section.
   // Issue #267 established a non-lossy re-ingest on the merge path, but this
   // path never had it: the Mentions section lives in the body handed to the LLM,
@@ -169,7 +175,7 @@ export async function updateRelatedPage(
   // the accumulated mentions are recovered from the unstripped page.
   await ctx.createOrUpdateFile(
     page.path,
-    await assembleFinalContent(ctx, frontmatter, guardedBody, newInfo, sourceFile, existingBody),
+    await assembleFinalContent(ctx, frontmatter, titledBody, newInfo, sourceFile, existingBody),
   );
   return true;
 }


### PR DESCRIPTION
Implements option (1) from your comment: a deterministic step after `preserveExistingSections`, no extra LLM call, the `preserveExistingSections` contract and its twelve tests untouched. New helper `reassertH1` in `section-header-canonicalizer.ts`, called at `related-page.ts:155` and `merge-page.ts:230`, exactly as sketched.

**One deviation from the sketch, and the reason for it.** The sketch restores `# ${pageName}`. At both call sites that name is the file base name — `get-existing-pages.ts:46` sets `title: f.basename`, and `merge-page.ts:101` derives `pageBasename` from the path. A file name is a slug of the title and loses characters the title carries. On a 2416-page vault, 1930 pages have an H1 and 677 of them (35%) hold a title the file name cannot reproduce: `Harvard-T-H-Chan-School-of-Public-Health` vs `# Harvard T.H. Chan School of Public Health`, `Lungu-et-al-2021` vs `# Lungu et al. (2021)`. With the "wrong H1 → replace" branch, those 677 titles would be flattened on every merge — the fix would repair the pages that lost a title and quietly damage the ones that kept theirs.

So the restored title is the page's own previous H1. A rewrite that returns a different H1 is still overwritten, and the identity still is not the model's call — but with the title the page already had. This also settles the `info.name` vs `pageBasename` question: the helper needs no name parameter at all.

For the same reason it never invents a title. A page with no H1 before the rewrite keeps none; 486 pages in that vault are in that state, and minting titles for them on the next merge would be a mass mutation rather than a repair.

The section-order symptom resolves as you predicted — the H1 is prepended, nothing is re-located. The lead-paragraph case stays out of scope.

Tests: four unit tests (dropped / different / unchanged / never had one) plus one integration test per call site asserting the title survives a reply that omits it. 2929 → 2935 tests, eslint 0, build green. Target `v1.26.1`.

Unrelated, noticed while running the suite: `src/__tests__/wiki/page-factory/append-source-slug.test.ts` imports `yaml`, which is not declared in `package.json` — the file errors on a clean install on `main` as well. Happy to open a separate issue.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
