### PR TITLE
test(cli): guard the `requestUrl` shim against a return to global `fetch`

### DIFF
--- a/src/__tests__/tools/llm-wiki-cli/obsidian-shim.test.ts
+++ b/src/__tests__/tools/llm-wiki-cli/obsidian-shim.test.ts
@@ -1,0 +1,75 @@
+// Regression guard for the CLI's `requestUrl` shim (#417 / PR #418).
+//
+// The shim stands in for Obsidian's `requestUrl`, which goes through Electron's
+// `net` and imposes no ceiling on how long a server may take before it sends
+// its first header. Built on Node's global `fetch` it inherited undici's
+// default `headersTimeout` of 300 s instead, and a non-streamed completion
+// sends no headers until the whole answer is ready — so every local-model call
+// over five minutes died with a bare `fetch failed`.
+//
+// A unit test cannot sit out the real ceiling, and undici's default is not
+// reachable to be shortened from a plain Node install. So the guard is placed
+// on the property that caused it: the shim must serve its request without
+// touching global `fetch` at all. A refactor back to `fetch` fails the first
+// test here regardless of any timeout, which is what makes it cheap.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { requestUrl } from '../../../../tools/llm-wiki-cli/src/obsidian';
+
+let server: Server | undefined;
+
+/** Start a throwaway loopback server on a free port; returns its base URL. */
+async function serve(
+  handler: (respond: (status: number, body: string) => void) => void,
+): Promise<string> {
+  server = createServer((_req, res) => {
+    handler((status, body) => {
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(body);
+    });
+  });
+  await new Promise<void>(resolve => server!.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') throw new Error('no port');
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (server !== undefined) {
+    await new Promise<void>(resolve => server!.close(() => resolve()));
+    server = undefined;
+  }
+});
+
+describe('llm-wiki-cli requestUrl shim — no global fetch, no header ceiling', () => {
+  it('serves a request without calling global fetch', async () => {
+    const base = await serve(respond => respond(200, JSON.stringify({ ok: true })));
+    // Any use of global fetch now fails loudly instead of silently
+    // re-introducing undici's headersTimeout.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      throw new Error('global fetch must not be used by the requestUrl shim');
+    });
+
+    const res = await requestUrl({ url: `${base}/v1/models` });
+
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ ok: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('waits for a server that withholds its headers before answering', async () => {
+    // 250 ms stands in for the five minutes a 12B model takes on one call:
+    // same shape — nothing at all on the socket, then the whole response —
+    // three orders of magnitude shorter so the suite stays fast.
+    const base = await serve(respond => {
+      setTimeout(() => respond(200, JSON.stringify({ slow: true })), 250);
+    });
+
+    const res = await requestUrl({ url: `${base}/v1/chat/completions`, method: 'POST', body: '{}' });
+
+    expect(res.status).toBe(200);
+    expect(res.json).toEqual({ slow: true });
+  });
+});

--- a/src/__tests__/tools/llm-wiki-cli/obsidian-shim.test.ts
+++ b/src/__tests__/tools/llm-wiki-cli/obsidian-shim.test.ts
@@ -10,8 +10,9 @@
 // A unit test cannot sit out the real ceiling, and undici's default is not
 // reachable to be shortened from a plain Node install. So the guard is placed
 // on the property that caused it: the shim must serve its request without
-// touching global `fetch` at all. A refactor back to `fetch` fails the first
-// test here regardless of any timeout, which is what makes it cheap.
+// touching global `fetch` at all. A refactor that reads `fetch` off the global
+// fails the first test here regardless of any timeout, which is what makes it
+// cheap.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createServer, type Server } from 'node:http';
@@ -25,7 +26,7 @@ async function serve(
 ): Promise<string> {
   server = createServer((_req, res) => {
     handler((status, body) => {
-      res.writeHead(status, { 'content-type': 'application/json' });
+      res.writeHead(status);
       res.end(body);
     });
   });
@@ -35,36 +36,40 @@ async function serve(
   return `http://127.0.0.1:${addr.port}`;
 }
 
-afterEach(async () => {
-  vi.restoreAllMocks();
-  if (server !== undefined) {
-    await new Promise<void>(resolve => server!.close(() => resolve()));
-    server = undefined;
-  }
-});
-
 describe('llm-wiki-cli requestUrl shim — no global fetch, no header ceiling', () => {
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    if (server !== undefined) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
   it('serves a request without calling global fetch', async () => {
     const base = await serve(respond => respond(200, JSON.stringify({ ok: true })));
-    // Any use of global fetch now fails loudly instead of silently
-    // re-introducing undici's headersTimeout.
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+    // Any call to global fetch from the shim now throws. The stub covers
+    // `fetch(url)` and `globalThis.fetch(url)` (both read off globalThis);
+    // refactors that bypass it are unlikely but would land here as an
+    // uncaught success rather than a thrown error.
+    const fetchMock = vi.fn(() => {
       throw new Error('global fetch must not be used by the requestUrl shim');
     });
+    vi.stubGlobal('fetch', fetchMock);
 
     const res = await requestUrl({ url: `${base}/v1/models` });
 
     expect(res.status).toBe(200);
     expect(res.json).toEqual({ ok: true });
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('waits for a server that withholds its headers before answering', async () => {
-    // 250 ms stands in for the five minutes a 12B model takes on one call:
-    // same shape — nothing at all on the socket, then the whole response —
-    // three orders of magnitude shorter so the suite stays fast.
+    // 100 ms stands in for the five minutes a 12B model takes on one call:
+    // same shape — nothing at all on the socket, then the whole response.
+    // The property under test is that no ceiling is imposed synchronously, so
+    // any delay comfortably above the loopback handshake pins it.
     const base = await serve(respond => {
-      setTimeout(() => respond(200, JSON.stringify({ slow: true })), 250);
+      setTimeout(() => respond(200, JSON.stringify({ slow: true })), 100);
     });
 
     const res = await requestUrl({ url: `${base}/v1/chat/completions`, method: 'POST', body: '{}' });


### PR DESCRIPTION
Follow-up to your suggestion on #418 — the belt-and-braces regression guard for the shim.

A unit test cannot sit out the real 300 s ceiling, and undici's default is not reachable to be shortened from a plain Node install. So the guard sits on the property that caused the bug rather than on its symptom: the shim serves a request against a loopback server while global `fetch` is replaced by a spy that throws. A refactor back to `fetch` fails that test immediately, with no timing involved.

To be straight about which of the two tests carries the weight: the first one does. The second starts a server that withholds its headers for 250 ms and asserts the shim waits — same shape as the five-minute case, three orders of magnitude shorter — and it passes under the old `fetch` implementation too. It documents the intent and guards against a short timeout being added to the shim later; it does not reproduce the original failure.

Negative-tested, so the guard is known to refuse: reverting `requestUrl` to the pre-#418 `fetch` body makes test 1 fail with `global fetch must not be used by the requestUrl shim`; the working tree was restored afterwards.

2929 → 2931 tests, eslint 0, no production code touched. Target `v1.26.1`.

(The one failing test file in a clean `pnpm install` is #424, unrelated to this branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
