### PR TITLE
fix(deps): declare yaml in devDependencies for append-source-slug.test.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "obsidian": "1.12.3",
         "tslib": "2.4.0",
         "typescript": "5.9.3",
-        "vitest": "4.1.6"
+        "vitest": "4.1.6",
+        "yaml": "^2.4.2"
       }
     },
     "node_modules/@ai-sdk/anthropic": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "obsidian": "1.12.3",
     "tslib": "2.4.0",
     "typescript": "5.9.3",
-    "vitest": "4.1.6"
+    "vitest": "4.1.6",
+    "yaml": "^2.4.2"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       vitest:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@16.18.126)(jsdom@29.1.1)(vite@8.0.13(@types/node@16.18.126)(esbuild@0.28.1)(yaml@2.8.3))
+      yaml:
+        specifier: ^2.4.2
+        version: 2.8.3
 
 packages:
 


### PR DESCRIPTION
## Why

`src/__tests__/wiki/page-factory/append-source-slug.test.ts:16` imports `yaml`, but `yaml` is not declared in `dependencies` / `devDependencies` / `peerDependencies` / `optionalDependencies`. It is in the tree only transitively (via vite's peer in vitest → eslint-plugin-obsidianmd → yaml-eslint-parser).

pnpm's strict isolation keeps `yaml` nested under `vite/node_modules/yaml` rather than hoisting it, so on a clean `pnpm install` from `main` this file fails to collect:

```
npx tsc --noEmit
src/__tests__/wiki/page-factory/append-source-slug.test.ts(16,36):
  error TS2307: Cannot find module 'yaml' or its corresponding type declarations.

pnpm test
Test Files  1 failed | 213 passed (214)
```

Two things hide it: `release.yml` uses `npm install --legacy-peer-deps` (flat layout hoists), and that workflow only runs `npm run build` (no test step). So a test file that fails to collect never turns CI red.

## Fix

Declare `yaml` in `devDependencies` with the version range that satisfies the transitive constraint (`^2.4.2`). The test file's own comment explains why a real YAML parser is used rather than the repo's frontmatter reader — using `parseFrontmatter` would make the test parse its own output, which is exactly the kind of self-parse that hides the bug under test.

Lockfile regenerated per pre-release-gate §2f.2 (in the project directory, not mktemp isolation, so npm reads current `node_modules` and writes back).

## Verified

- `pnpm lint` — 0 errors, 0 warnings
- `npx tsc --noEmit` — 0 errors
- `pnpm test` — **215 test files passed** (was 213 before; the previously-uncollectable file now runs), **2949 tests passed**
- `pnpm build` — clean

Closes #424. Target v1.26.x PATCH.
