### PR TITLE
fix(#435): decide the H1 by position, not by the first `# ` line

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -270,4 +270,42 @@ describe('reassertH1 (the title is not the model\'s call)', () => {
       'Siehe # Sulforaphan-Dosierung im Anhang.\n# Sulforaphan\n\nNeu',
     );
   });
+
+  // #435 Item 1: a `# ` line inside a `---` block the model echoed around the
+  // body is a comment, not the title. Taking it would have restored the page's
+  // title into the comment and left the model's title standing below it.
+  it('ignores a `# ` comment inside a leading `---` block', () => {
+    const existing = '# Sulforaphan\n\n## Beschreibung\nAlt';
+    const rewrite = '---\n# user note\ntitle: X\n---\n# Sulforaphan-Dosierung\n\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe(
+      '---\n# user note\ntitle: X\n---\n# Sulforaphan\n\nNeu',
+    );
+  });
+
+  // The likelier variant of the same mistake: `# ` opens a comment in most shell
+  // dialects, so any page carrying a bash example carries H1-looking lines.
+  it('ignores a `# ` comment inside a fenced code block', () => {
+    const existing = '# Sulforaphan\n\n## Beschreibung\nAlt';
+    const rewrite = '```bash\n# install the thing\n```\n\n# Sulforaphan-Dosierung\n\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe(
+      '```bash\n# install the thing\n```\n\n# Sulforaphan\n\nNeu',
+    );
+  });
+
+  // Same misreading on the READ side: a shell comment must not be adopted as the
+  // page's previous title, or the function would mint one for a page that had
+  // none — the mass mutation the file-name path was rejected for.
+  it('invents no title from a `# ` comment in the existing body', () => {
+    const existing = '```bash\n# install the thing\n```\n\n## Beschreibung\nAlt';
+    const rewrite = '## Beschreibung\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe(rewrite);
+  });
+
+  // A `---` further down is a thematic break, not frontmatter — the lines after
+  // it are ordinary body and can hold the H1.
+  it('finds an H1 that follows a mid-body thematic break', () => {
+    const existing = '# Sulforaphan\n\n## Beschreibung\nAlt';
+    const rewrite = 'Lead.\n\n---\n\n# Sulforaphan-Dosierung\n\nNeu';
+    expect(reassertH1(existing, rewrite)).toBe('Lead.\n\n---\n\n# Sulforaphan\n\nNeu');
+  });
 });

--- a/src/__tests__/wiki/lint/merge-duplicates-link-retarget.test.ts
+++ b/src/__tests__/wiki/lint/merge-duplicates-link-retarget.test.ts
@@ -60,3 +60,48 @@ describe('mergeDuplicatePages — link retargeting (#386)', () => {
     expect(summary).toBe('merged entities/Osteopontin-2 → entities/Osteopontin');
   });
 });
+
+// #435 Item 2 — the sibling of #419 on the lint path. Here the LLM client is
+// present on purpose: the programmatic fallback keeps the target's body verbatim
+// and can never lose the title, so only the adopted-rewrite path can.
+describe('mergeDuplicatePages — the merged body keeps the surviving page H1 (#435)', () => {
+  function ctxWithMergeAnswer(files: Record<string, string>, body: string) {
+    const { ctx, fake, deleted } = makeCtx(files);
+    (ctx as unknown as { getClient: () => unknown }).getClient = () => ({
+      createMessage: async () => JSON.stringify({ body, aliases: [] }),
+    });
+    return { ctx, fake, deleted };
+  }
+
+  it('restores the H1 when the merge answer drops it', async () => {
+    const { ctx, fake } = ctxWithMergeAnswer(
+      {
+        [TARGET]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin\n\nBone marker.\n',
+        [SOURCE]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin-2\n\nAlso a bone marker.\n',
+      },
+      '## Description\n\nA bone marker, and also a bone marker — merged prose long enough to clear the hundred-character floor this path applies.',
+    );
+
+    await mergeDuplicatePages(ctx, TARGET, SOURCE);
+
+    const written = fake.read(TARGET) ?? '';
+    expect(written).toContain('# Osteopontin\n');
+    expect(written.indexOf('# Osteopontin')).toBeLessThan(written.indexOf('## Description'));
+  });
+
+  it('does not let the merge answer rename the surviving page', async () => {
+    const { ctx, fake } = ctxWithMergeAnswer(
+      {
+        [TARGET]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin\n\nBone marker.\n',
+        [SOURCE]: '---\ntype: entity\ntags: [other]\n---\n\n# Osteopontin-2\n\nAlso a bone marker.\n',
+      },
+      '# Osteopontin and Osteopontin-2\n\n## Description\n\nMerged prose, long enough to clear the hundred-character floor that this path applies before it parses.',
+    );
+
+    await mergeDuplicatePages(ctx, TARGET, SOURCE);
+
+    const written = fake.read(TARGET) ?? '';
+    expect(written).toContain('# Osteopontin\n');
+    expect(written).not.toContain('# Osteopontin and Osteopontin-2');
+  });
+});

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -247,12 +247,12 @@ export function preserveExistingSections(
  * Pure, no LLM, O(lines).
  */
 export function reassertH1(existingBody: string, rewrite: string): string {
-  const previous = /^# .*/m.exec(existingBody)?.[0];
+  const previous = findH1(existingBody)?.text;
   if (previous === undefined) return rewrite;
 
-  const current = /^# .*/m.exec(rewrite);
+  const current = findH1(rewrite);
   if (current === null) return `${previous}\n\n${rewrite.replace(/^\s+/, '')}`;
-  if (current[0] === previous) return rewrite;
+  if (current.text === previous) return rewrite;
 
   // Splice at the match position instead of `replace(current[0], previous)`: a
   // string replacement interprets `$` escapes in the title it inserts (`# Kosten
@@ -260,7 +260,64 @@ export function reassertH1(existingBody: string, rewrite: string): string {
   // it substitutes the first occurrence ANYWHERE in the body — a preceding line
   // quoting the title mid-line takes the restore while the real H1 keeps the
   // model's version.
-  const head = rewrite.slice(0, current.index);
-  const tail = rewrite.slice(current.index + current[0].length);
+  const head = rewrite.slice(0, current.start);
+  const tail = rewrite.slice(current.end);
   return `${head}${previous}${tail}`;
+}
+
+/**
+ * Locate a body's H1 — the line, and where it sits (#435).
+ *
+ * A line starting with `# ` is not automatically the title. It is a comment when
+ * it stands inside a fenced code block (`# clone the repo` in a bash example) or
+ * inside a `---` block the model echoed around the body, and `reassertH1` used
+ * to accept both: on the read side a shell comment could be adopted as the
+ * page's previous title, and on the write side it took the restore while the
+ * model's title survived above it — the opposite of the contract.
+ *
+ * A `---` line opens a skipped block only in frontmatter position, i.e. as the
+ * body's first content line; further down it is a thematic break and the lines
+ * after it are ordinary body. Fences are closed by their own opening marker, so
+ * a ``` inside a ~~~ block does not end it.
+ *
+ * Pure, single pass, O(lines).
+ */
+function findH1(body: string): { text: string; start: number; end: number } | null {
+  let offset = 0;
+  let fence: string | null = null;
+  let inFrontmatter = false;
+  let seenContent = false;
+
+  for (const line of body.split('\n')) {
+    const start = offset;
+    offset += line.length + 1; // +1 for the '\n' that split() consumed
+    const trimmed = line.trim();
+
+    if (inFrontmatter) {
+      if (trimmed === '---') inFrontmatter = false;
+      continue;
+    }
+    if (fence !== null) {
+      if (trimmed.startsWith(fence)) fence = null;
+      continue;
+    }
+    if (trimmed === '') continue;
+
+    if (!seenContent && trimmed === '---') {
+      seenContent = true;
+      inFrontmatter = true;
+      continue;
+    }
+    seenContent = true;
+
+    const opener = /^(```|~~~)/.exec(trimmed);
+    if (opener) {
+      fence = opener[1];
+      continue;
+    }
+
+    if (line.startsWith('# ')) return { text: line, start, end: start + line.length };
+  }
+
+  return null;
 }

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -4,6 +4,7 @@ import { TOKENS_LINT_PAGE_FIX, WIKI_SUBFOLDERS } from '../../constants';
 import { buildSystemPrompt } from '../system-prompts';
 import { parseFrontmatter, enforceFrontmatterConstraints, serializeFrontmatter } from '../../core/frontmatter';
 import { parseJsonResponse } from '../../core/json';
+import { reassertH1 } from '../../core/section-header-canonicalizer';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
@@ -107,7 +108,13 @@ export async function mergeDuplicatePages(
           console.error(`mergeDuplicatePages: JSON parse failed for ${sourcePath} → ${targetPath}`, parseErr);
         }
         if (parsed?.body) {
-          mergedBody = parsed.body.trim();
+          // #435 Item 2: this path hands the model a body and adopts its answer,
+          // exactly like the merge and related-page paths in #419 — and the
+          // title line is inside that window with no layer owning it. Softer
+          // here (the surviving page's title is already captured into
+          // `aliases:` above, so identity survives a lost H1) but the same
+          // class, and the same deterministic repair applies.
+          mergedBody = reassertH1(targetBody, parsed.body.trim());
           llmMergeSucceeded = true;
         } else if (!parsed) {
           console.warn(`mergeDuplicatePages: JSON parse returned null for ${sourcePath} → ${targetPath}, falling back to programmatic merge`);


### PR DESCRIPTION
Closes #435 — both items.

**Item 1.** `reassertH1` took the first `^# ` line anywhere in the body. Your frontmatter example is covered, and so is the likelier variant of the same mistake: `# ` opens a comment in most shell dialects, so every page carrying a bash example carries H1-looking lines, and a rewrite that dropped its title would have had the page title spliced into `# install the thing` while the model's title stood below it.

The issue does not mention it, but the same misreading sat on the **read** side. A page with no H1 of its own but a fenced `# comment` would have handed that comment over as `previous` — inventing a title for a page that never had one. That is the mass mutation the file-name approach was rejected for in #419, arriving through the back door.

`findH1` walks the lines once. A `---` line opens a skipped block only in frontmatter position, i.e. as the body's first content line; further down it is a thematic break and the lines after it are ordinary body, which the sixth test pins. Fences are closed by their own opening marker, so a ``` inside a ~~~ block does not end it.

**Item 2.** `mergeDuplicatePages` adopts `parsed.body` as the merged body, so the title sits in the rewrite window there too; the same repair now runs against the surviving page's body. The programmatic fallback needs nothing — it keeps the target body verbatim and cannot lose the title — so both tests drive the LLM path: one client answers without an H1, the other answers with a renamed page.

Six tests. Five fail against the merged implementation — three on the title misidentification, two on the lint path. The sixth passes on both, which is what makes it a boundary guard rather than a fix.

Gate: `tsc --noEmit` clean, 2970 tests in 216 files green, `eslint .` 42 problems / 11 files — identical to the base.

Both items are in one PR because they are one mechanism; happy to split Item 2 out if you would rather patch the lint path separately.
