### PR TITLE
fix(frontmatter): preserve sources through constraints pass + drop blank first fm line (#438)

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -385,6 +385,51 @@ describe('enforceFrontmatterConstraints', () => {
     const parsed = parseFrontmatter(result);
     expect(parsed?.sources).toEqual(['[[sources/a_aaa]]', '[[sources/b_bbb]]']);
   });
+
+  // DocTpoint #450 review Finding 1: when a page's `sources:` header has
+  // already been emptied by the pre-fix constraints pass (the recovery
+  // population this PR is for), `preservedSources` reads as `['']` and
+  // the length check passes, so the next constraints pass would write
+  // `sources:\n  - ""` instead of omitting the key. The `aliases` branch
+  // filters empty entries at `:452`; mirror it here so the recovery
+  // population gets a clean read instead of a corrupted re-emit.
+  it('#450 Finding 1: omits the sources key entirely when every preserved entry is empty', () => {
+    const input = [
+      '---',
+      'type: concept',
+      'created: 2026-08-08',
+      'sources:',
+      'tags: [term]',
+      '---',
+      '# X',
+      '',
+      'body',
+    ].join('\n');
+    const result = enforceFrontmatterConstraints(input, 'concept');
+    // No `sources:` key in the output — the recovery population is not
+    // re-corrupted by the fix that protects it.
+    expect(result).not.toMatch(/^sources:/m);
+    // Tags still propagate normally.
+    const parsed = parseFrontmatter(result);
+    expect(parsed?.tags).toEqual(['term']);
+    expect(parsed?.sources).toBeUndefined();
+  });
+
+  it('#450 Finding 1: filters whitespace-only entries alongside truly empty ones', () => {
+    const input = [
+      '---',
+      'type: concept',
+      'sources: ["  ", "[[sources/valid]]"]',
+      'tags: [term]',
+      '---',
+      '# X',
+      '',
+      'body',
+    ].join('\n');
+    const result = enforceFrontmatterConstraints(input, 'concept');
+    const parsed = parseFrontmatter(result);
+    expect(parsed?.sources).toEqual(['[[sources/valid]]']);
+  });
 });
 
 describe('serializeFrontmatter', () => {

--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -347,6 +347,44 @@ describe('enforceFrontmatterConstraints', () => {
     const withoutValue = enforceFrontmatterConstraints(input, 'entity');
     expect(withoutValue).toContain(`created: ${today}`);
   });
+
+  it('#438 B: preserves block-style sources through a constraints pass', () => {
+    const input = [
+      '---',
+      'type: concept',
+      'created: 2026-08-08',
+      'sources:',
+      '  - "[[sources/a_aaa]]"',
+      '  - "[[sources/b_bbb]]"',
+      'tags: [term]',
+      '---',
+      '# X',
+      '',
+      'body',
+    ].join('\n');
+    const result = enforceFrontmatterConstraints(input, 'concept');
+    const parsed = parseFrontmatter(result);
+    // Both source links survive — prior behaviour kept the `sources:` header
+    // but discarded every `- ` entry, then never re-emitted the field (#438 B).
+    expect(parsed?.sources).toEqual(['[[sources/a_aaa]]', '[[sources/b_bbb]]']);
+    expect(parsed?.tags).toEqual(['term']);
+  });
+
+  it('#438 B: preserves flow-style sources through a constraints pass', () => {
+    const input = [
+      '---',
+      'type: concept',
+      'sources: ["[[sources/a_aaa]]", "[[sources/b_bbb]]"]',
+      'tags: [term]',
+      '---',
+      '# X',
+      '',
+      'body',
+    ].join('\n');
+    const result = enforceFrontmatterConstraints(input, 'concept');
+    const parsed = parseFrontmatter(result);
+    expect(parsed?.sources).toEqual(['[[sources/a_aaa]]', '[[sources/b_bbb]]']);
+  });
 });
 
 describe('serializeFrontmatter', () => {

--- a/src/__tests__/wiki/page-factory/append-source-slug.test.ts
+++ b/src/__tests__/wiki/page-factory/append-source-slug.test.ts
@@ -283,5 +283,28 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
       const out = appendSourceSlugToFrontmatter(before, 'Beta');
       expect(out).toBe(before);
     });
+
+    it('#438 A: does not introduce a blank line after the opening `---` when appending a source', () => {
+      const before = [
+        '---',
+        'type: concept',
+        'created: 2026-08-08',
+        'sources:',
+        '  - "[[sources/a_aaa]]"',
+        'tags: [term]',
+        '---',
+        '# X',
+        '',
+        'body',
+      ].join('\n');
+      const out = appendSourceSlugToFrontmatter(before, 'b_bbb');
+      const lines = out.split('\n');
+      // line index 1 is the first frontmatter line — must not be blank (#438 A)
+      expect(lines[0]).toBe('---');
+      expect(lines[1]).toBe('type: concept');
+      // Sources preserved + new one appended
+      expect(out).toContain('  - "[[sources/a_aaa]]"');
+      expect(out).toContain('  - "[[sources/b_bbb]]"');
+    });
   });
 });

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -658,7 +658,19 @@ export function enforceFrontmatterConstraints(
   // Preserve existing provenance (block OR flow form) across the rewrite.
   // parseFrontmatter handles both and strips quoting, matching the shape
   // yamlStringify expects on the serialize side.
-  const preservedSources = parseFrontmatter(content)?.sources;
+  //
+  // Filter empty / whitespace-only entries to avoid re-emitting a
+  // `sources:` key whose only entry is `\"\"` — that is the shape the
+  // previous broken constraints pass leaves on disk for the recovery
+  // population (this PR's fix audience). The `aliases` branch has the
+  // same guard at `:452`; mirroring it here is intentional. When
+  // `preservedSources` ends up empty, `serializeFrontmatter` is called
+  // with `sources: undefined` so the key is omitted entirely rather
+  // than emitted as `sources:\\n  - \"\"`.
+  const rawSources = parseFrontmatter(content)?.sources;
+  const preservedSources = Array.isArray(rawSources)
+    ? rawSources.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : undefined;
 
   const hasTags = foundTags || collectedTags.length > 0;
   const dedupedTags: string[] = [];

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -645,9 +645,20 @@ export function enforceFrontmatterConstraints(
   // Non-canonical fields (unknown keys) are passed through verbatim, preserving
   // prior enforce behavior. newLines already excludes type/tags/aliases/created/
   // updated and list items by construction; the filter is defensive.
+  //
+  // `sources:` is canonical but block-style is multi-line — its header line
+  // lands in newLines while its `- ` entries are dropped by the skip above,
+  // leaving a header with no entries. Exclude it here and re-emit the parsed
+  // array via serializeFrontmatter (mirrors extractPassthroughLines, which
+  // also treats sources as known). See #438 B.
   const passthroughLines = newLines.filter(line =>
     !line.startsWith('type:') && !line.startsWith('tags:') && !line.startsWith('aliases:') &&
-    !line.startsWith('created:') && !line.startsWith('updated:'));
+    !line.startsWith('created:') && !line.startsWith('updated:') && !line.startsWith('sources:'));
+
+  // Preserve existing provenance (block OR flow form) across the rewrite.
+  // parseFrontmatter handles both and strips quoting, matching the shape
+  // yamlStringify expects on the serialize side.
+  const preservedSources = parseFrontmatter(content)?.sources;
 
   const hasTags = foundTags || collectedTags.length > 0;
   const dedupedTags: string[] = [];
@@ -679,6 +690,7 @@ export function enforceFrontmatterConstraints(
       type: foundType ? pageType : undefined,
       created: resolveCreated(options, today),
       updated: today,
+      sources: Array.isArray(preservedSources) && preservedSources.length > 0 ? preservedSources : undefined,
       tags: dedupedTags,
       aliases: (foundAliases || collectedAliases.length > 0) ? collectedAliases : undefined,
     },

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -341,7 +341,7 @@ export function appendSourceSlugToFrontmatter(content: string, sourceSlug: strin
   if (!content.startsWith('---')) return content;
   const fmEnd = content.indexOf('\n---\n', 3);
   if (fmEnd === -1) return content;
-  const fmText = content.substring(3, fmEnd);
+  const fmText = content.substring(3, fmEnd).replace(/^\n/, '');
   const body = content.substring(fmEnd + 5);
   const sourceEntry = `[[sources/${sourceSlug}]]`;
 


### PR DESCRIPTION
Closes #438

## Two defects (both verified on main, reproduced via the reporter's pure-function script)

### A. `appendSourceSlugToFrontmatter` re-inserts a blank line after the opening `---`
`src/wiki/page-factory/create-page.ts:344` — `content.substring(3, fmEnd)` starts *on* the newline that terminates the opening fence, so the first split element is `''` and survives `lines.join('\n')`. Cosmetic for Obsidian but spurious diff on every unchanged page; not cosmetic for anything that treats frontmatter as YAML lines.

**Fix:** `.replace(/^\n/, '')` — same pattern `extractPassthroughLines` already uses.

### B. `enforceFrontmatterConstraints` empties block-style `sources:` (data loss)
`src/core/frontmatter.ts:648-650` — the passthrough filter excludes `type/tags/aliases/created/updated` but not `sources:`, so the header line is kept while every `- ` entry is dropped by the skip, and the serializer never re-emits `sources`. Silent provenance loss on every lint/regenerate/fill-empty pass.

**Fix:** exclude `sources:` from `passthroughLines` + thread the parsed array (block OR flow form, via `parseFrontmatter`) through `serializeFrontmatter` — re-emitted as canonical double-quoted block form (`- "[[x]]"`).

## Tests
- `#438 A`: first frontmatter line is not blank after append
- `#438 B` block-style: sources survive a constraints pass
- `#438 B` flow-style: sources survive (normalized to block form)

Author's alternating append+enforce repro now converges (was: blank line every append, sources emptied every enforce).

## Gate 1
lint 0/0 · tsc 0 · **3202 tests** (230 files, +3) · build clean · css-lint 0

