### PR TITLE
fix(lint): defer fillEmptyPage tag constraint to the runtime vocabulary

### DIFF
--- a/src/__tests__/wiki/lint-prompt-vocab-contradiction.test.ts
+++ b/src/__tests__/wiki/lint-prompt-vocab-contradiction.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { buildSystemPrompt } from '../../wiki/system-prompts';
+import { FIX_PROMPTS } from '../../wiki/prompts/fixes';
+import { getActiveEntityTags, getActiveConceptTags } from '../../core/tag-vocab';
+import { VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS } from '../../types';
+import type { LLMWikiSettings } from '../../types';
+
+// Issue #328 Phase 1 made the runtime injection (buildSystemPrompt ->
+// "Active Tag Vocabulary") the single source of truth for allowed tag values.
+// A lint prompt that restates the default taxonomy re-creates the dual source:
+// with a custom vocabulary the two layers travel in the same call and forbid
+// each other's values, so every answer the model can give violates one of them.
+
+function makeSettings(overrides: Partial<LLMWikiSettings> = {}): LLMWikiSettings {
+  return {
+    wikiFolder: 'wiki',
+    wikiLanguage: 'de',
+    extractionGranularity: 'standard',
+    customEntityTags: '',
+    customConceptTags: '',
+    tagVocabularyMode: 'default',
+    ...overrides,
+  } as LLMWikiSettings;
+}
+
+// A vocabulary that shares no value with the defaults — the case that makes
+// the contradiction observable (see #368, where the custom list was the
+// default list plus one term and therefore agreed with the baked-in copy).
+const customSettings = makeSettings({
+  tagVocabularyMode: 'custom',
+  customEntityTags: 'Mineralstoffe, Biochemie, Physiologie, Mikrobiom',
+  customConceptTags: 'Mineralstoffe, Biochemie, Physiologie, Mikrobiom',
+});
+
+const DEFAULT_TAXONOMY = [...VALID_ENTITY_TAGS, ...VALID_CONCEPT_TAGS];
+
+/** Lines that enumerate three or more default-taxonomy values — a baked-in enum. */
+function linesRestatingTheDefaultTaxonomy(prompt: string): string[] {
+  return prompt.split('\n').filter(line => {
+    const hits = DEFAULT_TAXONOMY.filter(t =>
+      new RegExp(`\\b${t}\\b`).test(line),
+    );
+    return new Set(hits).size >= 3;
+  });
+}
+
+describe('lint prompts vs. the active tag vocabulary', () => {
+  it('the system layer carries the active vocabulary on the lint task', async () => {
+    const system = await buildSystemPrompt(customSettings, async () => undefined, 'lint');
+    expect(system).toBeDefined();
+    expect(system).toContain('Active Tag Vocabulary');
+    for (const tag of getActiveEntityTags(customSettings)) {
+      expect(system).toContain(tag);
+    }
+    for (const tag of getActiveConceptTags(customSettings)) {
+      expect(system).toContain(tag);
+    }
+  });
+
+  it('no lint prompt restates the default taxonomy as a fixed list', () => {
+    for (const [name, prompt] of Object.entries(FIX_PROMPTS)) {
+      expect(
+        linesRestatingTheDefaultTaxonomy(prompt),
+        `${name} hardcodes tag values that a custom vocabulary forbids`,
+      ).toEqual([]);
+    }
+  });
+});

--- a/src/wiki/prompts/fixes.ts
+++ b/src/wiki/prompts/fixes.ts
@@ -44,7 +44,7 @@ Task:
 7. **IMPORTANT — Source Mentions:** Only create a "Mentions in Source" section if the existing content already contains verbatim source quotes. If no source quotes exist in the existing content, do NOT fabricate a "Mentions in Source" section — instead, note "*(No source content available for this page)*" in the description. NEVER invent fake citations or source references
 8. Preserve any existing frontmatter fields exactly (type, created, sources, tags, reviewed). Do NOT remove or alter these fields
 9. **Aliases are REQUIRED:** If the existing content has non-empty aliases, keep them. If aliases are missing or empty, you MUST generate 1-2 meaningful aliases following the fallback hierarchy: translation in Wiki language → alternative names → abbreviations. The aliases field MUST NOT be left empty
-10. **Tags constraint:** entity pages MUST use tags from: [person, organization, project, product, event, place, other]. Concept pages MUST use tags from: [theory, method, field, phenomenon, standard, term, other]. Never invent new tags outside these lists
+10. **Tags constraint:** use only values from the Active Tag Vocabulary given in the system prompt. Never invent new tags outside that list
 
 Output format: directly output the complete Markdown page content (do not output explanatory text)`,
 


### PR DESCRIPTION
Fixes #459.

`FIX_PROMPTS.fillEmptyPage` instruction 10 named the default tag taxonomy as a fixed list. It is sent in the same request as the *Active Tag Vocabulary (runtime)* section built by `buildSystemPrompt()` (`src/wiki/lint/fill-empty-page.ts:63`), so with `tagVocabularyMode: 'custom'` and a vocabulary disjoint from the defaults, the two layers forbid each other's values and no answer satisfies both. The issue has the full trace.

**Change**

- `src/wiki/prompts/fixes.ts` — instruction 10 now points at the runtime section rather than enumerating values. This follows what #328 Phase 1 established (the runtime layer is the single source of truth) and what #333 already did for the retag runner; the "do not invent" reminder stays in the user prompt.
- `src/__tests__/wiki/lint-prompt-vocab-contradiction.test.ts` — regression test. One case pins the system-layer contract, the other fails when any prompt in `FIX_PROMPTS` puts three or more default-taxonomy values on one line. It fails on `main` naming `fillEmptyPage` and passes here.

Full suite green locally: 233 files, 3312 tests.

**Not changed:** `generation.ts:49/110` mention `product, person, organization` and `theory, method, field` as parenthetical examples next to `{{entity_type}}`/`{{concept_type}}`. Those are illustrative rather than a mandate, and the value itself comes from the extraction, so I left them alone — happy to include them if you would rather have the examples parameterized too.

Close this without hesitation if you would rather solve it differently; the issue stands on its own.