### PR TITLE
fix(dedup): resolve ambiguous designators independently of page order (#446)

### DIFF
--- a/src/__tests__/core/ambiguous-designators.test.ts
+++ b/src/__tests__/core/ambiguous-designators.test.ts
@@ -1,0 +1,194 @@
+// Issue #446 — acceptance fixture for ambiguous short designators.
+//
+// Provenance: measured 2026-08-15 on a 2416-page entity/concept vault with the
+// plugin's own `computeSlug`. A designator is a title or an alias of 2-5
+// characters; a page counts once per slug, so a title and an alias that fold
+// together ("Hsp70" / "HSP70") are one designator rather than a collision.
+//
+// Scope note, because the number in the issue is wider than this fixture: 24
+// designators are carried by more than one page when entities and concepts are
+// pooled, but 15 of those are one entity plus one concept, which the resolver
+// settles deterministically because a same-type match wins before the cross-type
+// branch is reached. The 9 below are the ones where a single folder holds more
+// than one page for the designator — the case the resolution order actually
+// decided.
+//
+// What this pins: the deterministic gate never answers an ambiguous designator
+// on its own, never depends on page order, and never proposes a new page for a
+// name that already exists twice. It deliberately does NOT pin which candidate
+// wins on tags alone: a page carries the aspect it was created under and a note
+// the aspect it was written about, so tags order candidates and never decide
+// identity.
+
+import { describe, it, expect } from 'vitest';
+import { ConflictResolver, type PageRef, type PageType } from '../../core/conflict-resolver';
+import { computeSlug } from '../../core/slug';
+
+const WIKI = 'wiki';
+
+interface Designator {
+  designator: string;
+  pageType: PageType;
+  /** disjoint = no shared tag, identical = same tag set, partial = some overlap */
+  tagRelation: 'disjoint' | 'identical' | 'partial';
+  pages: Array<{ title: string; tags: string[] }>;
+}
+
+const DESIGNATORS: Designator[] = [
+  {
+    designator: 'DHA', pageType: 'entity', tagRelation: 'partial',
+    pages: [
+      { title: 'Dehydroascorbinsäure', tags: ['Biochemie'] },
+      { title: 'Docosahexaensäure', tags: ['Vitamine', 'Biochemie'] },
+    ],
+  },
+  {
+    designator: 'E433', pageType: 'entity', tagRelation: 'identical',
+    pages: [
+      { title: 'Polysorbat-80', tags: ['Lebensmittelzusatzstoff'] },
+      { title: 'Polysorbate', tags: ['Lebensmittelzusatzstoff'] },
+    ],
+  },
+  {
+    designator: 'EVOO', pageType: 'entity', tagRelation: 'identical',
+    pages: [
+      { title: 'Extra-natives-Olivenöl', tags: ['Lebensmittel', 'Ernährung'] },
+      { title: 'Olivenöl', tags: ['Lebensmittel', 'Ernährung'] },
+    ],
+  },
+  {
+    designator: 'LAB', pageType: 'entity', tagRelation: 'identical',
+    pages: [
+      { title: 'LactobacillusFructilactobacillus-Arten', tags: ['Bakterien', 'Mikrobiologie'] },
+      { title: 'Milchsäurebakterien', tags: ['Bakterien', 'Mikrobiologie'] },
+    ],
+  },
+  {
+    designator: 'LTβR', pageType: 'concept', tagRelation: 'identical',
+    pages: [
+      { title: 'LTβR-Signalweg', tags: ['Biochemie'] },
+      { title: 'Lymphotoxin-Beta-Rezeptor', tags: ['Biochemie'] },
+    ],
+  },
+  {
+    designator: 'MB', pageType: 'entity', tagRelation: 'partial',
+    pages: [
+      { title: 'Methylenblau', tags: ['Arzneimittel', 'Biochemie'] },
+      { title: 'Myoglobin', tags: ['Biochemie', 'Physiologie'] },
+    ],
+  },
+  {
+    designator: 'NAC', pageType: 'entity', tagRelation: 'disjoint',
+    pages: [
+      { title: 'N-Acetylcystein', tags: ['Supplement', 'Biochemie'] },
+      { title: 'Nucleus-accumbens', tags: ['Neurologie'] },
+    ],
+  },
+  {
+    designator: 'NO2-', pageType: 'entity', tagRelation: 'partial',
+    pages: [
+      { title: 'Nitrit', tags: ['Mineralstoffe', 'Biochemie'] },
+      { title: 'Stickstoffoxide', tags: ['Biochemie', 'Umweltmedizin'] },
+    ],
+  },
+  {
+    designator: 'PCC', pageType: 'entity', tagRelation: 'disjoint',
+    pages: [
+      { title: 'Posteriorer-Cingulärer-Kortex', tags: ['Neurologie'] },
+      { title: 'Propionyl-CoA-Carboxylase', tags: ['Biochemie'] },
+    ],
+  },
+];
+
+/** Build the page list a designator's pages form, in the given folder. */
+function pagesOf(d: Designator, folder: 'entities' | 'concepts'): PageRef[] {
+  return d.pages.map(p => ({
+    path: `${WIKI}/${folder}/${p.title}.md`,
+    title: p.title,
+    aliases: [d.designator],
+    tags: p.tags,
+  }));
+}
+
+function resolve(d: Designator, pages: PageRef[], tags?: string[]) {
+  return new ConflictResolver(WIKI, pages).resolve({
+    name: d.designator,
+    // The production caller slugifies the extracted name, and the rule is not
+    // lowercasing: `NO2-` loses its trailing dash on the way to `no2`.
+    slug: computeSlug(d.designator),
+    pageType: d.pageType,
+    tags,
+  });
+}
+
+const sameTypeFolder = (d: Designator) => (d.pageType === 'entity' ? 'entities' : 'concepts');
+const otherTypeFolder = (d: Designator) => (d.pageType === 'entity' ? 'concepts' : 'entities');
+
+describe('Issue #446 — ambiguous designators, same-type gate', () => {
+  it.each(DESIGNATORS)('$designator is reported as ambiguous, not merged silently', (d) => {
+    const result = resolve(d, pagesOf(d, sameTypeFolder(d)));
+
+    expect(result.action).toBe('disambiguate');
+    expect(result.candidates?.map(c => c.title).sort()).toEqual(d.pages.map(p => p.title).sort());
+  });
+
+  it.each(DESIGNATORS)('$designator resolves the same under every page order', (d) => {
+    const pages = pagesOf(d, sameTypeFolder(d));
+    const orders = [pages, [...pages].reverse()];
+    const results = orders.map(o => resolve(d, o).targetPath);
+
+    expect(new Set(results).size).toBe(1);
+  });
+
+  it.each(DESIGNATORS)('$designator never proposes a new page', (d) => {
+    // The pages exist; creating a third one for a name that is already an alias
+    // twice is the one answer that is certainly wrong.
+    for (const tags of [undefined, ['Toxikologie'], d.pages[0].tags]) {
+      expect(resolve(d, pagesOf(d, sameTypeFolder(d)), tags).action).not.toBe('create');
+    }
+  });
+
+  it.each(DESIGNATORS.filter(d => d.tagRelation !== 'identical'))(
+    '$designator ranks the tag-sharing page first without dropping the other',
+    (d) => {
+      // Take a tag that only the second page carries, and check it leads.
+      const second = d.pages[1];
+      const first = d.pages[0];
+      const distinguishing = second.tags.find(t => !first.tags.includes(t));
+      expect(distinguishing).toBeDefined();
+
+      const result = resolve(d, pagesOf(d, sameTypeFolder(d)), [distinguishing!]);
+      expect(result.candidates?.[0].title).toBe(second.title);
+      expect(result.candidates).toHaveLength(d.pages.length);
+    },
+  );
+
+  it.each(DESIGNATORS.filter(d => d.tagRelation === 'identical'))(
+    '$designator stays deterministic when the tags cannot separate the pages',
+    (d) => {
+      const pages = pagesOf(d, sameTypeFolder(d));
+      const shared = d.pages[0].tags;
+      const forward = resolve(d, pages, shared);
+      const backward = resolve(d, [...pages].reverse(), shared);
+
+      expect(backward.targetPath).toBe(forward.targetPath);
+      expect(forward.candidates).toHaveLength(d.pages.length);
+    },
+  );
+});
+
+describe('Issue #446 — the same designators from the cross-type side', () => {
+  // When the extraction classifies DHA as a concept, the two entity pages that
+  // carry it are cross-type matches and no same-type match exists. Same
+  // ambiguity, other branch: it keeps returning a collision, but the collision
+  // target no longer depends on the page order.
+  it.each(DESIGNATORS)('$designator picks the same cross-type target under every order', (d) => {
+    const pages = pagesOf(d, otherTypeFolder(d));
+    const forward = resolve(d, pages);
+    const backward = resolve(d, [...pages].reverse());
+
+    expect(forward.action).toBe('merge');
+    expect(forward.reason).toContain('Cross-type');
+    expect(backward.targetPath).toBe(forward.targetPath);
+  });
+});

--- a/src/__tests__/core/conflict-resolver.test.ts
+++ b/src/__tests__/core/conflict-resolver.test.ts
@@ -66,3 +66,64 @@ describe('ConflictResolver', () => {
     expect(result.reason).toContain('Cross-type');
   });
 });
+
+// Issue #446: a short designator can be title-or-alias on more than one page.
+// `E433` is an alias on both Polysorbat-80 and Polysorbate; `CR` is caloric
+// restriction and chromium. Which of them a resolution picks must not depend on
+// the order `getExistingWikiPages` happened to return.
+describe('ConflictResolver — ambiguous designators', () => {
+  const ambiguous = [
+    { path: 'wiki/entities/polysorbat-80.md', title: 'Polysorbat-80', aliases: ['E433'] },
+    { path: 'wiki/entities/polysorbate.md', title: 'Polysorbate', aliases: ['E433'] },
+  ];
+
+  it('resolves independently of page order', () => {
+    const forward = new ConflictResolver(WIKI_FOLDER, ambiguous)
+      .resolve({ name: 'E433', slug: 'e433', pageType: 'entity' });
+    const reversed = new ConflictResolver(WIKI_FOLDER, [...ambiguous].reverse())
+      .resolve({ name: 'E433', slug: 'e433', pageType: 'entity' });
+
+    expect(reversed.targetPath).toBe(forward.targetPath);
+  });
+
+  it('reports the ambiguity instead of silently merging', () => {
+    const result = new ConflictResolver(WIKI_FOLDER, ambiguous)
+      .resolve({ name: 'E433', slug: 'e433', pageType: 'entity' });
+
+    expect(result.action).toBe('disambiguate');
+    expect(result.candidates?.map(c => c.title).sort()).toEqual(['Polysorbat-80', 'Polysorbate']);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('ranks a candidate that shares a tag above one that does not', () => {
+    const tagged = [
+      { path: 'wiki/entities/chrom.md', title: 'Chrom', aliases: ['CR'], tags: ['Mineralstoffe'] },
+      { path: 'wiki/entities/kalorienrestriktion.md', title: 'Kalorienrestriktion', aliases: ['CR'], tags: ['Ernährung'] },
+    ];
+    const result = new ConflictResolver(WIKI_FOLDER, tagged)
+      .resolve({ name: 'CR', slug: 'cr', pageType: 'entity', tags: ['Ernährung'] });
+
+    expect(result.candidates?.[0].title).toBe('Kalorienrestriktion');
+    expect(result.targetPath).toBe('wiki/entities/kalorienrestriktion.md');
+  });
+
+  it('keeps every candidate when the tags overlap with none of them', () => {
+    // [R-chrom]: a page carries the aspect it was created under, a note the
+    // aspect it was written about — a disjoint tag set is a missing signal,
+    // never grounds for treating a match as a different subject.
+    const result = new ConflictResolver(WIKI_FOLDER, ambiguous)
+      .resolve({ name: 'E433', slug: 'e433', pageType: 'entity', tags: ['Toxikologie'] });
+
+    expect(result.action).toBe('disambiguate');
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it('leaves a single match on the unchanged merge path', () => {
+    const result = new ConflictResolver(WIKI_FOLDER, [ambiguous[0]])
+      .resolve({ name: 'E433', slug: 'e433', pageType: 'entity', tags: ['Toxikologie'] });
+
+    expect(result.action).toBe('merge');
+    expect(result.confidence).toBe('high');
+    expect(result.candidates).toBeUndefined();
+  });
+});

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -127,6 +127,58 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
     expect(result.path).toBe('wiki/entities/Novel.md');
   });
 
+  // Issue #446: two pages carry the designator "E433" as an alias. Before the
+  // fix the deterministic gate merged into whichever one getMarkdownFiles
+  // yielded first; now the ambiguity reaches the dedup call, and every exit
+  // that reaches no decision lands on the tag-ranked candidate rather than
+  // creating a third page for a name that is already an alias twice.
+  const ambiguousVault = {
+    files: {
+      'wiki/entities/Polysorbat-80.md': '---\naliases:\n  - E433\ntags:\n  - Lebensmittelzusatzstoff\n---\nbody',
+      'wiki/entities/Polysorbate.md': '---\naliases:\n  - E433\ntags:\n  - Chemie\n---\nbody',
+    },
+    mockVault: {
+      getMarkdownFiles: () => [
+        { path: 'wiki/entities/Polysorbat-80.md', basename: 'Polysorbat-80' },
+        { path: 'wiki/entities/Polysorbate.md', basename: 'Polysorbate' },
+      ],
+    },
+  };
+
+  it('falls back to the tag-ranked candidate when no client can decide', async () => {
+    const ctx = makeCtx({ ...ambiguousVault, client: null });
+    const result = await resolvePagePath(ctx, 'E433', 'entity', 'desc', ['Chemie']);
+    expect(result.path).toBe('wiki/entities/Polysorbate.md');
+  });
+
+  it('resolves an ambiguous designator independently of vault order', async () => {
+    const reversed = {
+      ...ambiguousVault,
+      mockVault: {
+        getMarkdownFiles: () => [...ambiguousVault.mockVault.getMarkdownFiles()].reverse(),
+      },
+    };
+    const forward = await resolvePagePath(makeCtx({ ...ambiguousVault, client: null }), 'E433', 'entity', 'desc');
+    const backward = await resolvePagePath(makeCtx({ ...reversed, client: null }), 'E433', 'entity', 'desc');
+    expect(backward.path).toBe(forward.path);
+  });
+
+  it('shows the matching pages to the dedup call ahead of the lexical filler', async () => {
+    let prompt = '';
+    const ctx = makeCtx({
+      ...ambiguousVault,
+      client: {
+        createMessage: async (args: unknown) => {
+          prompt = (args as { messages: Array<{ content: string }> }).messages[0].content;
+          return JSON.stringify({ match: true, path: 'wiki/entities/Polysorbate.md' });
+        },
+      },
+    });
+    const result = await resolvePagePath(ctx, 'E433', 'entity', 'desc', ['Chemie']);
+    expect(result.path).toBe('wiki/entities/Polysorbate.md');
+    expect(prompt.indexOf('Polysorbate.md')).toBeLessThan(prompt.indexOf('Polysorbat-80.md'));
+  });
+
   it('passes the slim "index" schema selector to buildSystemPrompt', async () => {
     // The dedup question is a same-type yes/no match; the matching criteria
     // live in the user prompt. Only "Wiki Structure" is needed from the

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -179,6 +179,33 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
     expect(prompt.indexOf('Polysorbate.md')).toBeLessThan(prompt.indexOf('Polysorbat-80.md'));
   });
 
+  // Code-review F1 (2026-08-16): every ambiguous-designator fallback must
+  // latch the extracted name as an alias on the resolved page, matching the
+  // pre-#446 merge path. Observable case: the designator carries a
+  // non-slug-normalized character (trailing dash) that survives as an alias
+  // but is stripped from the slug — so the extracted name is neither an
+  // existing alias nor equal to the page's filename, and the write is visible.
+  it('latches the extracted name on the tag-ranked fallback page (no-client exit)', async () => {
+    const ctx = makeCtx({
+      files: {
+        'wiki/entities/No2.md': '---\ntags:\n  - Biochemie\n---\nbody',
+        'wiki/entities/NO2.md': '---\ntags:\n  - other\n---\nbody',
+      },
+      mockVault: {
+        getMarkdownFiles: () => [
+          { path: 'wiki/entities/No2.md', basename: 'No2' },
+          { path: 'wiki/entities/NO2.md', basename: 'NO2' },
+        ],
+      },
+      client: null,
+    });
+    const result = await resolvePagePath(ctx, 'no2-', 'entity', 'desc', ['Biochemie']);
+    expect(result.path).toBe('wiki/entities/No2.md');
+    const written = ctx.written.get('wiki/entities/No2.md') ?? '';
+    expect(written).toContain('aliases:');
+    expect(written).toContain('no2-');
+  });
+
   it('passes the slim "index" schema selector to buildSystemPrompt', async () => {
     // The dedup question is a same-type yes/no match; the matching criteria
     // live in the user prompt. Only "Wiki Structure" is needed from the

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -159,17 +159,29 @@ export class ConflictResolver {
     }
 
     // 2. Cross-type match: exists in opposite folder
+    //
+    // Issue #446: the same designators collide here, only from the other side —
+    // when the extraction classifies `DHA` as a concept, the two entity pages
+    // that carry it are cross-type matches and there are no same-type ones. The
+    // ambiguity is identical; only the contract differs, because this branch
+    // reports a collision the caller merges into rather than a path it writes.
+    // Ranking the matches keeps that contract and drops the dependency on list
+    // order. Routing a cross-type ambiguity to the semantic dedup would be the
+    // fuller answer, but that call is same-type by construction and gets its
+    // own design.
     const otherExactPath = `${this.wikiFolder}/${otherFolder}/${check.slug}.md`;
-    match = otherTypePages.find(p => p.path === otherExactPath || slugMatchKeys(p).has(checkKey));
-    if (match) {
+    const crossMatches = otherTypePages.filter(p => p.path === otherExactPath || slugMatchKeys(p).has(checkKey));
+    if (crossMatches.length > 0) {
+      const [best] = rankByTagOverlap(crossMatches, check.tags);
       return {
         action: 'merge',
-        targetPath: match.path,
-        existingPath: match.path,
+        targetPath: best.path,
+        existingPath: best.path,
         existingType: otherFolder === WIKI_SUBFOLDERS.entities ? 'entity' : 'concept',
-        aliasToAdd: check.name !== match.title ? check.name : null,
-        confidence: 'high',
-        reason: `Cross-type collision: ${check.pageType} "${check.name}" → ${match.path}`,
+        aliasToAdd: check.name !== best.title ? check.name : null,
+        confidence: crossMatches.length > 1 ? 'medium' : 'high',
+        reason: `Cross-type collision: ${check.pageType} "${check.name}" → ${best.path}`
+          + (crossMatches.length > 1 ? ` (${crossMatches.length} candidates, ranked)` : ''),
       };
     }
 

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -109,10 +109,13 @@ export class ConflictResolver {
    * Determine what to do with a newly extracted entity/concept.
    * Returns a ConflictResolution that the caller should follow.
    *
-   * Resolution order (deterministic, first match wins):
-   * 1. Same-type slug/alias match → merge into existing page
-   * 2. Cross-type slug/alias match → merge into opposite folder page
-   * 3. No match → create new page
+   * Resolution order (deterministic):
+   * 1. Same-type exact path match → merge into existing page
+   * 2. Same-type slug/alias match on exactly one page → merge into that page
+   * 3. Same-type slug/alias match on more than one page → 'disambiguate'
+   *    with `candidates` ranked by tag overlap (Issue #446)
+   * 4. Cross-type slug/alias match → merge into opposite-folder page
+   * 5. No match → create new page
    */
   resolve(check: ConflictCheck): ConflictResolution {
     const folder = folderOf(check.pageType);

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -13,6 +13,8 @@ export interface PageRef {
   path: string;
   title: string;
   aliases?: string[];
+  /** Issue #446: domain tags of the page, used to rank ambiguous matches. */
+  tags?: string[];
 }
 
 export type PageType = 'entity' | 'concept';
@@ -21,9 +23,16 @@ export interface ConflictCheck {
   name: string;
   slug: string;
   pageType: PageType;
+  /**
+   * Issue #446: domain tags of the item being placed — in the ingest path the
+   * extracted `type`, which is what the generated page will carry as its own
+   * `tags:`. Ranking signal only, see `rankByTagOverlap`. Optional: a caller
+   * that has none leaves the ranking on its path tie-break.
+   */
+  tags?: string[];
 }
 
-export type ConflictAction = 'create' | 'merge' | 'flag';
+export type ConflictAction = 'create' | 'merge' | 'flag' | 'disambiguate';
 
 export interface ConflictResolution {
   action: ConflictAction;
@@ -33,6 +42,13 @@ export interface ConflictResolution {
   aliasToAdd?: string | null;   // alias to add (null = redundant with title/filename)
   confidence: 'high' | 'medium' | 'low';
   reason: string;
+  /**
+   * Issue #446: every same-type page the designator matched, ranked. Only set
+   * when `action` is 'disambiguate' (more than one match). `targetPath` is the
+   * top-ranked one, so a caller that ignores this field still resolves — and
+   * resolves the same way on every page order.
+   */
+  candidates?: PageRef[];
 }
 
 // ── Helpers ───────────────────────────────────────────────────────
@@ -53,6 +69,32 @@ function slugMatchKeys(page: PageRef): Set<string> {
     keys.add(computeSlug(alias));
   }
   return keys;
+}
+
+/**
+ * Issue #446: order pages that a designator matched equally well.
+ *
+ * Tags rank, they never decide: this function only permutes a list, it never
+ * drops a candidate and never turns a match into a non-match. Tag sets of a
+ * page and of a naming note are disjoint in the ordinary case — a page carries
+ * the aspect it was created under, a note the aspect it was written about — so
+ * a disjoint set is the absence of a signal, not evidence of a different
+ * subject.
+ *
+ * The tie-break is the path, compared by code unit rather than by locale, so
+ * the result is independent both of the input order and of the host's collation.
+ */
+function rankByTagOverlap(matches: PageRef[], checkTags?: string[]): PageRef[] {
+  const wanted = new Set((checkTags ?? []).map(t => t.toLowerCase()));
+  const overlap = (p: PageRef): number =>
+    wanted.size === 0 ? 0 : (p.tags ?? []).filter(t => wanted.has(t.toLowerCase())).length;
+
+  return [...matches].sort((a, b) => {
+    const byOverlap = overlap(b) - overlap(a);
+    if (byOverlap !== 0) return byOverlap;
+    if (a.path === b.path) return 0;
+    return a.path < b.path ? -1 : 1;
+  });
 }
 
 // ── Main resolver ─────────────────────────────────────────────────
@@ -90,13 +132,29 @@ export class ConflictResolver {
         reason: `Same-type exact path match: ${exactPath}`,
       };
     }
-    match = sameTypePages.find(p => slugMatchKeys(p).has(checkKey));
-    if (match) {
+    // Issue #446: a short designator is a title or an alias on more than one
+    // page often enough to matter (23 of them in a 2838-page vault). `find`
+    // returned whichever the page list happened to hold first, so the merge
+    // target was a function of vault iteration order and nothing said the
+    // question had been open.
+    const slugMatches = sameTypePages.filter(p => slugMatchKeys(p).has(checkKey));
+    if (slugMatches.length === 1) {
+      const only = slugMatches[0];
       return {
         action: 'merge',
-        targetPath: match.path,
+        targetPath: only.path,
         confidence: 'high',
-        reason: `Same-type slug/alias match: title=${match.title} slug=${check.slug}`,
+        reason: `Same-type slug/alias match: title=${only.title} slug=${check.slug}`,
+      };
+    }
+    if (slugMatches.length > 1) {
+      const ranked = rankByTagOverlap(slugMatches, check.tags);
+      return {
+        action: 'disambiguate',
+        targetPath: ranked[0].path,
+        candidates: ranked,
+        confidence: 'low',
+        reason: `Ambiguous designator: ${ranked.length} same-type pages match slug=${check.slug} (${ranked.map(p => p.title).join(', ')})`,
       };
     }
 

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -5,7 +5,7 @@ import { isInFolderScope } from '../../core/folder-scope';
 export async function getExistingWikiPages(
   app: App,
   wikiFolder: string
-): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; ctime?: number }>> {
+): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number }>> {
   const wikiFiles = app.vault
     .getMarkdownFiles()
     .filter(
@@ -17,7 +17,7 @@ export async function getExistingWikiPages(
         !f.path.includes('/contradictions/')
     );
 
-  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; ctime?: number }> = [];
+  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number }> = [];
   for (const f of wikiFiles) {
     const relPath = f.path.replace(wikiFolder + '/', '').replace('.md', '');
     const content = await app.vault.read(f);
@@ -46,6 +46,9 @@ export async function getExistingWikiPages(
       title: f.basename,
       wikiLink: `[[${relPath}|${f.basename}]]`,
       aliases: Array.isArray(fm?.aliases) ? fm.aliases : undefined,
+      // Issue #446: ranking signal for designators that match more than one
+      // page. Read here because the frontmatter is already parsed.
+      tags: Array.isArray(fm?.tags) ? fm.tags : undefined,
       ctime: f.stat?.ctime,
     });
   }

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -96,7 +96,10 @@ export async function createOrUpdatePage(
   console.debug('name:', info.name);
   console.debug('type:', info.type);
 
-  const result = await resolvePagePath(ctx, info.name, pageType, info.summary);
+  // Issue #446: `info.type` is the term this page will carry as its own `tags:`
+  // (see the generation template), so it is like-for-like with the candidate
+  // pages' tags and needs no new read at the note.
+  const result = await resolvePagePath(ctx, info.name, pageType, info.summary, info.type ? [info.type] : undefined);
   if (result.path === null) {
     if (result.collision) {
       // Cross-type collision: a page for this item already exists in the

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -124,11 +124,20 @@ export async function resolvePagePath(
   name: string,
   pageType: 'entity' | 'concept',
   summary: string,
+  tags?: string[],
 ): Promise<ResolvedPathResult> {
   const folder = pageType === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
   const otherFolder = pageType === 'entity' ? WIKI_SUBFOLDERS.concepts : WIKI_SUBFOLDERS.entities;
   const slug = slugify(name, ctx.settings.slugCase === 'preserve');
   const slugPath = `${ctx.settings.wikiFolder}/${folder}/${slug}.md`;
+
+  // Issue #446: what this call falls back to when it reaches no decision.
+  // `slugPath` (create a new page) for the ordinary case; for an ambiguous
+  // designator the matching pages demonstrably exist, so a new page is the one
+  // answer that is certainly wrong — it is replaced by the top-ranked
+  // candidate below, which is also what the pre-#446 code merged into, minus
+  // the dependency on vault iteration order.
+  let fallbackPath = slugPath;
 
   // Fast path: exact slug match (same type folder)
   const existing = await ctx.tryReadFile(slugPath);
@@ -151,7 +160,7 @@ export async function resolvePagePath(
 
     // Use ConflictResolver for deterministic slug/alias matching before LLM fallback.
     const resolver = new ConflictResolver(ctx.settings.wikiFolder, allPages);
-    const cr = resolver.resolve({ name, slug, pageType });
+    const cr = resolver.resolve({ name, slug, pageType, tags });
 
     if (cr.action === 'merge' && !cr.reason.includes('Cross-type')) {
       await appendAliases(ctx, cr.targetPath, [name]);
@@ -169,6 +178,18 @@ export async function resolvePagePath(
           targetPath: cr.targetPath,
         },
       };
+    }
+
+    // Issue #446: more than one same-type page carries this designator. The
+    // deterministic gate cannot say which one is meant — tags rank the
+    // candidates, they never decide identity — so the question goes to the
+    // semantic dedup below with the ranked candidates at the head of the
+    // list. Before this, `find` returned whichever page the vault happened to
+    // yield first and the ambiguity left no trace.
+    const ambiguous = cr.action === 'disambiguate' ? cr.candidates ?? [] : [];
+    if (ambiguous.length > 0) {
+      fallbackPath = cr.targetPath;
+      console.debug(`Entity resolution: ${cr.reason}`);
     }
 
     const sameTypePages = allPages
@@ -191,7 +212,12 @@ export async function resolvePagePath(
 
     if (sameTypePages.length === 0) return { path: slugPath };
 
-    const pagesList = selectDedupCandidates(name, summary, sameTypePages)
+    const selected = selectDedupCandidates(name, summary, sameTypePages);
+    // The pages that actually carry the designator lead the list; the lexical
+    // pre-filter supplies the rest as context.
+    const pagesList = (ambiguous.length > 0
+      ? [...ambiguous, ...selected.filter(p => !ambiguous.some(c => c.path === p.path))]
+      : selected)
       .map(p => {
         const aliasBlock = p.aliases?.length
           ? `\n  aliases: ${p.aliases.join(', ')}`
@@ -201,7 +227,7 @@ export async function resolvePagePath(
       .join('\n');
 
     const client = ctx.getClient();
-    if (!client) return { path: slugPath };
+    if (!client) return { path: fallbackPath };
 
     const prompt = renderTemplate(PROMPTS.resolveEntityDedup, {
       wikiFolder: ctx.settings.wikiFolder,
@@ -251,9 +277,9 @@ export async function resolvePagePath(
           ? `exception: ${String(parsed.error)}`
           : `${parsed.reason}, raw length ${parsed.rawLength}`;
       console.error(
-        `Entity resolution for "${name}": dedup reply unreadable (${detail}) — using slug path, no match decided`,
+        `Entity resolution for "${name}": dedup reply unreadable (${detail}) — using ${fallbackPath}, no match decided`,
       );
-      return { path: slugPath };
+      return { path: fallbackPath };
     }
 
     const result = parsed.value as { match?: boolean; path?: string | null };
@@ -266,10 +292,14 @@ export async function resolvePagePath(
       return { path: normalizedPath };
     }
   } catch (error) {
-    console.debug(`Entity resolution for "${name}" failed, using slug path:`, error);
+    console.debug(`Entity resolution for "${name}" failed, using ${fallbackPath}:`, error);
   }
 
-  return { path: slugPath };
+  // Also the `match === false` exit: for an ambiguous designator this is the
+  // one place where "neither candidate is it" would create a third page for a
+  // name that is already an alias twice, so it resolves to the top-ranked
+  // candidate instead. For every other call `fallbackPath` is `slugPath`.
+  return { path: fallbackPath };
 }
 
 /**

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -139,6 +139,18 @@ export async function resolvePagePath(
   // the dependency on vault iteration order.
   let fallbackPath = slugPath;
 
+  // Issue #446 follow-up (code-review F1): the pre-#446 merge path latched the
+  // designator as an alias on the merged page, so a later ingest hit it by
+  // single-match. The disambiguate fallback must keep that latch — without it,
+  // every re-ingest re-enters the ambiguity path (paying an LLM dedup call)
+  // and the merge target can flip when a candidate's tags change. `appendAliases`
+  // is idempotent (drops filename-equal + already-present aliases), so the
+  // ordinary `slugPath` (new-page) fallback is skipped via the guard below.
+  const latchAndReturn = async (path: string): Promise<ResolvedPathResult> => {
+    if (path !== slugPath) await appendAliases(ctx, path, [name]);
+    return { path };
+  };
+
   // Fast path: exact slug match (same type folder)
   const existing = await ctx.tryReadFile(slugPath);
   if (existing !== null) {
@@ -227,7 +239,7 @@ export async function resolvePagePath(
       .join('\n');
 
     const client = ctx.getClient();
-    if (!client) return { path: fallbackPath };
+    if (!client) return await latchAndReturn(fallbackPath);
 
     const prompt = renderTemplate(PROMPTS.resolveEntityDedup, {
       wikiFolder: ctx.settings.wikiFolder,
@@ -279,7 +291,7 @@ export async function resolvePagePath(
       console.error(
         `Entity resolution for "${name}": dedup reply unreadable (${detail}) — using ${fallbackPath}, no match decided`,
       );
-      return { path: fallbackPath };
+      return await latchAndReturn(fallbackPath);
     }
 
     const result = parsed.value as { match?: boolean; path?: string | null };
@@ -299,7 +311,7 @@ export async function resolvePagePath(
   // one place where "neither candidate is it" would create a third page for a
   // name that is already an alias twice, so it resolves to the top-ranked
   // candidate instead. For every other call `fallbackPath` is `slugPath`.
-  return { path: fallbackPath };
+  return await latchAndReturn(fallbackPath);
 }
 
 /**


### PR DESCRIPTION
## Summary

`ConflictResolver.resolve` matched same-type pages with `find`. When a short designator is a title or an alias on more than one page, the merge target was whichever page the vault iteration happened to yield first — and nothing recorded that the question had been open. `find` becomes `filter`, the matches are ranked, and an ambiguity reaches the semantic dedup call instead of being settled by list order.

**What this is:** an order-invariance fix. **What it is not:** the tag-based disambiguation the issue title promises. The correction in [#446](https://github.com/green-dalii/obsidian-llm-wiki/issues/446) has the numbers — tags change the outcome for five of the nine ambiguous designators in my vault, and on that path the dedup call still decides. The tag ranking is a rider on the fix, not its point.

## Changes

**`src/core/conflict-resolver.ts`**

- Same-type slug/alias match: `find` → `filter`. Exactly one match keeps the previous behavior byte for byte, including the reason string. More than one returns a new `'disambiguate'` action carrying every match, ranked.
- `targetPath` on that action is the top-ranked page, so a caller that ignores the new field still resolves — and resolves identically under every page order.
- Cross-type branch: the same designators collide there from the other side. When the extraction classifies `DHA` as a concept, the two entity pages carrying it are cross-type matches with no same-type match, and that branch used `find` as well. It now filters and ranks. The contract is unchanged — it still reports a collision the caller merges into — only the target no longer depends on page order.
- `rankByTagOverlap` orders candidates by overlap between the tags of the item being placed and the tags of the candidate pages, tie-broken by path compared by code unit rather than `localeCompare`, so the result does not depend on the host's collation either.

**`src/wiki/page-factory/path-resolution.ts`**

- An ambiguous designator goes to the existing semantic dedup call with the matching pages at the head of the candidate list.
- Every exit that reaches no decision — no client, unreadable reply, thrown error, and the `match === false` answer — resolves to the top-ranked candidate rather than the slug path. For a name that is already an alias on two pages, creating a third one is the single answer that is certainly wrong.
- `resolvePagePath` takes an optional `tags` argument (additive; the internal test wrapper is unchanged).

**`src/wiki/lint/get-existing-pages.ts`** — carries `tags` through, read from the frontmatter that is already parsed there.

**`src/wiki/page-factory/create-page.ts`** — feeds the extracted `type`, which is what the generated page will carry as its own `tags:`, so the comparison is like-for-like. The source note's tags are deliberately not read: `source-analyzer` takes only `aliases` and `language` from a note, and widening that belongs to the ingest side.

## Two decisions rather than omissions

Overrule either and I will adjust.

1. **The identical-tag cases are not routed to a merge/hierarchy decision.** Measured on my curated note level, 34 of 48 over-represented tag pairs are facet crossings and only 4 are hierarchies — tag identity carries no direction to read. The four identical cases in the fixture are duplicate or broader/narrower pairs, which is a merge question rather than a disambiguation one.
2. **Tags never decide identity, only order.** Vault-wide, 73% of pages are tag-disjoint from at least one note that names them, because a page carries the aspect it was created under and a note the aspect it was written about. Homonymy and aspect spread are indistinguishable in a tag comparison, so the ranking never drops a candidate and never turns a match into a non-match.

## Behavior change to be aware of

For a designator matching more than one same-type page, the resolution now goes through the dedup call where it previously merged silently. In my 2416-page vault that is 9 designators; for other vaults the rate is unmeasured. Single matches — the overwhelming majority — take exactly the path they did before, with no additional call.

## Tests

`src/__tests__/core/ambiguous-designators.test.ts` is the acceptance fixture: all 9 same-type ambiguous designators from a 2416-page vault with their real titles and tags, pinning that the deterministic gate never answers an ambiguous designator on its own, never depends on page order, and never proposes a new page for a name that already exists twice. It deliberately does not pin which candidate wins on tags alone.

36 of its 45 assertions are red on the parent commit; the 9 green ones guard the property that a merge must not become a create. Plus 8 unit and integration tests on the resolver and on `resolvePagePath`, 7 of which are red on the parent commit.

Total: 3312 → 3365.

## Gate 1

`pnpm lint --max-warnings=0` 0 · `npx tsc --noEmit` 0 · `pnpm test` 3366 passing (234 files) · `pnpm build` clean · `pnpm css-lint` 0 violations.


## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | `rankByTagOverlap` sort is O(m log m) with m=2-3 (the measured ambiguous set); `filter` vs `find` is the same O(n); `selected.filter(ambiguous.some)` worst ~7K path comparisons, executed only on the rare ambiguous path — all sub-millisecond |
| Memory | ✅ | transient Set + array copies of ≤3 items; no new unbounded structures |
| IO | ✅ | `tags` read from already-parsed frontmatter (`get-existing-pages.ts:51`) — zero additional `vault.read()` per page in the loop |
| Network | ⚠️ intentional | each same-type ambiguous designator now routes to the existing semantic-dedup LLM call (+1 per designator; ~23 per 2838-page vault measured) instead of a silent order-dependent merge. This is the #446 correctness-fix cost, bounded and documented under "Behavior change to be aware of" |
| Token | ✅ | ambiguous candidates lead the dedup prompt (≤m entries); page `tags` are NOT rendered into the prompt (path/title/aliases only) — the ranking is pre-computed, so no per-call token increase |

## Precondition and follow-up

The ingest-side tag normalization you mentioned does not appear to be in the tracker yet. Nothing here depends on it — the fixture carries its own page data — but the ranking reads real tags as soon as it runs against a vault, and inconsistent source tags cost exactly the notes whose spelling differs.

Separately, and not folded in here: for the 15 designators that are one entity plus one concept, the correct resolution depends entirely on the extraction picking the right type. A mis-typed `KHK` merges the ketohexokinase into the coronary-heart-disease page — deterministically, and wrongly. That is the classification path rather than the resolution path, and I will raise it on its own.

Closes #446 — or leaves it open for the tag work proper, whichever you prefer, given that this ships the invariant and not the signal.

