### PR TITLE
fix(path-resolution): the ambiguous fallback must not latch the designator as an alias

### DIFF
--- a/src/__tests__/core/conflict-resolver.test.ts
+++ b/src/__tests__/core/conflict-resolver.test.ts
@@ -126,4 +126,28 @@ describe('ConflictResolver — ambiguous designators', () => {
     expect(result.confidence).toBe('high');
     expect(result.candidates).toBeUndefined();
   });
+
+  it('stays ambiguous after the extracted name is appended as an alias', () => {
+    // Why the ambiguous fallback does not latch the designator (see
+    // path-resolution.ts): matching keys on computeSlug(title) and
+    // computeSlug(alias), so an alias that slugifies to a key the page already
+    // carries adds nothing. slugMatches stays at 2 and the next ingest reaches
+    // the same fallback — the dedup call a latch was meant to save is still
+    // paid. Fixture: a designator whose trailing character survives as an alias
+    // but is stripped from the slug.
+    const check = { name: 'no2-', slug: 'no2', pageType: 'entity' as const, tags: ['Biochemie'] };
+    const pages = [
+      { path: 'wiki/entities/No2.md', title: 'No2', aliases: ['NO2−'], tags: ['Biochemie'] },
+      { path: 'wiki/entities/NO2.md', title: 'NO2', aliases: [], tags: ['other'] },
+    ];
+
+    const first = new ConflictResolver(WIKI_FOLDER, pages).resolve(check);
+    expect(first.action).toBe('disambiguate');
+    expect(first.targetPath).toBe('wiki/entities/No2.md');
+
+    const latched = [{ ...pages[0], aliases: ['NO2−', 'no2-'] }, pages[1]];
+    const second = new ConflictResolver(WIKI_FOLDER, latched).resolve(check);
+    expect(second.action).toBe('disambiguate');
+    expect(second.candidates).toHaveLength(2);
+  });
 });

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -179,13 +179,17 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
     expect(prompt.indexOf('Polysorbate.md')).toBeLessThan(prompt.indexOf('Polysorbat-80.md'));
   });
 
-  // Code-review F1 (2026-08-16): every ambiguous-designator fallback must
-  // latch the extracted name as an alias on the resolved page, matching the
-  // pre-#446 merge path. Observable case: the designator carries a
-  // non-slug-normalized character (trailing dash) that survives as an alias
-  // but is stripped from the slug — so the extracted name is neither an
-  // existing alias nor equal to the page's filename, and the write is visible.
-  it('latches the extracted name on the tag-ranked fallback page (no-client exit)', async () => {
+  // #446 follow-up: an ambiguous-designator fallback must not latch the
+  // extracted name as an alias, unlike the decided merge paths, which still do.
+  // The latch cannot end the ambiguity it was meant to end — ConflictResolver
+  // matches over slug keys, and an alias whose slug the page already carries
+  // adds none (measured in conflict-resolver.test.ts) — so the next ingest
+  // returns here, and what the write leaves behind is the designator claimed by
+  // whichever candidate ranked first this time, and by the next one when the
+  // ranking moves. Fixture as in the original latch test: the designator
+  // carries a character that survives as an alias but is stripped from the
+  // slug, so a write would be visible.
+  it('does not latch the extracted name on the tag-ranked fallback page (no-client exit)', async () => {
     const ctx = makeCtx({
       files: {
         'wiki/entities/No2.md': '---\ntags:\n  - Biochemie\n---\nbody',
@@ -199,11 +203,15 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
       },
       client: null,
     });
+    // `written` is the seeded file map itself, so the pin is that no entry
+    // changed and none was added — not that the map is empty.
+    const before = new Map(ctx.written);
     const result = await resolvePagePath(ctx, 'no2-', 'entity', 'desc', ['Biochemie']);
     expect(result.path).toBe('wiki/entities/No2.md');
-    const written = ctx.written.get('wiki/entities/No2.md') ?? '';
-    expect(written).toContain('aliases:');
-    expect(written).toContain('no2-');
+    expect(ctx.written.size).toBe(before.size);
+    for (const [path, content] of before) {
+      expect(ctx.written.get(path)).toBe(content);
+    }
   });
 
   it('passes the slim "index" schema selector to buildSystemPrompt', async () => {

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -139,17 +139,17 @@ export async function resolvePagePath(
   // the dependency on vault iteration order.
   let fallbackPath = slugPath;
 
-  // Issue #446 follow-up (code-review F1): the pre-#446 merge path latched the
-  // designator as an alias on the merged page, so a later ingest hit it by
-  // single-match. The disambiguate fallback must keep that latch — without it,
-  // every re-ingest re-enters the ambiguity path (paying an LLM dedup call)
-  // and the merge target can flip when a candidate's tags change. `appendAliases`
-  // is idempotent (drops filename-equal + already-present aliases), so the
-  // ordinary `slugPath` (new-page) fallback is skipped via the guard below.
-  const latchAndReturn = async (path: string): Promise<ResolvedPathResult> => {
-    if (path !== slugPath) await appendAliases(ctx, path, [name]);
-    return { path };
-  };
+  // The ambiguous fallback deliberately does NOT latch the designator as an
+  // alias on the page it falls back to. The latch is the pre-#446 behaviour of
+  // the *decided* merge paths and stays there; on an ambiguous designator it
+  // cannot do what it does on a decided match, because ConflictResolver matches
+  // over slug keys (`slugMatchKeys`): an alias whose slug the page already
+  // carries adds no key, `slugMatches.length > 1` still holds, and the next
+  // ingest reaches this same fallback. What it would do is write the designator
+  // onto whichever candidate ranked first this time — and onto the next one
+  // when the ranking moves — so an unanswered question would spread as a global
+  // claim across the candidates. See the ConflictResolver test for the
+  // measurement.
 
   // Fast path: exact slug match (same type folder)
   const existing = await ctx.tryReadFile(slugPath);
@@ -239,7 +239,7 @@ export async function resolvePagePath(
       .join('\n');
 
     const client = ctx.getClient();
-    if (!client) return await latchAndReturn(fallbackPath);
+    if (!client) return { path: fallbackPath };
 
     const prompt = renderTemplate(PROMPTS.resolveEntityDedup, {
       wikiFolder: ctx.settings.wikiFolder,
@@ -291,7 +291,7 @@ export async function resolvePagePath(
       console.error(
         `Entity resolution for "${name}": dedup reply unreadable (${detail}) — using ${fallbackPath}, no match decided`,
       );
-      return await latchAndReturn(fallbackPath);
+      return { path: fallbackPath };
     }
 
     const result = parsed.value as { match?: boolean; path?: string | null };
@@ -311,7 +311,7 @@ export async function resolvePagePath(
   // one place where "neither candidate is it" would create a third page for a
   // name that is already an alias twice, so it resolves to the top-ranked
   // candidate instead. For every other call `fallbackPath` is `slugPath`.
-  return await latchAndReturn(fallbackPath);
+  return { path: fallbackPath };
 }
 
 /**


### PR DESCRIPTION
Follow-up to #446, on `b824c80` (merged in #471).

`b824c80` routes the three undecided exits of `resolvePagePath` through a
`latchAndReturn` that appends the extracted name as an alias to the tag-ranked
page, to keep a designator from re-entering the ambiguity path on every
re-ingest and paying another dedup call.

The latch cannot have that effect. Matching runs over slug keys —
`computeSlug(title)` plus `computeSlug(alias)` for every alias, in
`slugMatchKeys()` — so an alias whose slug the page already carries adds no key.
`slugMatches.length > 1` still holds and the next ingest lands in the same
fallback. Measured on the fixture of the F1 regression test itself, with the
latch applied between the two runs; this is the new test in
`conflict-resolver.test.ts`, and it passes on `main` as it stands:

```ts
const check = { name: 'no2-', slug: 'no2', pageType: 'entity' as const, tags: ['Biochemie'] };
const pages = [
  { path: 'wiki/entities/No2.md', title: 'No2', aliases: ['NO2−'], tags: ['Biochemie'] },
  { path: 'wiki/entities/NO2.md', title: 'NO2', aliases: [], tags: ['other'] },
];
// run 1 → disambiguate, top candidate No2.md
const latched = [{ ...pages[0], aliases: ['NO2−', 'no2-'] }, pages[1]];
// run 2, after the latch → disambiguate again, 2 candidates
```

The extra dedup call has a different origin: before #446 the ambiguity was
answered by `find` without asking the model at all, and #446 routes it to the
semantic dedup deliberately. Ending that call means deciding the ambiguity, not
latching an alias.

The same holds for the second purpose, keeping the merge target from flipping
when a candidate's tags change — and there the latch makes the case worse. The
designator stays ambiguous, so the ranking runs again and can still move; when
it moves, the latch writes the extracted name onto the new top candidate as
well. Over repeated ingests the designator accumulates as an alias on every
candidate that ever ranked first.

Two further points, both resolved by this PR:

- The final `return await latchAndReturn(fallbackPath)` sits outside the
  `try`/`catch`. `appendAliases` writes through `createOrUpdateFile`, which
  rethrows on anything but "file already exists", so `resolvePagePath` could
  throw at an exit whose own comment states that it must return a path. A throw
  from the latch inside the `try` is caught below and the same write retried,
  unprotected, at that exit.
- The latch fires exactly where nothing was decided — `match: false`, an
  unreadable reply, or no client. An alias is a global claim about the vault;
  writing one from an exit where the dedup declined to match records a decision
  nobody took.

What stays: the decided merge paths latch as before (same-type single match,
cross-type collision, `match: true`), and the `resolve()` JSDoc from `b824c80`
is untouched.

If you would rather keep a latch on part of these exits — say on `match: false`,
where the model at least answered, but not on the no-client and unreadable-reply
exits — say so and I will reshape it; the tests are structured to make that a
small change.

Gate 1: 234 files, 3382 tests green (3381 on the parent), `tsc --noEmit` clean.
The inverted F1 test is red on the parent.
