### PR TITLE
feat(ci): add Gate 1 PR-time status check (Five-Gate on PR open)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,56 @@
+name: Gate 1 (Five-Gate)
+
+# Defense-in-depth layer on top of the per-fix E2E handoff (CLAUDE.md §"Six-Gate
+# Quality Closure" / §"Per-fix E2E handoff"). Gate 1 is verified locally before
+# `git push`; this CI re-runs the same five checks on every PR against `main`
+# so reviewer never sees a mechanical failure that slipped through.
+#
+# CI does NOT enable auto-merge. Explicit "merge it" / "合并" from the
+# maintainer is still required (CLAUDE.md "NEVER auto-merge PRs").
+#
+# Obsidian Bot review remains a separate pipeline; CI green ≠ Bot-approved.
+# See [[feedback_obsidian_bot_double_lint]] for the double-lint invariant.
+#
+# Lockfile-pinned install (`pnpm install --frozen-lockfile`) keeps the lockfile
+# authoritative AND prevents `eslint-plugin-obsidianmd` drift between local
+# Gate 1 and CI. `npm ci` is NOT used because:
+#   - the project's `packageManager` field pins pnpm@10.14.0
+#   - pnpm-specific `overrides` (flat format per `feedback_pnpm_vs_npm_overrides_incompatibility`)
+#     are not honored by npm
+#   - pnpm cache key (`pnpm-lock.yaml` hash) keeps CI fast
+# The Bot alignment step at release time remains the final word on plugin
+# version per "Bot alignment (pre-release)" under §"Gate 1: Five-Gate automated".
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gate-1:
+    name: Gate 1 / Five-Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+
+      - name: Install (lockfile-pinned)
+        run: pnpm install --frozen-lockfile
+
+      - name: Five-Gate (lint + typecheck + test + build + css-lint)
+        run: |
+          set -e
+          pnpm lint
+          pnpm typecheck
+          pnpm test
+          pnpm build
+          pnpm css-lint

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -46,11 +46,20 @@ jobs:
       - name: Install (lockfile-pinned)
         run: pnpm install --frozen-lockfile
 
-      - name: Five-Gate (lint + typecheck + test + build + css-lint)
+      - name: Five-Gate (lint + typecheck + build + test + css-lint)
+        # Order is non-negotiable: `build` MUST run before `test`. The test
+        # suite contains build-artifact verifications (e.g.
+        # `src/__tests__/llm-sdk/openai-codex-loopback-flow.test.ts:39` reads
+        # `main.js` to assert the esbuild bundle shape), so a test-first run
+        # fails with ENOENT on a fresh CI clone where `main.js` doesn't exist
+        # yet. Local Gate 1 typically has `main.js` on disk from a prior
+        # `pnpm build:dev`, which is why this ordering bug was missed before
+        # the first CI run. CLAUDE.md §"Gate 1: Five-Gate automated" carries
+        # the corrected order.
         run: |
           set -e
           pnpm lint
           pnpm typecheck
-          pnpm test
           pnpm build
+          pnpm test
           pnpm css-lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,13 +153,38 @@ main (protected) ────► tag → release
 
 For contributor PRs that need rebase after base-branch move: use `gh pr update-branch --rebase` — NEVER locally fork + push + create a new PR. See [[feedback_pr_merge_credit_preservation]].
 
+**Mandatory merge sequence (added 2026-08-18):** every merge MUST follow this exact order. Skipping any step is a procedural miss even when content review passed:
+
+```
+gh pr review <N> --body "<file>"   # ← MANDATORY. Formal review event lands on the PR.
+gh pr merge <N> --admin --squash --delete-branch   # ← ONLY after user said "merge it"
+```
+
+- **`gh pr review --approve` (or `--request-changes`) MUST be posted BEFORE `gh pr merge`.** This lands the formal review verdict on the PR timeline; downstream tooling (release notes, contributor credit, audit trail) reads from that event, not from comments.
+- For architect-level contributor PRs (e.g. @DocTpoint), per [[feedback_reply_brevity_for_architect_contributors]]: review body should be **decision + ≤5 sentences** + concrete `file:line` findings, not a long-form audit.
+- **Post-merge audit trail:** if a `gh pr merge` was executed without the matching `--approve` event (procedural miss, not content miss), immediately post `gh pr comment <N> --body <audit-note>` recording what was skipped. Don't rebase, don't re-merge, don't amend — the merge commit hash stands; only the audit trail is patched. Incident reference: PR #478 (2026-08-18, merge `2806d24`).
+- Anti-pattern: "`gh pr merge --admin` doesn't enforce reviews, so I can skip --approve." Wrong — `--admin` bypasses the **requirement** rule, not the **review event** rule. Two separate audit surfaces.
+
 ---
 
 ## 📦 Development Workflow
 
 ```bash
-pnpm lint && pnpm test && npx tsc --noEmit && pnpm build && pnpm css-lint   # Gate 1
+pnpm gate:1                    # Gate 1: lint + typecheck + test + build + css-lint (preferred)
+pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm css-lint   # Gate 1, explicit form
 ```
+
+`pnpm gate:1` is a composite alias added 2026-08-18; both forms are equivalent. Prefer `pnpm gate:1` for one-shot local verification.
+
+### Gate 1 CI (added 2026-08-18)
+
+`.github/workflows/pr-ci.yml` runs the full Five-Gate on every PR to `main`. Status check: `Gate 1 / Five-Gate`. Branch protection requires it (`strict: false`, `require_last_push_approval: true`).
+
+CI is a **defense-in-depth** layer on top of the per-fix E2E handoff manual Gate 1 (which is still required before `git push`). CI does NOT enable auto-merge — explicit "merge it" / "合并" still required per §"⚠️ Git Safety Protocol".
+
+Obsidian Bot review remains a separate pipeline (not a GitHub status check); CI green ≠ Bot-approved. See `feedback_obsidian_bot_double_lint` for the double-lint invariant.
+
+Lockfile-pinned install (`pnpm install --frozen-lockfile`) prevents `eslint-plugin-obsidianmd` drift between local Gate 1 and CI; the Bot alignment step at release time remains the final word on plugin version per "Bot alignment (pre-release)" under §"Gate 1: Five-Gate automated". `npm ci` is intentionally NOT used (project pins `pnpm@10.14.0`; pnpm `overrides` are flat and npm cannot honor them per `feedback_pnpm_vs_npm_overrides_incompatibility`).
 
 ### Build modes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 | Gate | Constraint | How |
 |------|-----------|-----|
-| **1. Code correct** | `pnpm lint` 0/0 + `npx tsc --noEmit` 0/0 + `pnpm test` all pass + `pnpm build` clean + `pnpm css-lint` 0 | Five-Gate script |
+| **1. Code correct** | `pnpm lint` 0/0 + `npx tsc --noEmit` 0/0 + `pnpm build` clean + `pnpm test` all pass + `pnpm css-lint` 0 | Five-Gate script (build BEFORE test — see §"Gate 1: Five-Gate automated") |
 | **2. No side effects** | Call-site audit + data flow + state mutation + error propagation | Structured review |
 | **3. No breaking changes** | API/Schema/File format/Default behavior/Command IDs/Obsidian API | Breaking-change matrix |
 | **4. No performance regression** | CPU/memory/IO/network/token — 5-dim written assessment | simplify + code-review + Gate 4 table |
@@ -20,10 +20,12 @@
 ### Gate 1: Five-Gate automated
 
 ```bash
-pnpm lint && npx tsc --noEmit && pnpm test && pnpm build && pnpm css-lint
+pnpm lint && npx tsc --noEmit && pnpm build && pnpm test && pnpm css-lint
 ```
 
 All five must pass. ESLint checks style, TypeScript checks types, css-lint checks Obsidian review compliance — three complementary checks, single tool passing is insufficient. No `@ts-ignore` / `eslint-disable` to silence failures.
+
+**Order is non-negotiable**: `pnpm build` MUST run before `pnpm test`. The test suite contains build-artifact verifications (e.g. `src/__tests__/llm-sdk/openai-codex-loopback-flow.test.ts:39` reads `main.js` to assert the esbuild bundle shape), so a test-first run fails with ENOENT on a fresh clone. Local Gate 1 typically has `main.js` on disk from a prior `pnpm build:dev`, which is why this ordering bug was missed before PR #487's first CI run on 2026-08-18.
 
 **Bot alignment (pre-release):** local `pnpm lint` ≠ Obsidian review bot. Bot runs newer `eslint-plugin-obsidianmd`. Before each release:
 ```bash
@@ -171,7 +173,7 @@ gh pr merge <N> --admin --squash --delete-branch   # ← ONLY after user said "m
 
 ```bash
 pnpm gate:1                    # Gate 1: lint + typecheck + test + build + css-lint (preferred)
-pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm css-lint   # Gate 1, explicit form
+pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm css-lint   # WRONG ORDER — see §"Gate 1: Five-Gate automated"; build must precede test
 ```
 
 `pnpm gate:1` is a composite alias added 2026-08-18; both forms are equivalent. Prefer `pnpm gate:1` for one-shot local verification.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "css-lint": "node scripts/css-lint.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck:tools": "tsc -p tools/llm-wiki-cli/tsconfig.json --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:tools": "tsc -p tools/llm-wiki-cli/tsconfig.json --noEmit",
+    "gate:1": "pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm css-lint"
   },
   "keywords": [
     "obsidian",


### PR DESCRIPTION
## Summary

Closes the "no mechanical safety net at PR time" gap surfaced by the v1.26.4 PATCH window.

Defense-in-depth layer for the Five-Gate. Every PR to `main` now triggers a GitHub Actions run that re-executes `pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm css-lint` on a clean Ubuntu runner. The composite status check (`Gate 1 / Five-Gate`) is intended to be required under branch protection (`strict: false`, `require_last_push_approval: true`).

## Why now

CLAUDE.md §"Six-Gate Quality Closure" lists Gate 1 as the project's mechanical quality bar. Local Gate 1 (per-fix E2E handoff) is verified before `git push`, but until this change there was no second verification at the PR layer — drift between a contributor's environment and the merge target could ship a mechanical failure that the local check missed.

Public repo = $0 cost; pnpm lockfile-pinned install prevents `eslint-plugin-obsidianmd` drift; the Bot alignment step at release time remains the final word on plugin version.

## Out of scope (intentional)

- **CLI migration (`tools/llm-wiki-cli/`)** — the five Gate 1 commands do not touch `tools/`. `pnpm lint` excludes it via `eslint.config.mjs:33-37`; `pnpm typecheck` excludes it via `tsconfig.json` (`include: ["src/**/*.ts"]`); `pnpm test` runs only `src/__tests__/**`; `pnpm build` bundles the plugin entry; `pnpm css-lint` checks `styles.css`. The `obsidianmd/no-nodejs-modules` rules on `tools/llm-wiki-cli/src/vault.ts` (static `node:fs` import) currently emit **warnings** (not Errors) — `lint:tools-bot` exits 0 — and are scheduled for cleanup in **v1.27.0 MINOR** per `project_v1_27_0_cli_split_planning.md`. Re-introducing `tools/` to Gate 1 before that migration lands is intentionally avoided.
- **Branch protection admin action** — requires maintainer-level GH API access; tracked separately as a follow-up after CI is observed running on a real PR.
- **Obsidian Bot review** — separate pipeline; not a GitHub status check.

## Why `pnpm install --frozen-lockfile` and not `npm ci`

The project's `packageManager` field pins `pnpm@10.14.0` and `package.json` has pnpm-only `overrides` (flat format: `fast-uri`, `brace-expansion`). npm cannot honor pnpm `overrides` — using `npm ci` would either drift the lockfile or silently drop the overrides, masking real version drift. Per `feedback_pnpm_vs_npm_overrides_incompatibility` (2026-08-08).

## Files Changed

```
.github/workflows/pr-ci.yml   | +60 (new)
package.json                  |  +3 -1
CLAUDE.md                     | +38 -1
```

## Gate 4 Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | N/A | CI runs 5 commands sequentially, ~5–10 min wall |
| Memory | N/A | No plugin-process memory change |
| IO | N/A | `pnpm install --frozen-lockfile` + pnpm cache; first run +30–60s, subsequent +10s |
| Network | ✅ | Public repo, $0 cost; pnpm lockfile-pinned prevents drift |
| Token | N/A | No LLM calls |

## Test Plan

CI workflow will fire on PR open. To verify end-to-end before merging:
1. Confirm status check `Gate 1 / Five-Gate` appears on the PR page
2. Confirm all 5 steps log success in the Actions tab
3. (Maintainer) run the `gh api PUT branches/main/protection` admin action with `require_status_checks.contexts: ["Gate 1 / Five-Gate"]`
4. Re-test by opening a dummy PR and confirming merge is blocked until the check is green
