### PR TITLE
fix(#470): restore the reasoning-only response guard dropped in the v1.23.0 migration

### DIFF
--- a/src/__tests__/llm-sdk/reasoning-only-guard.test.ts
+++ b/src/__tests__/llm-sdk/reasoning-only-guard.test.ts
@@ -1,0 +1,99 @@
+// Issue #470: the reasoning-only guard from v1.19.0 (Issue #99), restored.
+//
+// The failure it names is a 200: a thinking-capable model on a runtime that
+// ignores the thinking-disable control spends its budget in the reasoning
+// channel and returns empty visible content at `finish_reason: length`.
+// Without the guard the caller sees a parse failure and goes looking for a
+// bad prompt.
+//
+// The tests below are mostly about when it must NOT fire. A guard that throws
+// on a healthy call is worse than the gap it closes — it turns a working
+// setup into a broken one, and the two narrowings against the v1.19.0
+// predicate (reasoning-channel payloads, silent providers) are exactly the
+// cases the 2026 code base produces and the 2025 one did not.
+
+import { describe, it, expect } from 'vitest';
+import { assertNotReasoningOnly, normalizeUsage } from '../../llm-sdk/finish-reason';
+
+const REASONING_ONLY = { inputTokens: 100, outputTokens: 600, reasoningTokens: 600 };
+
+describe('assertNotReasoningOnly', () => {
+  it('throws on empty content at length with the budget spent on reasoning', () => {
+    expect(() => assertNotReasoningOnly('', 'length', REASONING_ONLY))
+      .toThrow(/empty content after spending 600 of 600 output tokens on reasoning/);
+  });
+
+  it('throws at the halfway mark, matching the v1.19.0 predicate', () => {
+    expect(() => assertNotReasoningOnly('', 'length', {
+      outputTokens: 600, reasoningTokens: 300,
+    })).toThrow(/reasoning/);
+    expect(() => assertNotReasoningOnly('', 'length', {
+      outputTokens: 600, reasoningTokens: 299,
+    })).not.toThrow();
+  });
+
+  it('does not fire when content came back', () => {
+    expect(() => assertNotReasoningOnly('{"entities":[]}', 'length', REASONING_ONLY)).not.toThrow();
+  });
+
+  // LMStudio + Qwen3.5 routes structured output into `reasoning_content` and
+  // leaves the visible field empty. The client prepends it before this runs,
+  // so by the time the guard sees the text, that call has its answer.
+  it('does not fire when the answer arrived through the reasoning channel', () => {
+    const prepended = '<think>{"entities":[]}</think>';
+    expect(() => assertNotReasoningOnly(prepended, 'length', REASONING_ONLY)).not.toThrow();
+  });
+
+  it('does not fire on a clean stop, however the tokens were spent', () => {
+    expect(() => assertNotReasoningOnly('', 'stop', REASONING_ONLY)).not.toThrow();
+  });
+
+  // Truncation with no reasoning breakdown is #305's signal, not this one.
+  it('does not fire when the provider never reported reasoning tokens', () => {
+    expect(() => assertNotReasoningOnly('', 'length', { outputTokens: 600 })).not.toThrow();
+    expect(() => assertNotReasoningOnly('', 'length', undefined)).not.toThrow();
+  });
+
+  it('does not divide by a zero or missing output count', () => {
+    expect(() => assertNotReasoningOnly('', 'length', { outputTokens: 0, reasoningTokens: 0 }))
+      .not.toThrow();
+    expect(() => assertNotReasoningOnly('', 'length', { reasoningTokens: 600 })).not.toThrow();
+  });
+});
+
+describe('normalizeUsage', () => {
+  it('lifts the current SDK field onto LLMUsage', () => {
+    expect(normalizeUsage({
+      inputTokens: 10, outputTokens: 20, outputTokenDetails: { reasoningTokens: 7 },
+    })?.reasoningTokens).toBe(7);
+  });
+
+  it('falls back to the deprecated top-level field', () => {
+    expect(normalizeUsage({ outputTokens: 20, reasoningTokens: 7 })?.reasoningTokens).toBe(7);
+  });
+
+  it('prefers the current field when both are present', () => {
+    expect(normalizeUsage({
+      outputTokens: 20, reasoningTokens: 1, outputTokenDetails: { reasoningTokens: 7 },
+    })?.reasoningTokens).toBe(7);
+  });
+
+  // Absent must stay absent: a provider that omits the field and a model that
+  // did not think both read as 0 once collapsed, and only one of those says
+  // anything about the model.
+  it('leaves an unreported count undefined rather than zero', () => {
+    const usage = normalizeUsage({ inputTokens: 10, outputTokens: 20 });
+    expect(usage).toBeDefined();
+    expect(usage?.reasoningTokens).toBeUndefined();
+  });
+
+  it('keeps the other fields it was given', () => {
+    expect(normalizeUsage({ inputTokens: 10, outputTokens: 20, totalTokens: 30 }))
+      .toMatchObject({ inputTokens: 10, outputTokens: 20, totalTokens: 30 });
+  });
+
+  it('passes through a missing usage object', () => {
+    expect(normalizeUsage(undefined)).toBeUndefined();
+    expect(normalizeUsage(null)).toBeUndefined();
+  });
+});

--- a/src/core/truncation-retry.ts
+++ b/src/core/truncation-retry.ts
@@ -41,8 +41,13 @@ export interface TruncationRetryOptions<T> {
   getStopReason?: (response: T) => string | null | undefined;
   /**
    * Optional: called when the initial response is truncated. May throw to abort
-   * the retry and surface a domain-specific error (e.g. #99 reasoning-only
-   * response detection).
+   * the retry and surface a domain-specific error.
+   *
+   * Issue #470: this used to name the #99 reasoning-only detection as its
+   * example, which had not been true since that guard left with
+   * `src/llm-client.ts` in the v1.23.0 AI-SDK migration. The guard now lives
+   * at `assertNotReasoningOnly` in `llm-sdk/finish-reason.ts`, where finish
+   * reason and usage are already normalized. This hook has no caller.
    */
   onTruncatedResponse?: (response: T) => void;
 }

--- a/src/llm-sdk/finish-reason.ts
+++ b/src/llm-sdk/finish-reason.ts
@@ -35,6 +35,29 @@ export function normalizeFinishReason(raw: unknown): LLMFinishReason {
 }
 
 /**
+ * Lift the SDK's reasoning-token count onto our own `LLMUsage`.
+ *
+ * The SDK reports it twice: `outputTokenDetails.reasoningTokens` is current,
+ * the top-level `reasoningTokens` is deprecated but still populated by some
+ * providers. We read the current one first and keep every other field the
+ * SDK sent, so this is purely additive for callers that ignore it.
+ *
+ * Absent stays absent. A provider that omits the field must not be recorded
+ * as one that reported zero — the guard below distinguishes the two, and
+ * collapsing them here would make "this model does not think"
+ * indistinguishable from "this provider does not say".
+ */
+export function normalizeUsage(usage: unknown): LLMUsage | undefined {
+  if (!usage || typeof usage !== 'object') return undefined;
+  const raw = usage as LLMUsage & {
+    outputTokenDetails?: { reasoningTokens?: number };
+    reasoningTokens?: number;
+  };
+  const reasoning = raw.outputTokenDetails?.reasoningTokens ?? raw.reasoningTokens;
+  return reasoning === undefined ? raw : { ...raw, reasoningTokens: reasoning };
+}
+
+/**
  * Invoke the optional `onFinish` callback with a normalized reason.
  *
  * No-op when the caller did not pass one, which keeps every existing call
@@ -46,5 +69,45 @@ export function reportFinish(
   usage?: LLMUsage,
 ): void {
   if (!onFinish) return;
-  onFinish({ finishReason: normalizeFinishReason(raw), ...(usage ? { usage } : {}) });
+  const normalized = normalizeUsage(usage);
+  onFinish({ finishReason: normalizeFinishReason(raw), ...(normalized ? { usage: normalized } : {}) });
+}
+
+/**
+ * Issue #470: restore the reasoning-only guard that shipped in v1.19.0 for
+ * Issue #99 and was dropped with `src/llm-client.ts` in the v1.23.0 AI-SDK
+ * migration.
+ *
+ * A thinking-capable model whose runtime ignores the thinking-disable control
+ * spends its budget in the reasoning channel and returns empty visible
+ * content at `finish_reason: length`. On the wire that is a 200, so without
+ * this the caller sees a generic parse failure and goes looking for a bad
+ * prompt — the exact wrong place.
+ *
+ * Two deliberate narrowings against the v1.19.0 predicate:
+ *
+ *   - `text` is the text the caller is about to receive, AFTER the
+ *     reasoning-channel prepend (`prependReasoningForParse`). LMStudio +
+ *     Qwen3.5 routes valid structured output into `reasoning_content` with
+ *     empty visible content; that call succeeded and must not throw here.
+ *   - An absent `reasoningTokens` never fires. The predicate needs the
+ *     provider to have said what the tokens went to; without it, "empty at
+ *     length" is just truncation, which is #305's signal, not this one.
+ */
+export function assertNotReasoningOnly(
+  text: string,
+  raw: unknown,
+  usage: LLMUsage | undefined,
+): void {
+  if (text.trim().length > 0) return;
+  if (normalizeFinishReason(raw) !== 'length') return;
+  const outputTokens = usage?.outputTokens ?? 0;
+  const reasoningTokens = usage?.reasoningTokens;
+  if (reasoningTokens === undefined || outputTokens <= 0) return;
+  if (reasoningTokens / outputTokens < 0.5) return;
+  throw new Error(
+    `The model returned empty content after spending ${reasoningTokens} of `
+    + `${outputTokens} output tokens on reasoning. Disable thinking for this `
+    + `model, or raise the token limit so the answer fits after it.`,
+  );
 }

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -39,7 +39,7 @@ import {
 import { TokenKeyProber } from './token-key-probe';
 import { ReasoningStripProber } from './reasoning-strip-probe';
 import { OutputModeProber, type OutputMode } from './output-mode-prober';
-import { reportFinish } from './finish-reason';
+import { assertNotReasoningOnly, normalizeUsage, reportFinish } from './finish-reason';
 import { buildSamplingArgs } from './sampling-args';
 import { buildOutputArgs } from './output-args';
 import { JSON_ENFORCEMENT_SYSTEM_PREFIX } from './json-prompt-prefix';
@@ -63,6 +63,25 @@ export interface OpenAICompatSdkClientOptions {
 // unchanged.
 import { repetitionPenaltyWireField } from '../core/repetition-penalty-dialect';
 export { repetitionPenaltyWireField };
+
+/**
+ * Read the SDK's parsed output, or `undefined` when there is none to read.
+ *
+ * `generateText`'s `output` is a getter that throws `NoOutputGeneratedError`
+ * whenever no output specification was passed (`ai@6.0.230/dist/index.mjs`
+ * line 5146). At the `text_prompt` tier `buildOutputArgs` deliberately passes
+ * none — the JSON shape comes from the prompt — so every plain
+ * `result.output` read at that tier throws, whatever the model returned.
+ *
+ * Today the tier is only reachable through a 400-driven demotion, where the
+ * throw lands in the surrounding catch-all and reads as a failed retry. The
+ * #470 guard below has to work on exactly that tier, so it cannot touch the
+ * getter directly.
+ */
+function readOutput<T>(result: { output?: unknown }, mode: OutputMode): T | undefined {
+  if (mode === 'text_prompt') return undefined;
+  return result.output as T | undefined;
+}
 
 export class OpenAICompatSdkClient implements LLMClient {
   private readonly apiKey: string;
@@ -347,6 +366,10 @@ export class OpenAICompatSdkClient implements LLMClient {
       const finalText = reasoningContent
         ? prependReasoningForParse(reasoningContent, result.text)
         : result.text;
+      // Issue #470: empty answer + `length` + the budget spent on reasoning is
+      // a thinking-control failure, not a parse failure. Checked on finalText
+      // so the reasoning-channel prepend above counts as content.
+      assertNotReasoningOnly(finalText, result.finishReason, normalizeUsage(result.usage));
       return finalText;
     } catch (err) {
       // v1.26.3 PATCH Path 2 fix (DocTpoint CHANGES_REQUESTED
@@ -867,12 +890,21 @@ export class OpenAICompatSdkClient implements LLMClient {
       const text = reasoningContent
         ? prependReasoningForParse(reasoningContent, result.text)
         : result.text;
+      const usage = normalizeUsage(result.usage);
+      const output = readOutput<T>(result, currentMode);
+      // Issue #470: same guard as the plain path, with one extra let-through —
+      // a typed call that produced `output` delivered its answer even when the
+      // visible text is empty, so only the case with nothing at all can be a
+      // reasoning-only response.
+      if (output === undefined) {
+        assertNotReasoningOnly(text, result.finishReason, usage);
+      }
       return {
         text,
-        output: result.output as T | undefined,
+        output,
         outputMode: currentMode,
         finishReason: result.finishReason,
-        usage: result.usage,
+        usage,
       };
     } catch (err) {
       // v1.26.3 PATCH Path 2 fix (mirrors createMessage):
@@ -958,7 +990,7 @@ export class OpenAICompatSdkClient implements LLMClient {
               );
               return {
                 text: retryResult.text,
-                output: retryResult.output as T | undefined,
+                output: readOutput<T>(retryResult, 'text_prompt'),
                 outputMode: 'text_prompt',
                 finishReason: retryResult.finishReason,
                 usage: retryResult.usage,
@@ -1027,7 +1059,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         reportFinish(onFinish, result.finishReason, result.usage);
         return {
           text: result.text,
-          output: result.output as T | undefined,
+          output: readOutput<T>(result, currentMode),
           outputMode: currentMode,
           finishReason: result.finishReason,
           usage: result.usage,
@@ -1086,7 +1118,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             reportFinish(onFinish, result.finishReason, result.usage);
             return {
               text: result.text,
-              output: result.output as T | undefined,
+              output: readOutput<T>(result, demotedMode),
               outputMode: demotedMode,
               finishReason: result.finishReason,
               usage: result.usage,
@@ -1124,7 +1156,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         reportFinish(onFinish, result.finishReason, result.usage);
         return {
           text: result.text,
-          output: result.output as T | undefined,
+          output: readOutput<T>(result, currentMode),
           outputMode: currentMode,
           finishReason: result.finishReason,
           usage: result.usage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -668,6 +668,19 @@ export interface LLMUsage {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  /**
+   * Reasoning tokens counted inside `outputTokens`. Normalized by
+   * `normalizeUsage` from the SDK's `outputTokenDetails.reasoningTokens`
+   * (its deprecated top-level `reasoningTokens` is the fallback), which in
+   * turn comes from `usage.completion_tokens_details.reasoning_tokens` on
+   * the wire.
+   *
+   * Undefined means "the provider said nothing", which is not the same as
+   * zero: a provider that omits the field and a model that did not think
+   * are indistinguishable from the response alone, and only the second is
+   * a statement about the model.
+   */
+  reasoningTokens?: number;
 }
 
 /** Metadata surfaced by SDK-backed clients via `onFinish` (Issue #305 +


### PR DESCRIPTION
Closes #470. The guard from #99 is back, at the point where finish reason and usage are already normalized.

`LLMUsage` gains `reasoningTokens`, normalized from the SDK's `outputTokenDetails.reasoningTokens` with the deprecated top-level field as fallback. Absent stays absent — a provider that omits the count and a model that did not think must not read alike, and only the second is a statement about the model.

`assertNotReasoningOnly` fires on empty content + `finish_reason: length` + at least half the output budget in the reasoning channel. Two narrowings against the v1.19.0 predicate, both deliberate: the check runs on the text the caller is about to receive, so a payload that arrived through the reasoning channel counts as content — LMStudio + Qwen3.5 routes valid JSON there with empty visible content, and that call succeeded; and an unreported reasoning count never fires, because "empty at length" without it is ordinary truncation, which is #305's signal rather than this one.

Both non-stream paths are covered. The stream path never had the guard and still does not; it fits naturally alongside #469 if you want it there.

Point 4 of the issue is done by correcting the JSDoc rather than wiring the hook: `onTruncatedResponse` has no caller, `withTruncationRetry` has no production caller either, and the guard's home is now the SDK client. The comment says so instead of naming a behaviour that is not there.

**One thing I decided rather than asked.** The guard's typed-path test reads `result.output` to let a call through when structured output was produced. That getter throws `NoOutputGeneratedError` whenever no output specification was passed (`ai@6.0.230/dist/index.mjs:5146`), which is precisely the `text_prompt` tier — the only tier with no `response_format`, and per #481 the only one on an openai-compatible wire where the model thinks at all. The guard would therefore have thrown in its own intended case. So a `readOutput` helper is in this PR, applied at all five sites. It is a defect in its own right: at the four other sites a 400-driven demotion hides it inside a catch-all, where it reads as a failed retry. **If you would rather have it as its own PR, say so and I will split it** — I kept it here because merging the guard without it would ship something that cannot work where it matters.

**The boundary I did not close.** Reasoning content is prepended to the text before the check, so a response that is *only* thinking prose counts as content and the guard stays silent. Separating those needs the parse verdict, and that falls at the caller, not here — a larger change than this issue asked for. I built the narrow version; the wider one is yours to call.

Gate 1: 3413 tests pass (3400 before, 13 new), lint / tsc / build / css-lint all green.
