### PR TITLE
test(ci): relax timing assertion in page-batch-runner test (5ms slop for shared-runner jitter)

### DIFF
--- a/src/__tests__/wiki/engine-internals/page-batch-runner.test.ts
+++ b/src/__tests__/wiki/engine-internals/page-batch-runner.test.ts
@@ -309,6 +309,10 @@ describe('runBatchedWithRetry', () => {
       }),
     });
 
-    expect(result.elapsedMs).toBeGreaterThanOrEqual(30);
+    // GH Actions shared runners (Linux, ubuntu-latest) under load routinely
+    // fire a 30 ms `setTimeout` at 28–29 ms (timing jitter). 5 ms slop keeps the
+    // assertion semantic ("elapsed ≥ mocked sleep duration") without
+    // teaching maintainers to re-run a flake rather than read it.
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(25);
   });
 });


### PR DESCRIPTION
## Summary

Closes the timing-flake surfaced by DocTpoint on PR #487's first outside-customer CI: `Gate 1 / Five-Gate` failed on PR #484 with `AssertionError: expected 29 to be greater than or equal to 30` at `src/__tests__/wiki/engine-internals/page-batch-runner.test.ts:312`. 3394/3395 passed; a re-run went green — the test lets a mocked `execute` sleep 30 ms then asserts `elapsedMs >= 30`, so on a shared runner a 29 is an ordinary reading, not a regression.

This CI gate is brand new (shipped in #487 today). Letting it stay flaky means every PR's first CI run gets a "whoops, re-run" culture, which is the opposite of what a Gate 1 check is for.

## Fix

One number (`>= 30` → `>= 25`) + 5-line comment explaining the slop. The assertion semantic ("elapsed ≥ mocked sleep duration") is preserved.

Root cause: GitHub Actions shared runners (ubuntu-latest, Linux under load) routinely fire a 30 ms `setTimeout` at 28–29 ms due to scheduler jitter. The strict `>= 30` was a brittle assertion.

## Tests

- `pnpm test -- src/__tests__/wiki/engine-internals/page-batch-runner.test.ts` → 3400/3400 pass on this branch (no local flake — the issue only manifests on shared runners).
- `pnpm gate:1` → 5/5 PASS.
- The fix does not introduce new tests; it relaxes one existing one. The corresponding code path is unchanged.

## Relation to #487

#487 added the CI workflow. This PR is its first bug fix (a flake-test stabilisation). Branches in the queue (#470 reasoning guard, #482 staged extraction, etc.) have all passed the gate on their most recent runs — but DocTpoint's report shows the gate has a known-fail mode that would have bitten one of those branches eventually.

Once this merges, the `Gate 1 / Five-Gate` status check on branch protection (`strict: false`, `require_last_push_approval: true`) can be enabled without flake risk.

## Out of Scope

- Generalising the slop helper (`expectCloseTo(elapsed, expected, slopMs=5)`). DocTpoint offered; we left it for a follow-up if the pattern shows up in 2+ tests.
- The 2 other `setTimeout` mocks in the file (`line 279` 10 ms, `openai-codex-device-flow.test.ts:201` 2000 ms) — different timing magnitude, not affected by this flake pattern.

## Files Changed

```
src/__tests__/wiki/engine-internals/page-batch-runner.test.ts | +5 -1
```

## Gate 4 Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | N/A | Test-only |
| Memory | N/A | Test-only |
| IO | N/A | Test-only |
| Network | N/A | No change |
| Token | N/A | No change |
