### PR TITLE
feat(#481): choose output mode and thinking per pipeline step

### DIFF
--- a/src/__tests__/core/llm-client-wrapper.test.ts
+++ b/src/__tests__/core/llm-client-wrapper.test.ts
@@ -169,3 +169,59 @@ describe('wrapWithAdvancedSettings — typed-output path (createMessageWithOutpu
     expect(wrapped.createMessageWithOutput).toBeUndefined();
   });
 });
+
+// Issue #481 follow-up: the per-step policy is applied here, at the one seam
+// every call passes through. Two properties matter — an unset policy must not
+// add a single field (otherwise both arms of a comparison have moved before
+// it starts), and a named step must win over the call site, because the call
+// site passes `disableThinking` unconditionally while the policy names one
+// step deliberately.
+describe('wrapWithAdvancedSettings — per-task policy (#481)', () => {
+  it('adds nothing when no policy is configured', () => {
+    for (const task of ['extract', 'page-generate', 'merge-triage', undefined]) {
+      const body = sent({}, task === undefined ? {} : { task });
+      expect(body).not.toHaveProperty('outputModeOverride');
+      expect(body).not.toHaveProperty('enableThinking');
+    }
+  });
+
+  it('adds nothing to a step the policy does not name', () => {
+    const body = sent(
+      { taskPolicies: { extract: { outputMode: 'text_prompt', thinking: 'on' } } },
+      { task: 'page-generate' },
+    );
+    expect(body).not.toHaveProperty('outputModeOverride');
+    expect(body).not.toHaveProperty('enableThinking');
+  });
+
+  it('pins the output mode and thinking for the step it names', () => {
+    const body = sent(
+      { taskPolicies: { extract: { outputMode: 'text_prompt', thinking: 'on' } } },
+      { task: 'extract' },
+    );
+    expect(body.outputModeOverride).toBe('text_prompt');
+    expect(body.enableThinking).toBe(true);
+  });
+
+  it('overrides the call site, which passes disableThinking unconditionally', () => {
+    const body = sent(
+      { taskPolicies: { extract: { outputMode: 'default', thinking: 'on' } } },
+      { task: 'extract', enableThinking: false },
+    );
+    expect(body.enableThinking).toBe(true);
+    expect(body).not.toHaveProperty('outputModeOverride');
+  });
+
+  it('applies on the typed path too — the schema callers live there', () => {
+    const { client, sentBodies } = typedClientSpy();
+    const wrapped = wrapWithAdvancedSettings(client, {
+      maxTokensPerCall: 0,
+      taskPolicies: { 'merge-triage': { outputMode: 'text_prompt', thinking: 'on' } },
+    });
+    void wrapped.createMessageWithOutput!({
+      ...CALL, task: 'merge-triage',
+    } as Parameters<NonNullable<LLMClient['createMessageWithOutput']>>[0]);
+    expect(sentBodies[0].outputModeOverride).toBe('text_prompt');
+    expect(sentBodies[0].enableThinking).toBe(true);
+  });
+});

--- a/src/__tests__/core/task-policy.test.ts
+++ b/src/__tests__/core/task-policy.test.ts
@@ -1,0 +1,132 @@
+// Issue #481 follow-up: per-step output mode and thinking.
+//
+// The property that matters most here is the same one #208's resolver pins:
+// an unset policy must leave every step exactly as it was. Everything else in
+// this module is opt-in, and an opt-in that changes the default path is a
+// regression no measurement would catch — both arms would have moved.
+//
+// The second group covers the parser. It throws rather than skipping bad
+// entries on purpose: a skipped entry produces a run whose manifest names an
+// arm it did not execute, and the manifest is the only record tying a number
+// to its conditions.
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_TASK_POLICY,
+  formatTaskPolicyMap,
+  parseTaskPolicySpec,
+  resolveTaskPolicy,
+  thinkingEffort,
+} from '../../core/task-policy';
+
+// Every `task:` label a production call site passes today.
+const TASK_LABELS = [
+  'extract', 'extract-retry', 'lemma-classify', 'merge-triage', 'merge-body',
+  'reviewed-append', 'related-page', 'complementary', 'page-generate',
+  'source-page', 'pdf-convert', 'dedup', 'conversation-extract',
+  'conversation-extract-retry', 'conversation-page', 'conversation-save-dedup',
+  'contradictions', 'fix-dead-link', 'link-orphan', 'lint-alias', 'lint-dedup',
+  'lint-tag-fix', 'query-view-evaluate', 'schema-suggest', 'welcome-translate',
+];
+
+describe('resolveTaskPolicy — the default path is untouched', () => {
+  it('resolves every known task to the default when no policy is set', () => {
+    for (const task of TASK_LABELS) {
+      expect(resolveTaskPolicy(undefined, task)).toEqual(DEFAULT_TASK_POLICY);
+      expect(resolveTaskPolicy({}, task)).toEqual(DEFAULT_TASK_POLICY);
+    }
+  });
+
+  it('resolves an untagged call to the default', () => {
+    expect(resolveTaskPolicy(undefined, undefined)).toEqual(DEFAULT_TASK_POLICY);
+    expect(resolveTaskPolicy({ extract: { outputMode: 'text_prompt', thinking: 'on' } }, undefined))
+      .toEqual(DEFAULT_TASK_POLICY);
+  });
+
+  it('leaves the steps a policy does not name alone', () => {
+    const policies = parseTaskPolicySpec('extract=text:on');
+    expect(resolveTaskPolicy(policies, 'extract'))
+      .toEqual({ outputMode: 'text_prompt', thinking: 'on' });
+    for (const task of TASK_LABELS.filter(t => t !== 'extract')) {
+      expect(resolveTaskPolicy(policies, task)).toEqual(DEFAULT_TASK_POLICY);
+    }
+  });
+});
+
+describe('resolveTaskPolicy — wildcard', () => {
+  it('applies to every step that has no entry of its own', () => {
+    const policies = parseTaskPolicySpec('*=-:off,extract=text:on');
+    expect(resolveTaskPolicy(policies, 'extract'))
+      .toEqual({ outputMode: 'text_prompt', thinking: 'on' });
+    expect(resolveTaskPolicy(policies, 'page-generate'))
+      .toEqual({ outputMode: 'default', thinking: 'off' });
+    expect(resolveTaskPolicy(policies, 'merge-triage'))
+      .toEqual({ outputMode: 'default', thinking: 'off' });
+  });
+});
+
+describe('parseTaskPolicySpec', () => {
+  it('accepts the short aliases and the wire names', () => {
+    expect(parseTaskPolicySpec('a=schema,b=json,c=text,d=-')).toEqual({
+      a: { outputMode: 'json_schema', thinking: 'default' },
+      b: { outputMode: 'json_object', thinking: 'default' },
+      c: { outputMode: 'text_prompt', thinking: 'default' },
+      d: { outputMode: 'default', thinking: 'default' },
+    });
+    expect(parseTaskPolicySpec('a=json_schema:on')).toEqual({
+      a: { outputMode: 'json_schema', thinking: 'on' },
+    });
+  });
+
+  it('tolerates whitespace and empty entries', () => {
+    expect(parseTaskPolicySpec(' extract = text : on , , merge-triage=text ')).toEqual({
+      extract: { outputMode: 'text_prompt', thinking: 'on' },
+      'merge-triage': { outputMode: 'text_prompt', thinking: 'default' },
+    });
+  });
+
+  it('returns an empty map for an empty spec', () => {
+    expect(parseTaskPolicySpec('')).toEqual({});
+    expect(parseTaskPolicySpec('   ')).toEqual({});
+  });
+
+  it('throws on a malformed entry rather than skipping it', () => {
+    expect(() => parseTaskPolicySpec('extract')).toThrow(/expected "task=mode/);
+    expect(() => parseTaskPolicySpec('=text')).toThrow(/expected "task=mode/);
+    expect(() => parseTaskPolicySpec('extract=grammar')).toThrow(/unknown mode "grammar"/);
+    expect(() => parseTaskPolicySpec('extract=text:maybe')).toThrow(/unknown thinking "maybe"/);
+  });
+
+  it('round-trips through formatTaskPolicyMap', () => {
+    const spec = 'extract=text:on,page-generate=-:off';
+    const parsed = parseTaskPolicySpec(spec);
+    expect(parseTaskPolicySpec(formatTaskPolicyMap(parsed))).toEqual(parsed);
+  });
+});
+
+// The bounded levels (#481 follow-up). Unbounded thinking at the extraction
+// step spent the whole 16000-token batch budget in the reasoning channel and
+// returned nothing, twice, so "may think" and "may think this much" had to
+// become different settings.
+describe('parseTaskPolicySpec — bounded thinking', () => {
+  it('accepts the three effort levels', () => {
+    expect(parseTaskPolicySpec('extract=text:low,a=text:medium,b=text:high')).toEqual({
+      extract: { outputMode: 'text_prompt', thinking: 'low' },
+      a: { outputMode: 'text_prompt', thinking: 'medium' },
+      b: { outputMode: 'text_prompt', thinking: 'high' },
+    });
+  });
+
+  it('names them in the error for an unknown level', () => {
+    expect(() => parseTaskPolicySpec('extract=text:lowish'))
+      .toThrow(/expected one of -, off, on, low, medium, high/);
+  });
+
+  it('reports an effort only for the levels that name one', () => {
+    expect(thinkingEffort('low')).toBe('low');
+    expect(thinkingEffort('high')).toBe('high');
+    expect(thinkingEffort('on')).toBeUndefined();
+    expect(thinkingEffort('off')).toBeUndefined();
+    expect(thinkingEffort('default')).toBeUndefined();
+  });
+});

--- a/src/core/create-plugin-llm-client.ts
+++ b/src/core/create-plugin-llm-client.ts
@@ -50,5 +50,6 @@ export function createLLMClient(
     samplingSeed: settings.samplingSeed,
     chatTemperature: settings.chatTemperature,
     repetitionPenalty: settings.repetitionPenalty,
+    taskPolicies: settings.taskPolicies,
   });
 }

--- a/src/core/task-policy.ts
+++ b/src/core/task-policy.ts
@@ -1,0 +1,163 @@
+// task-policy.ts — per-step choice of wire output mode and thinking.
+//
+// Issue #481 established that on an openai-compatible wire the two are not
+// independent: a `response_format` on the request sets `reasoning_tokens` to
+// 0 regardless of `reasoning_effort`, `disableThinking`, or the server's own
+// switch. "Let this step think" is therefore not a flag but a decision about
+// the output mode, and it can only be made per step — the pipeline's schema
+// callers (extract, lemma-classify, merge-triage, the dedup pair) and its
+// prose callers (page-generate, source-page, merge-body, related-page,
+// complementary, pdf-convert) want opposite things from the same setting.
+//
+// Which of them benefits from reasoning is unmeasured. This module exists so
+// that it can be measured: an arm of a comparison run is a policy string, not
+// a patch and a rebuild.
+//
+// Default is "change nothing". An unset policy resolves to `default` on both
+// axes, which means the OutputModeProber picks the mode exactly as before and
+// the caller's own `enableThinking` argument is passed through untouched.
+// `src/__tests__/core/task-policy.test.ts` pins that.
+
+import type { OutputMode } from '../llm-sdk/output-mode-prober';
+
+/**
+ * Output mode for one step. `default` leaves the choice to the
+ * OutputModeProber's per-model cache (today's behaviour: start at
+ * `json_schema`, demote on a 400).
+ *
+ * The other three name a wire shape and pin it, skipping the prober for this
+ * step only. `text_prompt` is the one that matters for reasoning — it is the
+ * only mode that puts no `response_format` on the request.
+ */
+export type TaskOutputMode = 'default' | OutputMode;
+
+/**
+ * Thinking for one step. `default` passes the call site's own argument
+ * through, which is what every call site does with `disableThinking` today.
+ *
+ * `off` and `on` override it. Note that both are requests, not guarantees:
+ * with a `response_format` on the wire, `on` is overruled by the schema
+ * (#481), which is precisely why the two axes are set together here.
+ *
+ * `low` / `medium` / `high` are `on` with a budget — they send
+ * `reasoning_effort` at that level. The distinction earns its place: measured
+ * on gemma-4-26b, unbounded thinking at the extraction step consumed all
+ * 16000 tokens of the batch budget and returned nothing, twice. "Thinking
+ * helps here" and "thinking fits here" are different questions, and only the
+ * bounded levels can ask the first one.
+ */
+export type TaskThinking = 'default' | 'off' | 'on' | 'low' | 'medium' | 'high';
+
+/** The three that name a budget, as opposed to just not suppressing. */
+export const THINKING_EFFORTS = ['low', 'medium', 'high'] as const;
+export type ThinkingEffort = (typeof THINKING_EFFORTS)[number];
+
+export function thinkingEffort(thinking: TaskThinking): ThinkingEffort | undefined {
+  return (THINKING_EFFORTS as readonly string[]).includes(thinking)
+    ? thinking as ThinkingEffort
+    : undefined;
+}
+
+export interface TaskPolicy {
+  outputMode: TaskOutputMode;
+  thinking: TaskThinking;
+}
+
+export const DEFAULT_TASK_POLICY: TaskPolicy = Object.freeze({
+  outputMode: 'default',
+  thinking: 'default',
+});
+
+/** Wildcard key: applies to every task that has no entry of its own. */
+export const TASK_POLICY_WILDCARD = '*';
+
+export type TaskPolicyMap = Readonly<Record<string, TaskPolicy>>;
+
+/**
+ * The policy for one `task` label, or the default when none applies.
+ *
+ * Lookup order is specific → wildcard → default, so `*=text:on` can set a
+ * baseline for a whole run and a single `extract=schema:off` entry can hold
+ * one step out of it.
+ */
+export function resolveTaskPolicy(
+  policies: TaskPolicyMap | undefined,
+  task: string | undefined,
+): TaskPolicy {
+  if (!policies) return DEFAULT_TASK_POLICY;
+  if (task && policies[task]) return policies[task];
+  return policies[TASK_POLICY_WILDCARD] ?? DEFAULT_TASK_POLICY;
+}
+
+const MODE_ALIASES: Readonly<Record<string, TaskOutputMode>> = {
+  '-': 'default',
+  'default': 'default',
+  'schema': 'json_schema',
+  'json_schema': 'json_schema',
+  'json': 'json_object',
+  'json_object': 'json_object',
+  'text': 'text_prompt',
+  'text_prompt': 'text_prompt',
+};
+
+const THINKING_ALIASES: Readonly<Record<string, TaskThinking>> = {
+  '-': 'default',
+  'default': 'default',
+  'off': 'off',
+  'on': 'on',
+  'low': 'low',
+  'medium': 'medium',
+  'high': 'high',
+};
+
+/**
+ * Parse a policy spec into a map. The format is meant to survive a shell
+ * script and stay readable in a run manifest:
+ *
+ *   extract=text:on,merge-triage=text:on,page-generate=-:off
+ *
+ * One entry per task, `task=mode:thinking`, `-` for "leave alone", and the
+ * thinking half optional (`extract=text` means mode only). `*` as the task
+ * name sets the baseline for every step.
+ *
+ * Throws on anything it does not understand rather than skipping it. A
+ * silently ignored entry would mean an arm that did not run what its own
+ * manifest says it ran, and the manifest is the only record of which arm a
+ * number came from.
+ */
+export function parseTaskPolicySpec(spec: string): TaskPolicyMap {
+  const policies: Record<string, TaskPolicy> = {};
+  for (const rawEntry of spec.split(',')) {
+    const entry = rawEntry.trim();
+    if (entry === '') continue;
+    const eq = entry.indexOf('=');
+    if (eq <= 0) {
+      throw new Error(`task policy: expected "task=mode[:thinking]", got "${entry}"`);
+    }
+    const task = entry.slice(0, eq).trim();
+    const [rawMode = '', rawThinking = '-'] = entry.slice(eq + 1).trim().split(':');
+    const outputMode = MODE_ALIASES[rawMode.trim()];
+    const thinking = THINKING_ALIASES[rawThinking.trim()];
+    if (!outputMode) {
+      throw new Error(
+        `task policy for "${task}": unknown mode "${rawMode}" `
+        + `(expected one of -, schema, json, text)`,
+      );
+    }
+    if (!thinking) {
+      throw new Error(
+        `task policy for "${task}": unknown thinking "${rawThinking}" `
+        + `(expected one of -, off, on, low, medium, high)`,
+      );
+    }
+    policies[task] = { outputMode, thinking };
+  }
+  return policies;
+}
+
+/** Round-trips `parseTaskPolicySpec`, for stamping the arm into a manifest. */
+export function formatTaskPolicyMap(policies: TaskPolicyMap): string {
+  return Object.entries(policies)
+    .map(([task, policy]) => `${task}=${policy.outputMode}:${policy.thinking}`)
+    .join(',');
+}

--- a/src/llm-client-wrapper.ts
+++ b/src/llm-client-wrapper.ts
@@ -21,6 +21,8 @@
 import { LLMClient } from './types';
 import { capMaxTokens } from './core/token-cap';
 import { recordTaskUsage } from './core/llm-task-usage';
+import { resolveTaskPolicy, thinkingEffort, type TaskPolicyMap, type ThinkingEffort } from './core/task-policy';
+import type { OutputMode } from './llm-sdk/output-mode-prober';
 
 export interface WrapperSettings {
   maxTokensPerCall: number;
@@ -35,6 +37,11 @@ export interface WrapperSettings {
   samplingSeed?: number;
   chatTemperature?: number;
   repetitionPenalty?: number;
+  /**
+   * Issue #481 follow-up: per-step output mode / thinking. Unset means every
+   * step keeps today's behaviour — see src/core/task-policy.ts.
+   */
+  taskPolicies?: TaskPolicyMap;
 }
 
 // Closed union for the [llm] debug-log breadcrumb. Stays narrow so a typo
@@ -87,6 +94,7 @@ export function wrapWithAdvancedSettings(
     return client.createMessage({
       ...params,
       ...injectAdvancedSettings(params, settings, capTokens),
+      ...applyTaskPolicy(params.task, settings),
     });
   });
 
@@ -96,6 +104,7 @@ export function wrapWithAdvancedSettings(
       return client.createMessageWithOutput!({
         ...params,
         ...injectAdvancedSettings(params, settings, capTokens),
+        ...applyTaskPolicy(params.task, settings),
       });
     });
   }
@@ -137,6 +146,38 @@ function injectAdvancedSettings(
     ...(params.top_p === undefined && settings.extractionTopP !== undefined ? { top_p: settings.extractionTopP } : {}),
     ...(params.repetition_penalty === undefined && settings.repetitionPenalty !== undefined ? { repetition_penalty: settings.repetitionPenalty } : {}),
     ...(params.seed === undefined && settings.samplingSeed !== undefined ? { seed: settings.samplingSeed } : {}),
+  };
+}
+
+/**
+ * Overlay for the per-step policy (Issue #481 follow-up).
+ *
+ * Applied after `injectAdvancedSettings` and therefore wins over it and over
+ * the call site: the policy names one step deliberately, while the call site
+ * passes `disableThinking` because every call site does. An unset policy
+ * spreads `{}` and changes nothing, which is what keeps the default path
+ * byte-identical to pre-#481.
+ *
+ * Not applied on the stream path — it carries no `task` label (#469), so
+ * there is nothing to key a per-step decision on.
+ */
+function applyTaskPolicy(
+  task: string | undefined,
+  settings: WrapperSettings,
+): Partial<{
+  outputModeOverride: OutputMode;
+  enableThinking: boolean;
+  reasoningEffort: ThinkingEffort;
+}> {
+  const policy = resolveTaskPolicy(settings.taskPolicies, task);
+  const effort = thinkingEffort(policy.thinking);
+  return {
+    ...(policy.outputMode !== 'default' ? { outputModeOverride: policy.outputMode } : {}),
+    ...(policy.thinking !== 'default' ? { enableThinking: policy.thinking !== 'off' } : {}),
+    // A named level is `on` plus a budget; it rides alongside enableThinking
+    // rather than replacing it, because the suppression field and the effort
+    // field are the same wire key and the client decides which value it takes.
+    ...(effort ? { reasoningEffort: effort } : {}),
   };
 }
 

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -83,6 +83,26 @@ function readOutput<T>(result: { output?: unknown }, mode: OutputMode): T | unde
   return result.output as T | undefined;
 }
 
+/**
+ * Issue #481: when a per-task policy pins `text_prompt`, no `response_format`
+ * reaches the wire, so the only thing left telling the model to answer in JSON
+ * is the prompt. The 400-driven demotion paths below add
+ * `JSON_ENFORCEMENT_SYSTEM_PREFIX` when they fall to that tier; a pinned mode
+ * has no such retry to hang it on, so it is added up front instead.
+ *
+ * Only when the caller actually wanted JSON. A prose step pinned to
+ * `text_prompt` passes no `response_format`, and prefixing its system prompt
+ * with a JSON instruction would corrupt the very output being measured.
+ */
+function forcedTextPromptSystem(
+  system: string | undefined,
+  responseFormat: unknown,
+  outputModeOverride: OutputMode | undefined,
+): string | undefined {
+  if (outputModeOverride !== 'text_prompt' || !responseFormat) return system;
+  return system ? `${JSON_ENFORCEMENT_SYSTEM_PREFIX}\n\n${system}` : JSON_ENFORCEMENT_SYSTEM_PREFIX;
+}
+
 export class OpenAICompatSdkClient implements LLMClient {
   private readonly apiKey: string;
   private readonly baseURL: string;
@@ -272,7 +292,12 @@ export class OpenAICompatSdkClient implements LLMClient {
   }
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
-    const { model, max_tokens, system, messages, temperature, top_p, repetition_penalty, seed, enableThinking, response_format, onFinish } = params;
+    const { model, max_tokens, messages, temperature, top_p, repetition_penalty, seed, enableThinking, reasoningEffort, response_format, outputModeOverride, onFinish } = params;
+    // Issue #481: a pinned mode skips the prober for this call. `text_prompt`
+    // puts no `response_format` on the wire, so the JSON shape has to come from
+    // the prompt — the same prefix the 400-driven demotion adds at retry time,
+    // applied up front because there is no retry here.
+    const system = forcedTextPromptSystem(params.system, response_format, outputModeOverride);
 
     // v1.26.3 PATCH (Issue #443): translate the public `response_format`
     // shape into the AI SDK's `output` mechanism via `buildOutputArgs`
@@ -304,7 +329,7 @@ export class OpenAICompatSdkClient implements LLMClient {
     // `outputMode` reporting is honest (matches the wire shape the SDK
     // actually emits) and the wasted `json_schema → json_object`
     // demotion cycle on first 400 is skipped.
-    const currentMode = this.getCurrentOutputMode(model);
+    const currentMode = outputModeOverride ?? this.getCurrentOutputMode(model);
     const outputArgs = buildOutputArgs(response_format, currentMode);
 
     // [DEBUG-LOG v1.26.3 E2E] visible entry-point trace: response_format
@@ -332,6 +357,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         ...outputArgs,
         providerOptions: this.buildProviderOptions({
           enableThinking,
+          reasoningEffort,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
         ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -496,6 +522,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
             enableThinking,
+            reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -563,7 +590,10 @@ export class OpenAICompatSdkClient implements LLMClient {
         const retryLanguageModel = this.getProvider(model, this.fetchImpl);
         const { generateText } = await import('ai');
         // Retry without reasoningEffort — pass enableThinking=true so
-        // buildProviderOptions does not re-add the field. The user's
+        // buildProviderOptions does not re-add the field. A per-task policy's
+        // named effort (#481) is dropped here for the same reason: the backend
+        // just rejected that wire field, so re-sending it at another value
+        // would only earn a second 400. The user's
         // intent ("force-disable thinking") was honored by the first
         // attempt; on the retry we accept whatever the backend's
         // default reasoning behavior is, since the field itself is
@@ -710,6 +740,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             ...buildOutputArgs(response_format, demotedMode),
             providerOptions: this.buildProviderOptions({
               enableThinking,
+              reasoningEffort,
               repetitionPenalty: repetition_penalty,
             }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
             ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -771,6 +802,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
             enableThinking,
+            reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -821,7 +853,9 @@ export class OpenAICompatSdkClient implements LLMClient {
     messages: Array<{ role: 'user' | 'assistant'; content: string | MessageContentPart[] }>;
     response_format?: { type: 'json_object'; schema?: Record<string, unknown> | z.ZodType };
     task?: string;
+    outputModeOverride?: OutputMode;
     enableThinking?: boolean;
+    reasoningEffort?: 'low' | 'medium' | 'high';
     temperature?: number;
     top_p?: number;
     seed?: number;
@@ -834,12 +868,16 @@ export class OpenAICompatSdkClient implements LLMClient {
     finishReason: LLMFinishReason;
     usage?: LLMUsage;
   }> {
-    const { model, max_tokens, system, messages, response_format, enableThinking, repetition_penalty, temperature, top_p, seed, onFinish } = params;
+    const { model, max_tokens, messages, response_format, outputModeOverride, enableThinking, reasoningEffort, repetition_penalty, temperature, top_p, seed, onFinish } = params;
+    // See createMessage — a pinned `text_prompt` needs the prompt-side
+    // enforcement up front, because no demotion retry will add it.
+    const system = forcedTextPromptSystem(params.system, response_format, outputModeOverride);
 
     // v1.26.4 PATCH (Issue #474 — Layer 3): see createMessage. Use
     // getCurrentOutputMode for honest outputMode reporting on
-    // non-supportsStructuredOutputs providers.
-    const currentMode = this.getCurrentOutputMode(model);
+    // non-supportsStructuredOutputs providers. A per-task policy (#481) pins
+    // the mode ahead of both.
+    const currentMode = outputModeOverride ?? this.getCurrentOutputMode(model);
     const outputArgs = buildOutputArgs(response_format, currentMode);
 
     console.debug(
@@ -860,6 +898,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         ...outputArgs,
         providerOptions: this.buildProviderOptions({
           enableThinking,
+          reasoningEffort,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
         ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -976,6 +1015,7 @@ export class OpenAICompatSdkClient implements LLMClient {
                 ...buildOutputArgs(response_format, 'text_prompt'),
                 providerOptions: this.buildProviderOptions({
                   enableThinking,
+                  reasoningEffort,
                   repetitionPenalty: repetition_penalty,
                 }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
                 ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -1052,6 +1092,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
             enableThinking,
+            reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -1111,6 +1152,7 @@ export class OpenAICompatSdkClient implements LLMClient {
               ...buildOutputArgs(response_format, demotedMode),
               providerOptions: this.buildProviderOptions({
                 enableThinking,
+                reasoningEffort,
                 repetitionPenalty: repetition_penalty,
               }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
               ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -1149,6 +1191,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
             enableThinking,
+            reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
           ...buildSamplingArgs({ temperature, top_p, seed }),
@@ -1198,11 +1241,19 @@ export class OpenAICompatSdkClient implements LLMClient {
    */
   private buildProviderOptions(opts: {
     enableThinking?: boolean;
+    reasoningEffort?: 'low' | 'medium' | 'high';
     repetitionPenalty?: number;
   }): Record<string, Record<string, unknown>> {
     const openaiOpts: Record<string, unknown> = {};
 
-    if (opts.enableThinking === false && !this.reasoningStripProber.shouldStrip(this.baseURL)) {
+    // Issue #481: a named effort bounds the thinking instead of only permitting
+    // it. Same wire key as the force-disable path below, different value, and it
+    // takes precedence — asking for `low` and `none` at once is a contradiction
+    // the policy layer cannot produce (`off` yields no effort) and that a call
+    // site should not be able to smuggle in either.
+    if (opts.reasoningEffort && !this.reasoningStripProber.shouldStrip(this.baseURL)) {
+      openaiOpts.reasoningEffort = opts.reasoningEffort;
+    } else if (opts.enableThinking === false && !this.reasoningStripProber.shouldStrip(this.baseURL)) {
       // v1.26.0 Batch 6: force-disable thinking via reasoningEffort.
       //
       // Prior mechanism (PR #410 / Batch 2) used `thinking.type: 'disabled'`
@@ -1355,6 +1406,8 @@ export class OpenAICompatSdkClient implements LLMClient {
         ...(system ? { system } : {}),
         messages: messages.map((m) => ({ role: m.role, content: m.content })),
         maxOutputTokens: max_tokens,
+        // No effort here: the stream path carries no `task` label (#469), so
+        // no per-step policy can be resolved for it.
         providerOptions: this.buildProviderOptions({
           enableThinking,
           repetitionPenalty: repetition_penalty,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@
 import { App } from 'obsidian';
 import type { z } from 'zod';
 import type { RejectionReason } from './core/source-requirements';
+import type { TaskPolicyMap } from './core/task-policy';
+import type { OutputMode } from './llm-sdk/output-mode-prober';
 
 /**
  * Issue #244 — Programmatic Mentions writes (v1.23.3 / v1.24.0).
@@ -322,6 +324,13 @@ export interface LLMWikiSettings {
   // (where it was opt-out). The semantic is now opt-in: the user must
   // explicitly enable "Disable thinking" in Custom Advanced Settings.
   disableThinking?: boolean;
+
+  // Issue #481: per-step output mode and thinking. Unset — the default, and
+  // what every existing data.json has — means every step behaves exactly as
+  // before; see src/core/task-policy.ts. Deliberately not exposed in the UI:
+  // the settings worth offering are the ones a measurement has picked out, and
+  // this field is what makes that measurement possible.
+  taskPolicies?: TaskPolicyMap;
 
   // Advanced settings mode — 'default' hides the toggles/inputs; 'custom'
   // reveals them. In v1.20.0, 'default' no longer forces anything — the
@@ -718,8 +727,27 @@ export interface LLMClient {
      * Clients ignore it; the CLI groups its usage report by it.
      */
     task?: string;
+    /**
+     * Pin the wire output mode for this one call, bypassing the
+     * OutputModeProber's cached choice. Set by the client wrapper from the
+     * per-task policy (`src/core/task-policy.ts`); no call site passes it.
+     *
+     * Why it exists: `text_prompt` is the only mode that puts no
+     * `response_format` on the request, and per #481 that is the only way a
+     * schema-carrying step can think at all. A 400-driven demotion cannot
+     * serve here — it is a repair, and it never fires on a backend that
+     * accepts the schema.
+     */
+    outputModeOverride?: OutputMode;
     maxTokensPerCall?: number;  // Issue #75: cap for truncation retry
     enableThinking?: boolean;   // ROADMAP P3 #12: allow thinking for thinking-capable models
+    /**
+     * Bound the thinking rather than only permitting it. Sent as
+     * `reasoning_effort` at the named level — the same wire key the
+     * force-disable path uses with `'none'`. Set by the wrapper from the
+     * per-task policy; no call site passes it.
+     */
+    reasoningEffort?: 'low' | 'medium' | 'high';
     temperature?: number;       // Issue #128: per-request sampling temperature
     /**
      * Nucleus sampling. Travels with `temperature` because a preset is a pair:
@@ -781,7 +809,11 @@ export interface LLMClient {
     // shape and the Tier 1/2 fallback parseJsonResponse validation).
     response_format?: { type: 'json_object'; schema?: Record<string, unknown> | z.ZodType };
     task?: string;
+    /** See `createMessage`. Set by the wrapper from the per-task policy. */
+    outputModeOverride?: OutputMode;
     enableThinking?: boolean;
+    /** See `createMessage`. */
+    reasoningEffort?: 'low' | 'medium' | 'high';
     temperature?: number;
     top_p?: number;
     seed?: number;


### PR DESCRIPTION
Closes #481.

#481 established that on an openai-compatible wire, output mode and thinking are not
independent: a `response_format` on the request sets `reasoning_tokens` to 0 regardless of
`reasoning_effort`, of `disableThinking`, or of the server's own switch. Since #443 every
ingest call carries a schema, so no step of an ingest can think, and the setting that claims
to control it cannot reach the outcome.

That makes "let this step think" a decision about the output mode rather than a flag — and a
decision that can only be made per step. The schema callers (`extract`, `lemma-classify`,
`merge-triage`, the dedup pair) and the prose callers (`page-generate`, `source-page`,
`merge-body`, `related-page`, `complementary`, `pdf-convert`) want opposite things from one
setting.

## Why this shape and not the two you named

You left the direction to us and named two. I built a third, and the two you named are the
reason:

**The two-call cut** — one schema call, one thinking call — doubles the calls on the step
that is already the most expensive. On this vault one note currently takes about 400 s, and
the extraction step is where that time sits. It also has to answer, for every step, which of
the two results wins when they disagree, and nothing in the pipeline can answer that today.

**The provider opt-out** — dropping `response_format` for backends whose thinking matters —
reopens exactly what #443 and #463 closed. The schema is what made the typed output reliable
on LM Studio; a provider-wide opt-out trades a measured reliability gain for an unmeasured
reasoning gain.

Both give up something known for something unknown. The per-step policy gives up nothing:
its default resolves to "change nothing" on both axes, and each step can then be moved on its
own once a measurement says which of them benefits.

## What is in it

`src/core/task-policy.ts` maps a task label to `{outputMode, thinking}`, resolved specific →
wildcard → default. The client wrapper applies it at the one seam every call already passes
through, so **no call site changes**. An unset policy spreads `{}` and the path stays
byte-identical to today; `src/__tests__/core/task-policy.test.ts` pins that.

The spec format is meant to survive a shell script and stay readable in a run manifest:

```
extract=text:on,merge-triage=text:on,page-generate=-:off
```

`parseTaskPolicySpec` throws on anything it cannot read rather than skipping it. A silently
ignored entry would mean an arm that did not run what its own manifest says it ran, and the
manifest is the only record of which arm a number came from.

Two mechanics the wire forced:

- A pinned `text_prompt` puts no `response_format` on the request, so the JSON shape has to
  come from the prompt. The 400-driven demotion adds `JSON_ENFORCEMENT_SYSTEM_PREFIX` when it
  falls to that tier; a pinned mode has no retry to hang it on, so it is added up front — and
  only when the caller actually asked for JSON, so a prose step pinned to text is not
  corrupted by a JSON instruction.
- `low` / `medium` / `high` send `reasoning_effort` and take precedence over the force-disable
  path, which uses the same wire key with `none`. The reasoning-strip retry deliberately drops
  the field: the backend just rejected that key, so re-sending it at another value would only
  earn a second 400.

## One limitation, measured rather than assumed

The named levels do not bound anything on the backend where the need was measured. Unbounded
thinking at the extraction step consumed all 16000 tokens of the batch budget and returned
nothing, twice, on `google/gemma-4-26b-a4b-qat` via LM Studio — that is why a bound belongs in
the design. But on that same backend `low`, `medium`, `high` and omitting the field are
indistinguishable: three draws each at `temperature: 0`, byte-identical output at 417 reasoning
tokens, while `reasoning_effort: none` does switch reasoning off (0 tokens). There the field is
a switch, not a budget. The levels are the standard openai-compatible field and are carried for
the backends that honour it; on LM Studio a bounded arm is not available today.

## Not in this PR

The measurement scaffolding this was built with — CLI flags for the policy, an extraction token
floor, a prompt-suffix control arm, per-task usage summaries — stays out. It is a measuring
instrument, not product surface.

No UI either. The settings worth offering are the ones a measurement has picked out, and this
field is what makes that measurement possible. `taskPolicies` is unset in every existing
`data.json`, which is the no-op default.

The stream path is untouched: it carries no task label (#469), so there is nothing to key a
per-step decision on.

## Tests

3430 pass (237 files). New: 132 lines pinning policy resolution, spec parsing, the throw-on-
unreadable behaviour and the default no-op; 56 lines pinning that the wrapper applies the
policy on both non-stream paths and spreads nothing when it is unset.
