### PR TITLE
fix(contradictions): clamp the page in sections and restore what was withheld

### DIFF
--- a/src/__tests__/core/clamp-page-sections.test.ts
+++ b/src/__tests__/core/clamp-page-sections.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { clampPageSections, restoreWithheldSections } from '../../core/clamp-page-sections';
+
+const page = [
+  '---',
+  'type: entity',
+  'tags: [x]',
+  '---',
+  '',
+  '# Sulforaphane',
+  '',
+  'Lead paragraph.',
+  '',
+  '## Description',
+  'D'.repeat(200),
+  '',
+  '## Related Entities',
+  'R'.repeat(200),
+  '',
+  '## Mentions',
+  'M'.repeat(200),
+].join('\n');
+
+describe('clampPageSections', () => {
+  it('returns the input byte-identical when it fits', () => {
+    const out = clampPageSections(page, 10_000);
+    expect(out.text).toBe(page);
+    expect(out.withheld).toEqual([]);
+    expect(out.hardCut).toBe(false);
+  });
+
+  it('treats a budget of 0 as no clamp', () => {
+    expect(clampPageSections(page, 0).text).toBe(page);
+  });
+
+  it('drops whole sections from the end, never mid-sentence', () => {
+    const out = clampPageSections(page, 400);
+    expect(out.text).toContain('## Description');
+    expect(out.text).not.toContain('## Mentions\nM');
+    expect(out.hardCut).toBe(false);
+    // Nothing kept is a fragment: every retained section is present in full.
+    expect(out.text).toContain('D'.repeat(200));
+  });
+
+  it('names the omitted sections in the prompt text', () => {
+    const out = clampPageSections(page, 400);
+    expect(out.text).toMatch(/section\(s\) omitted here for length/);
+    expect(out.text).toContain('Mentions');
+  });
+
+  it('returns the withheld sections verbatim and in document order', () => {
+    const out = clampPageSections(page, 400);
+    expect(out.withheld.length).toBeGreaterThan(0);
+    expect(out.withheld[0].startsWith('## ')).toBe(true);
+    expect(out.withheld.join('\n')).toContain('M'.repeat(200));
+    const order = out.withheld.map(s => s.split('\n', 1)[0]);
+    expect(order).toEqual([...order].sort((a, b) => page.indexOf(a) - page.indexOf(b)));
+  });
+
+  it('keeps the preamble even when every section is dropped', () => {
+    // Budget above the preamble (64 chars) but below the first section.
+    const out = clampPageSections(page, 100);
+    expect(out.text).toContain('type: entity');
+    expect(out.withheld).toHaveLength(3);
+    expect(out.hardCut).toBe(false);
+  });
+
+  it('flags a hard cut when there is no section boundary to cut at', () => {
+    const flat = 'x'.repeat(5000);
+    const out = clampPageSections(flat, 100);
+    expect(out.hardCut).toBe(true);
+    expect(out.withheld).toEqual([]);
+    expect(out.text).toContain('truncated here for length');
+    expect(out.text.length).toBeLessThanOrEqual(100);
+  });
+
+  it('does not reorder: a short tail section is not kept after a long one is dropped', () => {
+    const p = ['## A', 'a'.repeat(300), '## B', 'b'.repeat(300), '## C', 'c'].join('\n');
+    const out = clampPageSections(p, 320);
+    expect(out.withheld.map(s => s.split('\n', 1)[0])).toEqual(['## B', '## C']);
+  });
+});
+
+describe('restoreWithheldSections', () => {
+  it('is a no-op when nothing was withheld', () => {
+    expect(restoreWithheldSections('# Page\n\nbody', [])).toBe('# Page\n\nbody');
+  });
+
+  it('puts the withheld sections back after a rewrite', () => {
+    const out = clampPageSections(page, 400);
+    const rewritten = '---\ntype: entity\n---\n\n# Sulforaphane\n\nRepaired.\n\n## Description\nnew';
+    const restored = restoreWithheldSections(rewritten, out.withheld);
+    for (const section of out.withheld) expect(restored).toContain(section);
+    expect(restored).toContain('Repaired.');
+  });
+
+  it('round-trips every byte of a clamped page through prompt and restore', () => {
+    const out = clampPageSections(page, 400);
+    const restored = restoreWithheldSections(out.text.split('\n\n[')[0], out.withheld);
+    for (const section of ['## Description', '## Related Entities', '## Mentions']) {
+      expect(restored).toContain(section);
+    }
+  });
+});

--- a/src/__tests__/wiki/contradiction-truncation.test.ts
+++ b/src/__tests__/wiki/contradiction-truncation.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { ContradictionManager } from '../../wiki/contradictions';
+import type { EngineContext } from '../../types';
+
+// A page well past the 6,000-character prompt budget, with the overflow in its
+// own `## ` sections. Before the clamp, everything after character 6,000 never
+// reached the model — and the model's answer was written back over the file.
+function bigPage(): string {
+  return [
+    '---',
+    'type: entity',
+    'source_page: "[[entities/Test]]"',
+    '---',
+    '',
+    '# Test',
+    '',
+    '## Description',
+    'D'.repeat(5800),
+    '',
+    '## Mentions',
+    'THE-TAIL-THAT-USED-TO-VANISH ' + 'M'.repeat(2000),
+  ].join('\n');
+}
+
+function makeCtx(pages: Record<string, string>, reply: string) {
+  const written: Record<string, string> = {};
+  let seenPrompt = '';
+  const ctx = {
+    settings: { wikiFolder: 'wiki', disableThinking: false },
+    app: {},
+    tryReadFile: async (p: string) => pages[p],
+    createOrUpdateFile: async (p: string, c: string) => { written[p] = c; },
+    getSchemaContext: async () => '',
+    getClient: () => ({
+      createMessage: async (params: { messages: Array<{ content: string }> }) => {
+        seenPrompt = params.messages[0].content;
+        return reply;
+      },
+    }),
+  } as unknown as EngineContext;
+  return { ctx, written, prompt: () => seenPrompt };
+}
+
+describe('resolveContradiction does not lose the part it could not show the model', () => {
+  const record = '---\nsource_page: "[[entities/Test]]"\n---\n\n## Conflict\nA vs B.';
+
+  it('withholds whole sections, says so in the prompt, and writes them back', async () => {
+    const pages = {
+      'wiki/contradictions/x.md': record,
+      'wiki/entities/Test.md': bigPage(),
+    };
+    // The model answers with a repaired page built only from what it saw.
+    const reply = '---\ntype: entity\n---\n\n# Test\n\n## Description\nRepaired.';
+    const { ctx, written, prompt } = makeCtx(pages, reply);
+
+    await new ContradictionManager(ctx).resolveContradiction('wiki/contradictions/x.md');
+
+    // The prompt is bounded and admits what it left out.
+    expect(prompt()).toMatch(/section\(s\) omitted here for length/);
+    expect(prompt()).toContain('Mentions');
+    expect(prompt()).not.toContain('THE-TAIL-THAT-USED-TO-VANISH');
+
+    // The file keeps it anyway.
+    const out = written['wiki/entities/Test.md'];
+    expect(out).toContain('Repaired.');
+    expect(out).toContain('THE-TAIL-THAT-USED-TO-VANISH');
+    expect(out).toContain('## Mentions');
+  });
+
+  it('leaves a page that fits byte-identical in the prompt', async () => {
+    const small = '---\ntype: entity\n---\n\n# Test\n\n## Description\nShort.';
+    const pages = {
+      'wiki/contradictions/x.md': record,
+      'wiki/entities/Test.md': small,
+    };
+    const { ctx, prompt } = makeCtx(pages, '# Test\n\n## Description\nRepaired.');
+    await new ContradictionManager(ctx).resolveContradiction('wiki/contradictions/x.md');
+    expect(prompt()).toContain(small);
+    expect(prompt()).not.toMatch(/omitted here for length/);
+  });
+
+  it('refuses to rewrite a page it cannot clamp at a section boundary', async () => {
+    const pages = {
+      'wiki/contradictions/x.md': record,
+      'wiki/entities/Test.md': '---\ntype: entity\n---\n\n' + 'x'.repeat(9000),
+    };
+    const { ctx, written } = makeCtx(pages, 'anything');
+    await expect(
+      new ContradictionManager(ctx).resolveContradiction('wiki/contradictions/x.md'),
+    ).rejects.toThrow(/no section boundary/);
+    expect(written['wiki/entities/Test.md']).toBeUndefined();
+  });
+});

--- a/src/core/clamp-page-sections.ts
+++ b/src/core/clamp-page-sections.ts
@@ -1,0 +1,125 @@
+// clamp-page-sections.ts — bound a page for a prompt without cutting it blind.
+//
+// Two call sites clamp a wiki page before sending it to the model, and both do
+// it with `String.prototype.substring`. That has three properties nobody wants
+// from a payload decision:
+//
+//   1. it lands mid-sentence, so the model reads a fragment as if it were the
+//      end of the page,
+//   2. it leaves no marker, so nothing in the prompt says content is missing —
+//      the model cannot account for what it did not receive, and
+//   3. on a path that writes the model's answer back over the page, whatever
+//      was cut is gone from disk, because the model was told to output the
+//      complete page and did so from what it saw.
+//
+// This clamps in `##` sections instead, drops from the end, and returns what it
+// withheld so the caller can put it back. Below the budget nothing happens at
+// all — the return is the input, byte for byte.
+
+/** What the clamp did, so the caller can both prompt and restore. */
+export interface ClampedPage {
+  /** The text to put in the prompt. Identical to the input when nothing was dropped. */
+  text: string;
+  /** Whole `## …` blocks withheld, in document order, verbatim including their heading. */
+  withheld: string[];
+  /**
+   * True when the budget forced a cut that is not section-shaped — a page whose
+   * preamble alone exceeds it, or one with no `##` heading to cut at. Then
+   * `withheld` is empty and the loss is not restorable, which a caller that
+   * writes back must treat as a reason not to.
+   */
+  hardCut: boolean;
+}
+
+/** Rendered into the prompt in place of what was dropped. */
+function marker(headings: string[]): string {
+  return `\n\n[${headings.length} section(s) omitted here for length: `
+    + `${headings.join(', ')}. They are unchanged and will be restored after your answer — `
+    + `do not attempt to reproduce them.]`;
+}
+
+/**
+ * Split into the part before the first `## ` heading and the `## ` blocks.
+ * Frontmatter and the lead paragraph stay in the preamble, which is never
+ * dropped: it carries the page's identity.
+ */
+function splitSections(content: string): { preamble: string; sections: string[] } {
+  const lines = content.split('\n');
+  const preamble: string[] = [];
+  const sections: string[] = [];
+  let current: string[] | null = null;
+  let inFrontmatter = lines[0]?.trim() === '---';
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (inFrontmatter && i > 0 && line.trim() === '---') {
+      inFrontmatter = false;
+      (current ?? preamble).push(line);
+      continue;
+    }
+    if (!inFrontmatter && /^##\s+\S/.test(line)) {
+      if (current) sections.push(current.join('\n'));
+      current = [line];
+      continue;
+    }
+    (current ?? preamble).push(line);
+  }
+  if (current) sections.push(current.join('\n'));
+  return { preamble: preamble.join('\n'), sections };
+}
+
+function headingOf(section: string): string {
+  return section.split('\n', 1)[0].replace(/^##\s+/, '').trim();
+}
+
+/**
+ * Clamp `content` to roughly `budget` characters by dropping whole trailing
+ * sections. A budget of 0 or less means no clamp, matching how the rest of the
+ * codebase reads an unset numeric limit.
+ */
+export function clampPageSections(content: string, budget: number): ClampedPage {
+  if (budget <= 0 || content.length <= budget) {
+    return { text: content, withheld: [], hardCut: false };
+  }
+
+  const { preamble, sections } = splitSections(content);
+
+  // No section boundary to cut at, or the preamble alone busts the budget:
+  // there is no honest section-shaped answer, so cut and say so.
+  if (sections.length === 0 || preamble.length >= budget) {
+    const note = '\n\n[content truncated here for length — the remainder was not sent]';
+    const room = Math.max(0, budget - note.length);
+    return { text: content.slice(0, room) + note, withheld: [], hardCut: true };
+  }
+
+  const kept: string[] = [];
+  const dropped: string[] = [];
+  let used = preamble.length;
+  for (const section of sections) {
+    const cost = section.length + 1;
+    // Once one section has been dropped, every later one goes too — keeping a
+    // short tail section after dropping a long middle one would reorder the
+    // page as the model sees it.
+    if (dropped.length === 0 && used + cost <= budget) {
+      kept.push(section);
+      used += cost;
+    } else {
+      dropped.push(section);
+    }
+  }
+
+  // Every section dropped and the preamble fits: still section-shaped, still
+  // restorable — the marker carries the whole list.
+  const text = [preamble, ...kept].join('\n') + marker(dropped.map(headingOf));
+  return { text, withheld: dropped, hardCut: false };
+}
+
+/**
+ * Put withheld sections back on the end of a rewritten page. No-op when
+ * nothing was withheld, which is the ordinary case.
+ */
+export function restoreWithheldSections(rewritten: string, withheld: string[]): string {
+  if (withheld.length === 0) return rewritten;
+  const body = rewritten.replace(/\s+$/, '');
+  return `${body}\n\n${withheld.join('\n\n')}\n`;
+}

--- a/src/wiki/contradictions.ts
+++ b/src/wiki/contradictions.ts
@@ -6,6 +6,7 @@ import { parseFrontmatter } from '../core/frontmatter';
 import { cleanMarkdownResponse } from '../core/markdown';
 import { renderTemplate } from '../core/template-renderer';
 import { TOKENS_CONTRADICTION } from '../constants';
+import { clampPageSections, restoreWithheldSections } from '../core/clamp-page-sections';
 import { PROMPTS } from '../prompts';
 import { resolveModelForTask } from '../core/model-resolver';
 import {
@@ -171,9 +172,23 @@ ${contradiction.source_page}
     const existingContent = await this.ctx.tryReadFile(pagePath);
     if (!existingContent) throw new Error('Affected wiki page not found');
 
+    // The page is clamped in whole `##` sections rather than characters, and
+    // what is withheld comes back after the rewrite. The prompt tells the model
+    // to output the complete page and the result is written over the file, so a
+    // blind cut here is not a smaller prompt — it is content deleted from disk.
+    const page = clampPageSections(existingContent, 6000);
+    if (page.hardCut) {
+      throw new Error(
+        'Affected wiki page exceeds the prompt budget and has no section boundary to '
+        + 'clamp at; refusing to rewrite it, because the model cannot be shown the part '
+        + 'it would be asked to preserve.',
+      );
+    }
+    const record = clampPageSections(contradictionContent, 3000);
+
     const prompt = renderTemplate(PROMPTS.resolveContradiction, {
-      existing_content: existingContent.substring(0, 6000),
-      contradiction_content: contradictionContent.substring(0, 3000),
+      existing_content: page.text,
+      contradiction_content: record.text,
     });
 
     const finalPrompt = applySectionLabels(prompt, this.ctx.settings);
@@ -193,7 +208,10 @@ ${contradiction.source_page}
       ...(this.ctx.settings.disableThinking ? { enableThinking: false } : {}),
     });
 
-    const cleaned = cleanMarkdownResponse(fixedContent);
+    const cleaned = restoreWithheldSections(
+      cleanMarkdownResponse(fixedContent),
+      page.withheld,
+    );
     await this.ctx.createOrUpdateFile(pagePath, cleaned);
     console.debug('Contradiction resolved:', contradictionPath);
   }


### PR DESCRIPTION
Found while measuring stage 3 of #482. The payload question I went in with turned out to be
smaller than the defect sitting next to it.

## The defect

`ContradictionManager.resolveContradiction` (`src/wiki/contradictions.ts:174`) sends the
affected page as `existingContent.substring(0, 6000)`. Three facts on that path compose badly:

1. The prompt (`prompts/fixes.ts`, `resolveContradiction`) instructs the model to preserve every
   existing fact — "Do NOT delete any existing content" — and to "Output the complete repaired
   page content (not just the modified parts)".
2. The answer is written back over the page with `createOrUpdateFile(pagePath, cleaned)`.
3. Nothing on the path preserves what the model was not shown. There is no
   `preserveExistingSections` guard here.

So for a page above the budget the model never sees the tail, answers with what it believes is
the complete page, and the write replaces the original. The content is gone from disk, and the
run reports success. The output cap (`TOKENS_CONTRADICTION`, 4000 tokens) does not catch it —
the answer is not truncated, it is complete with respect to a truncated input.

The cut is also silent and not section-shaped: nothing in the prompt says content is missing,
so the model cannot account for it, and the boundary lands mid-sentence.

On the vault this was found on, 55 of 2,416 knowledge pages exceed 6,000 characters (2.3%);
the largest is 33,054, where four fifths of the page would be dropped.

Same family as #292 and #287, one path further along.

## The fix

`src/core/clamp-page-sections.ts`:

- clamps in whole `##` sections, dropping from the end, never mid-sentence;
- names the omitted sections in the prompt text, so the model knows what it is not being shown
  and does not try to reproduce it;
- returns the withheld blocks verbatim, so `restoreWithheldSections` can put them back after
  the rewrite;
- below the budget returns the input **byte for byte** — 97.7% of pages on that vault, so the
  ordinary path is untouched;
- treats a budget of `0` as no clamp, matching how the codebase reads an unset numeric limit
  elsewhere.

One case cannot be made safe: a page over budget with no `##` boundary to cut at. Nothing can be
withheld and restored, so the rewrite is refused with an error saying why, rather than writing
back a page the model was never shown. That is the `hardCut` flag on the result.

The contradiction record is clamped through the same helper. It is not written back, so only
the reading is at stake there.

## Not in this PR

The merge triage (`page-factory/merge-triage.ts`) passes `existing_content` uncapped. I measured
before touching it and left it alone: median page 1,424 characters, p90 2,695 — the payload does
not grow with the vault, and adding a bound there would change behaviour without a reason. The
helper is available if a bound is ever wanted; the numbers are in #482.

## Tests

3427 pass (238 files). New: 11 cases on the clamp itself — byte-identity below budget, whole-
section dropping, the marker, verbatim withheld blocks in document order, the no-boundary hard
cut, and that a short tail section is not kept after a longer one is dropped (which would
reorder the page as the model sees it). Plus 3 on the wiring: the prompt admits the omission and
excludes the tail, the file keeps the tail anyway, and the unclamped case reaches the model
unchanged.
