### PR TITLE
docs(notice): bring the DocTpoint attribution line up to v1.26.4

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,7 +9,22 @@ listed in alphabetical order by GitHub handle:
 - DocTpoint — ingest reliability fixes, #383 folder-boundary follow-up
   analysis, source-slug = page-lemma deterministic merge (PR #357, #348),
   vault-wide link retarget for `mergeDuplicates` (PR #392, #386),
-  and `created:` provenance fix (PR #396, #388)
+  `created:` provenance fix (PR #396, #388), headless-CLI request path on
+  `node:http` so a slow local model is not truncated (PR #418), H1
+  re-assertion after an LLM body rewrite and H1-by-position (PR #422, #437,
+  Issue #419, #435), the parse-failure result type that makes a broken
+  response distinguishable from an empty one (PR #436, #444, Issue #407),
+  order-independent resolution of ambiguous designators and the removal of
+  the alias latch on the ambiguous fallback (PR #471, #478, Issue #446),
+  runtime tag-vocabulary deferral in the empty-page lint prompt (PR #460,
+  Issue #459), run-scoped extraction catalog for prompt-cache stability
+  (PR #483, Issue #452), staged extraction payload so the ingest prompt is
+  a function of the note rather than of the vault (PR #484, Issue #482),
+  per-step output mode and thinking policy (PR #490, Issue #481),
+  restoration of the reasoning-only response guard dropped in the v1.23.0
+  AI-SDK migration (PR #488, Issue #470), section-shaped contradiction
+  clamp that restores withheld content (PR #492), and issue reports #403,
+  #407, #423, #424, #443, #446, #449, #452, #463, #470, #481, #482
 - eucher — headless ingest CLI implementation (PR #372,
   `feat(tools): headless ingest CLI for running the engine under Node`),
   CLI sampling/thinking controls, plugin source resolution,


### PR DESCRIPTION
Housekeeping on my own attribution line, plus a DCO point I owe you.

## NOTICE

The `DocTpoint` entry was last extended around PR #396 and stops there — everything merged since (the v1.26.1, v1.26.3 and v1.26.4 work) is missing from it. `NOTICE` is the one attribution surface Apache-2.0 §4(d) carries into redistributions and derivative works, so it seemed worth keeping current rather than leaving it to drift further.

Added in the mechanism-first form the neighbouring entries use: the headless-CLI `node:http` request path (#418), H1 re-assertion and H1-by-position (#422, #437), the parse-failure result type (#436, #444), order-independent ambiguous-designator resolution and the alias-latch removal (#471, #478), the runtime tag-vocabulary deferral (#460), the run-scoped extraction catalog (#483), the staged extraction payload (#484), per-step output mode and thinking policy (#490), the reasoning-only guard restoration (#488), the section-shaped contradiction clamp (#492), and the issue reports behind fixes shipped in those releases.

No other entry is touched, and nothing already in my line is removed or reworded. If the level of detail is more than you want in that file, say so and I will cut it down — the neighbouring entries set the precedent I followed, not a preference of mine.

## DCO — a gap on my side

`CONTRIBUTING.md` asks for a `Signed-off-by:` line on commits submitted via pull request. Checking my own history: of my 51 commits on `main`, 11 predate the policy (adopted 2026-07-03 in `9bdce00`) and are covered by the "not retroactively required" clause, 3 carry a sign-off, and **37 do not**. That is my oversight, not an ambiguity in the policy.

Both commits in this pair of PRs are signed off, and everything from here on will be. For the 37 already merged, rather than rewrite any history:

> I certify that all of my past contributions to this repository, including those merged without an explicit `Signed-off-by:` line, were and are submitted under the terms of the Developer Certificate of Origin v1.1 (https://developercertificate.org/), and I hereby sign off on them retroactively.
>
> Signed-off-by: DocTpoint <tatamis.gruppe_6k@icloud.com>

If you would rather have that recorded somewhere more durable than a PR description — a line in `CONTRIBUTING.md`, or a note in `NOTICE` — tell me where and I will put it there.
