### PR TITLE
fix(#472): a designator is (letters, type) — stop consulting the opposite folder

### DIFF
--- a/src/__tests__/core/ambiguous-designators.test.ts
+++ b/src/__tests__/core/ambiguous-designators.test.ts
@@ -177,18 +177,21 @@ describe('Issue #446 — ambiguous designators, same-type gate', () => {
   );
 });
 
-describe('Issue #446 — the same designators from the cross-type side', () => {
-  // When the extraction classifies DHA as a concept, the two entity pages that
-  // carry it are cross-type matches and no same-type match exists. Same
-  // ambiguity, other branch: it keeps returning a collision, but the collision
-  // target no longer depends on the page order.
-  it.each(DESIGNATORS)('$designator picks the same cross-type target under every order', (d) => {
+describe('Issue #472 — the same designators from the cross-type side', () => {
+  // Under #446 this was the other half of the same ambiguity: classify DHA as a
+  // concept and the two entity pages carrying it became cross-type matches to
+  // merge into. #472 retires that reading. A designator is `(letters, type)` —
+  // `CR` is chromium as an entity and caloric restriction as a concept — so
+  // pages in the opposite folder are not weaker candidates for this item, they
+  // are candidates for a different item. Nothing there is ambiguous, and
+  // nothing there is a merge target.
+  it.each(DESIGNATORS)('$designator ignores the opposite folder entirely', (d) => {
     const pages = pagesOf(d, otherTypeFolder(d));
     const forward = resolve(d, pages);
     const backward = resolve(d, [...pages].reverse());
 
-    expect(forward.action).toBe('merge');
-    expect(forward.reason).toContain('Cross-type');
+    expect(forward.action).toBe('create');
+    expect(forward.targetPath).toBe(`${WIKI}/${sameTypeFolder(d)}/${computeSlug(d.designator)}.md`);
     expect(backward.targetPath).toBe(forward.targetPath);
   });
 });

--- a/src/__tests__/core/conflict-resolver.test.ts
+++ b/src/__tests__/core/conflict-resolver.test.ts
@@ -28,28 +28,32 @@ describe('ConflictResolver', () => {
     expect(result.targetPath).toBe('wiki/entities/foo.md');
   });
 
+  // Issue #472: a designator is `(letters, type)`. The same letters under the
+  // other type denote a different thing — `CR` is chromium as an entity and
+  // caloric restriction as a concept — so the opposite folder is not a merge
+  // target and not a reason to withhold the page. This test's NAME said so
+  // before its body did.
   it('returns create when only opposite-type page exists (cross-type considered distinct)', () => {
     const r = new ConflictResolver(WIKI_FOLDER, pages(['concepts/foo.md']));
     const result = r.resolve({ name: 'Foo', slug: 'foo', pageType: 'entity' });
-    expect(result.action).toBe('merge');    // cross-type collision → merge into concept
-    expect(result.reason).toContain('Cross-type');
+    expect(result.action).toBe('create');
+    expect(result.targetPath).toBe('wiki/entities/foo.md');
   });
 
-  it('returns merge with correct target when cross-type match exists', () => {
+  it('creates in its own folder even when the opposite folder holds the designator', () => {
     const r = new ConflictResolver(WIKI_FOLDER, pages(['concepts/foo.md', 'entities/bar.md']));
     const result = r.resolve({ name: 'Foo', slug: 'foo', pageType: 'entity' });
-    expect(result.action).toBe('merge');
-    expect(result.targetPath).toBe('wiki/concepts/foo.md');
-    expect(result.existingType).toBe('concept');
+    expect(result.action).toBe('create');
+    expect(result.targetPath).toBe('wiki/entities/foo.md');
   });
 
-  it('matches by alias in same page', () => {
+  it('does not match an opposite-type page by alias', () => {
     const r = new ConflictResolver(WIKI_FOLDER, [
       { path: 'wiki/entities/llm.md', title: 'LLM', aliases: ['Large Language Model'] },
     ]);
     const result = r.resolve({ name: 'Large Language Model', slug: 'large-language-model', pageType: 'concept' });
-    expect(result.action).toBe('merge');
-    expect(result.reason).toContain('Cross-type');
+    expect(result.action).toBe('create');
+    expect(result.targetPath).toBe('wiki/concepts/large-language-model.md');
   });
 
   it('selects correct high-confidence for same-type match', () => {
@@ -59,11 +63,11 @@ describe('ConflictResolver', () => {
     expect(result.targetPath).toBe('wiki/entities/vigilanz.md');  // same-type preferred
   });
 
-  it('handles case-insensitive slug collisions', () => {
+  it('does not reach into entities/ for a concept of the same name', () => {
     const r = new ConflictResolver(WIKI_FOLDER, pages(['entities/chain-of-thought.md', 'entities/chain-of-thought.md']));
     const result = r.resolve({ name: 'chain of thought', slug: 'chain-of-thought', pageType: 'concept' });
-    expect(result.action).toBe('merge');
-    expect(result.reason).toContain('Cross-type');
+    expect(result.action).toBe('create');
+    expect(result.targetPath).toBe('wiki/concepts/chain-of-thought.md');
   });
 });
 

--- a/src/__tests__/core/i18n.test.ts
+++ b/src/__tests__/core/i18n.test.ts
@@ -17,9 +17,9 @@ describe('getText', () => {
   });
 
   it('performs single placeholder replacement', () => {
-    const result = getText('en', 'crossTypeCollisionNotice', { count: '3' });
+    const result = getText('en', 'lintReadingPages', { count: '3' });
     expect(result).toContain('3');
-    expect(result).toContain('merged');
+    expect(result).toContain('Wiki pages');
   });
 
   it('performs multiple placeholder replacements', () => {

--- a/src/__tests__/wiki/auto-maintain-trigger.test.ts
+++ b/src/__tests__/wiki/auto-maintain-trigger.test.ts
@@ -20,7 +20,6 @@ describe('IngestReport.trigger dispatch (v1.22.6 #204)', () => {
       entitiesCreated: 0,
       conceptsCreated: 0,
       failedItems: [],
-      collisions: [],
       contradictionsFound: 0,
       success: true,
     };
@@ -35,7 +34,6 @@ describe('IngestReport.trigger dispatch (v1.22.6 #204)', () => {
       entitiesCreated: 0,
       conceptsCreated: 1,
       failedItems: [],
-      collisions: [],
       contradictionsFound: 0,
       success: true,
       trigger: 'auto',
@@ -51,7 +49,6 @@ describe('IngestReport.trigger dispatch (v1.22.6 #204)', () => {
       entitiesCreated: 1,
       conceptsCreated: 0,
       failedItems: [],
-      collisions: [],
       contradictionsFound: 0,
       success: true,
       trigger: 'manual',
@@ -88,7 +85,6 @@ function baseReport(): IngestReport {
     entitiesCreated: 0,
     conceptsCreated: 0,
     failedItems: [],
-    collisions: [],
     contradictionsFound: 0,
     success: true,
   };

--- a/src/__tests__/wiki/engine-internals/page-batch-runner.test.ts
+++ b/src/__tests__/wiki/engine-internals/page-batch-runner.test.ts
@@ -42,7 +42,6 @@ describe('runBatchedWithRetry', () => {
 
     expect(result.succeeded).toBe(3);
     expect(result.failed).toEqual([]);
-    expect(result.collisions).toEqual([]);
     expect(result.rateLimitInfo).toBeNull();
     // 1 task × 3 = 3 first-attempt calls, 0 retries
     expect(execute).toHaveBeenCalledTimes(3);
@@ -103,31 +102,6 @@ describe('runBatchedWithRetry', () => {
     expect(execute).toHaveBeenCalledTimes(2); // first throw + retry throw
   });
 
-  it('propagates collision from successful task result', async () => {
-    const tasks = [task('e1', { collision: true })];
-    const execute = vi.fn().mockResolvedValue({
-      success: true as const,
-      collision: {
-        name: 'e1',
-        sourceType: 'entity' as const,
-        targetType: 'concept' as const,
-        targetPath: 'concepts/e1.md',
-      },
-    });
-
-    const result = await runBatchedWithRetry({
-      tasks,
-      concurrency: 1,
-      batchDelayMs: 0,
-      checkCancelled: () => {},
-      apiDelay: vi.fn().mockResolvedValue(undefined),
-      execute,
-    });
-
-    expect(result.succeeded).toBe(1);
-    expect(result.collisions).toHaveLength(1);
-    expect(result.collisions[0].targetPath).toBe('concepts/e1.md');
-  });
 
   it('detects rate-limit failures across multiple failed tasks', async () => {
     const tasks = [

--- a/src/__tests__/wiki/page-factory-core.test.ts
+++ b/src/__tests__/wiki/page-factory-core.test.ts
@@ -110,7 +110,9 @@ describe('PageFactory — Core Paths', () => {
       expect(result.path).toBe('wiki/entities/unique-entity.md');
     });
 
-    it('detects cross-type collision and returns collision info', async () => {
+    // Issue #472: a concept of the same name is a different designator, so it
+    // is not a target and not an obstacle — the entity gets its own page.
+    it('ignores a same-name page in the opposite folder', async () => {
       const { ctx } = createMockContext({
         vaultFiles: {
           'wiki/concepts/shared-name.md': '---\ntype: concept\n---\n# Shared Name\nContent',
@@ -119,17 +121,10 @@ describe('PageFactory — Core Paths', () => {
       });
       const factory = new PageFactory(ctx);
 
-      const result = await (factory as unknown as { resolvePagePath: (n: string, t: 'entity' | 'concept', s: string) => Promise<{ path: string | null; collision?: unknown }> })
+      const result = await (factory as unknown as { resolvePagePath: (n: string, t: 'entity' | 'concept', s: string) => Promise<{ path: string | null }> })
         .resolvePagePath('Shared Name', 'entity', 'An entity with shared name');
 
-      expect(result.path).toBeNull();
-      expect(result.collision).toBeDefined();
-      expect(result.collision).toMatchObject({
-        name: 'Shared Name',
-        sourceType: 'entity',
-        targetType: 'concept',
-        targetPath: 'wiki/concepts/shared-name.md',
-      });
+      expect(result.path).toBe('wiki/entities/shared-name.md');
     });
   });
 
@@ -214,7 +209,7 @@ describe('PageFactory — Core Paths', () => {
       expect(content).toContain('Fresh content');
     });
 
-    it('handles cross-type collision by merging into target', async () => {
+    it('writes its own page instead of merging into the opposite folder', async () => {
       const { ctx, vault } = createMockContext({
         vaultFiles: {
           'wiki/concepts/collision.md': '---\ntype: concept\n---\n# Collision\nConcept content',
@@ -238,9 +233,11 @@ describe('PageFactory — Core Paths', () => {
         []
       );
 
-      // Should merge into the concept page
-      const content = vault.read('wiki/concepts/collision.md');
-      expect(content).toContain('Merged entity content into concept');
+      // Issue #472: the concept page keeps its content untouched; the entity
+      // is written to its own folder.
+      const concept = vault.read('wiki/concepts/collision.md');
+      expect(concept).not.toContain('Merged entity content into concept');
+      expect(vault.read('wiki/entities/collision.md')).toBeTruthy();
     });
   });
 

--- a/src/__tests__/wiki/page-factory/create-page.test.ts
+++ b/src/__tests__/wiki/page-factory/create-page.test.ts
@@ -66,7 +66,6 @@ describe('createOrUpdatePage — empty name guard', () => {
       { path: 'p.md', basename: 'p.md' },
     );
     expect(result.path).toBeNull();
-    expect(result.collision).toBeUndefined();
   });
 });
 

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -59,32 +59,26 @@ describe('resolvePagePath — exact-slug fast path', () => {
     // slugCase='preserve' keeps the original case in the slug.
     const result = await resolvePagePath(ctx, 'Karpathy', 'entity', 'summary');
     expect(result.path).toBe('wiki/entities/Karpathy.md');
-    expect(result.collision).toBeUndefined();
   });
 
-  it('appends an alias when a cross-type duplicate (concepts/ + entities/) exists', async () => {
-    // Both folders have a page with slug "Karpathy" → fast-path's existing
-    // check hits AND the other-folder cross-type check also hits, triggering
-    // appendAliases on the OPPOSITE folder.
+  it('leaves the opposite-folder page untouched when both folders hold the slug', async () => {
+    // Issue #472: the fast path used to probe the opposite folder and, on a
+    // hit, write the extracted name onto that page as an alias — "bridging"
+    // the two. A multi-word name survives `filterRedundantAliases` (which
+    // compares against the basename, not the slug), so the write was real: it
+    // put this name into the other type's namespace, after which the two pages
+    // matched each other on every later ingest. The opposite page is now
+    // neither read nor written.
+    const conceptBefore = '---\ntitle: Deep-Learning\n---\n\n# concepts/';
     const ctx = makeCtx({
       files: {
-        'wiki/concepts/Karpathy.md': '---\ntitle: Karpathy\n---\n\n# concepts/',
-        'wiki/entities/Karpathy.md': '---\ntitle: Karpathy\n---\n\n# entity',
+        'wiki/concepts/Deep-Learning.md': conceptBefore,
+        'wiki/entities/Deep-Learning.md': '---\ntitle: Deep-Learning\n---\n\n# entity',
       },
     });
-    // Name "Karpathy" slugifies to "Karpathy" (preserve case) → existing
-    // slugPath check returns non-null → cross-type branch → appendAliases
-    // is called with [name="Karpathy"]. But filterRedundantAliases drops
-    // "Karpathy" because it equals the basename case-insensitively, so the
-    // alias no-ops. We use a distinct alias string via the slug-mismatch
-    // route: name "KarpathyAlias" but pre-existing slugPath must still hit.
-    // Easier: pre-create the alias-matching page directly via the LLM
-    // fallback path. We test that branch separately; here we assert the
-    // no-op behavior for the canonical "same name" cross-type case.
-    const result = await resolvePagePath(ctx, 'Karpathy', 'entity', 'summary');
-    // slugPath exists → fast-path returns it; the cross-type alias was a
-    // no-op because name === basename (case-insensitive).
-    expect(result.path).toBe('wiki/entities/Karpathy.md');
+    const result = await resolvePagePath(ctx, 'Deep Learning', 'entity', 'summary');
+    expect(result.path).toBe('wiki/entities/Deep-Learning.md');
+    expect(ctx.written.get('wiki/concepts/Deep-Learning.md')).toBe(conceptBefore);
   });
 });
 
@@ -297,21 +291,14 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
   });
 });
 
-describe('resolvePagePath — collision shape (cross-type)', () => {
-  it('returns path=null + collision when ConflictResolver flags Cross-type', async () => {
+describe('resolvePagePath — the opposite type is a different designator (#472)', () => {
+  it('creates in its own folder when only the opposite folder holds the name', async () => {
     const ctx = makeCtx({
       files: {
         'wiki/concepts/Cross.md': '# concept exists',
       },
     });
     const result = await resolvePagePath(ctx, 'Cross', 'entity', 'desc');
-    if (result.collision) {
-      expect(result.path).toBeNull();
-      expect(result.collision.sourceType).toBe('entity');
-      expect(result.collision.targetType).toBe('concept');
-      expect(result.collision.targetPath).toBe('wiki/concepts/Cross.md');
-    }
-    // Either way, the result should be a slug OR a collision — never both.
-    expect(result.path === null || result.collision === undefined).toBe(true);
+    expect(result.path).toBe('wiki/entities/Cross.md');
   });
 });

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -37,9 +37,6 @@ export type ConflictAction = 'create' | 'merge' | 'flag' | 'disambiguate';
 export interface ConflictResolution {
   action: ConflictAction;
   targetPath: string;           // path to create or existing page to merge into
-  existingPath?: string;        // only when action is 'merge' or 'flag'
-  existingType?: PageType;      // type of the existing page (for cross-type collisions)
-  aliasToAdd?: string | null;   // alias to add (null = redundant with title/filename)
   confidence: 'high' | 'medium' | 'low';
   reason: string;
   /**
@@ -55,10 +52,6 @@ export interface ConflictResolution {
 
 function folderOf(pageType: PageType): string {
   return pageType === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
-}
-
-function oppositeFolder(pageType: PageType): string {
-  return pageType === 'entity' ? WIKI_SUBFOLDERS.concepts : WIKI_SUBFOLDERS.entities;
 }
 
 /** Return the slug-match key for a page: its title's slug + its alias slugs. */
@@ -114,14 +107,11 @@ export class ConflictResolver {
    * 2. Same-type slug/alias match on exactly one page → merge into that page
    * 3. Same-type slug/alias match on more than one page → 'disambiguate'
    *    with `candidates` ranked by tag overlap (Issue #446)
-   * 4. Cross-type slug/alias match → merge into opposite-folder page
-   * 5. No match → create new page
+   * 4. No match → create new page
    */
   resolve(check: ConflictCheck): ConflictResolution {
     const folder = folderOf(check.pageType);
-    const otherFolder = oppositeFolder(check.pageType);
     const sameTypePages = this.allPages.filter(p => p.path.includes(`/${folder}/`));
-    const otherTypePages = this.allPages.filter(p => p.path.includes(`/${otherFolder}/`));
     const checkKey = check.slug.toLowerCase();
 
     // 1. Same-type match: exact path match or slug/alias match
@@ -161,34 +151,7 @@ export class ConflictResolver {
       };
     }
 
-    // 2. Cross-type match: exists in opposite folder
-    //
-    // Issue #446: the same designators collide here, only from the other side —
-    // when the extraction classifies `DHA` as a concept, the two entity pages
-    // that carry it are cross-type matches and there are no same-type ones. The
-    // ambiguity is identical; only the contract differs, because this branch
-    // reports a collision the caller merges into rather than a path it writes.
-    // Ranking the matches keeps that contract and drops the dependency on list
-    // order. Routing a cross-type ambiguity to the semantic dedup would be the
-    // fuller answer, but that call is same-type by construction and gets its
-    // own design.
-    const otherExactPath = `${this.wikiFolder}/${otherFolder}/${check.slug}.md`;
-    const crossMatches = otherTypePages.filter(p => p.path === otherExactPath || slugMatchKeys(p).has(checkKey));
-    if (crossMatches.length > 0) {
-      const [best] = rankByTagOverlap(crossMatches, check.tags);
-      return {
-        action: 'merge',
-        targetPath: best.path,
-        existingPath: best.path,
-        existingType: otherFolder === WIKI_SUBFOLDERS.entities ? 'entity' : 'concept',
-        aliasToAdd: check.name !== best.title ? check.name : null,
-        confidence: crossMatches.length > 1 ? 'medium' : 'high',
-        reason: `Cross-type collision: ${check.pageType} "${check.name}" → ${best.path}`
-          + (crossMatches.length > 1 ? ` (${crossMatches.length} candidates, ranked)` : ''),
-      };
-    }
-
-    // 3. No match — create new
+    // 2. No match — create new
     return {
       action: 'create',
       targetPath: `${this.wikiFolder}/${folder}/${check.slug}.md`,

--- a/src/main-commands/ingest-commands.ts
+++ b/src/main-commands/ingest-commands.ts
@@ -275,7 +275,6 @@ export const ingestCommands = {
       const totalContradictions = reports.reduce((sum, r) => sum + r.contradictionsFound, 0);
       const totalElapsed = reports.reduce((sum, r) => sum + (r.elapsedSeconds || 0), 0);
       const allFailedItems = reports.flatMap(r => r.failedItems);
-      const allCollisions = reports.flatMap(r => r.collisions || []);
       const allRejectedFiles = reports.flatMap(r => r.rejectedFiles || []);
       const allSuccess = reports.every(r => r.success);
 
@@ -286,7 +285,6 @@ export const ingestCommands = {
         entitiesCreated: totalEntities,
         conceptsCreated: totalConcepts,
         failedItems: allFailedItems,
-        collisions: allCollisions,
         contradictionsFound: totalContradictions,
         success: allSuccess,
         elapsedSeconds: totalElapsed,

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -494,7 +494,6 @@ export const DE_TEXTS = {
     // möglicherweise noch.
     llmRetryRecoveredToast: 'LLM-Aufgabe: {count} Batch(es) wurden wegen einer vorübergehenden Provider-Antwort wiederholt. Details in der Konsole. Falls dies häufiger auftritt, reduziere die Page Generation Concurrency in den Provider-Einstellungen.',
     ingestReportFailedGuidance: 'Diese Elemente konnten nicht automatisch erstellt werden. Du kannst die entsprechenden Seiten manuell erstellen oder die Extraktions-Granularität senken und die Quelldatei erneut aufnehmen.',
-    ingestReportCollisions: 'Cross-Type-Kollisionen (als Aliase zusammengeführt)',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: 'Einzelne Quelle aufnehmen',
@@ -535,7 +534,6 @@ export const DE_TEXTS = {
     lintStageContradiction: 'Widersprüche werden erkannt',
     ingestionCancelling: 'Wird abgebrochen — Stopp nach aktuellem Batch',
     ingestionCancelled: 'Aufnahme abgebrochen',
-    crossTypeCollisionNotice: '{count} Einträge als Cross-Type-Alias zusammengeführt (Entity ↔ Concept Duplikate verhindert)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'Analyse Batch 1/{total}...',
     ingestBatchProgress: 'Analyse Batch {current}/{total} ({entities} Entitäten, {concepts} Konzepte bisher)...',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -490,7 +490,6 @@ export const EN_TEXTS = {
     rejectionReasonType: 'unsupported type',
     rejectionReasonDuplicate: 'duplicate content',
     ingestReportFailedGuidance: 'These items could not be automatically created. You can manually create the corresponding pages, or lower the extraction granularity and re-ingest the source file.',
-    ingestReportCollisions: 'Cross-type collisions (merged as aliases)',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: 'Ingest single source',
@@ -544,7 +543,6 @@ export const EN_TEXTS = {
     lintStageContradiction: 'Detecting contradictions',
     ingestionCancelling: 'Cancelling — will stop after current batch completes',
     ingestionCancelled: 'Ingestion cancelled',
-    crossTypeCollisionNotice: '{count} items merged as cross-type aliases (entity ↔ concept duplicates prevented)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n.
     // These were previously hardcoded English strings in wiki-engine.ts,
     // conversation-ingest.ts, and source-analyzer.ts, causing mixed-language

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -493,7 +493,6 @@ export const ES_TEXTS = {
     // el reintento solo recupera este lote.
     llmRetryRecoveredToast: 'Tarea LLM: {count} lote(s) requirieron reintento por una respuesta transitoria del proveedor. Consulta la consola para más detalles. Si esto se repite, reduce Page Generation Concurrency en la configuración del proveedor.',
     ingestReportFailedGuidance: 'Estos elementos no pudieron crearse automáticamente. Puedes crear manualmente las páginas correspondientes, o reducir la granularidad de extracción y volver a ingerir el archivo fuente.',
-    ingestReportCollisions: 'Colisiones cross-type (fusionadas como alias)',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: 'Ingestar fuente individual',
@@ -534,7 +533,6 @@ export const ES_TEXTS = {
     lintStageContradiction: 'Detectando contradicciones',
     ingestionCancelling: 'Cancelando — se detendrá tras el lote actual',
     ingestionCancelled: 'Ingesta cancelada',
-    crossTypeCollisionNotice: '{count} elementos fusionados como alias cross-type (duplicados entidad ↔ concepto evitados)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'Analizando lote 1/{total}...',
     ingestBatchProgress: 'Analizando lote {current}/{total} ({entities} entidades, {concepts} conceptos hasta ahora)...',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -468,7 +468,6 @@ export const FR_TEXTS = {
     rejectionReasonType: 'type non pris en charge',
     rejectionReasonDuplicate: 'contenu en double',
     ingestReportFailedGuidance: "Ces éléments n'ont pas pu être créés automatiquement. Vous pouvez créer manuellement les pages correspondantes, ou réduire la granularité d'extraction et réimporter le fichier source.",
-    ingestReportCollisions: 'Collisions cross-type (fusionnées comme alias)',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: 'Importer une source unique',
@@ -509,7 +508,6 @@ export const FR_TEXTS = {
     lintStageContradiction: 'Détection des contradictions',
     ingestionCancelling: 'Annulation — arrêt après le lot en cours',
     ingestionCancelled: 'Ingestion annulée',
-    crossTypeCollisionNotice: '{count} éléments fusionnés comme alias cross-type (doublons entité ↔ concept évités)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'Analyse du lot 1/{total}...',
     ingestBatchProgress: 'Analyse du lot {current}/{total} ({entities} entités, {concepts} concepts jusqu\'à présent)...',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -502,7 +502,6 @@ export const IT_TEXTS = {
     // completato" — il retry recupera solo questo batch.
     llmRetryRecoveredToast: 'Attività LLM: {count} batch hanno richiesto un nuovo tentativo a causa di una risposta transitoria del provider. Vedi la console per i dettagli. Se questo si ripete, riduci Page Generation Concurrency nelle impostazioni del provider.',
     ingestReportFailedGuidance: 'Questi elementi non sono stati creati automaticamente. Puoi creare manualmente le pagine corrispondenti, oppure abbassare la granularità di estrazione e ri-acquisire il file sorgente.',
-    ingestReportCollisions: 'Collisioni inter-tipo (unite come alias)',
 
     // Nomi Comandi (sentence case secondo la regola 1 dell'Obsidian Bot)
     cmdIngestSource: 'Acquisisci singola sorgente',
@@ -543,7 +542,6 @@ export const IT_TEXTS = {
     lintStageContradiction: 'Rilevamento delle contraddizioni',
     ingestionCancelling: 'Annullamento — si fermerà al completamento del batch corrente',
     ingestionCancelled: 'Acquisizione annullata',
-    crossTypeCollisionNotice: '{count} elementi uniti come alias inter-tipo (duplicati entità ↔ concetto prevenuti)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'Analisi batch 1/{total}...',
     ingestBatchProgress: 'Analisi batch {current}/{total} ({entities} entità, {concepts} concetti finora)...',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -465,7 +465,6 @@ export const JA_TEXTS = {
     rejectionReasonType: '非対応の形式',
     rejectionReasonDuplicate: '重複コンテンツ',
     ingestReportFailedGuidance: 'これらの項目は自動作成できませんでした。対応するページを手動で作成するか、抽出粒度を下げてソースファイルを再取り込みしてください。',
-    ingestReportCollisions: 'クロスタイプ衝突（エイリアスとして統合）',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: '単一ソースの取り込み',
@@ -506,7 +505,6 @@ export const JA_TEXTS = {
     lintStageContradiction: '矛盾を検出中',
     ingestionCancelling: 'キャンセル中 — 現在のバッチ完了後に停止します',
     ingestionCancelled: '取り込みがキャンセルされました',
-    crossTypeCollisionNotice: '{count}件がクロスタイプ別名として統合（エンティティ ↔ コンセプト重複を防止）',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'バッチ 1/{total} を分析中...',
     ingestBatchProgress: 'バッチ {current}/{total} を分析中（エンティティ {entities}、コンセプト {concepts} まで）...',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -493,7 +493,6 @@ export const KO_TEXTS = {
     // 복구합니다.
     llmRetryRecoveredToast: 'LLM 작업: {count}개 배치가 provider의 일시적 응답 문제로 재시도가 필요했습니다 (자동 복구됨). 자세한 내용은 콘솔을 참조하세요. 반복되면 Provider 설정에서 Page Generation Concurrency를 낮추세요.',
     ingestReportFailedGuidance: '이 항목은 자동으로 생성되지 않았습니다. 해당하는 페이지를 수동으로 생성하거나 추출 세분화를 낮추고 소스 파일을 다시 수집할 수 있습니다.',
-    ingestReportCollisions: '크로스타입 충돌 (별칭으로 병합됨)',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: '단일 소스 수집',
@@ -539,7 +538,6 @@ export const KO_TEXTS = {
     lintStageContradiction: '모순 감지 중',
     ingestionCancelling: '취소 중 — 현재 배치 완료 후 중지됩니다',
     ingestionCancelled: '수집이 취소되었습니다',
-    crossTypeCollisionNotice: '{count}개 항목이 크로스타입 별칭으로 병합됨（엔티티 ↔ 컨셉 중복 방지）',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: '배치 1/{total} 분석 중...',
     ingestBatchProgress: '배치 {current}/{total} 분석 중（엔티티 {entities}개, 컨셉 {concepts}개까지）...',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -493,7 +493,6 @@ export const PT_TEXTS = {
     // "Lint concluído" — a nova tentativa recupera apenas este lote.
     llmRetryRecoveredToast: 'Tarefa LLM: {count} lote(s) precisaram de nova tentativa devido a uma resposta transitória do provedor. Veja o console para detalhes. Se isso se repetir, reduza Page Generation Concurrency nas configurações do provedor.',
     ingestReportFailedGuidance: 'Estes itens não puderam ser criados automaticamente. Você pode criar as páginas manualmente ou reduzir a granularidade da extração e reingerir o arquivo fonte.',
-    ingestReportCollisions: 'Colisões cross-type (fundidas como alias)',
 
     // Command Names (sentence case per Obsidian Bot rule 1)
     cmdIngestSource: 'Ingerir fonte individual',
@@ -534,7 +533,6 @@ export const PT_TEXTS = {
     lintStageContradiction: 'Detectando contradições',
     ingestionCancelling: 'Cancelando — irá parar após o lote atual',
     ingestionCancelled: 'Ingestão cancelada',
-    crossTypeCollisionNotice: '{count} elementos fundidos como alias cross-type (duplicatas entidade ↔ conceito evitadas)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'Analisando lote 1/{total}...',
     ingestBatchProgress: 'Analisando lote {current}/{total} ({entities} entidades, {concepts} conceitos até agora)...',

--- a/src/texts/ru.ts
+++ b/src/texts/ru.ts
@@ -493,7 +493,6 @@ export const RU_TEXTS = {
     rejectionReasonType: 'неподдерживаемый тип',
     rejectionReasonDuplicate: 'дублирующееся содержимое',
     ingestReportFailedGuidance: 'Эти элементы не удалось создать автоматически. Вы можете вручную создать соответствующие страницы или снизить гранулярность извлечения и повторно импортировать исходный файл.',
-    ingestReportCollisions: 'Межтиповые коллизии (объединены как псевдонимы)',
 
     // Имена команд (предложный регистр по правилу 1 Obsidian Bot)
     cmdIngestSource: 'Импорт одного источника',
@@ -539,7 +538,6 @@ export const RU_TEXTS = {
     lintStageContradiction: 'Обнаружение противоречий',
     ingestionCancelling: 'Отмена — остановится после завершения текущего пакета',
     ingestionCancelled: 'Импорт отменён',
-    crossTypeCollisionNotice: '{count} элементов объединены как межтиповые псевдонимы (дубликаты entity ↔ concept предотвращены)',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: 'Анализ партии 1/{total}...',
     ingestBatchProgress: 'Анализ партии {current}/{total} ({entities} сущностей, {concepts} концепций пока)...',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -465,7 +465,6 @@ export const ZH_HANT_TEXTS = {
     rejectionReasonType: '不支援的型別',
     rejectionReasonDuplicate: '重複內容',
     ingestReportFailedGuidance: '這些條目未能自動建立。您可手動建立對應頁面，或降低提取顆粒度後重新攝入原始檔。',
-    ingestReportCollisions: '跨型別碰撞（已合併為別名）',
 
     // 命令名称（sentence case 遵循 Obsidian Bot 规则）
     cmdIngestSource: '攝入單個原始檔',
@@ -506,7 +505,6 @@ export const ZH_HANT_TEXTS = {
     lintStageContradiction: '正在偵測衝突',
     ingestionCancelling: '正在取消 — 當前批次完成後將停止',
     ingestionCancelled: '提取已取消',
-    crossTypeCollisionNotice: '{count} 個條目合併為跨型別別名（實體 ↔ 概念重複已防止）',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: '正在分析批次 1/{total}...',
     ingestBatchProgress: '正在分析批次 {current}/{total}（已提取 {entities} 個實體、{concepts} 個概念）...',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -467,7 +467,6 @@ export const ZH_TEXTS = {
     rejectionReasonType: '不支持的类型',
     rejectionReasonDuplicate: '重复内容',
     ingestReportFailedGuidance: '这些条目未能自动创建。您可手动创建对应页面，或降低提取颗粒度后重新摄入源文件。',
-    ingestReportCollisions: '跨类型碰撞（已合并为别名）',
 
     // 命令名称（sentence case 遵循 Obsidian Bot 规则）
     cmdIngestSource: '摄入单个源文件',
@@ -513,7 +512,6 @@ export const ZH_TEXTS = {
     lintStageContradiction: '正在检测矛盾',
     ingestionCancelling: '正在取消 — 当前批次完成后将停止',
     ingestionCancelled: '提取已取消',
-    crossTypeCollisionNotice: '{count} 个条目合并为跨类型别名（实体 ↔ 概念重复已防止）',
     // v1.26.3 PATCH follow-up (B2.5): status-bar progress text i18n
     ingestBatchInitial: '正在分析批次 1/{total}...',
     ingestBatchProgress: '正在分析批次 {current}/{total}（已提取 {entities} 个实体、{concepts} 个概念）...',

--- a/src/types.ts
+++ b/src/types.ts
@@ -541,7 +541,7 @@ export interface SchemaSuggestion {
 
 // Ingestion report passed to onDone callback
 
-// Result of page creation/update, with optional collision info
+// Result of page creation/update
 export interface PageCreationResult {
   path: string | null;
   /**
@@ -554,12 +554,6 @@ export interface PageCreationResult {
    * not be reported as creations.
    */
   created: boolean;
-  collision?: {
-    name: string;
-    sourceType: 'entity' | 'concept';
-    targetType: 'entity' | 'concept';
-    targetPath: string;
-  };
 }
 
 export interface IngestReport {
@@ -569,7 +563,6 @@ export interface IngestReport {
   entitiesCreated: number;
   conceptsCreated: number;
   failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }>;
-  collisions: Array<{ name: string; sourceType: 'entity' | 'concept'; targetType: 'entity' | 'concept'; targetPath: string }>;
   contradictionsFound: number;
   success: boolean;
   errorMessage?: string;

--- a/src/ui/modals/IngestReportModal-class.ts
+++ b/src/ui/modals/IngestReportModal-class.ts
@@ -7,11 +7,10 @@
 //   3. Skipped files (batch ingest only)
 //   4. Elapsed time
 //   5. Stats (created / updated / contradictions)
-//   6. Collisions (if any)
-//   7. Created / updated / failed page lists
-//   8. Rejected / skipped files (requirements gate, #164)
-//   9. Error message (if any)
-//   10. Close button
+//   6. Created / updated / failed page lists
+//   7. Rejected / skipped files (requirements gate, #164)
+//   8. Error message (if any)
+//   9. Close button
 //
 // Extracted from the original `src/ui/modals.ts` god file (PR split).
 // No behavior change — pure code movement.
@@ -44,7 +43,7 @@ export class IngestReportModal extends Modal {
   }
 
   onOpen() {
-    const { sourceFile, createdPages, updatedPages, entitiesCreated, conceptsCreated, failedItems, contradictionsFound, success, errorMessage, collisions, elapsedSeconds, skippedFiles, totalFilesInFolder, rejectedFiles } = this.report;
+    const { sourceFile, createdPages, updatedPages, entitiesCreated, conceptsCreated, failedItems, contradictionsFound, success, errorMessage, elapsedSeconds, skippedFiles, totalFilesInFolder, rejectedFiles } = this.report;
 
     const statusEmoji = success ? '✅' : '⚠️';
     this.contentEl.createEl('h2', { text: `${statusEmoji} ${this.t('ingestReportTitle')}` });
@@ -80,17 +79,6 @@ export class IngestReportModal extends Modal {
     statsEl.createEl('p', { text: this.t('ingestReportUpdatedPages').replace('{count}', String(updatedPages.length)) });
     if (contradictionsFound > 0) {
       statsEl.createEl('p', { text: this.t('ingestReportContradictionsFound').replace('{count}', String(contradictionsFound)) });
-    }
-
-    // Collisions
-    if (collisions && collisions.length > 0) {
-      this.contentEl.createEl('h3', { text: '🔀 ' + this.t('ingestReportCollisions') + ` (${collisions.length})` });
-      const list = this.contentEl.createEl('ul');
-      for (const c of collisions) {
-        const sourceTypeLabel = c.sourceType === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
-        const targetTypeLabel = c.targetType === 'entity' ? this.t('ingestReportEntityType') : this.t('ingestReportConceptType');
-        list.createEl('li', { text: `"${c.name}" (${sourceTypeLabel}) → ${targetTypeLabel}` });
-      }
     }
 
     // Created pages

--- a/src/wiki/conversation-ingest.ts
+++ b/src/wiki/conversation-ingest.ts
@@ -94,7 +94,6 @@ export class ConversationIngestor {
             entitiesCreated: 0,
             conceptsCreated: 0,
             failedItems: [],
-            collisions: [],
             contradictionsFound: 0,
             success: true,
             errorMessage: 'Knowledge already exists in Wiki',
@@ -257,7 +256,6 @@ CRITICAL RULES:
     parsed.created_pages.push(summaryPath);
 
     const failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }> = [];
-    const collisions: Array<{ name: string; sourceType: 'entity' | 'concept'; targetType: 'entity' | 'concept'; targetPath: string }> = [];
 
     for (const entity of parsed.entities) {
       await this.orch.apiDelay();
@@ -269,9 +267,6 @@ CRITICAL RULES:
         if (entityResult.path) {
           (entityResult.created ? parsed.created_pages : parsed.updated_pages)
             .push(entityResult.path);
-        }
-        if (entityResult.collision) {
-          collisions.push(entityResult.collision);
         }
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
@@ -290,9 +285,6 @@ CRITICAL RULES:
         if (conceptResult.path) {
           (conceptResult.created ? parsed.created_pages : parsed.updated_pages)
             .push(conceptResult.path);
-        }
-        if (conceptResult.collision) {
-          collisions.push(conceptResult.collision);
         }
       } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
@@ -316,7 +308,6 @@ CRITICAL RULES:
       entitiesCreated,
       conceptsCreated,
       failedItems,
-      collisions,
       contradictionsFound: parsed.contradictions?.length || 0,
       success: true,
       elapsedSeconds: Math.round((Date.now() - startTime) / 1000),

--- a/src/wiki/engine-internals/page-batch-runner.ts
+++ b/src/wiki/engine-internals/page-batch-runner.ts
@@ -8,7 +8,7 @@
  *   1. Slice tasks into concurrency-sized batches
  *   2. allSettled each batch
  *   3. For each failure, retry once after a 2s delay
- *   4. Aggregate collisions + failures
+ *   4. Aggregate failures
  *   5. detectRateLimitFailures across failures
  *   6. Sleep `batchDelayMs` between batches
  *   7. checkCancelled before each batch (abort-aware)
@@ -23,34 +23,20 @@ import { detectRateLimitFailures, type RateLimitInfo } from '../../core/rate-lim
 import { DEFAULT_API_RETRY_DELAY_MS } from '../../constants';
 
 /**
- * Collision data attached to a successful task result. Carried through the
- * pipeline so the caller can record collisions in the analysis report without
- * re-running the task.
- */
-export interface Collision {
-  name: string;
-  sourceType: 'entity' | 'concept';
-  targetType: 'entity' | 'concept';
-  targetPath: string;
-}
-
-/**
  * Result returned by the per-task `execute` callback. Discriminated by
  * `success` so TypeScript can narrow without casts at the call site.
  *
- *   - `success: true` — task ran without error; `collision` may still be set
- *     when an entity/concept resolved to an existing page with a different
- *     type ("Entity-vs-Concept collision" — the LLM and the wiki disagreed).
+ *   - `success: true` — task ran without error.
  *   - `success: false` — task failed; `failureReason` carries the error
  *     message used for retry + rate-limit detection.
  */
 export type TaskResult =
-  | { success: true; collision?: Collision }
+  | { success: true }
   | { success: false; failureReason: string };
 
 /**
  * A single unit of work for the batch runner. `id` is used in progress
- * messages, console output, and collision/failure records. `payload` is the
+ * messages, console output, and failure records. `payload` is the
  * opaque data the caller's `execute` callback consumes.
  *
  * Generic parameter `T` lets each call site carry its own payload type
@@ -90,15 +76,13 @@ export interface BatchRunnerOptions<T> {
 
 /**
  * Aggregate result from a batch run. Caller (WikiEngine) merges these into
- * its own analysis state (collisions / failedItems / created_pages).
+ * its own analysis state (failedItems / created_pages).
  */
 export interface BatchRunnerResult {
   /** Number of tasks that completed with `success: true` (first attempt OR successful retry). */
   succeeded: number;
   /** Tasks that failed even after the retry. */
   failed: Array<{ id: string; reason: string }>;
-  /** Collisions collected from successful tasks. */
-  collisions: Collision[];
   /** Rate-limit signal: null if no 429s detected. */
   rateLimitInfo: RateLimitInfo | null;
   /** Total wall time of the batch run in milliseconds. */
@@ -114,7 +98,7 @@ export interface BatchRunnerResult {
  *   - Slice `tasks` into `concurrency`-sized batches in order
  *   - For each batch:
  *     1. checkCancelled() — throws if user cancelled
- *     2. allSettled each task; capture collisions + failures
+ *     2. allSettled each task; capture failures
  *     3. For each failure, sleep `apiDelayMs` (default 2000ms) and retry once
  *     4. Sleep `batchDelayMs` before next batch (skip on last)
  *   - Detect rate-limit failures across all failures → return RateLimitInfo
@@ -131,7 +115,6 @@ export async function runBatchedWithRetry<T>(
   const startTime = Date.now();
   const succeeded: string[] = [];
   const failed: Array<{ id: string; reason: string }> = [];
-  const collisions: Collision[] = [];
 
   for (let i = 0; i < opts.tasks.length; i += opts.concurrency) {
     opts.checkCancelled();
@@ -140,7 +123,6 @@ export async function runBatchedWithRetry<T>(
     // First-attempt run.
     const firstAttempt = await runBatch(batch, opts);
     for (const id of firstAttempt.succeeded) succeeded.push(id);
-    collisions.push(...firstAttempt.collisions);
     const retryQueue = firstAttempt.retryQueue;
 
     // Single retry for failures.
@@ -151,7 +133,6 @@ export async function runBatchedWithRetry<T>(
         opts,
       );
       for (const id of retryAttempt.succeeded) succeeded.push(id);
-      collisions.push(...retryAttempt.collisions);
       // For rejected retry tasks, fall back to the FIRST-attempt reason
       // (the retry produced no new information). For success/fail-of-retry,
       // record the second-attempt reason.
@@ -177,7 +158,6 @@ export async function runBatchedWithRetry<T>(
   return {
     succeeded: succeeded.length,
     failed,
-    collisions,
     rateLimitInfo,
     elapsedMs: Date.now() - startTime,
   };
@@ -188,7 +168,6 @@ export async function runBatchedWithRetry<T>(
  * results so the caller can choose what to do with each category:
  *
  *   - `succeeded` — task IDs to push to the cumulative `succeeded` list
- *   - `collisions` — successful tasks that carried collision data
  *   - `retryQueue` — failures to either feed into a retry pass (first
  *     attempt) or record as final `failed` (retry pass); each entry has
  *     the task + the reason string for the failure
@@ -203,7 +182,6 @@ async function runBatch<T>(
   opts: BatchRunnerOptions<T>,
 ): Promise<{
   succeeded: string[];
-  collisions: Collision[];
   retryQueue: Array<{ task: BatchTask<T>; reason: string }>;
 }> {
   const settled = await Promise.allSettled(
@@ -221,7 +199,6 @@ async function runBatch<T>(
   );
 
   const succeeded: string[] = [];
-  const collisions: Collision[] = [];
   const retryQueue: Array<{ task: BatchTask<T>; reason: string }> = [];
 
   settled.forEach((result, idx) => {
@@ -235,11 +212,10 @@ async function runBatch<T>(
     const v = result.value;
     if (v.success) {
       succeeded.push(task.id);
-      if (v.collision) collisions.push(v.collision);
     } else {
       retryQueue.push({ task, reason: v.failureReason });
     }
   });
 
-  return { succeeded, collisions, retryQueue };
+  return { succeeded, retryQueue };
 }

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -5,11 +5,10 @@
 // / createNewPage) and 1 private router (createOrUpdatePage).
 //
 // Behavior (v1.24.1 Phase 2 refactor — preserved verbatim):
-//   - createOrUpdatePage resolves the path first (slug match / LLM dedup
-//     fallback / cross-type collision detection).
-//   - collision branch: merge into the EXISTING page in the opposite
-//     folder (preserves the cross-type information; reviewed pages use
-//     appendToReviewedPage, non-reviewed use mergePage).
+//   - createOrUpdatePage resolves the path first (same-type slug match / LLM
+//     dedup fallback). Issue #472: the opposite folder is not consulted, so
+//     there is no cross-type branch — same letters under the other type are a
+//     different designator.
 //   - new-file branch: LLM generates the body (entity or concept prompt).
 //   - existing-file branch: reviewed pages route to appendToReviewedPage;
 //     other pages route to mergePage.
@@ -76,8 +75,6 @@ export function sourceContextFromAnalysis(
  * Generic page CRUD (entity/concept unified). Returns:
  *   - { path } when a page was written.
  *   - { path: null } when the name was empty.
- *   - { path: null, collision: {...} } when a cross-type collision was
- *     detected and merged into the existing page.
  */
 export async function createOrUpdatePage(
   ctx: CreatePageContext,
@@ -102,26 +99,7 @@ export async function createOrUpdatePage(
   // pages' tags and needs no new read at the note.
   const result = await resolvePagePath(ctx, info.name, pageType, info.summary, info.type ? [info.type] : undefined);
   if (result.path === null) {
-    if (result.collision) {
-      // Cross-type collision: a page for this item already exists in the
-      // opposite folder. Don't create a duplicate file, but merge the new
-      // content into the existing page so the source's summary / mentions
-      // / sources aren't lost. Use the EXISTING page's type for the merge
-      // so it keeps its classification.
-      const { targetPath, targetType } = result.collision;
-      const existingContent = await ctx.tryReadFile(targetPath);
-      if (existingContent) {
-        const isReviewed = parseFrontmatter(existingContent)?.reviewed === true;
-        if (isReviewed) {
-          await appendToReviewedPage(ctx, info, sourceFile, existingContent, targetPath, sourceSlug);
-        } else {
-          await mergePage(ctx, info, targetType, sourceFile, existingContent, extraPagePaths, targetPath, sourceSlug, sourceContext);
-        }
-        console.debug(`Cross-type collision: merged "${info.name}" content into ${targetType} page ${targetPath}`);
-      }
-    }
-    // Either nothing was written, or the content was merged into a page that
-    // already existed in the opposite folder — never a creation.
+    // Nothing was written: the resolver reached no decision it could act on.
     return { ...result, created: false };
   }
   console.debug('Resolved path:', result.path);

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -6,11 +6,11 @@
 // testable.
 //
 // Behavior (v1.24.1 Phase 2 refactor — preserved verbatim):
-//   - resolvePagePath: exact-slug fast path → ConflictResolver (slug/alias
-//     match, including cross-type collision) → LLM semantic dedup fallback.
-//     Returns `{ path: null, collision: {...} }` when a cross-type collision
-//     is detected so callers merge into the existing page instead of
-//     creating a new file.
+//   - resolvePagePath: exact-slug fast path → ConflictResolver (same-type
+//     slug/alias match) → LLM semantic dedup fallback. Issue #472: matching is
+//     scoped to the item's own type throughout — a designator is `(letters,
+//     type)`, so the same letters in the opposite folder denote a different
+//     thing and are never consulted.
 //   - buildPagesListForPrompt: filters out sources/ by default (#234) and
 //     polluted basenames (L2); caps at MAX_PAGES=50 with entity/concept
 //     bias based on includePaths; emits a "(truncated)" suffix when the cap
@@ -82,12 +82,6 @@ export function selectDedupCandidates(
 /** Mirrors the subset of PageCreationResult we return. */
 export interface ResolvedPathResult {
   path: string | null;
-  collision?: {
-    name: string;
-    sourceType: 'entity' | 'concept';
-    targetType: 'entity' | 'concept';
-    targetPath: string;
-  };
 }
 
 /**
@@ -114,10 +108,9 @@ export interface PathResolutionContext extends AliasesContext {
  * Determine the actual file path for a new entity/concept, using slug-based
  * matching first and falling back to LLM semantic resolution.
  *
- * Returns `{ path: null, collision: {...} }` when a cross-type collision
- * is detected (same name exists in the opposite folder). Callers must NOT
- * create a new file in that case, but should merge the new content into
- * `collision.targetPath` so no information from the source is lost.
+ * Issue #472: the opposite folder is never consulted. A page there carrying
+ * the same letters is a different designator, so it can neither be a merge
+ * target nor a reason to withhold this one.
  */
 export async function resolvePagePath(
   ctx: PathResolutionContext,
@@ -127,7 +120,6 @@ export async function resolvePagePath(
   tags?: string[],
 ): Promise<ResolvedPathResult> {
   const folder = pageType === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
-  const otherFolder = pageType === 'entity' ? WIKI_SUBFOLDERS.concepts : WIKI_SUBFOLDERS.entities;
   const slug = slugify(name, ctx.settings.slugCase === 'preserve');
   const slugPath = `${ctx.settings.wikiFolder}/${folder}/${slug}.md`;
 
@@ -154,15 +146,11 @@ export async function resolvePagePath(
   // Fast path: exact slug match (same type folder)
   const existing = await ctx.tryReadFile(slugPath);
   if (existing !== null) {
-    // Check for historical cross-type duplicate: if the same name exists in the
-    // opposite folder, it means an earlier ingestion classified this item differently.
-    // Append the new name as an alias to bridge the two pages (Bug #1 fix).
-    const otherSlugPath = `${ctx.settings.wikiFolder}/${otherFolder}/${slug}.md`;
-    const otherExisting = await ctx.tryReadFile(otherSlugPath);
-    if (otherExisting !== null) {
-      console.warn(`Historical cross-type duplicate detected: ${folder}/${slug}.md and ${otherFolder}/${slug}.md both exist — appending alias`);
-      await appendAliases(ctx, otherSlugPath, [name]);
-    }
+    // Issue #472: a page in the opposite folder that happens to carry the same
+    // letters is a different designator, not a duplicate of this one. It is
+    // neither read nor written here — the previous code bridged the two with an
+    // alias, which wrote this name into the other type's namespace and made the
+    // two pages match each other on every later ingest.
     return { path: slugPath };
   }
 
@@ -174,22 +162,9 @@ export async function resolvePagePath(
     const resolver = new ConflictResolver(ctx.settings.wikiFolder, allPages);
     const cr = resolver.resolve({ name, slug, pageType, tags });
 
-    if (cr.action === 'merge' && !cr.reason.includes('Cross-type')) {
+    if (cr.action === 'merge') {
       await appendAliases(ctx, cr.targetPath, [name]);
       return { path: cr.targetPath };
-    }
-
-    if (cr.action === 'merge' && cr.reason.includes('Cross-type')) {
-      await appendAliases(ctx, cr.targetPath, [name]);
-      return {
-        path: null,
-        collision: {
-          name,
-          sourceType: pageType,
-          targetType: cr.existingType || (otherFolder === WIKI_SUBFOLDERS.entities ? 'entity' : 'concept'),
-          targetPath: cr.targetPath,
-        },
-      };
     }
 
     // Issue #446: more than one same-type page carries this designator. The

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -563,7 +563,6 @@ export class WikiEngine {
       entitiesCreated: 0,
       conceptsCreated: 0,
       failedItems: [],
-      collisions: [],
       contradictionsFound: 0,
       success: true,
       skipped: true,
@@ -883,7 +882,6 @@ export class WikiEngine {
     );
 
     const failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }> = [];
-    const collisions: Array<{ name: string; sourceType: 'entity' | 'concept'; targetType: 'entity' | 'concept'; targetPath: string }> = [];
     let analysis: SourceAnalysis | null = null;
 
     try {
@@ -1002,13 +1000,6 @@ export class WikiEngine {
                 (entityResult.created ? analysis!.created_pages : analysis!.updated_pages)
                   .push(entityResult.path);
               }
-              if (entityResult.collision) {
-                console.debug(`Entity "${entity.name}" → collision with ${entityResult.collision.targetType}`);
-                return {
-                  success: true as const,
-                  collision: entityResult.collision,
-                };
-              }
               return { success: true as const };
             } catch (error) {
               const reason = error instanceof Error ? error.message : String(error);
@@ -1022,13 +1013,6 @@ export class WikiEngine {
             if (conceptResult.path) {
               (conceptResult.created ? analysis!.created_pages : analysis!.updated_pages)
                 .push(conceptResult.path);
-            }
-            if (conceptResult.collision) {
-              console.debug(`Concept "${concept.name}" → collision with ${conceptResult.collision.targetType}`);
-              return {
-                success: true as const,
-                collision: conceptResult.collision,
-              };
             }
             return { success: true as const };
           } catch (error) {
@@ -1048,9 +1032,6 @@ export class WikiEngine {
           name: f.id.split(':')[1] ?? f.id,
           reason: f.reason,
         });
-      }
-      for (const c of pageGenResult.collisions) {
-        collisions.push(c);
       }
       if (pageGenResult.rateLimitInfo) {
         console.warn(
@@ -1174,7 +1155,7 @@ export class WikiEngine {
       // totalTime was computed above; do not redeclare here.
 
       console.debug('=== Ingestion complete ===');
-      console.debug(`Ingestion complete [${modeLabel}]: Created ${dedupedCreatedPages.length} pages (${entitiesCreated} entities + ${conceptsCreated} concepts), Updated ${updated} pages, ${collisions.length} cross-type collisions`);
+      console.debug(`Ingestion complete [${modeLabel}]: Created ${dedupedCreatedPages.length} pages (${entitiesCreated} entities + ${conceptsCreated} concepts), Updated ${updated} pages`);
       console.debug(`[Total time] ${totalTime}ms (${Math.round(totalTime/1000)}s)`);
       console.debug('[Phase breakdown]:');
       console.debug(`  - Source analysis: ${analysisTime}ms`);
@@ -1192,12 +1173,6 @@ export class WikiEngine {
         for (const line of llmByTask) console.debug(line);
       }
 
-      // Show collision notice if any occurred
-      if (collisions.length > 0) {
-        new Notice(getText(this.settings.language, 'crossTypeCollisionNotice')
-          .replace('{count}', String(collisions.length)), NOTICE_NORMAL);
-      }
-
       this.onDone?.({
         sourceFile: file.path,
         createdPages: dedupedCreatedPages,
@@ -1205,7 +1180,6 @@ export class WikiEngine {
         entitiesCreated,
         conceptsCreated,
         failedItems,
-        collisions,
         contradictionsFound: analysis.contradictions.length,
         success: true,
         elapsedSeconds: Math.round(totalTime / 1000),
@@ -1227,7 +1201,6 @@ export class WikiEngine {
           entitiesCreated: createdPages.filter(p => p.includes('/entities/')).length,
           conceptsCreated: createdPages.filter(p => p.includes('/concepts/')).length,
           failedItems,
-          collisions,
           contradictionsFound: analysis?.contradictions?.length || 0,
           success: false,
           cancelled: true,
@@ -1250,7 +1223,6 @@ export class WikiEngine {
         entitiesCreated: createdPages.filter(p => p.includes('/entities/')).length,
         conceptsCreated: createdPages.filter(p => p.includes('/concepts/')).length,
         failedItems,
-        collisions,
         contradictionsFound: analysis?.contradictions?.length || 0,
         success: false,
         errorMessage: errorMsg,


### PR DESCRIPTION
Closes #472.

## The rule

A designator is `(letters, type)`, not letters. `CR` is chromium as an entity
and caloric restriction as a concept; `KHK` is ketohexokinase and coronary
heart disease; `IF` is intrinsic factor and intermittent fasting. Pages in the
opposite folder that carry the same slug or alias are not weaker candidates
for this item — they are candidates for a different item.

`ConflictResolver.resolve` did not read it that way. When no same-type page
matched, it merged into the opposite folder. If the extraction had mis-typed
the item and the other meaning happened to live in the folder it picked, the
content went into a page about something else, silently: the slug matched, the
alias matched, and the resolution never reached semantic dedup because a
deterministic match had been found.

## What changed

Matching is scoped to the item's own type throughout. That removes the failure
mode instead of detecting it — no ranking, no routing to semantic dedup, no
LLM call added anywhere, and no new state to carry. Three places consulted the
opposite folder:

1. the cross-type branch in `ConflictResolver.resolve`, with `oppositeFolder`
   and the three fields only it ever set;
2. the `otherSlugPath` probe in the `resolvePagePath` fast path, which on a hit
   wrote the extracted name onto the opposite page as an alias. That write was
   real for multi-word names — `filterRedundantAliases` compares against the
   basename, not the slug — so the bridge put this name into the other type's
   namespace, after which the two pages matched each other on every later
   ingest;
3. the `{ path: null, collision }` return and the merge-into-target branch it
   drove in `create-page.ts`.

With the only producer gone, the collision report had nothing left to report,
so it goes with it: `PageCreationResult.collision`, `IngestReport.collisions`,
the `Collision` type and its channel through `page-batch-runner`, the notice
and the count in `wiki-engine`, the modal section, and `ingestReportCollisions`
+ `crossTypeCollisionNotice` across all 11 locales. **This is user-visible**: a
section of the ingest report and a post-run notice disappear. After step 1 they
would only ever have rendered empty, but it is the part worth looking at
closely in review.

A word on what that report was worth. Even when it fired correctly it could
not be resolved into an action: the remedy for a genuine cross-type duplicate
is merging two pages by hand, which is manual work whether or not a notice
appeared. A signal that cannot change what the reader does next is cost without
benefit — and after this change it would never fire at all.

Net: 28 files, +92 / −320.

## The trade

A mis-typed extraction now writes a second page instead of merging into the
existing one of the other type. That is deliberate. A duplicate is visible and
can be merged in a minute; a wrong merge is invisible and edits an unrelated
article. Mis-typing is a classification error, and the merge layer is the wrong
place to absorb it silently.

The duplicate is not free: a created page runs the full generation prompt, so a
mis-typed extraction now costs one page generation it previously avoided by
merging. We think that is the right side of the trade — the merge it avoided
was into the wrong article — but the cost is real and belongs on the table.

## On #446

This retires one half of #446's reasoning. The cross-type side was handled
deliberately there — `ambiguous-designators.test.ts` pins it with nine real
designators — on the reading that a cross-type match is the same ambiguity seen
from the other side. Under a typed key it is not an ambiguity at all. Those
tests keep their order-invariance assertion and change their expectation; the
same-type gate from #446, where the ambiguity is real, is untouched.

## On the measurement you asked for

You deferred #472 wanting the mis-typing rate first, and this PR does not
bring it. It cannot be recovered from a vault: the only record is the outcome,
and the outcome was written by the branch in question — the bridging alias in
step 2 above produces exactly the cross-folder overlap one would count. The
rate is obtainable prospectively or not at all.

The change does not need it. It is not a threshold to tune but a branch to
remove, and the argument for removing it is in the suite already: the test
named `returns create when only opposite-type page exists (cross-type
considered distinct)` asserted a merge. Its body now says what its name has
said all along.

Gate 1 green locally: lint, typecheck, 3433 tests, build, css-lint.
