### PR TITLE
fix(#502, #505): apply the picker's own exclusion rule wherever the vault root can be chosen

### DIFF
--- a/src/__tests__/core/folder-scope.test.ts
+++ b/src/__tests__/core/folder-scope.test.ts
@@ -4,6 +4,7 @@ import {
   isInFolderScope,
   isAtOrInFolderScope,
   isExcludedFromSourcePicker,
+  isIngestableSource,
 } from '../../core/folder-scope';
 
 describe('folderScopePrefix', () => {
@@ -118,5 +119,45 @@ describe('isExcludedFromSourcePicker', () => {
 
   it('keeps the vault root selectable', () => {
     expect(isExcludedFromSourcePicker('/', 'wiki', '.obsidian')).toBe(false);
+  });
+});
+
+// Issue #502 — the two rules above are each correct on their own, and the
+// two tests directly above pin them: the vault root stays selectable, and
+// root scope accepts every path. Composed at the folder-ingest call site
+// they cancel the picker's own boundary — choosing the root reinstates the
+// `wiki/` folder the picker deliberately refuses to offer, and the plugin
+// ingests its own generated pages as source material.
+//
+// `FileSuggestModal` and `MultiFileSuggestModal` already apply the picker
+// rule to the FILES they offer. `FolderSuggestModal` applies it to the
+// FOLDERS it offers, and the collection step that follows applied nothing.
+// This function is that missing file-level rule, in the same module as the
+// other three.
+describe('isIngestableSource', () => {
+  it('collects an ordinary source file inside the chosen folder', () => {
+    expect(isIngestableSource('Notizen/a.md', 'Notizen', false, 'wiki', '.obsidian')).toBe(true);
+  });
+
+  it('collects an ordinary source file when the vault root is chosen', () => {
+    expect(isIngestableSource('Notizen/a.md', '/', true, 'wiki', '.obsidian')).toBe(true);
+    expect(isIngestableSource('a.md', '/', true, 'wiki', '.obsidian')).toBe(true);
+  });
+
+  it('does not reinstate the wiki folder when the vault root is chosen', () => {
+    // Both premises hold and are pinned above ...
+    expect(isExcludedFromSourcePicker('wiki/entities/x.md', 'wiki', '.obsidian')).toBe(true);
+    expect(isInFolderScope('wiki/entities/x.md', '/', true)).toBe(true);
+    // ... so the collection step has to combine them.
+    expect(isIngestableSource('wiki/entities/x.md', '/', true, 'wiki', '.obsidian')).toBe(false);
+  });
+
+  it('keeps the folder boundary it inherits from isInFolderScope', () => {
+    expect(isIngestableSource('Notizen-temp/a.md', 'Notizen', false, 'wiki', '.obsidian')).toBe(false);
+    expect(isIngestableSource('Notizen.md', 'Notizen', false, 'wiki', '.obsidian')).toBe(false);
+  });
+
+  it('keeps a sibling folder sharing the wiki name prefix', () => {
+    expect(isIngestableSource('wiki-archive/x.md', '/', true, 'wiki', '.obsidian')).toBe(true);
   });
 });

--- a/src/__tests__/schema/auto-maintain.test.ts
+++ b/src/__tests__/schema/auto-maintain.test.ts
@@ -26,10 +26,12 @@ function makeManager(ingestSource: IngestFn, createBatchContext: BatchCtxFn) {
     autoWatchMode: 'auto',
     autoWatchDebounceMs: 0,
     watchedFolders: ['inbox'],
+    wikiFolder: 'wiki',
   } as unknown as LLMWikiSettings;
 
   const wikiEngine = { createBatchContext, ingestSource } as unknown as WikiEngine;
-  const app = {} as unknown as ConstructorParameters<typeof AutoMaintainManager>[0];
+  // isWatched() consults the shared exclusion rule, which needs the config dir.
+  const app = { vault: { configDir: '.obsidian' } } as unknown as ConstructorParameters<typeof AutoMaintainManager>[0];
   const plugin = {} as unknown as ConstructorParameters<typeof AutoMaintainManager>[3];
 
   return new AutoMaintainManager(app, settings, wikiEngine, plugin);
@@ -168,5 +170,57 @@ describe('AutoMaintainManager.assessWelcomeNeed — sync tier decision (v1.23.0)
     const result = (mgr as unknown as WelcomeAssessor).assessWelcomeNeed();
     // Direct value, not a Promise.
     expect(result).not.toHaveProperty('then');
+  });
+});
+
+// Issue #505 — the watched-folder picker is the same `FolderSuggestModal`
+// the ingest command uses, so it offers the vault root. Choosing it stores `/`
+// and `isWatched` compared `path.startsWith('/')` — no Obsidian vault path
+// begins with a slash, so the entry matched nothing. The settings list showed
+// `/` while the watcher silently watched nothing.
+//
+// Sibling of #502: the same picker, the same root entry, the same missing
+// exclusion rule underneath. Root has to mean "the whole vault, minus what the
+// picker refuses" here too, or a repaired root would watch the plugin's own
+// generated pages.
+describe('AutoMaintainManager.isWatched — the vault root', () => {
+  type WatchProbe = { isWatched: (path: string) => boolean };
+
+  function managerWatching(folders: string[]) {
+    const settings = {
+      language: 'en',
+      autoWatchMode: 'auto',
+      autoWatchDebounceMs: 0,
+      watchedFolders: folders,
+      wikiFolder: 'wiki',
+    } as unknown as LLMWikiSettings;
+    const app = { vault: { configDir: '.obsidian' } } as unknown as ConstructorParameters<typeof AutoMaintainManager>[0];
+    const wikiEngine = {} as unknown as WikiEngine;
+    const plugin = {} as unknown as ConstructorParameters<typeof AutoMaintainManager>[3];
+    return new AutoMaintainManager(app, settings, wikiEngine, plugin) as unknown as WatchProbe;
+  }
+
+  it('watches ordinary vault files when the root is the watched folder', () => {
+    const mgr = managerWatching(['/']);
+    expect(mgr.isWatched('Notizen/a.md')).toBe(true);
+    expect(mgr.isWatched('a.md')).toBe(true);
+  });
+
+  it('does not watch the wiki folder when the root is watched', () => {
+    const mgr = managerWatching(['/']);
+    expect(mgr.isWatched('wiki/entities/x.md')).toBe(false);
+  });
+
+  it('watches nothing when no folder is configured', () => {
+    expect(managerWatching([]).isWatched('Notizen/a.md')).toBe(false);
+  });
+
+  it('keeps a named folder anchored, with or without a trailing slash', () => {
+    for (const stored of ['inbox', 'inbox/']) {
+      const mgr = managerWatching([stored]);
+      expect(mgr.isWatched('inbox/a.md')).toBe(true);
+      expect(mgr.isWatched('inbox-archive/a.md')).toBe(false);
+      expect(mgr.isWatched('inbox.md')).toBe(false);
+    }
   });
 });

--- a/src/core/folder-scope.ts
+++ b/src/core/folder-scope.ts
@@ -75,3 +75,30 @@ export function isExcludedFromSourcePicker(
     isAtOrInFolderScope(path, configDir, false)
   );
 }
+
+/**
+ * Whether a file may be COLLECTED as an ingest source, given the folder the
+ * user chose. Combines the folder boundary with the picker's exclusion rule.
+ *
+ * Issue #502 — the folder picker applies `isExcludedFromSourcePicker` to the
+ * folders it offers, which hides `wiki/`. It also offers the vault root, and
+ * root scope accepts every path, so choosing the root put `wiki/` back: the
+ * plugin ingested its own generated pages as source material. Both halves are
+ * deliberate and separately tested; only their composition was missing a rule.
+ *
+ * The two file pickers (`FileSuggestModal`, `MultiFileSuggestModal`) already
+ * filter the FILES they offer this way. This is the same rule for the folder
+ * path, so all three entry points now agree on what counts as a source.
+ */
+export function isIngestableSource(
+  filePath: string,
+  folderPath: string,
+  isRoot: boolean,
+  wikiFolder: string,
+  configDir: string
+): boolean {
+  return (
+    isInFolderScope(filePath, folderPath, isRoot) &&
+    !isExcludedFromSourcePicker(filePath, wikiFolder, configDir)
+  );
+}

--- a/src/main-commands/ingest-commands.ts
+++ b/src/main-commands/ingest-commands.ts
@@ -25,7 +25,7 @@ import { TEXTS } from '../texts';
 import { getText } from '../core/i18n';
 import { slugify } from '../core/slug';
 import { parseFrontmatter } from '../core/frontmatter';
-import { isInFolderScope } from '../core/folder-scope';
+import { isIngestableSource } from '../core/folder-scope';
 import { COMPATIBLE_SOURCE_EXTENSIONS, NOTICE_NORMAL, NOTICE_ERROR } from '../constants';
 import { FileSuggestModal, FolderSuggestModal, MultiFileSuggestModal, IngestReportModal } from '../ui/modals';
 import { ProgressScope } from '../core/progress-notification';
@@ -145,7 +145,13 @@ export const ingestCommands = {
       // file-sitting-beside-the-folder, the folder itself).
       const files = this.app.vault.getFiles()
         .filter(f => allowedExts.includes(f.extension.toLowerCase()))
-        .filter(f => isInFolderScope(f.path, folder.path, folder.isRoot()));
+        .filter(f => isIngestableSource(
+          f.path,
+          folder.path,
+          folder.isRoot(),
+          this.settings.wikiFolder,
+          this.app.vault.configDir,
+        ));
 
       if (files.length === 0) {
         const msg = TEXTS[this.settings.language].selectFolderNoMdFiles.replace('{path}', folder.path);

--- a/src/schema/auto-maintain.ts
+++ b/src/schema/auto-maintain.ts
@@ -14,6 +14,7 @@ import { resolveModelForTask } from '../core/model-resolver';
 import { isLocalNoKeyProvider } from '../core/local-no-key-provider';
 import { resolveProviderApiKey } from '../llm-sdk/provider-api-key-resolver';
 import type { LLMClient } from '../types';
+import { isIngestableSource } from '../core/folder-scope';
 
 export class AutoMaintainManager {
   private app: App;
@@ -103,11 +104,25 @@ export class AutoMaintainManager {
   }
 
   // Check if a path falls within any watched folder
+  // Issue #505 — the watched-folder picker is the same FolderSuggestModal
+  // the ingest command uses, so the vault root is offered and stored as `/`.
+  // The previous hand-rolled comparison asked `path.startsWith('/')`, which no
+  // Obsidian vault path satisfies: the entry was displayed but matched nothing.
+  //
+  // Delegating to the shared rule fixes that and brings the picker's own
+  // exclusion along, which the root case needs — otherwise a repaired root
+  // would watch `wiki/` and feed the plugin its own generated pages (#502).
   private isWatched(path: string): boolean {
     if (this.settings.watchedFolders.length === 0) return false;
     return this.settings.watchedFolders.some(folder => {
-      const prefix = folder.endsWith('/') ? folder : `${folder}/`;
-      return path.startsWith(prefix);
+      const trimmed = folder.replace(/\/+$/, '');
+      return isIngestableSource(
+        path,
+        trimmed,
+        trimmed.length === 0,
+        this.settings.wikiFolder,
+        this.app.vault.configDir,
+      );
     });
   }
 


### PR DESCRIPTION
Closes #502. Closes #505.

## The change

Two sites let the user choose the **vault root**, and neither handled it. They are the same `FolderSuggestModal`, and both were missing the same rule underneath — but they failed in opposite directions.

**#502 — over-inclusion.** `Ingest from folder` collected every path at the root, so choosing it reinstated the `wiki/` folder the picker deliberately refuses to offer, and the plugin ingested its own generated pages as source material.

**#505 — a silent no-op.** The watched-folder picker stores the root as `/`, and `isWatched` asked `path.startsWith('/')`. No Obsidian vault path begins with a slash, so the entry matched nothing: the settings list showed `/` while the watcher watched nothing, with no error and no log line.

The rule both sites needed already exists — `isExcludedFromSourcePicker`, which `FileSuggestModal` and `MultiFileSuggestModal` already apply to the files they offer. This PR adds `isIngestableSource` next to the other three rules in `core/folder-scope.ts`, in the same pure/IO-free shape so it is unit-testable without a vault, and uses it at both sites. All four entry points now agree on what counts as a source.

For #502 the premises are each deliberate and separately tested (`keeps the vault root selectable`, `accepts every path at the vault root`); only their composition was missing a rule. For #505 the fix also has to bring the exclusion along, or a repaired root would start watching `wiki/`.

## Behaviour change worth calling out

An existing `/` entry in `watchedFolders` goes from doing nothing to watching the whole vault. That is what the user asked for — the entry only exists because they enabled auto-watch and picked the root — but it is a real change, and it starts costing LLM calls on the next edit.

If you would rather not make that jump, the alternative is to keep the root out of the watched-folder picker and drop existing `/` entries on load. Both resolve "the UI accepts an input it silently ignores"; they differ only in which way. I chose to honour the selection, so the two sites agree. Say the word and I will turn it around — it is a small change either way.

## Tests

Nine cases added, red before each fix and green after.

`folder-scope.test.ts` (5), next to the two that pin the premises: an ordinary file inside a chosen folder is collected · an ordinary file is collected at the root · `wiki/entities/x.md` is **not** collected at the root, asserting both premises first so the test documents why the third assertion has to hold · the inherited folder boundary still rejects `Notizen-temp/a.md` and `Notizen.md` · `wiki-archive/x.md` is still collected, so the name-prefix sibling is not swept up.

`auto-maintain.test.ts` (4): ordinary vault files are watched at the root · `wiki/` is not · an empty list watches nothing · a named folder stays anchored whether or not it was stored with a trailing slash.

The existing batch-context harness gains a vault stub and a `wikiFolder`, because the rule it now consults reads both.

## Gate

`pnpm lint --max-warnings=0` · `npx tsc --noEmit` · `pnpm build` · `pnpm test` · `pnpm css-lint` — all green on `7aed9eb`. Tests 3442 passed, of which 9 are new.

One note on ordering: `openai-codex-loopback-flow.test.ts` reads the built `main.js` from the working directory, so `pnpm test` fails on a clean tree unless `pnpm build` ran first. `pr-ci.yml` already orders it that way; worth knowing if you ever run the five commands by hand.

## Not in this PR

Honouring Obsidian's own **Excluded files** list (`userIgnoreFilters`) — filed separately as #503. It needs an untyped accessor or a direct read of `app.json`, which is a design call rather than a fix, so it did not belong in a PR sent unannounced.
