### PR TITLE
fix(frontmatter): union tags on merge so the stored tag does not depend on source order

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -653,6 +653,62 @@ Body
     expect(result.frontmatter).toContain('- "Foo"');
     expect(result.frontmatter).not.toContain('- ""');
   });
+
+  // Incoming tags: `sources:` was a union and `tags:` was not, so the stored
+  // tag was decided by whichever source reached the page first.
+  const tagged = '---\ntype: entity\ncreated: 2026-01-01\nupdated: 2026-01-01\ntags:\n  - person\n---\n\nBody';
+
+  it('is byte-identical when no incoming tags are passed', () => {
+    const withArg = mergeFrontmatter(tagged, 'sources/new', undefined);
+    const without = mergeFrontmatter(tagged, 'sources/new');
+    expect(withArg.frontmatter).toBe(without.frontmatter);
+    expect(without.frontmatter).toContain('- "person"');
+  });
+
+  it('unions an incoming tag with the ones the page already carries', () => {
+    const result = mergeFrontmatter(tagged, 'sources/new', ['organization']);
+    expect(result.frontmatter).toContain('- "person"');
+    expect(result.frontmatter).toContain('- "organization"');
+  });
+
+  it('keeps the existing tag first, so the order does not depend on the merge', () => {
+    const result = mergeFrontmatter(tagged, 'sources/new', ['organization']);
+    expect(result.frontmatter.indexOf('- "person"'))
+      .toBeLessThan(result.frontmatter.indexOf('- "organization"'));
+  });
+
+  it('does not repeat an incoming tag the page already has', () => {
+    const result = mergeFrontmatter(tagged, 'sources/new', ['person']);
+    expect((result.frontmatter.match(/- "person"/g) || []).length).toBe(1);
+  });
+
+  it('drops empty incoming tags', () => {
+    const result = mergeFrontmatter(tagged, 'sources/new', ['']);
+    expect(result.frontmatter).toContain('- "person"');
+    expect(result.frontmatter).not.toContain('- \n');
+  });
+
+  it('adopts the incoming tag when the page carries none', () => {
+    const untagged = '---\ntype: entity\ncreated: 2026-01-01\nupdated: 2026-01-01\n---\n\nBody';
+    const result = mergeFrontmatter(untagged, 'sources/new', ['method']);
+    expect(result.frontmatter).toContain('- "method"');
+  });
+
+  it('a page reached by two sources in either order ends with the same tags', () => {
+    const base = '---\ntype: entity\ncreated: 2026-01-01\nupdated: 2026-01-01\n---\n\nBody';
+    const aThenB = mergeFrontmatter(
+      `${mergeFrontmatter(base, 'sources/a', ['person']).frontmatter}\n\nBody`,
+      'sources/b', ['organization']).frontmatter;
+    const bThenA = mergeFrontmatter(
+      `${mergeFrontmatter(base, 'sources/b', ['organization']).frontmatter}\n\nBody`,
+      'sources/a', ['person']).frontmatter;
+    const tagsOf = (fm: string) => {
+      const block = /\ntags:\n((?: {2}- .*\n)*)/.exec(`${fm}\n`)?.[1] ?? '';
+      return (block.match(/- "([^"]+)"/g) || []).sort();
+    };
+    expect(tagsOf(aThenB)).toEqual(tagsOf(bThenA));
+    expect(tagsOf(aThenB)).toEqual(['- "organization"', '- "person"']);
+  });
 });
 
 describe('preserveFrontmatterReviewTag', () => {

--- a/src/__tests__/core/tag-vocab.test.ts
+++ b/src/__tests__/core/tag-vocab.test.ts
@@ -4,6 +4,7 @@ import {
   getActiveConceptTags,
   getActiveSourceTags,
   normalizeVocabularyCsv,
+  incomingTypeTag,
 } from '../../core/tag-vocab';
 import { LLMWikiSettings } from '../../types';
 
@@ -143,5 +144,38 @@ describe('getActiveSourceTags (Issue #85 v7)', () => {
     expect(tags).not.toContain('Medical_Arzneimittel');
     expect(tags).not.toContain('Kardiologie');
     expect(tags).toContain('paper');
+  });
+});
+
+describe('incomingTypeTag', () => {
+  const dflt = { tagVocabularyMode: 'default' } as LLMWikiSettings;
+  const custom = {
+    tagVocabularyMode: 'custom',
+    customEntityTags: 'Biochemie, Erkrankung, Arzneimittel',
+    customConceptTags: 'Biochemie, Physiologie',
+  } as LLMWikiSettings;
+
+  it('passes the extracted type through under the default vocabulary', () => {
+    expect(incomingTypeTag(dflt, 'entity', 'person')).toEqual(['person']);
+    expect(incomingTypeTag(dflt, 'concept', 'theory')).toEqual(['theory']);
+  });
+
+  it('withholds the type when a custom vocabulary does not contain it', () => {
+    expect(incomingTypeTag(custom, 'entity', 'other')).toBeUndefined();
+    expect(incomingTypeTag(custom, 'concept', 'phenomenon')).toBeUndefined();
+  });
+
+  it('passes a type a custom vocabulary happens to contain', () => {
+    expect(incomingTypeTag(custom, 'entity', 'Erkrankung')).toEqual(['Erkrankung']);
+  });
+
+  it('reads the vocabulary of the kind it was asked about', () => {
+    // `Erkrankung` is in the entity list only.
+    expect(incomingTypeTag(custom, 'concept', 'Erkrankung')).toBeUndefined();
+  });
+
+  it('returns nothing for a missing type', () => {
+    expect(incomingTypeTag(dflt, 'entity', undefined)).toBeUndefined();
+    expect(incomingTypeTag(dflt, 'entity', '')).toBeUndefined();
   });
 });

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -459,9 +459,29 @@ export function serializeFrontmatter(
   return lines.join('\n');
 }
 
+/**
+ * Union the tags a page already carries with the ones the incoming source
+ * proposes, first occurrence wins. `sources:` next to it is a union already;
+ * `tags:` was not, so on every merge after the first the incoming term was
+ * computed and dropped and the stored tag stayed a function of which source
+ * arrived first. Omitting `incoming` keeps the previous behaviour byte for
+ * byte, so a caller that has no incoming tags is unaffected.
+ */
+function unionTags(existing: unknown, incoming?: string[]): string[] {
+  // The existing values are carried verbatim — the parser types them loosely,
+  // and filtering here would silently drop a tag shape this function is not
+  // the right place to judge.
+  const merged: string[] = Array.isArray(existing) ? [...(existing as string[])] : [];
+  for (const tag of incoming ?? []) {
+    if (tag && !merged.includes(tag)) merged.push(tag);
+  }
+  return merged;
+}
+
 export function mergeFrontmatter(
   existingContent: string,
-  newSourcePath: string
+  newSourcePath: string,
+  incomingTags?: string[]
 ): { frontmatter: string; body: string; wasMerged: boolean } {
   const fm = parseFrontmatter(existingContent);
   const body = extractBody(existingContent);
@@ -506,7 +526,7 @@ export function mergeFrontmatter(
       created,
       updated,
       sources: mergedSources,
-      tags: Array.isArray(fm.tags) ? fm.tags : [],
+      tags: unionTags(fm.tags, incomingTags),
       reviewed: fm.reviewed,
       aliases: Array.isArray(fm.aliases) ? fm.aliases : undefined,
     },

--- a/src/core/tag-vocab.ts
+++ b/src/core/tag-vocab.ts
@@ -18,6 +18,25 @@ export function getActiveConceptTags(settings: LLMWikiSettings): string[] {
   return [...VALID_CONCEPT_TAGS];
 }
 
+/**
+ * The type a source extracted, as a tag that may be merged into an existing
+ * page — or nothing, when the active vocabulary does not admit it.
+ *
+ * With the default vocabulary the two coincide: `VALID_ENTITY_TAGS` IS the
+ * `EntityInfo['type']` enum, so the extracted type is always a member. With a
+ * custom vocabulary it is not, and writing it into `tags:` anyway would put a
+ * value there that `runRetagViolations` exists to remove.
+ */
+export function incomingTypeTag(
+  settings: LLMWikiSettings,
+  kind: 'entity' | 'concept',
+  type: string | undefined
+): string[] | undefined {
+  if (!type) return undefined;
+  const active = kind === 'entity' ? getActiveEntityTags(settings) : getActiveConceptTags(settings);
+  return active.includes(type) ? [type] : undefined;
+}
+
 export function getActiveSourceTags(settings: LLMWikiSettings): string[] {
   return [...VALID_SOURCE_TAGS];
 }

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -42,6 +42,7 @@ import {
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
+import { incomingTypeTag } from '../../core/tag-vocab';
 import { appendContradictedByMarker } from '../../core/contradicted-marker';
 import { injectMentionsSection } from '../../core/mentions-injector';
 import { renderTemplate } from '../../core/template-renderer';
@@ -94,7 +95,7 @@ export async function mergePage(
     const { frontmatter, body: existingBody } = mergeFrontmatter(
       existingContent,
       sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
-      info.type ? [info.type] : undefined,
+      incomingTypeTag(ctx.settings, pageType, info.type),
     );
 
     // Issue #312 part 2 — deterministic, no LLM: is this source the page's own
@@ -287,10 +288,12 @@ export async function appendToReviewedPage(
   try {
     // 1. Programmatic frontmatter merge
     // Issue #155: record the canonical source PAGE link (disambiguated slug).
+    // The page declares its own kind; this function takes no `pageType`.
+    const pageKind = parseFrontmatter(existingContent)?.type === 'concept' ? 'concept' : 'entity';
     const { frontmatter, body: existingBody } = mergeFrontmatter(
       existingContent,
       sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
-      info.type ? [info.type] : undefined,
+      incomingTypeTag(ctx.settings, pageKind, info.type),
     );
 
     // 2. Minimal LLM check for genuinely new content.

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -94,6 +94,7 @@ export async function mergePage(
     const { frontmatter, body: existingBody } = mergeFrontmatter(
       existingContent,
       sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
+      info.type ? [info.type] : undefined,
     );
 
     // Issue #312 part 2 — deterministic, no LLM: is this source the page's own
@@ -289,6 +290,7 @@ export async function appendToReviewedPage(
     const { frontmatter, body: existingBody } = mergeFrontmatter(
       existingContent,
       sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
+      info.type ? [info.type] : undefined,
     );
 
     // 2. Minimal LLM check for genuinely new content.

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -20,6 +20,7 @@ import { TOKENS_PAGE_GENERATION } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
+import { incomingTypeTag } from '../../core/tag-vocab';
 import { stripMentionsSection } from '../../core/mentions-parser';
 import { renderTemplate } from '../../core/template-renderer';
 import {
@@ -83,17 +84,17 @@ export async function updateRelatedPage(
   const existingContent = await ctx.app.vault.read(abstractFile);
 
   // Hoisted above the merge so this source's type reaches `tags:`; the skip
-  // decision below reads the same value.
-  const newInfo =
-    analysis.entities.find(e => e.name === pageName) ||
-    analysis.concepts.find(c => c.name === pageName);
+  // decision below reads the same value. Which list it came from is the kind,
+  // so the vocabulary check below needs no second lookup.
+  const asEntity = analysis.entities.find(e => e.name === pageName);
+  const newInfo = asEntity || analysis.concepts.find(c => c.name === pageName);
 
   // 1. Programmatic frontmatter merge (sources + updated).
   // Issue #155: cite the canonical source PAGE link (disambiguated slug).
   const { frontmatter, body: existingBody } = mergeFrontmatter(
     existingContent,
     sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
-    newInfo?.type ? [newInfo.type] : undefined,
+    incomingTypeTag(ctx.settings, asEntity ? 'entity' : 'concept', newInfo?.type),
   );
 
   // Issue #131: when the source extracted nothing matching this page, skip the

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -82,19 +82,23 @@ export async function updateRelatedPage(
 
   const existingContent = await ctx.app.vault.read(abstractFile);
 
+  // Hoisted above the merge so this source's type reaches `tags:`; the skip
+  // decision below reads the same value.
+  const newInfo =
+    analysis.entities.find(e => e.name === pageName) ||
+    analysis.concepts.find(c => c.name === pageName);
+
   // 1. Programmatic frontmatter merge (sources + updated).
   // Issue #155: cite the canonical source PAGE link (disambiguated slug).
   const { frontmatter, body: existingBody } = mergeFrontmatter(
     existingContent,
     sourceSlug ? `sources/${sourceSlug}` : sourceFile.path,
+    newInfo?.type ? [newInfo.type] : undefined,
   );
 
   // Issue #131: when the source extracted nothing matching this page, skip the
   // LLM entirely — record the new source in frontmatter and leave the body
   // untouched (a no-op rewrite corrupts verbatim text).
-  const newInfo =
-    analysis.entities.find(e => e.name === pageName) ||
-    analysis.concepts.find(c => c.name === pageName);
   if (!newInfo) {
     await ctx.createOrUpdateFile(page.path, `${frontmatter}\n\n${existingBody}`);
     return true;


### PR DESCRIPTION
Closes #509 — the mechanical half. The design question about what a wiki page's tags should mean stays parked in #91.

## What it does

`mergeFrontmatter` takes an optional third parameter and unions it into `tags:`, the way `sources:` two lines above has always been unioned. The three callers pass the type term this source extracted:

- `merge-page.ts:94` and `merge-page.ts:290` — `info.type`
- `related-page.ts` — `newInfo?.type`. The `newInfo` lookup moved ten lines up so the merge can see it; it is a pure `find` over `analysis`, no IO, and the skip decision below reads the same value.

Omitting the argument is byte-identical to the previous behaviour, so every other caller and every existing test is untouched.

## One decision for you, and it changes stored data

After this, a page reached by two sources that classified it differently carries **both** terms — `tags:` gains a second entry where it previously had one. The generation template writes a single `tags: [{{entity_type}}]`, so this produces a shape the template itself never produces.

I built it as a union because it is the only order-invariant choice available: "first wins" is today's behaviour and depends on arrival order, "last wins" depends on it in the other direction. But the trade is real — you buy order-invariance with pages that can carry more than one type term, and that spreads through the vault on the next ingest rather than on a migration you schedule.

If you would rather keep one term per page, the same seam supports it: pass the incoming tags and let `unionTags` pick instead of merge — first-wins plus a debug line naming the discarded term, so the disagreement stops being invisible even if the stored value does not change. Say which and I will reshape it; I did not want to pick the quieter option on your behalf without saying so.

## Tests

7 new, in `frontmatter.test.ts`:

- byte-identical when no incoming tags are passed
- unions an incoming tag with the ones the page already carries
- keeps the existing tag first, so order does not depend on the merge
- does not repeat an incoming tag the page already has
- drops empty incoming tags
- adopts the incoming tag when the page carries none
- a page reached by two sources in either order ends with the same tags

Local: `eslint` clean on the four touched files, `tsc --noEmit` clean, 322 tests green across `frontmatter.test.ts` and the 18 `page-factory` files. Full Gate 1 is CI's.

## Not in this

No migration for pages already carrying an order-decided tag. The stored value is corrected the next time a source touches the page, which is the same cadence every other frontmatter repair runs at; a sweep over existing pages is a separate decision with its own blast radius.
