### PR TITLE
fix(lint): pass unknown frontmatter fields through the duplicate merge (#356 parity)

### DIFF
--- a/src/__tests__/wiki/lint/merge-duplicates-passthrough.test.ts
+++ b/src/__tests__/wiki/lint/merge-duplicates-passthrough.test.ts
@@ -1,0 +1,53 @@
+// Issue #356 parity for the duplicate merge: `mergeDuplicatePages` was the one
+// frontmatter writer that re-serialized from the parsed object alone, so every
+// user-owned field of the surviving page was dropped by a merge. The LLM client
+// is absent on purpose — the programmatic merge is the path that writes the
+// frontmatter either way.
+
+import { describe, it, expect } from 'vitest';
+import { mergeDuplicatePages } from '../../../wiki/lint/merge-duplicates';
+import { createFakeLinkVault } from '../../__support__/link-vault';
+import type { EngineContext } from '../../../types';
+
+const TARGET = 'wiki/entities/Ferritin.md';
+const SOURCE = 'wiki/entities/Ferritin-2.md';
+
+function makeCtx(files: Record<string, string>) {
+  const fake = createFakeLinkVault(files);
+  const ctx = {
+    app: { vault: fake.vault, metadataCache: fake.metadataCache },
+    settings: { wikiFolder: 'wiki', language: 'en' },
+    getClient: () => null,
+    tryReadFile: async (path: string) => (files[path] === undefined ? fake.read(path) || null : fake.read(path)),
+    createOrUpdateFile: async (path: string, content: string) => { fake.write(path, content); },
+    deleteFile: async () => { /* not under test */ },
+    getSchemaContext: async () => undefined,
+  } as unknown as EngineContext;
+  return { ctx, fake };
+}
+
+describe('mergeDuplicatePages — unknown frontmatter fields of the surviving page (#356 parity)', () => {
+  it('passes them through verbatim', async () => {
+    const { ctx, fake } = makeCtx({
+      [TARGET]: '---\ntype: entity\ntags: [substance]\nredirect_to: "[[x]]"\nparent_org: Acme\n---\n\n# Ferritin\n\nIron store.\n',
+      [SOURCE]: '---\ntype: entity\ntags: [substance]\n---\n\n# Ferritin-2\n\nAlso the iron store.\n',
+    });
+    await mergeDuplicatePages(ctx, TARGET, SOURCE);
+    const written = fake.read(TARGET) ?? '';
+    expect(written).toContain('redirect_to: "[[x]]"');
+    expect(written).toContain('parent_org: Acme');
+    // The canonical fields still come from the merge, not from the passthrough.
+    expect(written.match(/^type:/gm)?.length).toBe(1);
+    expect(written.match(/^tags:/gm)?.length).toBe(1);
+  });
+
+  it('does not add anything when the survivor has no unknown fields', async () => {
+    const { ctx, fake } = makeCtx({
+      [TARGET]: '---\ntype: entity\ntags: [substance]\n---\n\n# Ferritin\n\nIron store.\n',
+      [SOURCE]: '---\ntype: entity\ntags: [substance]\n---\n\n# Ferritin-2\n\nAlso the iron store.\n',
+    });
+    await mergeDuplicatePages(ctx, TARGET, SOURCE);
+    const written = fake.read(TARGET) ?? '';
+    expect(written.startsWith('---\ntype: entity\n')).toBe(true);
+  });
+});

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -2,7 +2,7 @@ import { EngineContext } from '../../types';
 import { PROMPTS } from '../../prompts';
 import { TOKENS_LINT_PAGE_FIX, WIKI_SUBFOLDERS } from '../../constants';
 import { buildSystemPrompt } from '../system-prompts';
-import { parseFrontmatter, enforceFrontmatterConstraints, serializeFrontmatter } from '../../core/frontmatter';
+import { parseFrontmatter, enforceFrontmatterConstraints, serializeFrontmatter, extractPassthroughLines } from '../../core/frontmatter';
 import { parseJsonResponse } from '../../core/json';
 import { reassertH1 } from '../../core/section-header-canonicalizer';
 import { cleanMarkdownResponse } from '../../core/markdown';
@@ -156,7 +156,12 @@ export async function mergeDuplicatePages(
       reviewed: targetFm?.reviewed,
       aliases: dedupedAliases,
     },
-    { tagStyle: 'block' }
+    // Issue #356 parity: every other frontmatter writer passes unknown
+    // top-level fields through; this one re-serialized from the parsed object
+    // alone, so a duplicate merge dropped every user-owned field of the
+    // surviving page (`redirect_to:`, `parent_org:`, ...). Same helper, same
+    // semantics as mergeFrontmatter: the survivor's lines, verbatim.
+    { tagStyle: 'block', passthroughLines: extractPassthroughLines(targetContent) }
   ) + '\n\n' + mergedBody;
   const pageType = targetPath.includes(`/${WIKI_SUBFOLDERS.entities}/`)
     ? 'entity'


### PR DESCRIPTION
Closes #512.

`mergeDuplicatePages` was the one frontmatter writer without the #356 passthrough — a duplicate merge dropped every user-owned field of the surviving page. This passes the survivor's unknown lines through `serializeFrontmatter`, same helper and same semantics as `mergeFrontmatter`.

**What changes:** one option on the existing `serializeFrontmatter` call in `src/wiki/lint/merge-duplicates.ts`, plus the import.
**What does not:** the absorbed page's unknown fields (it is deleted; merging two metadata sets is not this path's decision), and the output for a survivor without unknown fields — byte-identical, covered by the control test.

**Test:** `src/__tests__/wiki/lint/merge-duplicates-passthrough.test.ts` — red on `main` (survivor with `redirect_to:` + `parent_org:` loses both), green with the fix; control: survivor without unknown fields is unchanged.

Gate 1: lint 0 · typecheck 0 · build clean · 3448 tests (3446 + 2).
