### PR TITLE
fix(#515): correct OpenRouter's Anthropic baseURL in the pass-through fixture

### DIFF
--- a/src/__tests__/llm-sdk/anthropic-sdk-client.test.ts
+++ b/src/__tests__/llm-sdk/anthropic-sdk-client.test.ts
@@ -438,7 +438,11 @@ describe('AnthropicSdkClient', () => {
       ['GLM-Anthropic', 'https://api.glm.ai/v1/anthropic'],
       ['DeepSeek Anthropic-compat', 'https://api.deepseek.com/anthropic'],
       ['MiniMax-Anthropic', 'https://api.MiniMax.chat/anthropic'],
-      ['OpenRouter Anthropic', 'https://openrouter.ai/api/v1/anthropic'],
+      // OpenRouter's Anthropic skin is /api/v1/messages, and createAnthropic
+      // appends only /messages — so /api/v1 is the baseURL a user must enter.
+      // /api/v1/anthropic 404s; the docs' /api (for clients that add /v1
+      // themselves) returns the HTML site page, not JSON.
+      ['OpenRouter Anthropic', 'https://openrouter.ai/api/v1'],
     ])('forwards %s baseURL unchanged to createAnthropic', async (_name, baseURL) => {
       const client = new AnthropicSdkClient({ apiKey: 'sk-ant-test', baseURL });
       await client.createMessage({


### PR DESCRIPTION
Fixes #515.

`src/__tests__/llm-sdk/anthropic-sdk-client.test.ts:441` listed `https://openrouter.ai/api/v1/anthropic` as OpenRouter's Anthropic-compatible baseURL. That path 404s. OpenRouter's Anthropic skin is `POST /api/v1/messages`, and `createAnthropic` appends only `/messages` — so `https://openrouter.ai/api/v1` is the value that works, which is also what `url-fallback.ts:buildModelsPaths` already assumes.

## Verified live, through this repo's own `@ai-sdk/anthropic@3.0.98`

Tracing `fetch` to capture the URL, real OpenRouter key, `anthropic/claude-haiku-4.5`:

| baseURL | URL the SDK hits | Result |
| --- | --- | --- |
| `…/api/v1/anthropic` (before) | `…/api/v1/anthropic/messages` | **404** |
| `…/api` (OpenRouter's documented value for clients that append `/v1/messages` themselves) | `…/api/messages` | 200 **HTML** → AI-SDK `Invalid JSON response` |
| `…/api/v1` (after) | `…/api/v1/messages` | **200**, valid Anthropic-format body |

The assertion is pass-through only, so the test passed either way — the value matters because `anthropic-compatible` is `requiresBaseUrl: true` and this table is what a user copies. `url-fallback` cannot rescue the old string: `hasV1Segment` matches its `/v1/`, so no candidate is ever generated and the 404 is terminal.

Scope is one fixture line plus a comment recording why `/api/v1` and not the `/api` from OpenRouter's docs. `PREDEFINED_PROVIDERS.openrouter` is untouched — it is already correct (`/api/v1/chat/completions` and `/api/v1/models` both verified 200).

## Gate

`pnpm lint` 0 · `pnpm typecheck` 0 · `pnpm build` clean · `pnpm test` 236 files / 3446 tests passed · `pnpm css-lint` 0 violations (run in CONTRIBUTING order, build before test).

## Not in this PR

Two neighbours in the same table look stale and would fail the same way if copied — flagged in #515 for someone with those accounts: `GLM-Anthropic` `https://api.glm.ai/v1/anthropic` and `z.ai` `https://api.z.ai/v1`.
