### PR TITLE
feat(candidate-window): one ranked window for the dedup and dead-link prompts — rank on page prose, drop the full-list fallback and the 3,000-char cut (Issue #519)

### DIFF
--- a/src/__tests__/core/candidate-window.test.ts
+++ b/src/__tests__/core/candidate-window.test.ts
@@ -1,0 +1,101 @@
+// The candidate window (`core/candidate-window.ts`): one ranked list for every
+// prompt that shows the model "existing pages". These tests pin the contract
+// the two call sites (semantic dedup, Fix Dead Links) rely on — not the hit
+// rate, which is a measurement over a vault, but the mechanics that produced
+// it: prose counts, function words do not, ties keep pool order, the window
+// is always K.
+
+import { describe, it, expect } from 'vitest';
+import { selectCandidateWindow, contextKeywords, contextAround } from '../../core/candidate-window';
+import { CANDIDATE_WINDOW_TOP_K } from '../../constants';
+
+interface P { path: string; title: string; aliases?: string[]; text?: string }
+const page = (title: string, text?: string, aliases?: string[]): P =>
+  ({ path: `wiki/entities/${title}.md`, title, aliases, text });
+
+describe('contextKeywords', () => {
+  it('keeps words of five or more characters, once each, lower-cased', () => {
+    expect(contextKeywords('Die Darm-Hirn-Achse verbindet Darm und Gehirn; die Achse ist bidirektional.'))
+      .toEqual(['darm-hirn-achse', 'verbindet', 'gehirn', 'achse', 'bidirektional']);
+  });
+
+  it('reads only the first 300 characters', () => {
+    const far = 'x'.repeat(300) + ' weitentfernt';
+    expect(contextKeywords(far)).not.toContain('weitentfernt');
+  });
+});
+
+describe('selectCandidateWindow — prose signal', () => {
+  it('ranks a page whose prose carries the context words above one that only shares a short token', () => {
+    const byProse = page('Transferrinsättigung', 'laborwert des eisenstoffwechsels, quotient aus serumeisen und transferrin.');
+    const byToken = page('Eisen', 'spurenelement.');
+    const window = selectCandidateWindow(
+      { name: 'TSAT', context: 'Laborwert des Eisenstoffwechsels.' },
+      [byToken, byProse],
+    );
+    expect(window[0].path).toBe(byProse.path);
+  });
+
+  it('drops a keyword that occurs on more than the cap share of pages', () => {
+    // "werden" stands on every page; it must not lift any of them. Only the
+    // page that also says "entzündungshemmend" scores.
+    const pool = [
+      page('A', 'kann verwendet werden.'),
+      page('B', 'wird oft verwendet werden.'),
+      page('C', 'soll entzündungshemmend werden.'),
+      page('D', 'muss werden.'),
+    ];
+    const window = selectCandidateWindow({ name: 'Zz', context: 'werden entzündungshemmend' }, pool);
+    expect(window[0].path).toBe(pool[2].path);
+    // and the rest keep pool order — "werden" gave them nothing to sort by
+    expect(window.slice(1).map(p => p.title)).toEqual(['A', 'B', 'D']);
+  });
+
+  it('does not score prose when no page carries text (lexical only, as before)', () => {
+    const pool = [page('Hypertonie'), page('Typ-2-Diabetes'), page('Zöliakie')];
+    const window = selectCandidateWindow(
+      { name: 'Diabetes-mellitus-Typ-2', context: 'Diabetes als chronische Stoffwechselerkrankung.' },
+      pool,
+    );
+    expect(window[0].title).toBe('Typ-2-Diabetes');
+  });
+});
+
+describe('selectCandidateWindow — shape', () => {
+  it('is always K pages, or the whole pool when smaller', () => {
+    const big = Array.from({ length: CANDIDATE_WINDOW_TOP_K + 25 }, (_, i) => page(`S-${i}`));
+    expect(selectCandidateWindow({ name: 'Q', context: '' }, big).length).toBe(CANDIDATE_WINDOW_TOP_K);
+    expect(selectCandidateWindow({ name: 'Q', context: '' }, big, 5).length).toBe(5);
+    expect(selectCandidateWindow({ name: 'Q', context: '' }, big.slice(0, 3)).length).toBe(3);
+    expect(selectCandidateWindow({ name: 'Q', context: '' }, [])).toEqual([]);
+  });
+
+  it('keeps pool order among equals, so the rendered prefix is stable between calls', () => {
+    const pool = Array.from({ length: 10 }, (_, i) => page(`Seite-${i}`, 'nichts gemeinsames.'));
+    const a = selectCandidateWindow({ name: 'Unbekannt', context: 'Keinerlei Überlappung.' }, pool);
+    const b = selectCandidateWindow({ name: 'Unbekannt', context: 'Keinerlei Überlappung.' }, pool);
+    expect(a.map(p => p.path)).toEqual(pool.map(p => p.path));
+    expect(b).toEqual(a);
+  });
+
+  it('returns the caller\'s own objects, richer fields included', () => {
+    const pool = [{ ...page('X', 'text'), wikiLink: '[[wiki/entities/X|X]]', ctime: 1 }];
+    const window = selectCandidateWindow({ name: 'X', context: '' }, pool);
+    expect(window[0]).toBe(pool[0]);
+    expect(window[0].wikiLink).toBe('[[wiki/entities/X|X]]');
+  });
+});
+
+describe('contextAround', () => {
+  const text = 'A'.repeat(500) + ' siehe [[Darm-Hirn-Achse]] im Detail ' + 'B'.repeat(500);
+
+  it('cuts a window around the first needle that occurs', () => {
+    const ctx = contextAround(text, ['[[Darm-Hirn-Achse', 'Darm-Hirn-Achse'], 20);
+    expect(ctx).toContain('[[Darm-Hirn-Achse');
+    expect(ctx.length).toBeLessThanOrEqual(20 + '[[Darm-Hirn-Achse'.length + 20);
+  });
+
+  it('falls back to the start of the text when nothing is found', () => {
+    expect(contextAround(text, ['nicht-da'], 10)).toBe('A'.repeat(20));
+  });
+});

--- a/src/__tests__/wiki/lint/fix-dead-link-window.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link-window.test.ts
@@ -1,0 +1,78 @@
+// Fix Dead Links: the page list in the prompt is the candidate window, not
+// the vault in iteration order cut at 3,000 characters.
+//
+// Before: `existing_pages` was every page, rendered in `getMarkdownFiles()`
+// order and truncated by `substring(0, 3000)` — on a 2,800-page wiki an
+// arbitrary ~2 % in which the prompt was then told to look for "semantic
+// similarity". Whether the true target was in it was a matter of file order.
+// Now the list is the shared window (`core/candidate-window.ts`), ranked
+// against the link's target name and the text around the link.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fixDeadLink } from '../../../wiki/lint/fix-dead-link';
+import * as getExistingPages from '../../../wiki/lint/get-existing-pages';
+import type { EngineContext, LLMClient } from '../../../types';
+import { CANDIDATE_WINDOW_TOP_K } from '../../../constants';
+
+type ExistingPage = Awaited<ReturnType<typeof getExistingPages.getExistingWikiPages>>[number];
+
+function makeCtx(client: LLMClient, sourceContent: string): EngineContext {
+  return {
+    app: {},
+    settings: { wikiFolder: 'wiki', wikiLanguage: 'de', disableThinking: false, slugCase: 'preserve' },
+    getClient: () => client,
+    getSchemaContext: () => ({}),
+    tryReadFile: async (): Promise<string | null> => sourceContent,
+    createOrUpdateFile: async (): Promise<void> => {},
+  } as unknown as EngineContext;
+}
+
+function wikiPage(i: number, title: string, text: string): ExistingPage {
+  return {
+    path: `wiki/entities/${title}.md`,
+    title,
+    wikiLink: `[[entities/${title}|${title}]]`,
+    aliases: undefined,
+    ctime: i,
+    text,
+  };
+}
+
+const SOURCE =
+  '# Quelle\n\n' +
+  'Die Achse zwischen Darm und Gehirn — siehe [[Darm-Hirn-Verbindung]] — läuft über den Vagusnerv ' +
+  'und mikrobielle Metaboliten wie kurzkettige Fettsäuren.\n';
+
+describe('fixDeadLink — existing_pages is the ranked candidate window', () => {
+  // 80 pages whose titles share nothing with the link; only one of them
+  // describes the same thing in its prose. It sits at position 75 — at
+  // ~47 rendered characters a line, beyond the 3,000-char cut of the old
+  // list, which ended around line 63.
+  const pool: ExistingPage[] = Array.from({ length: 80 }, (_, i) =>
+    wikiPage(i, `Fachbegriff-${i}`, `eintrag nummer ${i} ohne inhaltlichen bezug.`),
+  );
+  pool[75] = wikiPage(75, 'Darm-Hirn-Achse',
+    'bidirektionale verbindung zwischen darm und gehirn über den vagusnerv, das immunsystem und mikrobielle metaboliten.');
+
+  let prompt = '';
+  beforeEach(() => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue(pool);
+    prompt = '';
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('puts the page that describes the link first and sends at most K pages', async () => {
+    const createMessage = vi.fn(async (args: { messages: Array<{ content: string }> }) => {
+      prompt = args.messages[0].content;
+      return JSON.stringify({ action: 'correct', correct_link: '[[entities/Darm-Hirn-Achse|Darm-Hirn-Achse]]' });
+    });
+    const ctx = makeCtx({ createMessage } as unknown as LLMClient, SOURCE);
+
+    const out = await fixDeadLink(ctx, 'wiki/sources/Quelle.md', 'Darm-Hirn-Verbindung');
+
+    expect(out).toContain('corrected');
+    const listed = prompt.split('\n').filter(l => l.startsWith('- [[entities/'));
+    expect(listed.length).toBe(CANDIDATE_WINDOW_TOP_K);
+    expect(listed[0]).toContain('[[entities/Darm-Hirn-Achse|Darm-Hirn-Achse]]');
+  });
+});

--- a/src/__tests__/wiki/page-factory/dedup-candidate-selection.test.ts
+++ b/src/__tests__/wiki/page-factory/dedup-candidate-selection.test.ts
@@ -3,25 +3,27 @@
 // The semantic dedup call used to ship EVERY same-type page to the LLM. On a
 // real vault (~1285 entities) that is ~77K chars ≈ 40K prompt tokens for a
 // yes/no answer worth 16 completion tokens. The pre-filter ranks candidates
-// with the zero-token lexical matcher and sends only the top K.
+// with zero-token matching and sends only the top K.
 //
 // The risk this file guards: a pre-filter that drops the TRUE duplicate
 // creates a duplicate page — a correctness bug, and in a from-scratch rebuild
-// it happens at scale. So the criterion is RECALL = 100% over every fixture
-// pair: for each (new candidate, true existing target), the target MUST be in
-// the selected set. A failure means raise K or widen the fallback — never
-// lower the bar.
+// it happens at scale. So the criterion is RECALL over every fixture pair:
+// for each (new candidate, true existing target), the target MUST be in the
+// selected set.
 //
-// Both branches are covered:
-//   - lexical branch: shared tokens exist → top-K must contain the target
-//   - fallback branch: zero lexical overlap (translations, initialisms) → the
-//     full list is returned, so the target is trivially retained
+// What changed with the candidate window (`core/candidate-window.ts`): the
+// zero-overlap case no longer returns the full list. Measured at a local 26B,
+// the full list held the target and the model found it 0 of 18 times; the
+// recall that list appeared to protect was never delivered. Instead the
+// window ranks on the page's own PROSE as well — a translation or initialism
+// whose expansion the page spells out is found that way — and the window is
+// always K pages, zero-signal pages filling the tail in pool order.
 
 import { describe, it, expect } from 'vitest';
 import { selectDedupCandidates } from '../../../wiki/page-factory/path-resolution';
 import { DEDUP_CANDIDATE_TOP_K } from '../../../constants';
 
-interface Page { path: string; title: string; aliases?: string[] }
+interface Page { path: string; title: string; aliases?: string[]; text?: string }
 
 function page(title: string, aliases?: string[]): Page {
   return { path: `wiki/entities/${title}.md`, title, aliases };
@@ -80,24 +82,35 @@ describe('selectDedupCandidates — lexical branch keeps the true duplicate', ()
   });
 });
 
-describe('selectDedupCandidates — zero-overlap fallback returns the full list', () => {
-  it('retains "Massachusetts Institute of Technology" for the candidate "MIT"', () => {
-    // Pins the NAME-gated fallback: the summary token "in" incidentally
-    // substring-matches "Indiana" and "Institute", so a fallback gated on
-    // the ranked list being empty would take the lexical branch here and
-    // rank on summary noise. The name "MIT" matches nothing → full list.
-    const target = page('Massachusetts Institute of Technology');
-    const pages = [page('Stanford'), page('Indiana University'), target, page('ETH Zürich')];
+describe('selectDedupCandidates — zero name overlap: the prose finds what the title cannot', () => {
+  it('finds "Massachusetts Institute of Technology" for "MIT" through the page text, ahead of 40 distractors', () => {
+    // The name "MIT" matches no title. The candidate's summary says
+    // "Cambridge" and "Forschungsuniversität"; only the target page says
+    // both in its prose. Before the window this case sent the full list.
+    const target: Page = {
+      ...page('Massachusetts Institute of Technology'),
+      text: 'private forschungsuniversität in cambridge, massachusetts, gegründet 1861.',
+    };
+    const distractors = Array.from({ length: 40 }, (_, i) => ({
+      ...page(`Hochschule-${i}`),
+      text: `staatliche hochschule nummer ${i} mit technischem schwerpunkt.`,
+    }));
+    const pages = [...distractors.slice(0, 20), target, ...distractors.slice(20)];
     const selected = selectDedupCandidates(
       'MIT',
       'Private Forschungsuniversität in Cambridge.',
       pages,
     );
-    expect(selected).toEqual(pages);
-    expect(selected.map(p => p.path)).toContain(target.path);
+    expect(selected.length).toBe(DEDUP_CANDIDATE_TOP_K);
+    expect(selected[0].path).toBe(target.path);
   });
 
-  it('retains the Chinese page 清华大学 for the candidate "Tsinghua University"', () => {
+  it('keeps the Chinese page 清华大学 in the window for "Tsinghua University" when the pool is small', () => {
+    // Across scripts there is no lexical signal at all. The window does not
+    // pretend otherwise: with nothing to rank on, pages keep pool order and
+    // the whole pool fits into K. (On a pool larger than K this target is out
+    // of reach of any lexical window — and was out of reach of the full list
+    // too, measured 0 of 18.)
     const target = page('清华大学');
     const pages = [page('北京大学'), target, page('复旦大学')];
     const selected = selectDedupCandidates(
@@ -106,7 +119,15 @@ describe('selectDedupCandidates — zero-overlap fallback returns the full list'
       pages,
     );
     expect(selected).toEqual(pages);
-    expect(selected.map(p => p.path)).toContain(target.path);
+  });
+
+  it('never returns more than K, even when nothing scores', () => {
+    const pages = Array.from({ length: 100 }, (_, i) => page(`Seite-${i}`));
+    const selected = selectDedupCandidates('Zzzz', 'Qqqq.', pages);
+    expect(selected.length).toBe(DEDUP_CANDIDATE_TOP_K);
+    // Zero-signal pages fill in pool order, so the prefix stays stable
+    // across calls (the KV-prefix cache depends on it).
+    expect(selected.map(p => p.path)).toEqual(pages.slice(0, DEDUP_CANDIDATE_TOP_K).map(p => p.path));
   });
 
   it('returns the input unchanged when there are no pages at all', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -190,14 +190,35 @@ export const TOKENS_DEDUP_RESOLUTION = 3000;
 export const TOKENS_LEMMA_CLASSIFY = 2000;
 
 /**
- * Max candidate pages shown to the LLM in the semantic dedup prompt.
- * The full same-type list grows with the vault (~77K chars at ~1285
- * entities) and the call is prefill-bound; the top-K keyword pre-filter
- * keeps the prompt flat. When the candidate's name shares no token with
- * any page (translations, initialisms) the full list is sent instead —
- * recall over cost. Raise K rather than weaken that fallback.
+ * Pages a prompt shows the model when it asks "which existing page is this?"
+ * — the semantic dedup and Fix Dead Links draw from the same ranked window
+ * (`core/candidate-window.ts`). The full list grew with the vault (~77K
+ * chars at ~1285 entities) and, measured at a local 26B, the model did not
+ * find a synonym's target in it (0 of 18) while it found the same targets
+ * 9 of 9 times in a 30-entry window that contained them. The window is
+ * always K pages: there is no fallback to the full list, because the list
+ * was never where recall came from.
  */
-export const DEDUP_CANDIDATE_TOP_K = 30;
+export const CANDIDATE_WINDOW_TOP_K = 30;
+
+/** Kept for the dedup call sites and tests that name the window by its first use. */
+export const DEDUP_CANDIDATE_TOP_K = CANDIDATE_WINDOW_TOP_K;
+
+/**
+ * How much of a page's prose the window ranks against — read once per page
+ * in `getExistingWikiPages`, lower-cased, cut here. 2,000 characters is what
+ * the measurement scanned; the first paragraph of a page carries most of
+ * the words its aliases will be described with.
+ */
+export const CANDIDATE_WINDOW_TEXT_CHARS = 2000;
+
+/**
+ * A context keyword found on more than this share of the pool's pages is
+ * dropped before scoring. On any vault those are the function words of its
+ * language ("werden", "through"); the cap replaces a stop list that would
+ * have to know the language.
+ */
+export const CANDIDATE_WINDOW_DF_CAP = 0.5;
 
 /**
  * v1.24.0 #216 — max tokens for the merge triage pre-flight classification.

--- a/src/core/candidate-window.ts
+++ b/src/core/candidate-window.ts
@@ -1,0 +1,139 @@
+// core/candidate-window.ts — the one ranked window every prompt draws from
+// when it shows the model a list of "existing pages".
+//
+// Until now each call site built that list on its own, and two of them bounded
+// it blindly. The semantic dedup fell back to the FULL same-type list whenever
+// the candidate's name shared no token with any title (61 % of entity trials
+// on a 2,800-page vault), and Fix Dead Links took every page in vault
+// iteration order and cut the rendered text at 3,000 characters. Measured at a
+// local 26B model: the full list contained the target by construction and the
+// model found it 0 of 18 times; a 30-entry window that contained the target,
+// 9 of 9. So the question is not "cap or no cap" but WHICH RANKING puts the
+// target into K slots without a model call.
+//
+// The answer measured over 1,585 hidden-alias trials (every curated alias of
+// every page hidden in turn, the item described by the note it came from):
+// ranking on the page's own prose, not only on title and aliases, moves the
+// target into the window in 42 % of trials against 25 % for the shipped name
+// gate; on ten hand-picked synonym cases 2 of 10 became 7 of 10.
+//
+// Score per page = lexical (title 3 / alias 2 per query token, the existing
+// `localKeywordMatch`) + 1 per context keyword found in the page's prose.
+// Keywords that occur in more than CANDIDATE_WINDOW_DF_CAP of the pool's pages
+// are dropped before scoring: on any vault those are the function words of its
+// language, so the cap replaces a language-specific stop list. Ties keep pool
+// order, so a caller's ordering (ctime, for the KV-prefix cache) survives
+// among equals. The window is always K pages, or the whole pool when it is
+// smaller: pages without any signal fill the tail in pool order instead of
+// triggering a list the model cannot use.
+//
+// What this does not reach: a target whose title, aliases and prose share
+// nothing with the item — a page written in another script, an initialism
+// whose expansion the page never spells out. The full list did not reach it
+// either (0 of 18 above); it only looked as if it did.
+
+import { localKeywordMatch } from './index-search';
+import { CANDIDATE_WINDOW_TOP_K, CANDIDATE_WINDOW_DF_CAP } from '../constants';
+
+/** Page shape the window ranks. `text` is the page's prose, lower-cased. */
+export interface WindowPage {
+  path: string;
+  title: string;
+  aliases?: string[];
+  text?: string;
+}
+
+/** What the caller knows about the item it is looking for. */
+export interface WindowQuery {
+  /** The item's name (a candidate entity, a dead link's target). */
+  name: string;
+  /**
+   * Text around the item — the extraction summary, the sentence that carries
+   * the link. Only the first 300 characters are used, for both signals.
+   */
+  context: string;
+}
+
+const CONTEXT_CHARS = 300;
+const MIN_KEYWORD_CHARS = 5;
+
+/**
+ * The context words worth looking for in a page's prose: lower-cased, split on
+ * anything that is not a letter, digit or hyphen, at least MIN_KEYWORD_CHARS
+ * long, each once. Short tokens are left to the lexical matcher, which scores
+ * them against titles and aliases only.
+ */
+export function contextKeywords(context: string): string[] {
+  const seen = new Set<string>();
+  for (const token of context.substring(0, CONTEXT_CHARS).toLowerCase().split(/[^\p{L}\p{N}-]+/u)) {
+    if (token.length >= MIN_KEYWORD_CHARS) seen.add(token);
+  }
+  return [...seen];
+}
+
+/**
+ * Rank `pool` against `query` and return the top `topK` pages, pool order
+ * among equals. The returned objects are the caller's own (not copies), so a
+ * caller may hand in a richer page type and get it back. `options.dfCap`
+ * overrides CANDIDATE_WINDOW_DF_CAP — a measurement knob, no call site sets it.
+ */
+export function selectCandidateWindow<T extends WindowPage>(
+  query: WindowQuery,
+  pool: T[],
+  topK: number = CANDIDATE_WINDOW_TOP_K,
+  options: { dfCap?: number } = {},
+): T[] {
+  if (pool.length === 0 || topK <= 0) return [];
+
+  // Lexical signal — the matcher already shipped for this purpose. The name is
+  // additionally matched with hyphens/underscores split so compound candidates
+  // share tokens with reordered variants ("Diabetes-mellitus-Typ-2" ↔
+  // "Typ-2-Diabetes").
+  const nameQuery = `${query.name} ${query.name.split(/[-_]+/).join(' ')}`;
+  const context = query.context.substring(0, CONTEXT_CHARS);
+  const lexical = new Map(
+    localKeywordMatch(
+      `${nameQuery} ${context}`,
+      pool.map(p => ({ path: p.path, title: p.title, aliases: p.aliases ?? [] })),
+    ).map(r => [r.path, r.score]),
+  );
+
+  // Prose signal — one point per context keyword found in the page's text.
+  // Document frequency is counted over this pool and this call; a keyword on
+  // more than the cap's share of pages says nothing about any one of them.
+  const textScore = new Array<number>(pool.length).fill(0);
+  const withText = pool.filter(p => p.text !== undefined).length;
+  if (withText > 0) {
+    const maxPages = Math.floor(withText * (options.dfCap ?? CANDIDATE_WINDOW_DF_CAP));
+    for (const keyword of contextKeywords(context)) {
+      const hits: number[] = [];
+      for (let i = 0; i < pool.length; i++) {
+        if (pool[i].text !== undefined && pool[i].text!.includes(keyword)) hits.push(i);
+      }
+      if (hits.length === 0 || hits.length > maxPages) continue;
+      for (const i of hits) textScore[i] += 1;
+    }
+  }
+
+  return pool
+    .map((page, i) => ({ page, i, score: (lexical.get(page.path) ?? 0) + textScore[i] }))
+    .sort((a, b) => b.score - a.score || a.i - b.i)
+    .slice(0, topK)
+    .map(r => r.page);
+}
+
+/**
+ * The stretch of `text` around the first occurrence of `needle` (or of the
+ * first of several needles), `radius` characters to each side. Falls back to
+ * the start of the text when nothing is found — the caller wanted a context
+ * and gets the best one available.
+ */
+export function contextAround(text: string, needles: string[], radius: number): string {
+  for (const needle of needles) {
+    if (!needle) continue;
+    const at = text.indexOf(needle);
+    if (at === -1) continue;
+    return text.substring(Math.max(0, at - radius), at + needle.length + radius);
+  }
+  return text.substring(0, radius * 2);
+}

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -1,6 +1,6 @@
 import { EngineContext } from '../../types';
 import { PROMPTS } from '../../prompts';
-import { TOKENS_LINT_PAGE_FIX, WIKI_SUBFOLDERS } from '../../constants';
+import { TOKENS_LINT_PAGE_FIX, WIKI_SUBFOLDERS, CANDIDATE_WINDOW_TOP_K } from '../../constants';
 import { buildSystemPrompt } from '../system-prompts';
 import { renderTemplate } from '../../core/template-renderer';
 import { parseJsonResponse } from '../../core/json';
@@ -12,7 +12,11 @@ import {
   replaceDeadLink,
 } from '../../core/dead-link-detector';
 import { getExistingWikiPages } from './get-existing-pages';
+import { selectCandidateWindow, contextAround } from '../../core/candidate-window';
 import { FixDeadLinkSchema, type FixDeadLink } from '../../llm-sdk/output-schemas';
+
+/** Characters to each side of the dead link that describe what it points to (300 in all, the dedup summary length). */
+const DEAD_LINK_CONTEXT_RADIUS = 150;
 
 const PLURAL_MAP: Record<string, string> = {
   entity: WIKI_SUBFOLDERS.entities,
@@ -128,12 +132,19 @@ export async function fixDeadLink(
   }
 
   // ---- LLM path: semantic matching with alias-aware prompt ----
-  const pagesList = existingPages
-    .filter(p => {
-      const bn = p.title || '';
-      const hasPollutedBasename = /^(entities|concepts|sources)([^\s\-_a-zA-Z0-9])/.test(bn);
-      return !hasPollutedBasename;
-    })
+  // The pages the model sees are the shared candidate window
+  // (`core/candidate-window.ts`), ranked against the link's target name and
+  // the text around the link. Before this the list was every page in vault
+  // iteration order, cut at 3,000 rendered characters — on a 2,800-page wiki
+  // an arbitrary 2–3 % that the prompt then searched for "semantic
+  // similarity", and the target's presence in it was a matter of file order.
+  const pool = existingPages.filter(p => {
+    const bn = p.title || '';
+    const hasPollutedBasename = /^(entities|concepts|sources)([^\s\-_a-zA-Z0-9])/.test(bn);
+    return !hasPollutedBasename;
+  });
+  const linkContext = contextAround(sourceContent, [`[[${targetName}`, targetBasename], DEAD_LINK_CONTEXT_RADIUS);
+  const pagesList = selectCandidateWindow({ name: targetBasename, context: linkContext }, pool, CANDIDATE_WINDOW_TOP_K)
     .map(p => {
       const aliasSuffix = p.aliases?.length ? ` \`aliases: ${p.aliases.join(', ')}\`` : '';
       return `- ${p.wikiLink}${aliasSuffix}`;
@@ -142,7 +153,7 @@ export async function fixDeadLink(
   const prompt = renderTemplate(PROMPTS.fixDeadLink, {
     source_content: sourceContent.substring(0, 2000),
     target_name: targetName,
-    existing_pages: pagesList.substring(0, 3000),
+    existing_pages: pagesList,
   });
 
   const client = ctx.getClient();

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -1,11 +1,12 @@
 import { App } from 'obsidian';
-import { parseFrontmatter } from '../../core/frontmatter';
+import { parseFrontmatter, extractBody } from '../../core/frontmatter';
+import { CANDIDATE_WINDOW_TEXT_CHARS } from '../../constants';
 import { isInFolderScope } from '../../core/folder-scope';
 
 export async function getExistingWikiPages(
   app: App,
   wikiFolder: string
-): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number }>> {
+): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }>> {
   const wikiFiles = app.vault
     .getMarkdownFiles()
     .filter(
@@ -17,7 +18,7 @@ export async function getExistingWikiPages(
         !f.path.includes('/contradictions/')
     );
 
-  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number }> = [];
+  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }> = [];
   for (const f of wikiFiles) {
     const relPath = f.path.replace(wikiFolder + '/', '').replace('.md', '');
     const content = await app.vault.read(f);
@@ -50,6 +51,12 @@ export async function getExistingWikiPages(
       // page. Read here because the frontmatter is already parsed.
       tags: Array.isArray(fm?.tags) ? fm.tags : undefined,
       ctime: f.stat?.ctime,
+      // The page's prose, for the candidate window (`core/candidate-window.ts`).
+      // The file is already read here to parse its frontmatter; keeping a
+      // bounded, lower-cased slice of the body costs no second read and lets
+      // the dedup and dead-link prompts rank pages by what they say, not only
+      // by what they are called.
+      text: extractBody(content).toLowerCase().slice(0, CANDIDATE_WINDOW_TEXT_CHARS),
     });
   }
   return pages;

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -20,7 +20,7 @@
 import { WIKI_SUBFOLDERS, TOKENS_DEDUP_RESOLUTION, DEDUP_CANDIDATE_TOP_K } from '../../constants';
 import { slugify } from '../../core/slug';
 import { ConflictResolver } from '../../core/conflict-resolver';
-import { localKeywordMatch } from '../../core/index-search';
+import { selectCandidateWindow } from '../../core/candidate-window';
 import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { PROMPTS } from '../../prompts';
 import { parseJsonResult } from '../../core/json';
@@ -36,47 +36,32 @@ export interface DedupCandidatePage {
   path: string;
   title: string;
   aliases?: string[];
+  /** The page's prose, lower-cased — ranks the window by what the page says. */
+  text?: string;
 }
 
 /**
  * Pre-filter the same-type page list before it is rendered into the
- * semantic dedup prompt. The full list grows with the vault and made the
- * call prefill-bound (~40K prompt tokens for a 16-token answer), so only
- * the top-K lexically ranked candidates are kept.
+ * semantic dedup prompt: the top-K of the shared candidate window
+ * (`core/candidate-window.ts`), ranked on title, aliases AND the page's own
+ * prose against the candidate's name and summary.
  *
- * Recall guard (binding): the fallback to the FULL list is gated on the
- * candidate's NAME alone, not on the ranked result. Summary tokens are
- * ranking signal only — incidental substrings ("in" ⊂ "institute") make
- * the ranked list non-empty for almost any query on a large vault, so a
- * ranked-list-empty check would never fire and the translation/initialism
- * case ("MIT" vs "Massachusetts Institute of Technology", "Tsinghua
- * University" vs "清华大学") would silently lose its true duplicate. A
- * missed duplicate becomes a duplicate page, so that rare case pays the
- * old full-list cost instead of risking correctness.
- *
- * The name is additionally matched with hyphens/underscores split so
- * compound candidates share tokens with reordered variants
- * ("Diabetes-mellitus-Typ-2" ↔ "Typ-2-Diabetes").
+ * This used to fall back to the FULL same-type list whenever the name shared
+ * no token with any title — "recall over cost", on the reasoning that a
+ * missed duplicate becomes a duplicate page. Measured, the fallback fired on
+ * 61 % of entity candidates (41 % of concepts) at ~40K prompt tokens each,
+ * and the model found a synonym's target in that list 0 of 18 times while it
+ * found the same targets 9 of 9 times in a 30-entry window that contained
+ * them. The list held the target; it did not deliver it. The prose signal is
+ * what moves the target into the window: 42 % of hidden-alias trials against
+ * 25 % for the name gate, and 7 of 10 synonym cases against 2 of 10.
  */
 export function selectDedupCandidates(
   name: string,
   summary: string,
   sameTypePages: DedupCandidatePage[],
 ): DedupCandidatePage[] {
-  const normalized = sameTypePages.map(p => ({
-    path: p.path,
-    title: p.title,
-    aliases: p.aliases ?? [],
-  }));
-  const nameQuery = `${name} ${name.split(/[-_]+/).join(' ')}`;
-  const nameHits = localKeywordMatch(nameQuery, normalized);
-  if (nameHits.length === 0) return sameTypePages;
-  const ranked = localKeywordMatch(`${nameQuery} ${summary.substring(0, 300)}`, normalized);
-  const byPath = new Map(sameTypePages.map(p => [p.path, p]));
-  return ranked
-    .slice(0, DEDUP_CANDIDATE_TOP_K)
-    .map(r => byPath.get(r.path))
-    .filter((p): p is DedupCandidatePage => p !== undefined);
+  return selectCandidateWindow({ name, context: summary }, sameTypePages, DEDUP_CANDIDATE_TOP_K);
 }
 
 /** Mirrors the subset of PageCreationResult we return. */


### PR DESCRIPTION
Closes #519.

## Summary

One ranked candidate window (`src/core/candidate-window.ts`) for every prompt that shows the model "existing pages"; the semantic dedup and Fix Dead Links consume it. The dedup no longer falls back to the full same-type list, Fix Dead Links no longer sends the vault in file order cut at 3,000 characters. Pages are ranked on their own prose as well as on title and aliases — measured on a 2,412-page vault, the true target lands in the 30-window in 43 % of hidden-alias trials against 25 % for the shipped name gate (details and the arms in #519).

## What changed

- `src/core/candidate-window.ts` (new) — `selectCandidateWindow(query, pool, topK)`: lexical score (the existing `localKeywordMatch`, title 3 / alias 2 per token, name matched hyphen-split as before) + 1 per context keyword (≥ 5 chars, first 300 chars of context) found in the page's `text`; keywords on more than `CANDIDATE_WINDOW_DF_CAP` (0.5) of the pool's pages are dropped before scoring — a document-frequency cap instead of a stop list, so it does not need to know the vault's language. Stable sort, pool order among equals, always `topK` pages or the whole pool. `contextKeywords` and `contextAround` exported for the call sites and the tests.
- `src/wiki/lint/get-existing-pages.ts` — every page carries `text`: `extractBody(content).toLowerCase().slice(0, CANDIDATE_WINDOW_TEXT_CHARS)` (2,000). The file is already read here for its frontmatter; this keeps a bounded slice instead of discarding the body.
- `src/wiki/page-factory/path-resolution.ts` — `selectDedupCandidates` delegates to the window with `DEDUP_CANDIDATE_TOP_K`; signature and call site unchanged, `DedupCandidatePage` gains `text?`. The name-gated full-list fallback is gone (why: below).
- `src/wiki/lint/fix-dead-link.ts` — the LLM path renders the window ranked against the link's target basename and the 300 characters around the first `[[target` in the source; `existing_pages` is no longer `substring(0, 3000)`. Pre-check, safety net and stub policy untouched.
- `src/constants.ts` — `CANDIDATE_WINDOW_TOP_K = 30` (`DEDUP_CANDIDATE_TOP_K` kept as its alias so existing imports and tests stand), `CANDIDATE_WINDOW_TEXT_CHARS = 2000`, `CANDIDATE_WINDOW_DF_CAP = 0.5`; the "raise K rather than weaken that fallback" note is replaced by what was measured.

## Why the full-list fallback goes

The fallback was "recall over cost": a missed duplicate becomes a duplicate page, so a name with no title token paid the full list. Measured at a local 26B, the full list contained the target in every one of 18 synonym calls and the model found it in none; a 30-entry window that contained the same target, 9 of 9. The cost was real (61 % of entity candidates on a 2,800-page vault, ~40K prompt tokens each) and the recall was nominal. The prose signal is what the fallback was standing in for: a translation or an initialism whose expansion the page spells out is found by the words, not by the list.

What the window still cannot reach: a target whose title, aliases and prose share nothing with the item (cross-script, an initialism the page never expands). The test file says so instead of pretending the old behaviour covered it — `清华大学` stays in the window for "Tsinghua University" because a 3-page pool fits into K, not because anything matched.

## Tests

- `src/__tests__/core/candidate-window.test.ts` (new, 10): keyword extraction, prose ranks above a short-token match, the document-frequency cap drops a word on every page, lexical-only when no page carries text, always-K shape, pool order among equals (the rendered prefix is stable between calls), returns the caller's own objects, `contextAround`.
- `src/__tests__/wiki/page-factory/dedup-candidate-selection.test.ts` — the lexical-branch and token-proof tests unchanged; the "full list" section rewritten: "MIT" now finds "Massachusetts Institute of Technology" through the page text ahead of 40 distractors; zero-signal pages fill the window in pool order; never more than K.
- `src/__tests__/wiki/lint/fix-dead-link-window.test.ts` (new, 1): 80 pages whose titles share nothing with the link, the describing page at position 75 (beyond the old 3,000-char cut) — it is listed first and the list is K lines.

Gate 1 on this machine against the same run on `main` (603c9ee): lint 0 → 0, typecheck clean, 236 files / 3,446 tests → 238 / 3,458, build clean, css-lint 0. `openai-codex-loopback-flow.test.ts` fails in both trees until `main.js` has been built once, then passes — not related.

## Measured with the shipped code

The probe in `llm-wiki-measure/plugin-probes/dedup-window-probe.test.ts` has an arm that runs this PR's `selectCandidateWindow` over the production page shape (body lower-cased, 2,000 chars) at caps 0.5 / 0.25 / none: entities 42.8 % / 42.8 % / 42.8 %, concepts 40.5 % / 40.2 % / 40.8 % — the cap is neutral on this vault and kept as the language-neutral guard; the ≥ 5-char filter does the work. The shipped status quo, same probe on bare `main` (603c9ee), same trials: 25.3 % / 24.5 %, full list sent in 36.0 % / 28.7 %.

## Not in this PR

- `buildPagesListForPrompt` (generation window) and the related-link corrector — #484 stage 2 territory; the module is shaped to take them.
- A fallback of any kind when nothing scores. Considered and left out: the only candidate was the full list, and the full list is the thing that was measured not to work.
- Weights. 3 / 2 / 1 are the existing matcher's plus one for prose; not tuned, stated.
