### PR TITLE
fix(frontmatter): carry block-form unknown fields through the constraints pass (#356 parity)

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -942,4 +942,40 @@ related_links:
     expect(result).toContain('  - "[[Foo]]"');
     expect(result).toContain('  - "[[Bar]]"');
   });
+  it('enforceFrontmatterConstraints preserves an unknown scalar field', () => {
+    // Control for the block-list case below: the single-line shape has been
+    // carried since the #356 follow-up and must stay byte-identical.
+    const content = `---
+type: concept
+tags: [a]
+redirect_to: "[[canonical]]"
+parent_org: Acme
+---
+
+# Body`;
+    const result = enforceFrontmatterConstraints(content, 'concept');
+    expect(result).toContain('redirect_to: "[[canonical]]"');
+    expect(result).toContain('parent_org: Acme');
+  });
+
+  it('enforceFrontmatterConstraints preserves an unknown list field (YAML block form)', () => {
+    // Same page shape as the array-helper case above, through the constraints
+    // pass. Before the fix the pass kept the header line and dropped every
+    // `- ` entry beneath it, so a user-owned block list came back as a bare
+    // `related_links:` — the key survived, its value did not.
+    const content = `---
+type: concept
+tags: [a]
+related_links:
+  - "[[Foo]]"
+  - "[[Bar]]"
+---
+
+# Body`;
+    const result = enforceFrontmatterConstraints(content, 'concept');
+    expect(result).toContain('related_links:');
+    expect(result).toContain('  - "[[Foo]]"');
+    expect(result).toContain('  - "[[Bar]]"');
+    expect(parseFrontmatter(result)?.related_links).toEqual(['[[Foo]]', '[[Bar]]']);
+  });
 });

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -578,7 +578,6 @@ export function enforceFrontmatterConstraints(
   const today = new Date().toISOString().split('T')[0];
 
   const lines = fmText.split('\n');
-  const newLines: string[] = [];
   let collectedTags: string[] = [];
   let foundType = false;
   let foundTags = false;
@@ -637,23 +636,17 @@ export function enforceFrontmatterConstraints(
         j++;
       }
       if (j > i + 1) i = j - 1;
-    } else if (!line.startsWith('- ')) {
-      newLines.push(line);
     }
   }
 
-  // Non-canonical fields (unknown keys) are passed through verbatim, preserving
-  // prior enforce behavior. newLines already excludes type/tags/aliases/created/
-  // updated and list items by construction; the filter is defensive.
-  //
-  // `sources:` is canonical but block-style is multi-line — its header line
-  // lands in newLines while its `- ` entries are dropped by the skip above,
-  // leaving a header with no entries. Exclude it here and re-emit the parsed
-  // array via serializeFrontmatter (mirrors extractPassthroughLines, which
-  // also treats sources as known). See #438 B.
-  const passthroughLines = newLines.filter(line =>
-    !line.startsWith('type:') && !line.startsWith('tags:') && !line.startsWith('aliases:') &&
-    !line.startsWith('created:') && !line.startsWith('updated:') && !line.startsWith('sources:'));
+  // Non-canonical fields (unknown keys) are passed through verbatim — the same
+  // helper and the same semantics as mergeFrontmatter and the array helpers
+  // (#356 follow-up). The loop above used to collect them itself, but it trims
+  // every line and skips every `- ` item, so a block-form list under an unknown
+  // key came back as its header alone. `sources:` is canonical and is re-emitted
+  // from the parsed array below (see #438 B); `extractPassthroughLines` already
+  // treats it as known.
+  const passthroughLines = extractPassthroughLines(content);
 
   // Preserve existing provenance (block OR flow form) across the rewrite.
   // parseFrontmatter handles both and strips quoting, matching the shape


### PR DESCRIPTION
Closes #522.

## What

`enforceFrontmatterConstraints` collected its passthrough lines inside its own line walk — every line trimmed, every `- ` item skipped — so a user-owned block list under an unknown key came back as its header alone (`related_links:` with no entries, a YAML null). Every other writer — `mergeFrontmatter`, both array helpers, and the duplicate merge with #513 — takes the lines from `extractPassthroughLines`, which keeps the indented continuation lines of an unknown key.

Same helper here, same semantics: `const passthroughLines = extractPassthroughLines(content);`, and the loop no longer builds its own list (it still collects type/tags/aliases). `sources:` keeps its re-emit from the parsed array (#438 B); the helper already treats it as known.

## Side difference, stated

A literal `reviewed: false` line used to be carried verbatim by the old loop and is now omitted — the same as `mergeFrontmatter` has always done, because the serializer emits `reviewed` only when true. No other canonical line changes shape; the two `- ` item skips that fed the bug were only ever reached for unknown keys.

## Test

`src/__tests__/core/frontmatter.test.ts`, in the #356 passthrough block:

- red → green: a block-form `related_links:` list loses both entries before, keeps both after (asserted on the lines and on `parseFrontmatter` of the result);
- control: a single-line `redirect_to:` + `parent_org:` page through the same pass, unchanged before and after.

Gate: lint, typecheck, build, 3448 tests.

## Relation to #513

Independent change in a different function; applies on `main` with or without #513. With #513 merged, the duplicate merge hands this pass the survivor's unknown fields and this is what keeps the block-form ones alive at `merge-duplicates.ts:170`.
