### PR TITLE
fix(ingest): strip non-schema sections from generated pages (#258)

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -4,6 +4,7 @@ import {
   classifyHeader,
   preserveExistingSections,
   reassertH1,
+  stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
 
 describe('canonicalizeSectionHeaders (deterministic repair of LLM-garbled section headers)', () => {
@@ -307,5 +308,98 @@ describe('reassertH1 (the title is not the model\'s call)', () => {
     const existing = '# Sulforaphan\n\n## Beschreibung\nAlt';
     const rewrite = 'Lead.\n\n---\n\n# Sulforaphan-Dosierung\n\nNeu';
     expect(reassertH1(existing, rewrite)).toBe('Lead.\n\n---\n\n# Sulforaphan\n\nNeu');
+  });
+});
+
+describe('stripUnknownSections (drop prompt-scaffolding sections the model copied into the body)', () => {
+  const DE = [
+    'Grundlegende Informationen', 'Beschreibung', 'Verwandte Inhalte',
+    'Erwähnungen in der Quelle', 'Neue Informationen', 'Definition',
+    'Hauptmerkmale', 'Anwendungen', 'Verwandte Konzepte', 'Verwandte Entitäten',
+    'Quelle', 'Kerninhalt', 'Wichtige Entitäten', 'Wichtige Konzepte',
+    'Hauptpunkte', 'Aufgelöste Widersprüche', 'Neue Behauptung',
+    'Bestehendes Wissen', 'Lösungsvorschlag', 'Quellseite',
+    'Verwandte Seiten', 'Aktualisiert',
+  ];
+
+  // The real S37 leak: the tag-vocabulary block copied verbatim from the prompt.
+  it('drops the ## Active Tag Vocabulary block and keeps everything schema-valid', () => {
+    const body = [
+      '# NF-κB-Signalweg',
+      '',
+      '## Beschreibung',
+      'NF-κB ist ein Master-Regulator der Inflammation.',
+      '',
+      '## Active Tag Vocabulary (Issue #85 — user-controlled)',
+      '',
+      'When assigning `type`, you MUST use one of the following allowed values.',
+      '- Erkrankung',
+      '- Pharmakologie',
+      '',
+      '## Verwandte Konzepte',
+      '- [[concepts/Inflammation|Inflammation]]',
+      '',
+      '## Erwähnungen in der Quelle',
+      '- "NF-κB – Master-Regulator" — [[Notizen/Biochemie|Biochemie]]',
+    ].join('\n');
+
+    const r = stripUnknownSections(body, DE);
+    expect(r).not.toContain('Active Tag Vocabulary');
+    expect(r).not.toContain('MUST use one of the following');
+    expect(r).not.toContain('- Erkrankung');
+    // Every schema section survives, in order, with its content.
+    expect(r).toContain('## Beschreibung');
+    expect(r).toContain('Master-Regulator der Inflammation');
+    expect(r).toContain('## Verwandte Konzepte');
+    expect(r).toContain('- [[concepts/Inflammation|Inflammation]]');
+    expect(r).toContain('## Erwähnungen in der Quelle');
+    expect(r).toContain('[[Notizen/Biochemie|Biochemie]]');
+    // H1 and lead structure untouched.
+    expect(r).toContain('# NF-κB-Signalweg');
+  });
+
+  it('keeps a concept page intact (Definition/Hauptmerkmale/Anwendungen are valid labels)', () => {
+    const body = [
+      '## Definition', 'Autophagie ist ein Abbauprozess.',
+      '', '## Hauptmerkmale', '- Zelluläre Homöostase',
+      '', '## Anwendungen', 'Prävention neurodegenerativer Prozesse.',
+      '', '## Verwandte Konzepte', '- [[concepts/Mitophagie|Mitophagie]]',
+    ].join('\n');
+    expect(stripUnknownSections(body, DE)).toBe(body);
+  });
+
+  it('is a no-op when every section is a known label', () => {
+    const body = '## Beschreibung\nText.\n\n## Erwähnungen in der Quelle\n- "x" — [[Notizen/A|A]]';
+    expect(stripUnknownSections(body, DE)).toBe(body);
+  });
+
+  it('leaves frontmatter and the lead paragraph before the first ## untouched', () => {
+    const body = [
+      '---', 'type: entity', '---', '', '# Titel', '', 'Einleitungstext ohne Header.',
+      '', '## Fremde Sektion', 'Müll.',
+    ].join('\n');
+    const r = stripUnknownSections(body, DE);
+    expect(r).toContain('type: entity');
+    expect(r).toContain('# Titel');
+    expect(r).toContain('Einleitungstext ohne Header.');
+    expect(r).not.toContain('## Fremde Sektion');
+    expect(r).not.toContain('Müll.');
+  });
+
+  it('does not widen the gap — no run of 3+ blank lines where a section was removed', () => {
+    const body = '## Beschreibung\nText.\n\n## Weg\nMüll.\n\n## Verwandte Konzepte\n- [[concepts/X|X]]';
+    const r = stripUnknownSections(body, DE);
+    expect(r).not.toMatch(/\n\n\n/);
+    expect(r).toContain('## Beschreibung');
+    expect(r).toContain('## Verwandte Konzepte');
+  });
+
+  it('still snaps near-miss headers via the canonicalizer, only strips true foreigners', () => {
+    // canonicalize first (repairs the garble), then strip (removes the foreigner).
+    const body = '## Erwägungen in der Quelle\n- "x" — [[Notizen/A|A]]\n\n## Active Tag Vocabulary\nMüll.';
+    const canon = canonicalizeSectionHeaders(body, DE);
+    const r = stripUnknownSections(canon, DE);
+    expect(r).toContain('## Erwähnungen in der Quelle');
+    expect(r).not.toContain('Active Tag Vocabulary');
   });
 });

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -321,3 +321,42 @@ function findH1(body: string): { text: string; start: number; end: number } | nu
 
   return null;
 }
+
+/**
+ * Drop any `## …` section whose header is not a known schema label — the
+ * complement of canonicalizeSectionHeaders. The generation prompt appends the
+ * active tag vocabulary as an `## Active Tag Vocabulary` block (system-prompts
+ * `appendTagVocabularyToPrompt`); a local model copies that prompt scaffolding
+ * verbatim into its output, so it lands as a body section on the finished page.
+ * Observed in ~36% of pages on the S37 rebuild — the canonicalizer leaves it
+ * untouched because it snaps nothing (distance to every label ≫ MAX_DISTANCE).
+ *
+ * The schema, not the model, decides which sections exist, so re-assert that
+ * after generation: a section is kept only when its header snaps to a canonical
+ * label (exact or near-miss), and dropped otherwise. Run AFTER
+ * canonicalizeSectionHeaders so genuine near-misses are already repaired and
+ * only true foreign sections remain. Content before the first `##` (frontmatter,
+ * H1, lead paragraph) is untouched. Pure, O(lines × labels).
+ *
+ * Safe on the generation paths only (createNewPage / mergePage / updateRelatedPage);
+ * reviewed pages route through appendToReviewedPage and never reach here, so no
+ * hand-curated section is ever at risk.
+ */
+export function stripUnknownSections(content: string, canonicalLabels: string[]): string {
+  const out: string[] = [];
+  let dropping = false;
+  for (const line of content.split('\n')) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      dropping = snapHeaderToCanonical(m[1], canonicalLabels) === null;
+      if (dropping) {
+        // Trim the blank lines that trailed the previous kept section so the
+        // removal leaves no widening gap.
+        while (out.length && out[out.length - 1].trim() === '') out.pop();
+        continue;
+      }
+    }
+    if (!dropping) out.push(line);
+  }
+  return out.join('\n');
+}

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -31,7 +31,7 @@ import { PROMPTS } from '../../prompts';
 import { TOKENS_PAGE_GENERATION } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
-import { canonicalizeSectionHeaders } from '../../core/section-header-canonicalizer';
+import { canonicalizeSectionHeaders, stripUnknownSections } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { parseFrontmatter, enforceFrontmatterConstraints } from '../../core/frontmatter';
 import { injectMentionsSection } from '../../core/mentions-injector';
@@ -227,8 +227,11 @@ export async function createNewPage(
     // garbled `## Verwandte …` header still resolves its section for prefix
     // correction.
     const canonicalizedContent = canonicalizeSectionHeaders(enforcedContent, Object.values(labels));
+    // Drop prompt-scaffolding sections the model copied into the body (e.g.
+    // `## Active Tag Vocabulary`) — the schema decides which sections exist.
+    const prunedContent = stripUnknownSections(canonicalizedContent, Object.values(labels));
     const correctedContent = correctRelatedLinkPrefixes(
-      canonicalizedContent,
+      prunedContent,
       info.related_entities,
       info.related_concepts,
       labels.related_entities,

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -39,6 +39,7 @@ import {
   canonicalizeSectionHeaders,
   preserveExistingSections,
   reassertH1,
+  stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
@@ -217,8 +218,9 @@ export async function mergePage(
     // 3. Assemble final content (re-assert related-link types deterministically).
     const labels = getSectionLabels(ctx.settings);
     const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
+    const prunedBody = stripUnknownSections(canonicalizedBody, Object.values(labels));
     const correctedBody = correctRelatedLinkPrefixes(
-      canonicalizedBody,
+      prunedBody,
       info.related_entities,
       info.related_concepts,
       labels.related_entities,

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -26,6 +26,7 @@ import {
   canonicalizeSectionHeaders,
   preserveExistingSections,
   reassertH1,
+  stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { getSectionLabels } from '../system-prompts';
@@ -142,8 +143,9 @@ export async function updateRelatedPage(
   // stayed garbled — and Tier-B retrieval matches labels exactly — while a
   // `sources/`-mis-prefixed link in a Related section was never re-typed.
   const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
+  const prunedBody = stripUnknownSections(canonicalizedBody, Object.values(labels));
   const correctedBody = correctRelatedLinkPrefixes(
-    canonicalizedBody,
+    prunedBody,
     newInfo.related_entities,
     newInfo.related_concepts,
     labels.related_entities,


### PR DESCRIPTION
## What

The schema decides which `## …` sections a page has. `canonicalizeSectionHeaders` already re-asserts that for garbled canonical labels; it leaves invented sections untouched. Local models invent them regularly: the tag-vocabulary block from the system prompt copied verbatim into the page body, a `## 基本信息` or `# Title` heading (#258), a `## Notes` afterthought. #283 removed one prompt-side cause; this PR is the deterministic guard for the class.

## How

- New pure `stripUnknownSections` in `core/section-header-canonicalizer.ts`: drops any `## …` whose header does not snap to a canonical label (exact or near-miss, sharing `snapHeaderToCanonical` with the canonicalizer).
- Runs right after the canonicalizer on the three generation paths (`createNewPage` / `mergePage` / `updateRelatedPage`).
- Content before the first `##` is untouched. Reviewed pages route through `appendToReviewedPage` and never reach this step, so no curated section is at risk.
- Conservative on purpose: the whitelist is every known section label, so only a truly foreign section is dropped and a real one never is.

## Measurement

German vault, local 26B model, v1.2x (the vocabulary block sat in the user prompt then): ~36 % of generated pages carried the copied block as a body section. The block has since moved into the system prompt (#328 follow-up); how often it is still echoed was not re-measured — the guard does not depend on where the block sits.

## Not in this PR

- The misplaced-`## Grundlegende Informationen` variant of #258 (a valid label in the wrong place) — different mechanism.
- Any prompt wording change.

## Tests

6 new (the 3 loss cases verified red under mutation). Against `main` (002da74): tests 3433 → 3439, lint unchanged (35), `tsc` clean, build clean.
