### PR TITLE
fix(alias): NFC-normalise and Turkish-fold the alias comparison keys (#366, phase 2)

### DIFF
--- a/src/__tests__/core/slug.test.ts
+++ b/src/__tests__/core/slug.test.ts
@@ -225,6 +225,22 @@ describe('filterRedundantAliases', () => {
     expect(result).toEqual([]);
   });
 
+  it('compares NFC-normalised: a decomposed basename from disk and a composed alias are the same name', () => {
+    // macOS hands out NFD filenames ("A" + COMBINING DIAERESIS); the model writes
+    // the composed "Ä". Bare toLowerCase() keeps them apart and the alias would
+    // be kept as if it were new.
+    const decomposedPath = 'wiki/entities/' + 'A\u0308rzte'.normalize('NFD') + '.md';
+    const result = filterRedundantAliases(decomposedPath, ['Ärzte', 'Mediziner']);
+    expect(result).toEqual(['Mediziner']);
+  });
+
+  it('cross-page uniqueness folds İ/i the same way slugKeys does', () => {
+    // toLowerCase() maps İ to i + COMBINING DOT ABOVE, so "İstanbul" and
+    // "istanbul" would pass the gate as two aliases.
+    const result = filterRedundantAliases('wiki/entities/new-page.md', ['istanbul'], ['İstanbul']);
+    expect(result).toEqual([]);
+  });
+
   it('omitting the cross-page argument preserves v1.25.9 behaviour (backward-compat)', () => {
     // No third argument — should not throw, must still apply filename + batch dedup.
     const result = filterRedundantAliases('wiki/entities/vigilanz.md', ['Vigilanz']);
@@ -308,6 +324,14 @@ describe('slugKeys with turkishFold (Issue #366)', () => {
     const b = slugKeys('şehir', [], { turkishFold: true });
     expect([...a][0]).toBe('şehir');
     expect([...b][0]).toBe('şehir');
+  });
+
+  it('NFC-normalises before keying, with and without the fold', () => {
+    const nfc = 'Doğa'.normalize('NFC');
+    const nfd = 'Doğa'.normalize('NFD');
+    expect(nfc).not.toBe(nfd); // the inputs really differ
+    expect([...slugKeys(nfd)]).toEqual([...slugKeys(nfc)]);
+    expect([...slugKeys(nfd, [], { turkishFold: true })]).toEqual([...slugKeys(nfc, [], { turkishFold: true })]);
   });
 
   it('omitting opts preserves the v1.25.9 behaviour (backward-compat)', () => {

--- a/src/core/slug.ts
+++ b/src/core/slug.ts
@@ -81,7 +81,11 @@ export function slugKeys(
   const fold = opts.turkishFold === true;
   for (const raw of [name, ...aliases]) {
     if (typeof raw !== 'string') continue;
-    const trimmed = raw.trim();
+    // NFC first: a name read back from disk may be decomposed (macOS hands
+    // out NFD filenames) while the model writes composed text, and
+    // `computeSlug` compares code points — without this the two forms of
+    // one umlaut are two keys. The file-naming path is untouched.
+    const trimmed = raw.trim().normalize('NFC');
     if (trimmed.length === 0) continue;
     // Fold BEFORE slugifying so that `[[İsim]]` and `[[isim]]` collapse
     // to the same comparison key inside a Turkish vault. ASCII `I`
@@ -123,20 +127,30 @@ export function slugKeys(
 //
 // The constant itself lives in `src/constants.ts` so it can be
 // tuned centrally without grepping the codebase.
+//
+// The comparison key is NFC-normalised and folded like `slugKeys` (not bare
+// `toLowerCase()`): a page basename that came back from disk decomposed and
+// a composed alias from the model must meet, and `İstanbul`/`istanbul` must
+// be one alias, not two — `toLowerCase()` turns `İ` into `i` + COMBINING DOT
+// ABOVE, so without the fold the uniqueness gate never fires on that pair.
+function aliasKey(raw: string): string {
+  return turkishCaseFold(raw.trim().normalize('NFC'));
+}
+
 export function filterRedundantAliases(
   pagePath: string,
   candidateAliases: string[],
   existingAliasesAcrossPages?: readonly string[],
 ): string[] {
   const fileName = pagePath.split('/').pop() || '';
-  const fileKey = fileName.replace(/\.md$/i, '').trim().toLowerCase();
+  const fileKey = aliasKey(fileName.replace(/\.md$/i, ''));
   const crossPageKeys = new Set<string>();
   if (existingAliasesAcrossPages) {
     for (const raw of existingAliasesAcrossPages) {
       if (typeof raw !== 'string') continue;
       const trimmed = raw.trim();
       if (trimmed.length >= MIN_ALIAS_LENGTH) {
-        crossPageKeys.add(trimmed.toLowerCase());
+        crossPageKeys.add(aliasKey(trimmed));
       }
     }
   }
@@ -145,7 +159,7 @@ export function filterRedundantAliases(
     if (typeof alias !== 'string') return false;
     const trimmed = alias.trim();
     if (trimmed.length < MIN_ALIAS_LENGTH) return false;
-    const key = trimmed.toLowerCase();
+    const key = aliasKey(trimmed);
     if (key === fileKey) return false; // already resolves to this file — redundant
     if (crossPageKeys.has(key)) return false; // already used on another page — wikilink ambiguity
     if (seen.has(key)) return false; // duplicate within the batch (case-insensitive)


### PR DESCRIPTION
## What

#366 shipped phase 1 in v1.25.10 (`slugKeys` with the opt-in Turkish fold). This is the comparison-key half announced as phase 2.

`filterRedundantAliases` compares with bare `toLowerCase()` on three keys (basename, cross-page aliases, candidate); `slugKeys` folds but never normalises. Two gaps, both observed on a German vault:

- no NFC/NFD normalisation anywhere in the comparison path — a basename read back from disk decomposed (macOS) and a composed alias from the model are two keys for one umlaut, so the redundancy/uniqueness gate lets the alias through as new;
- `İstanbul` / `istanbul` pass as two aliases, because `toLowerCase()` turns `İ` into `i` + COMBINING DOT ABOVE; `turkishCaseFold` exists for exactly this and was wired only into `slugKeys`.

## How

Both functions now key on `turkishCaseFold(s.trim().normalize('NFC'))`. The file-naming path (`computeSlug`) is untouched; filenames stay byte-stable.

## Not in this PR

- Any change to how files are named or to existing pages.

## Tests

Three new: NFD basename vs NFC alias → redundant; `İ`/`i` cross-page → one alias; `slugKeys` NFD/NFC equal with and without the fold. Red before (3 failures), green after. Against `main` (002da74): tests 3433 → 3436, lint unchanged (35), `tsc` clean, build clean.
