### PR TITLE
Closes #533: fix(llm): isUrlError treats a model-404 as a URL fault — wasted fallback loop, wrong setting blamed

### DIFF
--- a/src/__tests__/core/url-fallback.test.ts
+++ b/src/__tests__/core/url-fallback.test.ts
@@ -145,6 +145,22 @@ describe('isUrlError', () => {
     const err = new Error('status 404: Not Found');
     expect(isUrlError(err)).toBe(true);
   });
+
+  it('does not retry OpenRouter model 404 as a URL error', () => {
+    const err = Object.assign(
+      new Error('status 404: No endpoints found for openrouter/retired-model'),
+      { statusCode: 404 },
+    );
+    const responseBodyErr = Object.assign(
+      new Error('Provider returned error 404'),
+      {
+        statusCode: 404,
+        responseBody: '{"error":{"message":"No endpoints found for openrouter/retired-model"}}',
+      },
+    );
+    expect(isUrlError(err)).toBe(false);
+    expect(isUrlError(responseBodyErr)).toBe(false);
+  });
 });
 
 describe('resolveBaseUrlWithFallback', () => {

--- a/src/core/url-fallback.ts
+++ b/src/core/url-fallback.ts
@@ -128,7 +128,10 @@ export function invalidateCache(userUrl?: string): void {
 export function isUrlError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
 
-  const err = error as Error & { statusCode?: number };
+  const err = error as Error & { statusCode?: number; responseBody?: string };
+  if (isModelNotFound404(err)) {
+    return false;
+  }
   if (typeof err.statusCode === 'number') {
     return err.statusCode === 404;
   }
@@ -136,6 +139,11 @@ export function isUrlError(error: unknown): boolean {
   // Fallback: parse "status 404: ..." pattern from error.message
   // (set by mapAiSdkError for APICallError thrown from AI-SDK).
   return /status\s+404\b/.test(error.message);
+}
+
+function isModelNotFound404(error: Error & { responseBody?: string }): boolean {
+  return /no endpoints found for\b/i.test(error.message)
+    || /no endpoints found for\b/i.test(error.responseBody ?? '');
 }
 
 // ─── Orchestrator ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #533.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.