### PR TITLE
test(ci): tolerate libuv timer granularity in url-fallback delay assertion

### DIFF
--- a/src/__tests__/core/url-fallback.test.ts
+++ b/src/__tests__/core/url-fallback.test.ts
@@ -230,8 +230,13 @@ describe('resolveBaseUrlWithFallback', () => {
       testFn,
     });
     const elapsed = Date.now() - start;
-    // 2 candidates tried after original fails: at least 2 × RETRY_DELAY_MS
-    expect(elapsed).toBeGreaterThanOrEqual(RETRY_DELAY_MS * 2);
+    // 2 candidates tried after original fails: at least 2 × RETRY_DELAY_MS.
+    // 30ms tolerance: libuv caches loop time (~1ms granularity), so on a
+    // loaded CI runner setTimeout(300) can resolve up to a few ms "early"
+    // against a freshly captured Date.now(). Removing either delay still
+    // fails by two orders of magnitude (a fired delay costs ~300ms;
+    // nothing else on this path takes measurable time).
+    expect(elapsed).toBeGreaterThanOrEqual(RETRY_DELAY_MS * 2 - 30);
     expect(testFn).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
Single test-only change: the wall-clock assertion in `url-fallback.test.ts` required `elapsed >= RETRY_DELAY_MS * 2` exactly (600ms), and one CI run measured **599ms** — libuv caches loop time (~1ms granularity), so on a loaded shared runner `setTimeout(300)` can resolve marginally early against a freshly captured `Date.now()`.

The 30ms tolerance keeps the assertion's intent intact: if either delay were removed entirely, elapsed drops to single-digit milliseconds and still fails by two orders of magnitude (mutation-verified during development: production delay removed → test fails measuring 3ms).

First observed on PR #547's Gate 1 run; the same test code had passed ~40 prior CI runs unchanged — intermittent by nature, not tied to any branch's changes.
