### PR TITLE
fix(llm-sdk): key the token-key and reasoning-strip probe caches per (baseURL, model)

### DIFF
--- a/src/__tests__/llm-sdk/reasoning-strip-probe.test.ts
+++ b/src/__tests__/llm-sdk/reasoning-strip-probe.test.ts
@@ -13,18 +13,29 @@ import { OutputModeProber } from '../../llm-sdk/output-mode-prober';
 // Batch 6: if the cache or the classifier ever drift, the tests fail.
 
 describe('ReasoningStripProber', () => {
-  it('starts empty for any baseURL', () => {
+  const MODEL = 'qwen3-30b';
+  const SIBLING = 'gemma-4-26b';
+
+  it('starts empty for any (baseURL, model)', () => {
     const prober = new ReasoningStripProber();
-    expect(prober.shouldStrip('https://api.deepseek.com/v1')).toBe(false);
-    expect(prober.shouldStrip('https://api.example.com/v1')).toBe(false);
+    expect(prober.shouldStrip('https://api.deepseek.com/v1', MODEL)).toBe(false);
+    expect(prober.shouldStrip('https://api.example.com/v1', MODEL)).toBe(false);
   });
 
-  it('markStrip + shouldStrip round-trip per baseURL', () => {
+  it('markStrip + shouldStrip round-trip per (baseURL, model)', () => {
     const prober = new ReasoningStripProber();
-    prober.markStrip('https://api.deepseek.com/v1');
-    expect(prober.shouldStrip('https://api.deepseek.com/v1')).toBe(true);
+    prober.markStrip('https://api.deepseek.com/v1', MODEL);
+    expect(prober.shouldStrip('https://api.deepseek.com/v1', MODEL)).toBe(true);
     // Different baseURL unaffected
-    expect(prober.shouldStrip('https://api.openai.com/v1')).toBe(false);
+    expect(prober.shouldStrip('https://api.openai.com/v1', MODEL)).toBe(false);
+  });
+
+  it('does not strip for a sibling model on the same gateway (#551)', () => {
+    // One backend behind the gateway rejects reasoning_effort, the
+    // sibling supports it — the sibling must keep the pass-through.
+    const prober = new ReasoningStripProber();
+    prober.markStrip('https://api.deepseek.com/v1', MODEL);
+    expect(prober.shouldStrip('https://api.deepseek.com/v1', SIBLING)).toBe(false);
   });
 
   // v1.26.0 Batch 6 review (PR #411 simplify 2026-08-05): the previous

--- a/src/llm-sdk/__tests__/openai-compat-token-key-fallback.test.ts
+++ b/src/llm-sdk/__tests__/openai-compat-token-key-fallback.test.ts
@@ -167,4 +167,48 @@ describe('OpenAICompatSdkClient — token-key fallback integration', () => {
     expect(result).toBe('other-ok');
     expect(mockGenerateText).toHaveBeenCalledTimes(1);
   });
+
+  it('lets a sibling model probe after another model populated the cache (#551)', async () => {
+    // mockReset (not clearAllMocks): the previous test leaves a consumed-
+    // once queue behind, and clearAllMocks does not drop queued
+    // implementations.
+    mockGenerateText.mockReset();
+    // Model A on the gateway rejects max_tokens: 400 → retry succeeds →
+    // the cache now holds a verdict for (baseURL, model-a).
+    mockGenerateText
+      .mockRejectedValueOnce(new APICallError({
+        message: 'status 400', statusCode: 400, responseBody: '{}',
+        responseHeaders: {}, url: 'https://gateway.example.com/v1/chat/completions',
+        requestBodyValues: {},
+      }))
+      .mockResolvedValueOnce({ text: 'a-ok' });
+
+    await client.createMessage({
+      model: 'model-a', max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+
+    // Model B on the SAME gateway also 400s on its first call. With the
+    // per-baseURL cache the retry guard `!getCachedKey(baseURL)` was
+    // already false — B's 400 was thrown and the repair path was
+    // permanently disabled for the whole gateway. Per (baseURL, model)
+    // B gets its own probe: retry fires and succeeds.
+    vi.clearAllMocks();
+    mockGenerateText
+      .mockRejectedValueOnce(new APICallError({
+        message: 'status 400', statusCode: 400, responseBody: '{}',
+        responseHeaders: {}, url: 'https://gateway.example.com/v1/chat/completions',
+        requestBodyValues: {},
+      }))
+      .mockResolvedValueOnce({ text: 'b-ok' });
+
+    const result = await client.createMessage({
+      model: 'model-b', max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(result).toBe('b-ok');
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/llm-sdk/__tests__/token-key-probe.test.ts
+++ b/src/llm-sdk/__tests__/token-key-probe.test.ts
@@ -3,9 +3,15 @@
 // TDD for the simplified runtime probe-then-cache mechanism:
 // no error-body parsing, no regex matching.
 // Just "status 400 → try the other key once".
+//
+// Issue #551: the cache is keyed per (baseURL, model) — the wire format
+// is a property of the backend behind the model, not of the gateway URL.
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TokenKeyProber } from '../token-key-probe';
+
+const MODEL = 'qwen3-30b';
+const SIBLING = 'gemma-4-26b';
 
 describe('TokenKeyProber', () => {
   let prober: TokenKeyProber;
@@ -25,43 +31,58 @@ describe('TokenKeyProber', () => {
   });
 
   describe('getCachedKey() / setCachedKey()', () => {
-    it('returns undefined for unseen baseURL', () => {
-      expect(prober.getCachedKey('https://api.example.com/v1')).toBeUndefined();
+    it('returns undefined for unseen (baseURL, model)', () => {
+      expect(prober.getCachedKey('https://api.example.com/v1', MODEL)).toBeUndefined();
     });
 
     it('stores and retrieves cached key', () => {
-      prober.setCachedKey('https://api.example.com/v1', 'max_completion_tokens');
-      expect(prober.getCachedKey('https://api.example.com/v1')).toBe('max_completion_tokens');
+      prober.setCachedKey('https://api.example.com/v1', MODEL, 'max_completion_tokens');
+      expect(prober.getCachedKey('https://api.example.com/v1', MODEL)).toBe('max_completion_tokens');
     });
 
     it('treats different baseURLs independently', () => {
-      prober.setCachedKey('https://api.openai.com/v1', 'max_completion_tokens');
-      prober.setCachedKey('https://api.example.com/v1', 'max_tokens');
-      expect(prober.getCachedKey('https://api.openai.com/v1')).toBe('max_completion_tokens');
-      expect(prober.getCachedKey('https://api.example.com/v1')).toBe('max_tokens');
+      prober.setCachedKey('https://api.openai.com/v1', MODEL, 'max_completion_tokens');
+      prober.setCachedKey('https://api.example.com/v1', MODEL, 'max_tokens');
+      expect(prober.getCachedKey('https://api.openai.com/v1', MODEL)).toBe('max_completion_tokens');
+      expect(prober.getCachedKey('https://api.example.com/v1', MODEL)).toBe('max_tokens');
+    });
+
+    it('does not let one model\'s verdict bind its sibling on the same gateway (#551)', () => {
+      prober.setCachedKey('https://api.example.com/v1', MODEL, 'max_completion_tokens');
+      expect(prober.getCachedKey('https://api.example.com/v1', SIBLING)).toBeUndefined();
     });
   });
 
   describe('invalidate()', () => {
-    it('removes entry for a specific baseURL', () => {
-      prober.setCachedKey('https://api.example.com/v1', 'max_completion_tokens');
+    it('removes every model probed behind a baseURL', () => {
+      prober.setCachedKey('https://api.example.com/v1', MODEL, 'max_completion_tokens');
+      prober.setCachedKey('https://api.example.com/v1', SIBLING, 'max_tokens');
       prober.invalidate('https://api.example.com/v1');
-      expect(prober.getCachedKey('https://api.example.com/v1')).toBeUndefined();
+      expect(prober.getCachedKey('https://api.example.com/v1', MODEL)).toBeUndefined();
+      expect(prober.getCachedKey('https://api.example.com/v1', SIBLING)).toBeUndefined();
     });
 
     it('clears all entries when called without arg', () => {
-      prober.setCachedKey('https://api.openai.com/v1', 'max_completion_tokens');
-      prober.setCachedKey('https://api.example.com/v1', 'max_tokens');
+      prober.setCachedKey('https://api.openai.com/v1', MODEL, 'max_completion_tokens');
+      prober.setCachedKey('https://api.example.com/v1', MODEL, 'max_tokens');
       prober.invalidate();
-      expect(prober.getCachedKey('https://api.openai.com/v1')).toBeUndefined();
-      expect(prober.getCachedKey('https://api.example.com/v1')).toBeUndefined();
+      expect(prober.getCachedKey('https://api.openai.com/v1', MODEL)).toBeUndefined();
+      expect(prober.getCachedKey('https://api.example.com/v1', MODEL)).toBeUndefined();
     });
 
     it('does not affect other baseURLs after specific invalidation', () => {
-      prober.setCachedKey('https://api.openai.com/v1', 'max_completion_tokens');
-      prober.setCachedKey('https://api.example.com/v1', 'max_tokens');
+      prober.setCachedKey('https://api.openai.com/v1', MODEL, 'max_completion_tokens');
+      prober.setCachedKey('https://api.example.com/v1', MODEL, 'max_tokens');
       prober.invalidate('https://api.openai.com/v1');
-      expect(prober.getCachedKey('https://api.example.com/v1')).toBe('max_tokens');
+      expect(prober.getCachedKey('https://api.example.com/v1', MODEL)).toBe('max_tokens');
+    });
+
+    it('does not treat a baseURL sharing a prefix as a match', () => {
+      // The composite key joins with '::' — 'https://a' must not clear
+      // 'https://a.example.com'.
+      prober.setCachedKey('https://a.example.com/v1', MODEL, 'max_tokens');
+      prober.invalidate('https://a');
+      expect(prober.getCachedKey('https://a.example.com/v1', MODEL)).toBe('max_tokens');
     });
   });
 });

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -233,7 +233,7 @@ export class OpenAICompatSdkClient implements LLMClient {
       // (max_tokens). On rejection we probe + cache + next request
       // uses the swapped key.
       transformRequestBody: (args: Record<string, unknown>) => {
-        const cached = this.tokenKeyProber.getCachedKey(this.baseURL);
+        const cached = this.tokenKeyProber.getCachedKey(this.baseURL, modelId);
         if (!cached) return args;
         if (cached === 'max_tokens') return args;
         // cached === 'max_completion_tokens'
@@ -336,6 +336,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         maxOutputTokens: max_tokens,
         ...outputArgs,
         providerOptions: this.buildProviderOptions({
+          model,
           enableThinking,
           reasoningEffort,
           repetitionPenalty: repetition_penalty,
@@ -503,6 +504,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           maxOutputTokens: max_tokens,
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
@@ -555,7 +557,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         APICallError.isInstance(err) &&
         err.statusCode === 400 &&
         enableThinking === false &&
-        !this.reasoningStripProber.shouldStrip(this.baseURL) &&
+        !this.reasoningStripProber.shouldStrip(this.baseURL, model) &&
         ReasoningStripProber.isReasoningFieldError(err.responseBody ?? err.message ?? '')
       ) {
         // [DEBUG-LOG v1.26.3 E2E] reasoning-strip probe matched — the
@@ -587,6 +589,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           maxOutputTokens: max_tokens,
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
@@ -595,7 +598,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         // Retry succeeded — commit the cache decision now. If the
         // retry above throws, this line never runs and the cache is
         // untouched; the outer catch propagates the error.
-        this.reasoningStripProber.markStrip(this.baseURL);
+        this.reasoningStripProber.markStrip(this.baseURL, model);
         console.debug(`[REASONING-STRIP-DEBUG] baseURL=${this.baseURL} cache committed (markStrip). Future calls on this baseURL will skip the probe.`);
         reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
@@ -721,6 +724,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             maxOutputTokens: max_tokens,
             ...buildOutputArgs(response_format, demotedMode),
             providerOptions: this.buildProviderOptions({
+              model,
               enableThinking,
               reasoningEffort,
               repetitionPenalty: repetition_penalty,
@@ -770,10 +774,10 @@ export class OpenAICompatSdkClient implements LLMClient {
       // error message clearly names a reasoning-related field, or
       // `json_object` / `response_format`). Token-key is the broader
       // catch-all for any other 400.
-      if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL)) {
+      if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL, model)) {
         // The default wire format is `max_tokens`. If the gateway
         // rejected it, try `max_completion_tokens`.
-        this.tokenKeyProber.setCachedKey(this.baseURL, 'max_completion_tokens');
+        this.tokenKeyProber.setCachedKey(this.baseURL, model, 'max_completion_tokens');
         const retryLanguageModel = this.getProvider(model, this.fetchImpl);
         const { generateText } = await import('ai');
         const result = await generateText({
@@ -783,6 +787,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           maxOutputTokens: max_tokens,
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
@@ -900,6 +905,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         maxOutputTokens: max_tokens,
         ...outputArgs,
         providerOptions: this.buildProviderOptions({
+          model,
           enableThinking,
           reasoningEffort,
           repetitionPenalty: repetition_penalty,
@@ -1020,6 +1026,7 @@ export class OpenAICompatSdkClient implements LLMClient {
                 maxOutputTokens: max_tokens,
                 ...buildOutputArgs(response_format, 'text_prompt'),
                 providerOptions: this.buildProviderOptions({
+                  model,
                   enableThinking,
                   reasoningEffort,
                   repetitionPenalty: repetition_penalty,
@@ -1120,6 +1127,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           maxOutputTokens: max_tokens,
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
@@ -1180,6 +1188,7 @@ export class OpenAICompatSdkClient implements LLMClient {
               maxOutputTokens: max_tokens,
               ...buildOutputArgs(response_format, demotedMode),
               providerOptions: this.buildProviderOptions({
+                model,
                 enableThinking,
                 reasoningEffort,
                 repetitionPenalty: repetition_penalty,
@@ -1208,8 +1217,8 @@ export class OpenAICompatSdkClient implements LLMClient {
       }
 
       // Token-key probe (coarse any-400 fallback).
-      if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL)) {
-        this.tokenKeyProber.setCachedKey(this.baseURL, 'max_completion_tokens');
+      if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL, model)) {
+        this.tokenKeyProber.setCachedKey(this.baseURL, model, 'max_completion_tokens');
         const retryLanguageModel = this.getProvider(model, this.fetchImpl);
         const { generateText } = await import('ai');
         const result = await generateText({
@@ -1219,6 +1228,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           maxOutputTokens: max_tokens,
           ...outputArgs,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
@@ -1269,6 +1279,8 @@ export class OpenAICompatSdkClient implements LLMClient {
    * full post-mortem.
    */
   private buildProviderOptions(opts: {
+    /** Issue #551: the strip cache is keyed per (baseURL, model). */
+    model: string;
     enableThinking?: boolean;
     reasoningEffort?: 'low' | 'medium' | 'high';
     repetitionPenalty?: number;
@@ -1280,9 +1292,9 @@ export class OpenAICompatSdkClient implements LLMClient {
     // takes precedence — asking for `low` and `none` at once is a contradiction
     // the policy layer cannot produce (`off` yields no effort) and that a call
     // site should not be able to smuggle in either.
-    if (opts.reasoningEffort && !this.reasoningStripProber.shouldStrip(this.baseURL)) {
+    if (opts.reasoningEffort && !this.reasoningStripProber.shouldStrip(this.baseURL, opts.model)) {
       openaiOpts.reasoningEffort = opts.reasoningEffort;
-    } else if (opts.enableThinking === false && !this.reasoningStripProber.shouldStrip(this.baseURL)) {
+    } else if (opts.enableThinking === false && !this.reasoningStripProber.shouldStrip(this.baseURL, opts.model)) {
       // v1.26.0 Batch 6: force-disable thinking via reasoningEffort.
       //
       // Prior mechanism (PR #410 / Batch 2) used `thinking.type: 'disabled'`
@@ -1440,6 +1452,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         // No effort here: the stream path carries no `task` label (#469), so
         // no per-step policy can be resolved for it.
         providerOptions: this.buildProviderOptions({
+          model,
           enableThinking,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
@@ -1515,6 +1528,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
@@ -1555,7 +1569,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         APICallError.isInstance(err) &&
         err.statusCode === 400 &&
         enableThinking === false &&
-        !this.reasoningStripProber.shouldStrip(this.baseURL) &&
+        !this.reasoningStripProber.shouldStrip(this.baseURL, model) &&
         ReasoningStripProber.isReasoningFieldError(err.responseBody ?? err.message ?? '')
       ) {
         const retryLanguageModel = this.getProvider(model, this.streamFetchImpl);
@@ -1566,6 +1580,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
@@ -1584,7 +1599,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         // throws (network blip, transient 5xx), the cache is not
         // poisoned; the outer catch propagates the error and the
         // next call gets a fresh probe.
-        this.reasoningStripProber.markStrip(this.baseURL);
+        this.reasoningStripProber.markStrip(this.baseURL, model);
         if (reasoningContent) {
           fullText = wrapReasoningContent(reasoningContent, fullText);
         }
@@ -1594,8 +1609,8 @@ export class OpenAICompatSdkClient implements LLMClient {
       // v1.23.0 P1.5 follow-up: token-key probe-then-retry for streaming.
       // Same logic as createMessage — cache the alt key for this
       // baseURL and retry. No error-body inspection.
-      if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL)) {
-        this.tokenKeyProber.setCachedKey(this.baseURL, 'max_completion_tokens');
+      if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL, model)) {
+        this.tokenKeyProber.setCachedKey(this.baseURL, model, 'max_completion_tokens');
         const retryLanguageModel = this.getProvider(model, this.streamFetchImpl);
         const { streamText } = await import('ai');
         const result = streamText({
@@ -1604,6 +1619,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],

--- a/src/llm-sdk/openai-sdk-client.ts
+++ b/src/llm-sdk/openai-sdk-client.ts
@@ -155,6 +155,7 @@ export class OpenAISdkClient implements LLMClient {
         // object but TypeScript can't narrow `unknown` → JSONValue
         // automatically. Cast at the boundary; runtime behavior is fine.
         providerOptions: this.buildProviderOptions({
+          model,
           enableThinking,
           repetitionPenalty: repetition_penalty,
           // Built here, discarded by the SDK. `createOpenAI()(modelId)` returns
@@ -193,6 +194,7 @@ export class OpenAISdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             repetitionPenalty: repetition_penalty,
             responseFormat: response_format,
@@ -219,7 +221,7 @@ export class OpenAISdkClient implements LLMClient {
         err.statusCode === 400 &&
         enableThinking === false &&
         this.baseURL !== undefined &&
-        !this.reasoningStripProber.shouldStrip(this.baseURL) &&
+        !this.reasoningStripProber.shouldStrip(this.baseURL, model) &&
         ReasoningStripProber.isReasoningFieldError(err.message ?? '')
       ) {
         const retryLanguageModel = this.getProvider(model, this.fetchImpl);
@@ -230,6 +232,7 @@ export class OpenAISdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
             responseFormat: response_format,
@@ -239,7 +242,7 @@ export class OpenAISdkClient implements LLMClient {
         // Retry succeeded — commit the cache decision now. If the
         // retry above throws, this line never runs and the cache is
         // untouched; the outer catch propagates the error.
-        this.reasoningStripProber.markStrip(this.baseURL);
+        this.reasoningStripProber.markStrip(this.baseURL, model);
         reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
       }
@@ -266,6 +269,8 @@ export class OpenAISdkClient implements LLMClient {
    * matches the v1.20.0 "provider-first thinking control" policy.
    */
   private buildProviderOptions(opts: {
+    /** Issue #551: the strip cache is keyed per (baseURL, model). */
+    model: string;
     enableThinking?: boolean;
     repetitionPenalty?: number;
     responseFormat?: { type: 'json_object' };
@@ -278,7 +283,7 @@ export class OpenAISdkClient implements LLMClient {
 
     if (
       opts.enableThinking === false &&
-      !(this.baseURL !== undefined && this.reasoningStripProber.shouldStrip(this.baseURL))
+      !(this.baseURL !== undefined && this.reasoningStripProber.shouldStrip(this.baseURL, opts.model))
     ) {
       // v1.26.0 Batch 6 + Bug-1 fix: switch from 'low' to 'none' for the
       // official OpenAI Responses path; gate on shouldStrip(baseURL).
@@ -394,6 +399,7 @@ export class OpenAISdkClient implements LLMClient {
         messages: messages.map((m) => ({ role: m.role, content: m.content })),
         maxOutputTokens: max_tokens,
         providerOptions: this.buildProviderOptions({
+          model,
           enableThinking,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
@@ -457,6 +463,7 @@ export class OpenAISdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
@@ -496,7 +503,7 @@ export class OpenAISdkClient implements LLMClient {
         err.statusCode === 400 &&
         enableThinking === false &&
         this.baseURL !== undefined &&
-        !this.reasoningStripProber.shouldStrip(this.baseURL) &&
+        !this.reasoningStripProber.shouldStrip(this.baseURL, model) &&
         ReasoningStripProber.isReasoningFieldError(err.message ?? '')
       ) {
         const retryLanguageModel = this.getProvider(model, this.streamFetchImpl);
@@ -507,6 +514,7 @@ export class OpenAISdkClient implements LLMClient {
           messages: messages.map((m) => ({ role: m.role, content: m.content })),
           maxOutputTokens: max_tokens,
           providerOptions: this.buildProviderOptions({
+            model,
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
@@ -528,7 +536,7 @@ export class OpenAISdkClient implements LLMClient {
         } catch { /* no reasoning */ }
         // Bug-3: markStrip AFTER retry succeeds. If the stream throws,
         // the cache stays untouched and the outer catch propagates.
-        this.reasoningStripProber.markStrip(this.baseURL);
+        this.reasoningStripProber.markStrip(this.baseURL, model);
         if (reasoningContent) {
           fullText = wrapReasoningContent(reasoningContent, fullText);
         }

--- a/src/llm-sdk/reasoning-strip-probe.ts
+++ b/src/llm-sdk/reasoning-strip-probe.ts
@@ -77,11 +77,16 @@ const FIELD_MARKERS = [
  * ReasoningStripProber — per-client "should I strip reasoningEffort?"
  * cache.
  *
- * Cache keyed by baseURL because the same gateway typically uses the
- * same wire format across all models. Value is presence (true) — the
- * key itself is the signal — so a Set is the right primitive, not a
- * Map<string, true> (which would carry a dead second type parameter
- * and a dead `=== true` check on every read).
+ * Cache keyed by (baseURL, model) — Issue #551. The wire format is a
+ * property of the backend behind the model, not of the gateway URL: a
+ * per-model routing proxy or a multi-model LM Studio can host a backend
+ * that rejects `reasoning_effort` next to one that supports it, and the
+ * earlier per-baseURL key silently dropped the pass-through for the
+ * sibling that supports it. Same composite-key design as
+ * OutputModeProber. Value is presence (true) — the key itself is the
+ * signal — so a Set is the right primitive, not a Map<string, true>
+ * (which would carry a dead second type parameter and a dead `=== true`
+ * check on every read).
  *
  * v1.26.0 Batch 6 review (PR #411 simplify 2026-08-05): the previous
  * design also exposed an `invalidate(baseUrl?)` overload with zero
@@ -94,21 +99,26 @@ const FIELD_MARKERS = [
 export class ReasoningStripProber {
   private readonly cache = new Set<string>();
 
-  /**
-   * Read cached strip decision for a baseURL.
-   * `true` = we already learned this backend rejects reasoningEffort
-   * and the next call should omit it.
-   */
-  shouldStrip(baseUrl: string): boolean {
-    return this.cache.has(baseUrl);
+  /** Composite key: baseURL + model so sibling models share no state. */
+  private key(baseUrl: string, model: string): string {
+    return `${baseUrl}::${model}`;
   }
 
   /**
-   * Mark a baseURL as "strip reasoningEffort on future calls".
-   * Called after a 400 retry revealed the field was the cause.
+   * Read cached strip decision for a (baseURL, model) pair.
+   * `true` = we already learned this backend rejects reasoningEffort
+   * and the next call should omit it.
    */
-  markStrip(baseUrl: string): void {
-    this.cache.add(baseUrl);
+  shouldStrip(baseUrl: string, model: string): boolean {
+    return this.cache.has(this.key(baseUrl, model));
+  }
+
+  /**
+   * Mark a (baseURL, model) pair as "strip reasoningEffort on future
+   * calls". Called after a 400 retry revealed the field was the cause.
+   */
+  markStrip(baseUrl: string, model: string): void {
+    this.cache.add(this.key(baseUrl, model));
   }
 
   /**

--- a/src/llm-sdk/token-key-probe.ts
+++ b/src/llm-sdk/token-key-probe.ts
@@ -32,31 +32,46 @@ export type TokenKey = 'max_tokens' | 'max_completion_tokens';
 /**
  * TokenKeyProber — per-client token-key cache.
  *
- * Cache keyed by baseURL (not model) because the same gateway
- * typically uses the same wire format across all models.
+ * Cache keyed by (baseURL, model) — Issue #551. The wire format is a
+ * property of the backend behind the model, not of the gateway URL: a
+ * per-model routing proxy (LiteLLM, one-api) or a multi-model LM Studio
+ * can host both answers behind one baseURL. The earlier per-baseURL key
+ * let one model's probe verdict rewrite every sibling's requests, and —
+ * because the 400-retry is gated on cache emptiness — permanently
+ * disabled the repair path for the whole gateway. Same composite-key
+ * design as OutputModeProber.
  */
 export class TokenKeyProber {
   private readonly cache: Map<string, TokenKey> = new Map();
 
-  /** Read cached key for a baseURL, or undefined if not yet probed. */
-  getCachedKey(baseUrl: string): TokenKey | undefined {
-    return this.cache.get(baseUrl);
+  /** Composite key: baseURL + model so sibling models share no state. */
+  private key(baseUrl: string, model: string): string {
+    return `${baseUrl}::${model}`;
   }
 
-  /** Write a probed/known-good key for a baseURL. */
-  setCachedKey(baseUrl: string, key: TokenKey): void {
-    this.cache.set(baseUrl, key);
+  /** Read cached key for a (baseURL, model) pair, or undefined if not yet probed. */
+  getCachedKey(baseUrl: string, model: string): TokenKey | undefined {
+    return this.cache.get(this.key(baseUrl, model));
+  }
+
+  /** Write a probed/known-good key for a (baseURL, model) pair. */
+  setCachedKey(baseUrl: string, model: string, key: TokenKey): void {
+    this.cache.set(this.key(baseUrl, model), key);
   }
 
   /**
    * Invalidate cached entries. Called when the user changes baseURL
    * or API key (re-probe on next request), or for unit tests.
+   * A bare baseURL clears every model probed behind it.
    */
   invalidate(baseUrl?: string): void {
     if (baseUrl === undefined) {
       this.cache.clear();
-    } else {
-      this.cache.delete(baseUrl);
+      return;
+    }
+    const prefix = `${baseUrl}::`;
+    for (const key of [...this.cache.keys()]) {
+      if (key.startsWith(prefix)) this.cache.delete(key);
     }
   }
 


### PR DESCRIPTION
Closes #551.

One commit. One long-lived client serves every task and the model arrives per call, so several models share one baseURL and one set of probe caches. `OutputModeProber` already keys per `(baseURL, model)` — its header documents why. `TokenKeyProber` and `ReasoningStripProber` keyed on baseURL alone, with the three consequences from the issue: the first probed model's token key rewrote every sibling's requests unprobed; the 400-retry branches are gated on cache emptiness, so a sibling's token-key 400 was thrown with the repair path permanently disabled for the whole gateway; and `markStrip(baseURL)` silently dropped the `reasoning_effort`/`enableThinking` pass-through for siblings whose backend supports them.

## What changed

- Both probers adopt the `OutputModeProber` composite key (`baseURL::model`). Single-model setups produce identical behavior before and after — the key differs only when a second model actually shares the gateway.
- `TokenKeyProber.invalidate(baseUrl)` clears every model probed behind the baseURL; the `::` join keeps `https://a` from matching `https://a.example.com`.
- `ReasoningStripProber` keeps its no-invalidate design (removed in the PR #411 simplify round — not reintroduced).
- `buildProviderOptions` in both clients takes the model to key the strip check; all 20 call sites thread it. `transformRequestBody` keys on `(baseURL, modelId)`.

## Tests

+4 unit (sibling isolation for both probers, per-baseURL invalidate, prefix separation) and +1 client-level regression: model B still gets its own probe after model A populated the cache — the exact throw path from the issue. All verified RED against the per-baseURL sources (7 failures), green after.

## Gate 1

lint 0 · tsc 0 · build clean · 3656/3656 tests · css-lint 0

## Gate 2: Side effects

- Call-site audit: every `shouldStrip`/`markStrip`/`getCachedKey`/`setCachedKey` caller threads a model already in scope (tsc-enforced — the new required parameter enumerated them). No consumer outside the two clients.
- Cache capacity grows from O(gateways) to O(gateways × models actually used) — a handful of in-memory strings per client instance.

## Gate 3: Breaking changes

None detected. The caches are in-memory per client instance; no settings, schema, or ID changes.

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | N/A | Same lookups, one string concat per read |
| Memory | ✅ | One entry per (gateway, model) actually probed |
| IO | N/A | |
| Network | ✅ | Siblings stop inheriting wrong verdicts — fewer doomed requests |
| Token | N/A | |
