### PR TITLE
docs(llm-sdk): clear stale per-baseURL wording after Issue #551 composite-key fix

### DIFF
--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -103,7 +103,7 @@ export class OpenAICompatSdkClient implements LLMClient {
    * backends (Gemini-via-shim per #137) reject `reasoning_effort: 'none'`
    * with HTTP 400. On 400 with a reasoning-related field name in the
    * error message, we strip the field and retry exactly once; the
-   * strip decision is cached per baseURL so subsequent calls skip
+   * strip decision is cached per (baseURL, model) so subsequent calls skip
    * the probe. Mirrors the [[TokenKeyProber]] design.
    */
   private readonly reasoningStripProber = new ReasoningStripProber();
@@ -226,13 +226,17 @@ export class OpenAICompatSdkClient implements LLMClient {
       // cached on the instance in the constructor.
       supportsStructuredOutputs: this.supportsStructuredOutputs,
       // v1.23.0 P1.5 follow-up: token-key probe hook. Read the
-      // current cached key for this baseURL at request time — this
+      // current cached key for this (baseURL, model) at request time — this
       // closure captures `this` so each request consults the latest
       // probe result. If we have no cached entry, the transform is
       // a no-op and the request goes out with the AI-SDK default
       // (max_tokens). On rejection we probe + cache + next request
       // uses the swapped key.
       transformRequestBody: (args: Record<string, unknown>) => {
+        // Issue #551 follow-up: keyed per (baseURL, modelId). The URL-fallback
+        // probe uses synthetic 'gpt-4o-mini' (probeBaseURL) — its slot is
+        // never populated; no swap applied there (safe — the probe is a
+        // separate connectivity check, not a request that needs the token-key fix).
         const cached = this.tokenKeyProber.getCachedKey(this.baseURL, modelId);
         if (!cached) return args;
         if (cached === 'max_tokens') return args;
@@ -533,7 +537,7 @@ export class OpenAICompatSdkClient implements LLMClient {
       // strip must run first when the message clearly identifies the
       // reasoning field as the cause.
       //
-      // Guard: skip retry if we've already cached "strip" for this
+      // Guard: skip retry if we've already cached "strip" for this (baseURL, model)
       // baseURL — means the first retry already happened (and the
       // retry would either succeed or fail the same way).
       //
@@ -599,7 +603,7 @@ export class OpenAICompatSdkClient implements LLMClient {
         // retry above throws, this line never runs and the cache is
         // untouched; the outer catch propagates the error.
         this.reasoningStripProber.markStrip(this.baseURL, model);
-        console.debug(`[REASONING-STRIP-DEBUG] baseURL=${this.baseURL} cache committed (markStrip). Future calls on this baseURL will skip the probe.`);
+        console.debug(`[REASONING-STRIP-DEBUG] baseURL=${this.baseURL} cache committed (markStrip). Future calls on this (baseURL, model) will skip the probe.`);
         reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
       }
@@ -766,7 +770,7 @@ export class OpenAICompatSdkClient implements LLMClient {
       // of a false-positive retry is one extra HTTP call (<1s LAN).
       //
       // Guard: skip retry if we already have a cached key for this
-      // baseURL — means the first retry already happened (and failed),
+      // (baseURL, model) — means the first retry already happened (and failed),
       // so retrying again would loop.
       //
       // Runs AFTER the reasoning-strip + json-object-strip branches
@@ -1608,7 +1612,7 @@ export class OpenAICompatSdkClient implements LLMClient {
 
       // v1.23.0 P1.5 follow-up: token-key probe-then-retry for streaming.
       // Same logic as createMessage — cache the alt key for this
-      // baseURL and retry. No error-body inspection.
+      // (baseURL, model) and retry. No error-body inspection.
       if (APICallError.isInstance(err) && err.statusCode === 400 && !this.tokenKeyProber.getCachedKey(this.baseURL, model)) {
         this.tokenKeyProber.setCachedKey(this.baseURL, model, 'max_completion_tokens');
         const retryLanguageModel = this.getProvider(model, this.streamFetchImpl);

--- a/src/llm-sdk/openai-sdk-client.ts
+++ b/src/llm-sdk/openai-sdk-client.ts
@@ -78,7 +78,7 @@ export class OpenAISdkClient implements LLMClient {
    * baseURLs (e.g. user-provided self-hosted) may reject
    * `reasoning_effort: 'none'` with HTTP 400. On 400 with a
    * reasoning-related field name in the error message, strip the field
-   * and retry exactly once. Per-baseURL cache prevents infinite loops.
+   * and retry exactly once. Per-(baseURL, model) cache prevents infinite loops.
    * Mirrors the [[ReasoningStripProber]] use in OpenAICompatSdkClient.
    */
   private readonly reasoningStripProber = new ReasoningStripProber();
@@ -286,10 +286,10 @@ export class OpenAISdkClient implements LLMClient {
       !(this.baseURL !== undefined && this.reasoningStripProber.shouldStrip(this.baseURL, opts.model))
     ) {
       // v1.26.0 Batch 6 + Bug-1 fix: switch from 'low' to 'none' for the
-      // official OpenAI Responses path; gate on shouldStrip(baseURL).
+      // official OpenAI Responses path; gate on shouldStrip((baseURL, model)).
       //
       // The shouldStrip guard prevents a regression spotted during
-      // code-review (Aug 2026): once Layer-3 marks a baseURL as
+      // code-review (Aug 2026): once Layer-3 marks a (baseURL, model) as
       // "strip" (because it 400'd on reasoning_effort), the next call
       // must NOT re-inject the field — otherwise the catch-block guard
       // `!shouldStrip` short-circuits and the reasoning-strip retry

--- a/src/llm-sdk/reasoning-strip-probe.ts
+++ b/src/llm-sdk/reasoning-strip-probe.ts
@@ -9,7 +9,7 @@ import { classifyFieldError } from './shared-rejection-verbs';
 // (two-marker pattern, mirrors the established
 // `[[isPdfRelatedLlmError]]` classifier in `src/wiki/wiki-engine.ts:587-608`),
 // strip the field from the next attempt, and retry exactly once. Cache
-// the per-baseURL "strip" decision so subsequent calls skip the probe.
+// the per-(baseURL, model) "strip" decision so subsequent calls skip the probe.
 //
 // Design (mirrors [[token-key-probe.ts]]):
 //
@@ -44,9 +44,13 @@ import { classifyFieldError } from './shared-rejection-verbs';
 //   - 401 (auth) / 429 (rate) / 5xx (server) have distinct status codes
 //     and are NOT covered here.
 //
-// Why per-baseURL not per-model:
-//   Same gateway → same wire format → same rejection behaviour. Model
-//   granularity would over-invalidate the cache.
+// Why per-(baseURL, model) — Issue #551:
+//   The wire format is a property of the backend behind the model, not
+//   of the gateway URL. A per-model routing proxy (LiteLLM, one-api)
+//   or a multi-model LM Studio can host a backend that rejects
+//   `reasoning_effort` next to one that supports it — the shared
+//   per-baseURL cache silently dropped the pass-through for the
+//   sibling that does. Same composite-key design as OutputModeProber.
 
 /**
  * Rejection verbs shared with OutputModeProber via

--- a/src/llm-sdk/token-key-probe.ts
+++ b/src/llm-sdk/token-key-probe.ts
@@ -10,7 +10,7 @@
 //   2. If the gateway returns HTTP 400, retry ONCE with the other
 //      token key (max_completion_tokens). No error-body inspection,
 //      no regex matching, no model-name hardcoding.
-//   3. If the retry succeeds, cache the working key for this baseURL
+//   3. If the retry succeeds, cache the working key for this (baseURL, model) pair
 //      so subsequent requests skip the probe.
 //   4. If the retry also fails, throw the *original* error. The
 //      extra HTTP call on the false-positive path is harmless
@@ -60,8 +60,8 @@ export class TokenKeyProber {
   }
 
   /**
-   * Invalidate cached entries. Called when the user changes baseURL
-   * or API key (re-probe on next request), or for unit tests.
+   * Invalidate cached entries. Test helper today — production re-probes
+   * by client reconstruction; or for unit tests.
    * A bare baseURL clears every model probed behind it.
    */
   invalidate(baseUrl?: string): void {


### PR DESCRIPTION
Follow-up to #552 (closes #551). Review-only polish: no behavioural wire change on single-model users.

The #552 composite-key fix moved the two probe caches from per-baseURL to per-(baseURL, model) and rewrote the class-JSDocs, but ~10 adjacent prose blocks still said per-baseURL — a header that now argues the exact opposite of the merged change. This sweep clears them:

- `reasoning-strip-probe.ts` — the untouched "Why per-baseURL not per-model" header block now argues per-(baseURL, model) with Issue #551 rationale.
- `token-key-probe.ts` — step-3 header phrasing + `invalidate()` JSDoc ("Called when user changes baseURL/API key" → test helper; production re-probes by client reconstruction).
- `openai-compat-sdk-client.ts` — transformRequestBody comment, Guard phrases, [REASONING-STRIP-DEBUG] log wording, stream-ordering notes; note inside `getProvider(transformRequestBody)` for probeBaseURL's synthetic `gpt-4o-mini` (that slot is never populated — safe, it's a connectivity check).
- `openai-sdk-client.ts` — Layer-3 cache description + gate guards.

The narrow triple-condition regression from #551 review (cached swap + URL fallback + gateway rejects max_tokens) is documented as a visible abort; threading the request model into `probeBaseURL` is not justified this cycle.

## Gate 1
lint 0 · tsc 0 · build clean · 3677/3677 tests · css-lint 0

## Gate 2: Side effects
Comment/log-only — no code path, no call-site, no error-propagation change. No behavioural change for single-model or multi-model users (wire bytes identical).

## Gate 3: Breaking changes
None.

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | N/A | Comment-only |
| Memory | N/A |  |
| IO | N/A |  |
| Network | N/A |  |
| Token | N/A |  |