### PR TITLE
chore(deps): move pnpm settings to pnpm-workspace.yaml — pnpm >= 11 no longer reads the `pnpm` field

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -89,9 +89,11 @@ audit surfaces. If `--approve` was skipped, post `gh pr comment <N> --body-file
   re-resolves from registry and drifts from pnpm).
 - **Always** `rm -f pnpm-lock.yaml && pnpm install && npm install
   --legacy-peer-deps --package-lock-only` in the project directory. The
-  project pins `pnpm@10.14.0` and uses flat `pnpm.overrides` — npm `overrides`
-  has different semantics, so `package.json` declares BOTH keys with the
-  same flat values to keep both lockfiles aligned.
+  project pins `pnpm@10.14.0`; the flat pnpm overrides live in
+  `pnpm-workspace.yaml` (the `pnpm` field in package.json is deprecated and
+  pnpm >= 11 no longer reads it, Issue #556) — npm `overrides` has different
+  semantics, so `package.json` keeps the top-level key with the same flat
+  values to keep both lockfiles aligned.
 
 ### Issue close keyword
 

--- a/package.json
+++ b/package.json
@@ -54,15 +54,6 @@
     "fast-uri": "3.1.5",
     "brace-expansion": "5.0.9"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ],
-    "overrides": {
-      "fast-uri": "3.1.5",
-      "brace-expansion": "5.0.9"
-    }
-  },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.98",
     "@ai-sdk/openai": "3.0.86",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+onlyBuiltDependencies:
+  - esbuild
+overrides:
+  fast-uri: 3.1.5
+  brace-expansion: 5.0.9


### PR DESCRIPTION
Closes #556.

**What moves.** `overrides` (fast-uri 3.1.5, brace-expansion 5.0.9) and `onlyBuiltDependencies` (esbuild) move from the `pnpm` field in `package.json` to a new `pnpm-workspace.yaml`; the deprecated `pnpm` block is removed. The top-level `overrides` stays — it is npm's copy of the same pins (#501). One line in `MEMORY.md` (lockfile rule) follows the move, since it records where the pnpm pins live; the sync pair is now: top-level `overrides` (npm) <-> `pnpm-workspace.yaml` (pnpm).

**Measured** (details in #556): with this layout the pins survive a from-scratch `--lockfile-only` re-resolve under pnpm 10.14.0 (today's `packageManager`) **and** under pnpm 11.24.0; without it, pnpm 11 silently drops them. The per-invocation WARN disappears with the removed block.

**Unchanged on purpose.** `pnpm-lock.yaml` is byte-identical — the recorded `overrides:` values do not change, only where pnpm reads them from. `packageManager` stays at 10.14.0: bumping it is a separate decision, and this PR exists precisely so that whenever that bump happens, nothing is silently lost. CI needs no change (`pnpm/action-setup` 10.14.0, `--frozen-lockfile`; 10.14 reads the workspace file — measured, and `pnpm install --frozen-lockfile` validates against the untouched lockfile). `package-lock.json` untouched: npm ignores `pnpm-workspace.yaml` and keeps using the top-level `overrides`.

Tests: five-gate green locally (lint, typecheck, build, test 3677/3677, css-lint).
