### PR TITLE
fix(alias): thread the minAliasLength floor to the create path; feed f9a680e's cross-page gate at path resolution

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -432,6 +432,23 @@ describe('enforceFrontmatterConstraints', () => {
   });
 });
 
+describe('enforceFrontmatterConstraints: minAliasLength reaches the create path', () => {
+  const input = '---\ntype: entity\naliases: ["ML", "Maschinelles Lernen"]\n---\n\nBody';
+  const opts = { pagePath: 'wiki/entities/machine-learning.md' };
+
+  it('applies the settings floor to model-written aliases at page birth', () => {
+    const settings = { minAliasLength: 3 } as unknown as LLMWikiSettings;
+    const result = enforceFrontmatterConstraints(input, 'entity', settings, opts);
+    expect(result).toContain('Maschinelles Lernen');
+    expect(result).not.toContain('"ML"');
+  });
+
+  it('keeps the constant floor of 2 when the setting is absent', () => {
+    const result = enforceFrontmatterConstraints(input, 'entity', undefined, opts);
+    expect(result).toContain('"ML"');
+  });
+});
+
 describe('serializeFrontmatter', () => {
   it('emits fields in canonical order: type, created, updated, passthrough, sources, tags, reviewed, aliases', () => {
     const block = serializeFrontmatter(

--- a/src/__tests__/wiki/page-factory/aliases.test.ts
+++ b/src/__tests__/wiki/page-factory/aliases.test.ts
@@ -6,7 +6,7 @@
 // how aliases get added, deduplicated, or rewritten into the frontmatter.
 
 import { describe, it, expect, vi } from 'vitest';
-import { appendAliases, resolveMinAliasLength, type AliasesContext } from '../../../wiki/page-factory/aliases';
+import { aliasClaimsFromPages, appendAliases, resolveMinAliasLength, type AliasesContext } from '../../../wiki/page-factory/aliases';
 
 function makeContext(initial: Record<string, string>): AliasesContext & {
   written: Map<string, string>;
@@ -155,5 +155,50 @@ describe('appendAliases — minAliasLength setting', () => {
     expect(resolveMinAliasLength({ minAliasLength: 1 })).toBe(2);
     expect(resolveMinAliasLength({ minAliasLength: 7 })).toBe(2);
     expect(resolveMinAliasLength({ minAliasLength: 2.5 })).toBe(2);
+  });
+});
+
+describe('appendAliases — cross-page uniqueness gate', () => {
+  it('drops an alias another page already claims, keeps the rest', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['existing']) });
+    await appendAliases(ctx, PAGE, ['Wachheit', 'Aufmerksamkeit'], ['Aufmerksamkeit']);
+    const written = ctx.written.get(PAGE)!;
+    expect(written).toContain('  - "Wachheit"');
+    expect(written).not.toContain('  - "Aufmerksamkeit"');
+  });
+
+  it('matches claims case-insensitively', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['existing']) });
+    await appendAliases(ctx, PAGE, ['wachheit'], ['Wachheit']);
+    // every candidate collided — nothing to add, file untouched
+    expect(ctx.written.get(PAGE)!).toBe(makePage(['existing']));
+  });
+
+  it('without the claims argument behaves as before (no cross-page gate)', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['existing']) });
+    await appendAliases(ctx, PAGE, ['Aufmerksamkeit']);
+    expect(ctx.written.get(PAGE)!).toContain('  - "Aufmerksamkeit"');
+  });
+});
+
+describe('aliasClaimsFromPages', () => {
+  const pages = [
+    { path: 'wiki/entities/a.md', title: 'Alpha', aliases: ['A-Zeichen', ''] },
+    { path: 'wiki/entities/b.md', title: 'Beta', aliases: undefined },
+    { path: 'wiki/concepts/c.md', title: 'Gamma', aliases: ['Drittname'] },
+  ];
+
+  it('collects basenames and aliases of every OTHER page', () => {
+    const claims = aliasClaimsFromPages(pages, 'wiki/entities/b.md');
+    expect(claims).toContain('Alpha');
+    expect(claims).toContain('A-Zeichen');
+    expect(claims).toContain('Gamma');
+    expect(claims).toContain('Drittname');
+    expect(claims).not.toContain('Beta');
+  });
+
+  it('skips blank aliases', () => {
+    const claims = aliasClaimsFromPages(pages, 'wiki/concepts/c.md');
+    expect(claims).not.toContain('');
   });
 });

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -1,6 +1,6 @@
 import { VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS, VALID_SOURCE_TAGS, LLMWikiSettings } from '../types';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from './tag-vocab';
-import { filterRedundantAliases } from './slug';
+import { filterRedundantAliases, resolveMinAliasLength } from './slug';
 
 export interface FrontmatterData {
   reviewed?: boolean;
@@ -727,7 +727,7 @@ export function enforceFrontmatterConstraints(
   // Self-pointing aliases (alias === page basename) are dropped here when the
   // caller knows the path — see EnforceFrontmatterOptions.pagePath.
   const aliases = options?.pagePath
-    ? filterRedundantAliases(options.pagePath, collectedAliases)
+    ? filterRedundantAliases(options.pagePath, collectedAliases, undefined, resolveMinAliasLength(settings))
     : collectedAliases;
 
   const frontmatter = serializeFrontmatter(

--- a/src/core/slug.ts
+++ b/src/core/slug.ts
@@ -14,7 +14,7 @@ export function slugify(text: string, preserveCase = false): string {
 // preserveCase skips the final toLowerCase() for file creation (Issue #111).
 // All comparison/matching callers must NOT pass preserveCase so slugs stay
 // case-insensitively comparable regardless of the user's slugCase setting.
-import { MIN_ALIAS_LENGTH } from '../constants';
+import { MIN_ALIAS_LENGTH, MIN_ALIAS_LENGTH_MIN, MIN_ALIAS_LENGTH_MAX } from '../constants';
 
 export function computeSlug(text: string, preserveCase = false): string {
   if (!text || text.trim().length === 0) return 'untitled';
@@ -134,6 +134,21 @@ export function slugKeys(
 // ABOVE, so without the fold the uniqueness gate never fires on that pair.
 function aliasKey(raw: string): string {
   return turkishCaseFold(raw.trim().normalize('NFC'));
+}
+
+/**
+ * The alias floor a caller applies: the `minAliasLength` setting when it is an
+ * integer inside the accepted range, the `MIN_ALIAS_LENGTH` constant otherwise.
+ * Lives next to `filterRedundantAliases` so BOTH writers of `aliases:` (the
+ * append path and `enforceFrontmatterConstraints` on the create path) resolve
+ * the same floor from the same place — before this, only the append path read
+ * the setting and the create path silently fell back to the constant.
+ */
+export function resolveMinAliasLength(settings?: { minAliasLength?: number }): number {
+  const v = settings?.minAliasLength;
+  return Number.isInteger(v) && (v as number) >= MIN_ALIAS_LENGTH_MIN && (v as number) <= MIN_ALIAS_LENGTH_MAX
+    ? (v as number)
+    : MIN_ALIAS_LENGTH;
 }
 
 export function filterRedundantAliases(

--- a/src/wiki/page-factory/aliases.ts
+++ b/src/wiki/page-factory/aliases.ts
@@ -12,10 +12,13 @@
 //   - Replaces the existing `aliases:` block if present, otherwise injects a
 //     fresh block before the closing `---`.
 
-import { filterRedundantAliases } from '../../core/slug';
-import { MIN_ALIAS_LENGTH, MIN_ALIAS_LENGTH_MIN, MIN_ALIAS_LENGTH_MAX } from '../../constants';
-import type { LLMWikiSettings } from '../../types';
+import { filterRedundantAliases, resolveMinAliasLength } from '../../core/slug';
 import { parseFrontmatter } from '../../core/frontmatter';
+
+// Moved to core/slug.ts so the create path (enforceFrontmatterConstraints)
+// resolves the same floor without importing from the page factory; re-exported
+// here so existing importers keep working.
+export { resolveMinAliasLength };
 
 /**
  * Minimal context contract required by `appendAliases`. The real
@@ -26,18 +29,7 @@ export interface AliasesContext {
   tryReadFile: (path: string) => Promise<string | null>;
   createOrUpdateFile: (path: string, content: string) => Promise<void>;
   /** Optional: only `minAliasLength` is read here. Absent → MIN_ALIAS_LENGTH. */
-  settings?: Pick<LLMWikiSettings, 'minAliasLength'>;
-}
-
-/**
- * The alias floor this context applies: the `minAliasLength` setting when it
- * is an integer inside the accepted range, the constant otherwise.
- */
-export function resolveMinAliasLength(settings?: Pick<LLMWikiSettings, 'minAliasLength'>): number {
-  const v = settings?.minAliasLength;
-  return Number.isInteger(v) && (v as number) >= MIN_ALIAS_LENGTH_MIN && (v as number) <= MIN_ALIAS_LENGTH_MAX
-    ? (v as number)
-    : MIN_ALIAS_LENGTH;
+  settings?: { minAliasLength?: number };
 }
 
 /**
@@ -55,6 +47,7 @@ export async function appendAliases(
   ctx: AliasesContext,
   pagePath: string,
   newAliases: string[],
+  existingAliasesAcrossPages?: readonly string[],
 ): Promise<void> {
   const content = await ctx.tryReadFile(pagePath);
   if (!content) return;
@@ -62,7 +55,7 @@ export async function appendAliases(
   // Drop aliases that already equal the page's filename (case-insensitive),
   // e.g. adding "Vigilanz" to vigilanz.md. Common on cross-type collisions
   // where the colliding name is identical to the existing page's name.
-  const candidates = filterRedundantAliases(pagePath, newAliases, undefined, resolveMinAliasLength(ctx.settings));
+  const candidates = filterRedundantAliases(pagePath, newAliases, existingAliasesAcrossPages, resolveMinAliasLength(ctx.settings));
   if (candidates.length === 0) return;
 
   const fm = parseFrontmatter(content);
@@ -93,4 +86,28 @@ export async function appendAliases(
   const newContent = `---${newFm}\n---${body}`;
   await ctx.createOrUpdateFile(pagePath, newContent);
   console.debug(`appendAliases: added ${toAdd.join(', ')} to ${pagePath}`);
+}
+/**
+ * The names another page may not claim again: every OTHER page's basename and
+ * aliases. Feeds `filterRedundantAliases`' cross-page gate (f9a680e), which was
+ * introduced for exactly this and never had a caller. Basenames are included
+ * alongside aliases because Obsidian resolves `[[X]]` to basenames first: an
+ * alias equal to another page's basename is shadowed and never carries a
+ * resolution.
+ */
+export function aliasClaimsFromPages(
+  pages: ReadonlyArray<{ path: string; title: string; aliases?: string[] }>,
+  excludePath: string,
+): string[] {
+  const claims: string[] = [];
+  for (const p of pages) {
+    if (p.path === excludePath) continue;
+    if (p.title) claims.push(p.title);
+    if (Array.isArray(p.aliases)) {
+      for (const a of p.aliases) {
+        if (typeof a === 'string' && a.trim()) claims.push(a);
+      }
+    }
+  }
+  return claims;
 }

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -27,7 +27,7 @@ import { parseJsonResult } from '../../core/json';
 import { normalizeLLMPath } from '../../core/prompt-builders';
 import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
-import { appendAliases, type AliasesContext } from './aliases';
+import { appendAliases, aliasClaimsFromPages, type AliasesContext } from './aliases';
 import { PathResolutionLLMSchema } from '../../llm-sdk/output-schemas';
 import { callLlm } from '../../core/llm-dispatch';
 
@@ -148,7 +148,11 @@ export async function resolvePagePath(
     const cr = resolver.resolve({ name, slug, pageType, tags });
 
     if (cr.action === 'merge') {
-      await appendAliases(ctx, cr.targetPath, [name]);
+      // f9a680e's cross-page gate, fed for the first time: `allPages` is
+      // already in scope, so the name is only appended when no OTHER page's
+      // basename or alias claims it — a duplicated claim would silently merge
+      // every future occurrence of the name into whichever page matches first.
+      await appendAliases(ctx, cr.targetPath, [name], aliasClaimsFromPages(allPages, cr.targetPath));
       return { path: cr.targetPath };
     }
 
@@ -259,8 +263,10 @@ export async function resolvePagePath(
     if (result.match && result.path) {
       const normalizedPath = normalizeLLMPath(result.path, ctx.settings.wikiFolder);
       console.debug(`Entity resolution: "${name}" matched existing page "${normalizedPath}"`);
-      // Append the new name as an alias to the existing page to prevent future duplicates
-      await appendAliases(ctx, normalizedPath, [name]);
+      // Append the new name as an alias to the existing page to prevent future
+      // duplicates — through the same cross-page gate as the deterministic
+      // merge above (`allPages` is still in scope here).
+      await appendAliases(ctx, normalizedPath, [name], aliasClaimsFromPages(allPages, normalizedPath));
       return { path: normalizedPath };
     }
   } catch (error) {


### PR DESCRIPTION
Closes #558.

**What changes.** Three moves, no behaviour change for callers that pass nothing:

- `resolveMinAliasLength` moves to `core/slug.ts`, next to the filter it parameterises (re-exported from `page-factory/aliases.ts`, existing importers unchanged). `enforceFrontmatterConstraints` now resolves the floor from the settings it already receives — the create path and the append path apply the same floor from the same place.
- `appendAliases` takes an optional `existingAliasesAcrossPages` and threads it into `filterRedundantAliases` — the parameter `f9a680e` introduced, fed for the first time.
- Both `appendAliases` call sites in `path-resolution.ts` (deterministic merge, LLM-decided match) pass `aliasClaimsFromPages(allPages, targetPath)`: the basenames and aliases of every OTHER page, built from the `getExistingWikiPages` snapshot already in scope at both sites — no extra vault read.

**One named semantic choice.** The claim set includes basenames alongside aliases, because Obsidian resolves `[[X]]` to basenames first: an alias equal to another page's basename is shadowed and never carries a resolution. Claims below the floor do not block — `f9a680e`'s own rule, unchanged.

**Not in this PR.** The cross-page gate on the create path: `enforceFrontmatterConstraints` has no pages snapshot in scope, and wiring one would mean a vault read per created page — that cost belongs to the run-wide snapshot question, not to this fix.

Tests: +7 (floor at the create path with and without the setting; gate drops a claimed alias and keeps the rest; case-insensitive claim matching; no-argument call unchanged; claims helper excludes the target page and blank entries). Five-gate green locally: lint, typecheck, build, test 3684/3684, css-lint.
