### PR TITLE
docs(MEMORY): add 6 missing lessons learned from session memory

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -193,6 +193,60 @@ Distilled from 75 session-level feedback entries. Full text in
   open Issues/PRs before continuing any non-trivial change. Compaction
   erases decisions that look obvious only with full context. (`feedback_post_compact_rehydration`)
 
+### GitHub heuristics & review-event surfaces
+
+- **`Refs #N` semantic can auto-close issues on doc-only PRs.** 2026-07-14:
+  PR #278 (doc-only CLAUDE.md/ROADMAP.md) body said "to close #255" and
+  GitHub's heuristic closed #255 even though the PR had zero runtime change.
+  Use "tracked by" / "see" / "blocked by" in doc PR body text. Verify
+  issue state right after merge; `gh issue reopen N` if unexpectedly closed.
+  (`feedback_github_refs_heuristic_close`)
+- **Local lint is blind to whole-repo issues.** `pnpm lint` = `eslint src/`
+  only; Obsidian review Bot scans the entire repo `.ts` tree including
+  `tools/`. v1.26.1 shipped a blocking `unsafe-call` Error in
+  `tools/llm-wiki-cli/src/obsidian.ts` that local lint never saw. Run
+  `pnpm lint:tools-bot` before every release. (`feedback_obsidian_bot_tools_cli_warnings`)
+
+### CLI surface (post-PR #511 demote)
+
+- **`pnpm llm-wiki` script no longer exists.** PR #511 (v1.27.0) demoted
+  `tools/llm-wiki-cli/` → `tools/dev-instrument/` (dev-only measurement
+  instrument, NOT a user CLI). The `package.json` `bin` field was removed.
+  **User-facing CLI now lives in the sibling repo
+  [`green-dalii/obsidian-llm-wiki-cli`](https://github.com/green-dalii/obsidian-llm-wiki-cli)**
+  (`npm i -g karpathywiki-cli`). This repo's `tools/dev-instrument/` is for
+  engine contributors only — do not point users at it. (`project_v1_27_0_cli_demote_done`)
+
+### Engine invariants (engine contributors)
+
+- **Dedup halving was dead code.** v1.26.0 Batch 2: counter reset inside
+  the for-loop so concurrency halving never actually halved; `null` and
+  `{"duplicates":[]}` both routed to `[]` conflated truncation with success.
+  Fix PR #411 (Batches 6+7). Future LLM business paths need retry + backoff
+  + halving + log + Notice — extract `callLlmWithRetry<T>()` from
+  `runDedupPhase` before adding a 6th caller. (`feedback_dedup_phase_halving_dead_code`,
+  `feedback_dedup_phase_truncation_vs_empty_conflation`, `feedback_llm_retry_extraction`)
+- **`schema/config.md` MUST stay pure user-domain knowledge.** v1.26.0 Batch
+  1 (Issue #328) fixed the dual-source tag-vocab problem: schema file owns
+  user domain knowledge (page templates, content rules, naming conventions,
+  merge policies); runtime parameters (tag vocabulary, folder layout, output
+  language, page-type registration) MUST be injected at call time via
+  `getSchemaContext()`, never baked into the schema file. Violating
+  reintroduces the dual-source drift Phase 1 was designed to eliminate.
+  (`feedback-schema-phase1-option-a-decision`, `feedback_schema_template_programmatic_injection`)
+
+### PR self-approve & maintainer passby
+
+- **GitHub blocks self-approve on own PR.** Platform hard restriction:
+  `gh pr review <N> --approve` on your own PR fails with
+  `GraphQL: Review Can not approve your own pull request`. For own-PR
+  merges, use `gh pr merge <N> --admin --squash --delete-branch` (the
+  `--admin` flag bypasses the requirement rule, not the review event
+  rule). After merge, post `gh pr comment <N> --body-file <audit-note>`
+  to patch the audit trail. Document the procedural miss in the audit
+  note; do NOT rebase or amend. (`feedback_pr_merge_workflow`,
+  `feedback_pr_review_vs_comment`)
+
 ---
 
 ## Release cadence (since v1.20.2)


### PR DESCRIPTION
## What
The root `MEMORY.md` is the project's external, contributor-facing memory —
the file non-Claude-Code agents read to pick up where previous work left
off. The 'Lessons learned' section listed only 6 of the 12 patterns the
session memory tracks. This PR closes that gap so the next agent has the
full rule surface, not a subset.

## Diff
\`MEMORY.md\` | +54/-0. H2 count 7 → 7 (structure unchanged).

## 6 patterns added
1. **\`Refs #N\` heuristic auto-close on doc-only PRs** (2026-07-14 incident
   — PR #278 body said 'to close #255' and GitHub auto-closed a runtime
   issue on a doc-only PR)
2. **Local lint blind to whole-repo** — \`pnpm lint\` is \`eslint src/\` only;
   Obsidian Bot scans whole repo \`.ts\` tree including \`tools/\`.
   Run \`pnpm lint:tools-bot\` before every release.
3. **\`pnpm llm-wiki\` script disappeared** after PR #511 demote
   (\`tools/llm-wiki-cli/\` → \`tools/dev-instrument/\`, dev-only).
   User CLI now lives in the sibling repo
   [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli).
4. **Dedup halving was dead code** — counter reset inside for-loop;
   \`null\` / \`{\"duplicates\":[]}\` conflated (PR #411 Batches 6+7).
5. **\`schema/config.md\` MUST stay pure user-domain knowledge** —
   runtime params injected via \`getSchemaContext()\`, never baked into
   the schema file (Issue #328 Phase 1 fix).
6. **GitHub blocks self-approve on own PR** — for own-PR merges use
   \`gh pr merge --admin --squash --delete-branch\`; post audit-note
   comment after merge to patch the audit trail.

## What's NOT in this PR
- The 6 patterns already in the file (lockfile, issue state, AI marker,
  gh release cleanup, settings panel, force-disable thinking) are
  unchanged. Keeping the diff surgical.
- No H2 structure change — verified \`grep -c "^## "\` stays 7.
- No code changes.

## Verification
- \`git diff --stat\`: 1 file changed, 54 insertions(+), 0 deletions(-)
- H2 count: 7 (was 7)
- \`pnpm gate:1\` N/A (docs-only)
- Commit \`4b9ee2f\` follows CLAUDE.md git commit standards (no AI
  trailer; canonical author; descriptive subject)