### PR TITLE
fix(gate): link markup is not an aside — exclude its brackets from parenSpans

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The plugin composes with the rest of your Obsidian stack — each tool below plu
 
 **Most users should ignore this section.** The plugin's user-facing CLI lives in the sibling repo [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — install with `npm i -g karpathywiki-cli` and run `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-What ships in this repo at `tools/dev-instrument/` is the **dev-only headless measurement instrument** for engine contributors — it runs the real `WikiEngine.ingestSource` against a vault on disk with no Obsidian runtime, prints per-task token + wall-clock accounting — same numbers that drive the perf evidence in CLAUDE.md and release notes. See [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) for the entry command, env vars, measurement modes, and exit-code spec.
+What ships in this repo at `tools/dev-instrument/` is the **dev-only headless measurement instrument** for engine contributors — it runs the real `WikiEngine.ingestSource` against a vault on disk with no Obsidian runtime, prints per-task token + wall-clock accounting — same numbers that drive the perf evidence in CLAUDE.md and release notes. See [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) for the entry command, env vars, measurement modes, and exit-code spec.
 
 ---
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -225,7 +225,7 @@ SEO metadata (not user-visible, parsed by crawlers / LLMs) — 简体中文本�
 
 **大多数用户可以跳过本节。** 插件的面向用户的 CLI 位于独立仓库 [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) ——以 npm 包 `karpathywiki-cli` 形式发布。安装：`npm i -g karpathywiki-cli`，运行 `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`。
 
-本仓库内 [`tools/dev-instrument/`](https://github.com/green-dalii/obsidian-llm-wiki/tree/main/tools/dev-instrument) 装的是 **dev-only 无头测量工具** —— 面向引擎贡献者，跑真正的 `WikiEngine.ingestSource`，无 Obsidian 运行时，输出每任务的 token + wall-clock 统计——正是 `CLAUDE.md` 和发布说明中性能证据的同源数据。入口命令、env 变量、测量模式、退出码规范详见 [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md)。
+本仓库内 [`tools/dev-instrument/`](https://github.com/green-dalii/obsidian-llm-wiki/tree/main/tools/dev-instrument) 装的是 **dev-only 无头测量工具** —— 面向引擎贡献者，跑真正的 `WikiEngine.ingestSource`，无 Obsidian 运行时，输出每任务的 token + wall-clock 统计——正是 `CLAUDE.md` 和发布说明中性能证据的同源数据。入口命令、env 变量、测量模式、退出码规范详见 [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md)。
 
 ---
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -194,7 +194,7 @@ Das Plugin ergänzt sich mit dem Rest Ihres Obsidian-Stacks — jedes der folgen
 
 **Die meisten Nutzer können diesen Abschnitt überspringen.** Die nutzerseitige CLI des Plugins liegt im Schwester-Repo [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — Installation mit `npm i -g karpathywiki-cli`, dann `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-Was in diesem Repo unter `tools/dev-instrument/` liegt, ist das **reine Dev-Messinstrument** für Engine-Mitarbeiter — es führt den echten `WikiEngine.ingestSource` ohne Obsidian-Runtime gegen einen Vault auf der Festplatte aus, gibt pro Task Token- und Wall-Clock-Abrechnung aus — dieselben Zahlen, die die Performance-Belege in CLAUDE.md und den Release Notes liefern. Siehe [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) für Entry-Command, Env-Variablen, Mess-Modi und Exit-Code-Spezifikation.
+Was in diesem Repo unter `tools/dev-instrument/` liegt, ist das **reine Dev-Messinstrument** für Engine-Mitarbeiter — es führt den echten `WikiEngine.ingestSource` ohne Obsidian-Runtime gegen einen Vault auf der Festplatte aus, gibt pro Task Token- und Wall-Clock-Abrechnung aus — dieselben Zahlen, die die Performance-Belege in CLAUDE.md und den Release Notes liefern. Siehe [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) für Entry-Command, Env-Variablen, Mess-Modi und Exit-Code-Spezifikation.
 
 ---
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -217,7 +217,7 @@ El plugin se combina con el resto de tu stack de Obsidian — cada herramienta d
 
 **La mayoría de usuarios puede saltarse esta sección.** La CLI orientada al usuario del plugin vive en el repositorio hermano [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — instala con `npm i -g karpathywiki-cli` y ejecuta `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-Lo que se envía en este repo bajo `tools/dev-instrument/` es el **instrumento de medición headless dev-only** para contribuidores del motor — ejecuta el `WikiEngine.ingestSource` real contra un vault en disco sin runtime de Obsidian, imprime el cómputo de tokens + tiempo real por tarea — los mismos números que respaldan la evidencia de rendimiento en `CLAUDE.md` y las release notes. Consulta [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) para el comando de entrada, variables de entorno, modos de medición y especificación del código de salida.
+Lo que se envía en este repo bajo `tools/dev-instrument/` es el **instrumento de medición headless dev-only** para contribuidores del motor — ejecuta el `WikiEngine.ingestSource` real contra un vault en disco sin runtime de Obsidian, imprime el cómputo de tokens + tiempo real por tarea — los mismos números que respaldan la evidencia de rendimiento en `CLAUDE.md` y las release notes. Consulta [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) para el comando de entrada, variables de entorno, modos de medición y especificación del código de salida.
 
 ---
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -217,7 +217,7 @@ Le plugin s'intègre au reste de votre stack Obsidian — chacun des outils ci-d
 
 **La plupart des utilisateurs peuvent ignorer cette section.** La CLI utilisateur du plugin vit dans le dépôt frère [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — installez avec `npm i -g karpathywiki-cli` puis exécutez `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-Ce qui est livré dans ce repo sous `tools/dev-instrument/` est l'**instrument de mesure headless dev-only** pour les contributeurs du moteur — il exécute le vrai `WikiEngine.ingestSource` contre un coffre sur disque sans runtime Obsidian, imprime la comptabilité par tâche (tokens + temps réel) — les mêmes chiffres qui alimentent les preuves de performance dans CLAUDE.md et les notes de version. Voir [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) pour la commande d'entrée, les variables d'environnement, les modes de mesure et la spécification du code de sortie.
+Ce qui est livré dans ce repo sous `tools/dev-instrument/` est l'**instrument de mesure headless dev-only** pour les contributeurs du moteur — il exécute le vrai `WikiEngine.ingestSource` contre un coffre sur disque sans runtime Obsidian, imprime la comptabilité par tâche (tokens + temps réel) — les mêmes chiffres qui alimentent les preuves de performance dans CLAUDE.md et les notes de version. Voir [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) pour la commande d'entrée, les variables d'environnement, les modes de mesure et la spécification du code de sortie.
 
 ---
 

--- a/docs/README_IT.md
+++ b/docs/README_IT.md
@@ -217,7 +217,7 @@ Il plugin si compone con il resto del tuo stack Obsidian — ciascuno degli stru
 
 **La maggior parte degli utenti può ignorare questa sezione.** La CLI rivolta all'utente del plugin vive nel repo fratello [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — installa con `npm i -g karpathywiki-cli` ed esegui `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-Quello che spedisce questo repo in `tools/dev-instrument/` è lo **strumento di misurazione headless solo-dev** per i contributori del motore — esegue il vero `WikiEngine.ingestSource` contro un vault su disco senza runtime Obsidian, stampa la contabilità di token + wall-clock per-task — gli stessi numeri che alimentano le prove di prestazioni in `CLAUDE.md` e nelle release notes. Vedi [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) per il comando di ingresso, le variabili d'ambiente, le modalità di misurazione e la specifica del codice di uscita.
+Quello che spedisce questo repo in `tools/dev-instrument/` è lo **strumento di misurazione headless solo-dev** per i contributori del motore — esegue il vero `WikiEngine.ingestSource` contro un vault su disco senza runtime Obsidian, stampa la contabilità di token + wall-clock per-task — gli stessi numeri che alimentano le prove di prestazioni in `CLAUDE.md` e nelle release notes. Vedi [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) per il comando di ingresso, le variabili d'ambiente, le modalità di misurazione e la specifica del codice di uscita.
 
 ## 🔍 Come funziona il recupero
 

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -217,7 +217,7 @@ SEO metadata (not user-visible, parsed by crawlers / LLMs) — 日本語ロー�
 
 **大半のユーザーはこのセクションを無視して構いません。** 本プラグインのユーザー向け CLI は兄弟リポジトリ [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) にあります —— `karpathywiki-cli` という npm パッケージとして公開されています。`npm i -g karpathywiki-cli` でインストールし、`karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>` で実行します。
 
-本リポジトリの `tools/dev-instrument/` にあるのは、エンジンコントリビューター向けの **dev-only ヘッドレス計測器** です。Obsidian ランタイムなしで実際の `WikiEngine.ingestSource` を vault に対して実行し、タスク単位の token + wall-clock 統計を出力します —— CLAUDE.md やリリースノートに載っている性能エビデンスと同じ数値です。エントリコマンド、環境変数、計測モード、終了コード仕様は [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) を参照。
+本リポジトリの `tools/dev-instrument/` にあるのは、エンジンコントリビューター向けの **dev-only ヘッドレス計測器** です。Obsidian ランタイムなしで実際の `WikiEngine.ingestSource` を vault に対して実行し、タスク単位の token + wall-clock 統計を出力します —— CLAUDE.md やリリースノートに載っている性能エビデンスと同じ数値です。エントリコマンド、環境変数、計測モード、終了コード仕様は [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) を参照。
 
 ---
 

--- a/docs/README_KO.md
+++ b/docs/README_KO.md
@@ -216,7 +216,7 @@ SEO metadata (not user-visible, parsed by crawlers / LLMs):
 
 **대부분의 사용자는 이 섹션을 건너뛰어도 됩니다.** 본 플러그인의 사용자용 CLI는 형제 리포지토리 [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli)에 있습니다 — `karpathywiki-cli` npm 패키지로 배포됩니다. `npm i -g karpathywiki-cli`로 설치하고 `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`로 실행하세요.
 
-본 리포지토리의 `tools/dev-instrument/`에 들어 있는 것은 엔진 기여자용 **dev-only 헤드리스 측정 도구**입니다. Obsidian 런타임 없이 실제 `WikiEngine.ingestSource`를 vault에 대해 실행하고, 작업 단위 토큰 + wall-clock 집계를 출력합니다 — CLAUDE.md 및 릴리스 노트의 perf evidence에 사용되는 수치입니다. 진입 명령, 환경 변수, 측정 모드, 종료 코드 사양은 [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md)를 참조하세요.
+본 리포지토리의 `tools/dev-instrument/`에 들어 있는 것은 엔진 기여자용 **dev-only 헤드리스 측정 도구**입니다. Obsidian 런타임 없이 실제 `WikiEngine.ingestSource`를 vault에 대해 실행하고, 작업 단위 토큰 + wall-clock 집계를 출력합니다 — CLAUDE.md 및 릴리스 노트의 perf evidence에 사용되는 수치입니다. 진입 명령, 환경 변수, 측정 모드, 종료 코드 사양은 [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md)를 참조하세요.
 
 ---
 

--- a/docs/README_PT.md
+++ b/docs/README_PT.md
@@ -190,7 +190,7 @@ O plugin compõe-se com o restante do seu stack Obsidian — cada ferramenta aba
 
 **A maioria dos utilizadores deve ignorar esta secção.** A CLI voltada para o utilizador do plugin vive no repositório irmão [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — instale com `npm i -g karpathywiki-cli` e execute `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-O que vem neste repositório em `tools/dev-instrument/` é o **instrumento de medição headless só-dev** para contribuidores do motor — executa o verdadeiro `WikiEngine.ingestSource` contra um cofre em disco sem runtime Obsidian, imprime a contabilidade de tokens e wall-clock por tarefa — os mesmos números que conduzem a evidência de desempenho em `CLAUDE.md` e nas notas de versão. Veja [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) para o comando de entrada, variáveis de ambiente, modos de medição e especificação do código de saída.
+O que vem neste repositório em `tools/dev-instrument/` é o **instrumento de medição headless só-dev** para contribuidores do motor — executa o verdadeiro `WikiEngine.ingestSource` contra um cofre em disco sem runtime Obsidian, imprime a contabilidade de tokens e wall-clock por tarefa — os mesmos números que conduzem a evidência de desempenho em `CLAUDE.md` e nas notas de versão. Veja [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) para o comando de entrada, variáveis de ambiente, modos de medição e especificação do código de saída.
 
 ## 🔍 Como funciona a recuperação
 

--- a/docs/README_RU.md
+++ b/docs/README_RU.md
@@ -193,7 +193,7 @@
 
 **Большинству пользователей этот раздел можно пропустить.** Пользовательская CLI плагина живёт в родственном репозитории [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) — установите через `npm i -g karpathywiki-cli` и выполните `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`.
 
-То, что поставляется в этом репозитории в `tools/dev-instrument/`, — это **dev-only headless измерительный инструмент** для контрибьюторов движка — он запускает настоящий `WikiEngine.ingestSource` против хранилища на диске без Obsidian-окружения, выводит учёт токенов и wall-clock по задачам — те же цифры, что стоят за свидетельствами производительности в `CLAUDE.md` и примечаниях к релизу. См. [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md) для входной команды, переменных окружения, измерительных режимов и спецификации кодов выхода.
+То, что поставляется в этом репозитории в `tools/dev-instrument/`, — это **dev-only headless измерительный инструмент** для контрибьюторов движка — он запускает настоящий `WikiEngine.ingestSource` против хранилища на диске без Obsidian-окружения, выводит учёт токенов и wall-clock по задачам — те же цифры, что стоят за свидетельствами производительности в `CLAUDE.md` и примечаниях к релизу. См. [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md) для входной команды, переменных окружения, измерительных режимов и спецификации кодов выхода.
 
 ---
 

--- a/docs/README_ZH-Hant.md
+++ b/docs/README_ZH-Hant.md
@@ -191,7 +191,7 @@
 
 **大多數使用者可跳過本節。** 外掛的面向使用者 CLI 位於獨立倉庫 [green-dalii/obsidian-llm-wiki-cli](https://github.com/green-dalii/obsidian-llm-wiki-cli) ——以 npm 套件 `karpathywiki-cli` 形式發佈。安裝：`npm i -g karpathywiki-cli`，執行 `karpathywiki-cli ingest --sources <path> --wiki <path> --provider <id> --key <key>`。
 
-本倉庫內 [`tools/dev-instrument/`](https://github.com/green-dalii/obsidian-llm-wiki/tree/main/tools/dev-instrument) 裝的是 **dev-only 無頭測量儀器** —— 給引擎貢獻者用，跑真正的 `WikiEngine.ingestSource`，無 Obsidian 執行環境，輸出每任務的 token + wall-clock 統計——與 CLAUDE.md 及發佈說明中的效能證據同一組數字。入口指令、env 變數、測量模式、退出碼規範詳見 [`tools/dev-instrument/README.md`](tools/dev-instrument/README.md)。
+本倉庫內 [`tools/dev-instrument/`](https://github.com/green-dalii/obsidian-llm-wiki/tree/main/tools/dev-instrument) 裝的是 **dev-only 無頭測量儀器** —— 給引擎貢獻者用，跑真正的 `WikiEngine.ingestSource`，無 Obsidian 執行環境，輸出每任務的 token + wall-clock 統計——與 CLAUDE.md 及發佈說明中的效能證據同一組數字。入口指令、env 變數、測量模式、退出碼規範詳見 [`tools/dev-instrument/README.md`](https://github.com/green-dalii/obsidian-llm-wiki/blob/main/tools/dev-instrument/README.md)。
 
 ## 🔍 檢索原理
 

--- a/src/__tests__/core/candidate-gate.test.ts
+++ b/src/__tests__/core/candidate-gate.test.ts
@@ -193,3 +193,44 @@ describe('estimated language profiles (unmeasured — the setting is opt-in)', (
     expect(classify(t, 'ハプトグロビン', P.ja)).toBe('prose');
   });
 });
+
+// Link markup is syntax, not an aside: PAREN_RE matches the inner `[X]` of a
+// `[[X]]` and both halves of `[text](url)`, so a name the author linked was
+// classified `aside` — the opposite of what a link means. Measured on a German
+// vault (16 notes, 321 candidates): 32 verdicts move `aside` → `prose`, none
+// the other way.
+describe('classifyCandidate — link markup is not a parenthesis', () => {
+  it('reads a wikilinked name as prose, not as an aside', () => {
+    const t = 'Die Kaskade läuft über [[NF-κB]] und endet in Zytokinfreisetzung.';
+    expect(classifyCandidate(t, 'NF-κB')).toBe('prose');
+  });
+
+  it('keeps BOTH names of a piped link readable', () => {
+    const t = 'Es wird bevorzugt vor [[ACE-Hemmer|ACEi]] eingesetzt und senkt die Mortalität.';
+    expect(classifyCandidate(t, 'ACE-Hemmer')).toBe('prose');
+    expect(classifyCandidate(t, 'ACEi')).toBe('prose');
+  });
+
+  it('treats a markdown link like the text it displays', () => {
+    const t = 'Der Wirkstoff steht auf der [WHO-Liste der essenziellen Medikamente](https://example.org/x).';
+    expect(classifyCandidate(t, 'WHO-Liste der essenziellen Medikamente')).toBe('prose');
+  });
+
+  it('reads an embed like a wikilink', () => {
+    const t = 'Die Abbildung ![[Mitochondrium]] zeigt den Aufbau im Detail und erklärt ihn.';
+    expect(classifyCandidate(t, 'Mitochondrium')).toBe('prose');
+  });
+
+  // The rule cuts both ways: markup changes nothing, so a parenthesis that
+  // merely CONTAINS a link is still a parenthesis.
+  it('leaves a real parenthesis an aside even when it holds a link', () => {
+    const t = 'Hormonelle Dysregulation (z. B. Leptin-Resistenz, [[Insulinresistenz]]) ist typisch.';
+    expect(classifyCandidate(t, 'Insulinresistenz')).toBe('aside');
+  });
+
+  // A citation in square brackets carries no `(url)` and stays an aside.
+  it('leaves a bare bracketed citation an aside', () => {
+    const t = 'Die Methodik folgt dem Standard [ATS Statement: Guidelines 2002].';
+    expect(classifyCandidate(t, 'ATS Statement: Guidelines 2002')).toBe('aside');
+  });
+});

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -3,7 +3,9 @@
 // The extraction names candidates; this decides the clear cases before any
 // further call is spent on them. A candidate whose name never appears in the
 // source text, or appears only inside parentheses, enumerations or short list
-// items, gets no page — and is removed from the other candidates' related_*
+// items, gets no page — the brackets of link markup do not count as
+// parentheses, so a name the author wikilinked or hyperlinked is not an
+// aside — and is removed from the other candidates' related_*
 // lists so the gate never manufactures a dead link. Measured on a German
 // sample (10 notes, 115 candidates): 9.6 % absent, 19.1 % aside, 71.3 % prose
 // with the rules below (a first rule — plain substring, any sentence with two
@@ -184,11 +186,51 @@ function needleOf(name: string, profile: GateLanguageProfile): RegExp | null {
   return new RegExp(`(?<![\\p{L}\\p{N}])${body}(?![\\p{L}\\p{N}])`, 'giu');
 }
 
+/** Link markup, whose brackets are syntax: `[[wikilink]]`, `![[embed]]`, `[text](url)`. */
+const LINK_RE = /!?\[\[[^\]\n]*\]\]|!?\[[^[\]\n]*\]\([^)\n]*\)/g;
+
+function linkSpans(text: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  const re = new RegExp(LINK_RE.source, 'g');
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) spans.push([m.index, m.index + m[0].length]);
+  return spans;
+}
+
+/**
+ * The bracket pairs that mark an aside — link markup excluded, because a name
+ * the author linked is the opposite of a passing mention.
+ *
+ * PAREN_RE matches the inner `[X]` of a `[[X]]` and both halves of
+ * `[text](url)`, so before this every wikilinked or hyperlinked name was
+ * classified `aside`: no page, and — through pruneDropped — no edge from any
+ * surviving page either. In an Obsidian vault that inverts the signal the
+ * gate is meant to read, since a wikilink is the most explicit statement a
+ * note makes about relevance.
+ *
+ * Excluding the span rather than rewriting the text keeps BOTH names of a
+ * piped link readable: `[[ACE-Hemmer|ACEi]]` names the thing twice, and a
+ * candidate may carry either. Collapsing a link to its display text instead
+ * turned 7 of 87 measured `aside` verdicts into `absent`.
+ *
+ * A parenthesis that merely CONTAINS a link stays an aside: `(e.g. [[X]])`
+ * reads as an aside without the brackets of the link too. Markup changes
+ * nothing in either direction. A bare bracketed citation carries no `(url)`
+ * and stays an aside as well.
+ *
+ * Measured on a German vault, 16 notes and 321 candidates: 32 verdicts move
+ * `aside` → `prose`, none the other way.
+ */
 function parenSpans(text: string): Array<[number, number]> {
+  const links = linkSpans(text);
   const spans: Array<[number, number]> = [];
   const re = new RegExp(PAREN_RE.source, 'g');
   let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) spans.push([m.index, m.index + m[0].length]);
+  while ((m = re.exec(text)) !== null) {
+    const start = m.index, end = start + m[0].length;
+    if (links.some(([a, b]) => start >= a && end <= b)) continue;
+    spans.push([start, end]);
+  }
   return spans;
 }
 


### PR DESCRIPTION
Closes #562

`parenSpans` now drops any bracket pair that lies inside a link span (`[[wikilink]]`, `![[embed]]`, `[text](url)`). The text itself is untouched.

**Why not rewrite the text to the display form.** That loses the other half of a piped link — `[[ACE-Hemmer|ACEi]]` names the thing twice and a candidate may carry either name. Measured on the same sample it turned 7 of 87 `aside` verdicts into `absent`: a different drop, not a fix.

**Why not rescue `aside` candidates by their `coverage` value.** It would make a model judgement load-bearing for a gate whose whole point is that its threshold sits in code. On inspection `discussed` marked plain enumeration entries (`(*Lactobacillus*, *Bifidobacterium*, …)`) as readily as it marked real ones.

**The rule cuts both ways.** A parenthesis that merely *contains* a link stays an aside, because it reads as one without the link's brackets too. A bare bracketed citation carries no `(url)` and stays an aside as well. Both are pinned by tests.

Re-measured on the vault above after the change: 32 verdicts move `aside` → `prose`, none move the other way.

Six tests added. `pnpm lint` and `npx tsc --noEmit` clean.

---

**On the first commit.** This branch carries `docs: make the dev-instrument README link absolute in all 11 READMEs` ahead of the fix. That is #565, and it is here only so CI on this branch can run green: `main` is red at `89118bc` because #560 introduced a relative link the #375 guard forbids (#563), and every branch cut from `main` inherits those 11 failures.

Merge #565 first and this commit drops out of the branch on rebase; merge this PR first and #565 becomes empty. Either order is fine — the two changes touch no common file.
