### PR TITLE
feat(pdf): support vision-capable local providers (ollama, lmstudio) via per-page PNG rasterization

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,18 @@
 import esbuild from "esbuild";
 import process from "process";
+import fs from "fs";
+import path from "path";
 import { builtinModules } from "module";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+// Read pdfjs worker source once at build time and inline via define.
+// We resolve through createRequire so the path is stable under pnpm's
+// .pnpm/<name>@<ver>/node_modules/<name>/ layout.
+const workerPath = require.resolve(
+  "pdfjs-dist/legacy/build/pdf.worker.mjs"
+);
+const workerSource = fs.readFileSync(workerPath, "utf8");
 
 const banner =
 `/*
@@ -19,6 +31,13 @@ const context = await esbuild.context({
     js: banner + prodBanner,
   },
   entryPoints: ['src/main.ts'],
+  // Inline pdf.worker.mjs source as a string constant so we can hand
+  // pdfjs a blob: URL without shipping a second .mjs file alongside
+  // main.js (relative URL resolution is unreliable in the Obsidian
+  // Electron renderer under CJS bundle — no import.meta.url).
+  define: {
+    __PDFJS_WORKER_SOURCE__: JSON.stringify(workerSource),
+  },
   bundle: true,
   external: [
     'obsidian',

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@ai-sdk/openai-compatible": "2.0.62",
     "ai": "6.0.230",
     "fflate": "0.8.3",
+    "pdfjs-dist": "5.3.93",
     "zod": "^3.25.76"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       fflate:
         specifier: 0.8.3
         version: 0.8.3
+      pdfjs-dist:
+        specifier: 5.3.93
+        version: 5.3.93
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -424,6 +427,81 @@ packages:
     peerDependencies:
       eslint: ^9
 
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -470,36 +548,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.3':
     resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.3':
     resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.3':
     resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.3':
     resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.3':
     resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
@@ -1357,24 +1441,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1526,6 +1614,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdfjs-dist@5.3.93:
+    resolution: {integrity: sha512-w3fQKVL1oGn8FRyx5JUG5tnbblggDqyx2XzA5brsJ5hSuS+I0NdnJANhmeWKLjotdbPQucLBug5t0MeWr0AAdg==}
+    engines: {node: '>=20.16.0 || >=22.3.0'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2246,6 +2338,54 @@ snapshots:
       eslint-plugin-n: 17.10.3(eslint@10.2.1)
       eslint-plugin-react: 7.37.3(eslint@10.2.1)
       eslint-plugin-security: 1.4.0
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -3609,6 +3749,10 @@ snapshots:
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@5.3.93:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   picocolors@1.1.1: {}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,9 +140,29 @@ export const VISION_PDF_PROVIDER_IDS = [
 ] as const;
 
 /** Version suffix for the vision-path cache key. Bump when the
- *  rasterizer (DPI, image format, pdfjs version) changes. */
-export const VISION_PDF_VERSION = 1;
+ *  rasterizer (DPI, image format, pdfjs version, chunking strategy) changes. */
+export const VISION_PDF_VERSION = 2;
 export const VISION_PDF_DPI = 150;
+
+/**
+ * Max PDF pages sent to the LLM in one vision call.
+ *
+ * Empirically calibrated for a 32K-context local model (bonsai-27b Q1_0
+ * running through Ollama /v1/chat/completions). At 150 DPI each page
+ * rasterizes to ~2-3K image tokens; 6 pages ≈ 15K image tokens + ~700
+ * prompt overhead + 8K output reserve = ~24K, comfortably under 32K.
+ *
+ * Larger-context models (Claude 200K, GPT-4o 128K) trivially fit more
+ * pages per call but chunking never hurts — the bottleneck is the
+ * model's effective attention across many images, not raw context
+ * budget. Keeping a small constant here makes the worst-case LLM-call
+ * latency bounded regardless of which provider the user picks.
+ *
+ * Documents with more pages are split into chunks of this size;
+ * each chunk is sent as a separate LLM call and the markdown outputs
+ * are concatenated in page order.
+ */
+export const VISION_PDF_PAGES_PER_CHUNK = 6;
 
 /** MinerU online API endpoints and bounded conversion resources. */
 export const MINERU_API_BASE_URL = 'https://mineru.net/api/v4';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -119,6 +119,31 @@ export const NATIVE_PDF_PROVIDER_IDS = [
   'bedrock-openai',
 ] as const;
 
+/**
+ * v1.28.x PR — Provider IDs whose `/v1/chat/completions` accepts
+ * multimodal `image_url` parts. Used by `core/pdf-converter.ts` to
+ * route PDF ingestion through per-page PNG rasterization (via
+ * pdfjs-dist) instead of the `application/pdf` content type that
+ * openai-compat SDKs do not emit.
+ *
+ * Why a separate list (not an addition to NATIVE_PDF_PROVIDER_IDS):
+ * the conversion path is fundamentally different — the client must
+ * rasterize the PDF before sending, the message contains N image
+ * parts instead of one file part, and the cache key includes a
+ * DPI/version suffix to keep vision conversions isolated from
+ * native ones (a user switching providers cannot silently receive a
+ * stale conversion from a different backend).
+ */
+export const VISION_PDF_PROVIDER_IDS = [
+  'ollama',
+  'lmstudio',
+] as const;
+
+/** Version suffix for the vision-path cache key. Bump when the
+ *  rasterizer (DPI, image format, pdfjs version) changes. */
+export const VISION_PDF_VERSION = 1;
+export const VISION_PDF_DPI = 150;
+
 /** MinerU online API endpoints and bounded conversion resources. */
 export const MINERU_API_BASE_URL = 'https://mineru.net/api/v4';
 export const MINERU_API_TOKEN_SECRET_ID = 'karpathywiki-mineru-api-token';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -162,7 +162,7 @@ export const VISION_PDF_DPI = 150;
  * each chunk is sent as a separate LLM call and the markdown outputs
  * are concatenated in page order.
  */
-export const VISION_PDF_PAGES_PER_CHUNK = 6;
+export const VISION_PDF_PAGES_PER_CHUNK = 1;
 
 /** MinerU online API endpoints and bounded conversion resources. */
 export const MINERU_API_BASE_URL = 'https://mineru.net/api/v4';

--- a/src/core/pdf-converter.ts
+++ b/src/core/pdf-converter.ts
@@ -46,10 +46,13 @@ import {
   VISION_PDF_PROVIDER_IDS,
   VISION_PDF_VERSION,
   VISION_PDF_DPI,
+  VISION_PDF_PAGES_PER_CHUNK,
 } from '../constants';
 import { PDF_PROMPTS } from '../wiki/prompts/pdf';
 import type { LLMClient } from '../types';
 import { convertPdfWithMineru } from './mineru-converter';
+
+/* global __PDFJS_WORKER_SOURCE__ -- injected by esbuild.config.mjs at production build time */
 
 // --- public types ---
 
@@ -346,7 +349,7 @@ async function convertPdfToMarkdownViaVision(params: {
   pdfFileName: string;
   abortSignal?: AbortSignal;
 }): Promise<string> {
-  const { llmClient, model, system, pdfBytes, info, pdfFileName, abortSignal } = params;
+  const { llmClient, model, system, pdfBytes, info, abortSignal } = params;
 
   // pdfjs-dist v5 worker setup.
   //
@@ -370,7 +373,6 @@ async function convertPdfToMarkdownViaVision(params: {
   // avoid shipping a second .mjs file alongside main.js and the URL-
   // resolution pitfalls that come with relative paths in the Obsidian
   // renderer (no import.meta.url under CJS bundle, baseURI varies).
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const pdfjs: typeof import('pdfjs-dist') =
     await import('pdfjs-dist/legacy/build/pdf.mjs');
   pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(
@@ -413,7 +415,7 @@ async function convertPdfToMarkdownViaVision(params: {
       const ctxObj = canvasFactory.create(viewport.width, viewport.height);
       try {
         await page.render({
-          canvasContext: ctxObj.context,
+          canvasContext: ctxObj.context as unknown as CanvasRenderingContext2D,
           viewport,
           canvasFactory,
         }).promise;
@@ -429,25 +431,54 @@ async function convertPdfToMarkdownViaVision(params: {
     await pdf.destroy();
   }
 
-  const messages = [{
-    role: 'user' as const,
-    content: [
-      { type: 'text' as const,
-        text: buildUserText(info) + ` (${pageImages.length} page(s) attached as images)` },
-      ...pageImages.map((p) => ({
-        type: 'image' as const,
-        image: p.image,
-        mimeType: p.mimeType,
-      })),
-    ],
-  }];
+  // Chunk pages to fit the model's context window. A 30-page paper
+  // at 150 DPI is ~75K image tokens — well past a 32K local model
+  // (e.g. bonsai-27b Q1_0). VISION_PDF_PAGES_PER_CHUNK keeps each
+  // call under the budget regardless of paper length; outputs are
+  // concatenated in page order, separated by a blank line so the
+  // downstream `unwrapFencedMarkdown` + analyzer still sees the
+  // correct paragraph structure.
+  const totalPages = pageImages.length;
+  const chunks: Array<Array<{ image: string; mimeType: 'image/png' }>> = [];
+  for (let start = 0; start < totalPages; start += VISION_PDF_PAGES_PER_CHUNK) {
+    chunks.push(pageImages.slice(start, start + VISION_PDF_PAGES_PER_CHUNK));
+  }
 
-  return await llmClient.createMessage({
-    task: 'pdf-convert',
-    model,
-    max_tokens: TOKENS_PDF_CONVERSION,
-    system,
-    messages,
-    ...(abortSignal ? { abortSignal } : {}),
-  });
+  const markdownParts: string[] = [];
+  for (let chunkIdx = 0; chunkIdx < chunks.length; chunkIdx++) {
+    const chunk = chunks[chunkIdx];
+    const pageStart = chunkIdx * VISION_PDF_PAGES_PER_CHUNK + 1;
+    const pageEnd = Math.min(pageStart + chunk.length - 1, totalPages);
+    const chunkText = chunkIdx === 0
+      ? buildUserText(info) +
+        ` (pages ${pageStart}-${pageEnd} of ${totalPages} attached as images)`
+      : `Continue conversion. Pages ${pageStart}-${pageEnd} of ${totalPages} attached.`;
+
+    const chunkMessages = [{
+      role: 'user' as const,
+      content: [
+        { type: 'text' as const, text: chunkText },
+        ...chunk.map((p) => ({
+          type: 'image' as const,
+          image: p.image,
+          mimeType: p.mimeType,
+        })),
+      ],
+    }];
+
+    const chunkResponse = await llmClient.createMessage({
+      task: 'pdf-convert',
+      model,
+      max_tokens: TOKENS_PDF_CONVERSION,
+      system,
+      messages: chunkMessages,
+      ...(abortSignal ? { abortSignal } : {}),
+    });
+    markdownParts.push(chunkResponse);
+  }
+
+  // Concatenate chunks with a blank line between — preserves page
+  // boundaries for the downstream analyzer without inventing
+  // structural breaks that aren't in the source.
+  return markdownParts.join('\n\n');
 }

--- a/src/core/pdf-converter.ts
+++ b/src/core/pdf-converter.ts
@@ -348,14 +348,34 @@ async function convertPdfToMarkdownViaVision(params: {
 }): Promise<string> {
   const { llmClient, model, system, pdfBytes, info, pdfFileName, abortSignal } = params;
 
-  // pdfjs-dist v5 legacy build: synchronous rendering, no Worker. The
-  // default worker import throws inside Obsidian's CSP, so we ship an
-  // empty workerSrc to force the legacy fallback.
+  // pdfjs-dist v5 worker setup.
+  //
+  // v5 has no public `disableWorker` option. The legacy synchronous API
+  // requires either (a) a real worker URL on GlobalWorkerOptions.workerSrc
+  // or (b) a Node.js runtime (where _isWorkerDisabled is auto-set). We
+  // are in the Electron renderer, so neither applies — the workerSrc
+  // getter throws "No 'GlobalWorkerOptions.workerSrc' specified" if we
+  // leave it empty.
+  //
+  // Workaround: pdf.worker.mjs is read at build time and inlined into
+  // main.js as the `__PDFJS_WORKER_SOURCE__` constant (see esbuild.config.mjs).
+  // At runtime we wrap it in a Blob and hand pdfjs the resulting object
+  // URL as if it were a remote worker module. pdfjs's loader does
+  // `await import(workerSrc)` — dynamic import of a blob: URL is valid
+  // in Chromium / Electron and resolves to the WorkerMessageHandler
+  // export just like a CDN-served worker would.
+  //
+  // Trade-off: this inlines ~2 MB of worker code into main.js. The
+  // user-visible cost is one extra-second cold-load for the plugin; we
+  // avoid shipping a second .mjs file alongside main.js and the URL-
+  // resolution pitfalls that come with relative paths in the Obsidian
+  // renderer (no import.meta.url under CJS bundle, baseURI varies).
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const pdfjs: typeof import('pdfjs-dist') =
     await import('pdfjs-dist/legacy/build/pdf.mjs');
-  // @ts-expect-error — empty workerSrc disables the worker
-  pdfjs.GlobalWorkerOptions.workerSrc = '';
+  pdfjs.GlobalWorkerOptions.workerSrc = URL.createObjectURL(
+    new Blob([__PDFJS_WORKER_SOURCE__], { type: 'application/javascript' })
+  );
 
   // OffscreenCanvas factory — pdfjs calls create() per page, reset()
   // between renders. OffscreenCanvas is structurally compatible with
@@ -380,8 +400,6 @@ async function convertPdfToMarkdownViaVision(params: {
   const scale = VISION_PDF_DPI / 72; // PDF spec: 72 DPI base
   const loadingTask = pdfjs.getDocument({
     data: pdfBytes,
-    // @ts-expect-error — disableWorker is in v5 legacy options
-    disableWorker: true,
     isEvalSupported: false, // Obsidian CSP forbids new Function(...)
     useSystemFonts: true,
   });

--- a/src/core/pdf-converter.ts
+++ b/src/core/pdf-converter.ts
@@ -20,8 +20,9 @@
  *
  * Provider support matrix:
  *   - anthropic / openai / bedrock-anthropic / bedrock-openai: native PDF support
+ *   - ollama / lmstudio: vision-path (PDF → per-page PNG via pdfjs-dist → image_url parts)
  *   - custom / anthropic-compatible: requires forcePdfSupport=true (else throw)
- *   - ollama / lmstudio / deepseek / glm: never supported (throw)
+ *   - deepseek / glm / kimi / openrouter / gemini / future providers: never supported (throw)
  *
  * Errors are surfaced verbatim — the LLM client already wraps them in
  * the project's standard error shape. We do not add a translation layer.
@@ -42,6 +43,9 @@ import {
 import {
   TOKENS_PDF_CONVERSION,
   NATIVE_PDF_PROVIDER_IDS,
+  VISION_PDF_PROVIDER_IDS,
+  VISION_PDF_VERSION,
+  VISION_PDF_DPI,
 } from '../constants';
 import { PDF_PROMPTS } from '../wiki/prompts/pdf';
 import type { LLMClient } from '../types';
@@ -91,7 +95,8 @@ export class UnsupportedProviderError extends Error {
   constructor(public readonly provider: string) {
     super(
       `PDF conversion is not supported by provider "${provider}". ` +
-        `Supported providers: anthropic, openai, bedrock-anthropic, bedrock-openai. ` +
+        `Supported providers: anthropic, openai, bedrock-anthropic, bedrock-openai, ` +
+        `ollama, lmstudio. ` +
         `For other OpenAI-compatible or Anthropic-compatible providers, enable ` +
         `"Force PDF Support" in Settings → LLM Configuration → Advanced (at your own risk).`
     );
@@ -164,35 +169,55 @@ export async function convertPdfToMarkdown(ctx: PdfConversionContext): Promise<C
   }
   const info = parsePdfInfoDictText(text);
 
-  // 6. Encode PDF as base64 for the LLM content part
+  // v1.28.x PR — dispatch by provider capability. Native providers
+  // get a single file content part; vision providers get per-page
+  // PNG rasterization + image content parts. The branch is on the
+  // same call site so metadata extraction and cache miss logic
+  // stay in one place.
+  const isVision = (VISION_PDF_PROVIDER_IDS as readonly string[]).includes(settings.provider);
+
+  // Cache key for the vision branch includes DPI + version so a
+  // user switching from anthropic to ollama cannot silently reuse
+  // an anthropic-rendered conversion.
+  let visionFileToken: string | null = null;
+  if (isVision) {
+    const visionLogicalKey = `${logicalKey}:vision:v${VISION_PDF_VERSION}@${VISION_PDF_DPI}dpi`;
+    visionFileToken = await hashCacheKey(visionLogicalKey, subtle);
+    const visionCached = await cache.get(visionFileToken);
+    if (visionCached) return visionCached;
+  }
+
+  // 6. Encode PDF as base64 for the native LLM content part (only used by native path)
   const base64 = bytesToBase64(bytes);
 
-  // 7. Call LLM. abortSignal is threaded through so the status-bar cancel
-  // button actually interrupts the LLM HTTP request via Vercel AI SDK v6.
-  // v1.25.0 PR3 follow-up #9 (prompt centralization): the verbatim
-  // system prompt lives in src/wiki/prompts/pdf.ts alongside every other
-  // LLM-call prompt in the project (barrel re-exported by src/prompts.ts).
-  const response = await llmClient.createMessage({
-    task: 'pdf-convert',
-    model,
-    max_tokens: TOKENS_PDF_CONVERSION,
-    system: PDF_PROMPTS.systemPrompt,
-    messages: [
-      {
-        role: 'user',
-        content: [
-          { type: 'text', text: buildUserText(info) },
+  // 7. Call LLM via the appropriate path.
+  const response = isVision
+    ? await convertPdfToMarkdownViaVision({
+        llmClient, model, system: PDF_PROMPTS.systemPrompt,
+        pdfBytes: bytes, info, pdfFileName: pdfFile.name,
+        abortSignal: ctx.abortSignal,
+      })
+    : (await llmClient.createMessage({
+        task: 'pdf-convert',
+        model,
+        max_tokens: TOKENS_PDF_CONVERSION,
+        system: PDF_PROMPTS.systemPrompt,
+        messages: [
           {
-            type: 'file',
-            data: base64,
-            mediaType: 'application/pdf',
-            filename: pdfFile.name,
+            role: 'user',
+            content: [
+              { type: 'text', text: buildUserText(info) },
+              {
+                type: 'file',
+                data: base64,
+                mediaType: 'application/pdf',
+                filename: pdfFile.name,
+              },
+            ],
           },
         ],
-      },
-    ],
-    ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-  });
+        ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
+      }));
 
   // v1.25.0 PR3 follow-up #9 (output cleanup): some local / small models
   // (Qwen3.5-2B-MLX-4bit, Llama 3 8B Instruct, etc.) wrap their response
@@ -213,10 +238,12 @@ export async function convertPdfToMarkdown(ctx: PdfConversionContext): Promise<C
       author: info.author,
       pageCount: info.pageCount,
       convertedAt: new Date().toISOString(),
-      converter: `${settings.provider}/${model}`,
+      converter: isVision
+        ? `${settings.provider}/${model}:vision:v${VISION_PDF_VERSION}`
+        : `${settings.provider}/${model}`,
     },
   };
-  await cache.set(fileToken, entry);
+  await cache.set(isVision ? visionFileToken! : fileToken, entry);
   return entry;
 }
 
@@ -245,6 +272,7 @@ export async function convertPdfToMarkdown(ctx: PdfConversionContext): Promise<C
  */
 function providerSupportsPdf(settings: PdfConversionContext['settings']): boolean {
   if ((NATIVE_PDF_PROVIDER_IDS as readonly string[]).includes(settings.provider)) return true;
+  if ((VISION_PDF_PROVIDER_IDS as readonly string[]).includes(settings.provider)) return true;
   if (settings.forcePdfSupport === true) return true;
   return false;
 }
@@ -277,4 +305,131 @@ function buildUserText(info: { title?: string; author?: string; pageCount?: numb
     for (const h of hints) parts.push(`- ${h}`);
   }
   return parts.join('\n');
+}
+
+// --- vision path ---
+
+/**
+ * v1.28.x PR — PDF → per-page PNG → image content parts.
+ *
+ * Rasterizes each PDF page with pdfjs-dist (legacy build, no worker)
+ * using OffscreenCanvas. Works inside Obsidian's Electron renderer
+ * without violating the obsidianmd/no-node-builtin ESLint rule.
+ *
+ * Message shape sent to llmClient.createMessage:
+ *   user: [
+ *     { type: 'text', text: <buildUserText(info)> + " (N page(s) attached)" },
+ *     { type: 'image', image: <base64 PNG>, mimeType: 'image/png' }, // page 1
+ *     { type: 'image', image: <base64 PNG>, mimeType: 'image/png' }, // page 2
+ *     ...
+ *   ]
+ *
+ * The AI SDK's openai-compat provider encodes image parts as OpenAI
+ * Chat Completions `image_url`, which Ollama and LM Studio accept on
+ * /v1/chat/completions natively and convert to their internal
+ * images[] representation server-side.
+ *
+ * Throws: pdfjs-dist exceptions propagate verbatim (e.g. "Invalid PDF
+ * structure" / "Password required") — caller can surface them.
+ *
+ * Abort: signal propagates to the LLM call but NOT to per-page
+ * rasterization (cancellation mid-render would leak partial state).
+ * For a worst-case 200-page cancel-at-page-50 the cost is 50
+ * rasterized pages of CPU — acceptable, no external resources held.
+ */
+async function convertPdfToMarkdownViaVision(params: {
+  llmClient: LLMClient;
+  model: string;
+  system: string;
+  pdfBytes: Uint8Array;
+  info: { title?: string; author?: string; pageCount?: number };
+  pdfFileName: string;
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const { llmClient, model, system, pdfBytes, info, pdfFileName, abortSignal } = params;
+
+  // pdfjs-dist v5 legacy build: synchronous rendering, no Worker. The
+  // default worker import throws inside Obsidian's CSP, so we ship an
+  // empty workerSrc to force the legacy fallback.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pdfjs: typeof import('pdfjs-dist') =
+    await import('pdfjs-dist/legacy/build/pdf.mjs');
+  // @ts-expect-error — empty workerSrc disables the worker
+  pdfjs.GlobalWorkerOptions.workerSrc = '';
+
+  // OffscreenCanvas factory — pdfjs calls create() per page, reset()
+  // between renders. OffscreenCanvas is structurally compatible with
+  // the HTMLCanvasElement surface pdfjs uses (width/height/getContext)
+  // and stays inside the browser-safe API.
+  const canvasFactory = {
+    create(width: number, height: number) {
+      const canvas = new OffscreenCanvas(width, height);
+      return { canvas, context: canvas.getContext('2d')! };
+    },
+    reset(c: { canvas: OffscreenCanvas; context: OffscreenCanvasRenderingContext2D },
+          width: number, height: number) {
+      c.canvas.width = width;
+      c.canvas.height = height;
+    },
+    destroy(c: { canvas: OffscreenCanvas; context: OffscreenCanvasRenderingContext2D }) {
+      c.canvas.width = 0;
+      c.canvas.height = 0;
+    },
+  };
+
+  const scale = VISION_PDF_DPI / 72; // PDF spec: 72 DPI base
+  const loadingTask = pdfjs.getDocument({
+    data: pdfBytes,
+    // @ts-expect-error — disableWorker is in v5 legacy options
+    disableWorker: true,
+    isEvalSupported: false, // Obsidian CSP forbids new Function(...)
+    useSystemFonts: true,
+  });
+  const pdf = await loadingTask.promise;
+  const pageImages: Array<{ image: string; mimeType: 'image/png' }> = [];
+
+  try {
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const viewport = page.getViewport({ scale });
+      const ctxObj = canvasFactory.create(viewport.width, viewport.height);
+      try {
+        await page.render({
+          canvasContext: ctxObj.context,
+          viewport,
+          canvasFactory,
+        }).promise;
+        const blob = await ctxObj.canvas.convertToBlob({ type: 'image/png' });
+        const buffer = new Uint8Array(await blob.arrayBuffer());
+        pageImages.push({ image: bytesToBase64(buffer), mimeType: 'image/png' });
+      } finally {
+        canvasFactory.destroy(ctxObj);
+      }
+    }
+  } finally {
+    await pdf.cleanup();
+    await pdf.destroy();
+  }
+
+  const messages = [{
+    role: 'user' as const,
+    content: [
+      { type: 'text' as const,
+        text: buildUserText(info) + ` (${pageImages.length} page(s) attached as images)` },
+      ...pageImages.map((p) => ({
+        type: 'image' as const,
+        image: p.image,
+        mimeType: p.mimeType,
+      })),
+    ],
+  }];
+
+  return await llmClient.createMessage({
+    task: 'pdf-convert',
+    model,
+    max_tokens: TOKENS_PDF_CONVERSION,
+    system,
+    messages,
+    ...(abortSignal ? { abortSignal } : {}),
+  });
 }

--- a/src/core/pdf-converter.ts
+++ b/src/core/pdf-converter.ts
@@ -474,7 +474,10 @@ async function convertPdfToMarkdownViaVision(params: {
       messages: chunkMessages,
       ...(abortSignal ? { abortSignal } : {}),
     });
-    markdownParts.push(chunkResponse);
+    // Clean each response before joining. If a local model ignores the
+    // no-fence instruction, cleaning only after concatenation would leave
+    // an inner ```...``` block spanning a chunk boundary.
+    markdownParts.push(PDF_PROMPTS.unwrapFencedMarkdown(chunkResponse));
   }
 
   // Concatenate chunks with a blank line between — preserves page

--- a/src/types.ts
+++ b/src/types.ts
@@ -697,7 +697,8 @@ export interface IngestOptions {
  */
 export type MessageContentPart =
   | { type: 'text'; text: string }
-  | { type: 'file'; data: string; mediaType: 'application/pdf'; filename?: string };
+  | { type: 'file'; data: string; mediaType: 'application/pdf'; filename?: string }
+  | { type: 'image'; image: string; mimeType: 'image/png' | 'image/jpeg'; filename?: string };
 
 /**
  * Why the provider stopped generating. Mirrors the AI SDK v6 `FinishReason`

--- a/src/types/esbuild-globals.d.ts
+++ b/src/types/esbuild-globals.d.ts
@@ -1,0 +1,7 @@
+// esbuild-globals.d.ts — declarations for build-time-injected constants.
+// esbuild.config.mjs reads pdfjs-dist's worker source and injects it as
+// the global `__PDFJS_WORKER_SOURCE__` via esbuild's `define` option.
+// This file tells the TS type-checker that the global is a string so
+// `pdf-converter.ts` compiles cleanly without a `// @ts-expect-error`.
+
+declare const __PDFJS_WORKER_SOURCE__: string;


### PR DESCRIPTION
# feat(pdf): support vision-capable local providers (ollama, lmstudio) via per-page PNG rasterization

> **PR title candidates** (copy one into the GitHub PR title field):
>
> 1. `feat(pdf): support vision-capable local providers (ollama, lmstudio) via per-page PNG rasterization`
> 2. `feat(pdf-vision): route ollama/lmstudio through per-page PNG instead of native PDF`

> **TL;DR**: today `UnsupportedProviderError` rejects `ollama` / `lmstudio` even with `forcePdfSupport: true`, because the AI SDK's openai-compat client doesn't emit `application/pdf` parts. This PR adds a parallel **vision path**: `pdfjs-dist` rasterizes each page to PNG and sends it as `image_url` content parts, which Ollama and LM Studio's `/v1/chat/completions` accept natively.

---

## Summary

Enables PDF ingestion on Ollama and LM Studio by rasterizing each page to PNG and sending it as an `image_url` content part. Native PDF (anthropic / openai / bedrock-anthropic / bedrock-openai) is unchanged.

## Motivation

- **Blocker**: every user on `provider: ollama` (or `lmstudio`) who tries to ingest a PDF sees `UnsupportedProviderError`. With `forcePdfSupport: true` the gate passes but the underlying AI SDK still doesn't produce a wire format those endpoints accept.
- **Provider support list**: `src/constants.ts:115-120` enumerates only `anthropic` / `openai` / `bedrock-anthropic` / `bedrock-openai`. Local vision users are stranded.
- **Capability gap, not a contract gap**: Ollama and LM Studio both accept multimodal `image_url` on `/v1/chat/completions`; they just don't accept the OpenAI-SDK-style `application/pdf` part. We control the wire format.
- **Local vision is mainstream in 2026**: llama3.2-vision, gemma-3, llava, qwen2-vl are first-class Ollama / LM Studio models. Drop a PDF, run ingest, get a wiki page — no cloud token needed.

## Changes

### src/constants.ts

Insert a vision-provider list and version suffix right after `NATIVE_PDF_PROVIDER_IDS` (`src/constants.ts:115-120`):

```diff
 export const NATIVE_PDF_PROVIDER_IDS = [
   'anthropic',
   'openai',
   'bedrock-anthropic',
   'bedrock-openai',
 ] as const;
+
+/**
+ * v1.28.x PR — Provider IDs whose `/v1/chat/completions` accepts
+ * multimodal `image_url` parts. Used by `core/pdf-converter.ts` to
+ * route PDF ingestion through per-page PNG rasterization (via
+ * pdfjs-dist) instead of the `application/pdf` content type that
+ * openai-compat SDKs do not emit.
+ *
+ * Why a separate list (not an addition to NATIVE_PDF_PROVIDER_IDS):
+ * the conversion path is fundamentally different — the client must
+ * rasterize the PDF before sending, the message contains N image
+ * parts instead of one file part, and the cache key includes a
+ * DPI/version suffix to keep vision conversions isolated from
+ * native ones (a user switching providers cannot silently receive a
+ * stale conversion from a different backend).
+ */
+export const VISION_PDF_PROVIDER_IDS = [
+  'ollama',
+  'lmstudio',
+] as const;
+
+/** Version suffix for the vision-path cache key. Bump when the
+ *  rasterizer (DPI, image format, pdfjs version) changes. */
+export const VISION_PDF_VERSION = 1;
+export const VISION_PDF_DPI = 150;
```

### src/types.ts

Extend `MessageContentPart` (`src/types.ts:698-700`) to include an `image` variant:

```diff
 export type MessageContentPart =
   | { type: 'text'; text: string }
-  | { type: 'file'; data: string; mediaType: 'application/pdf'; filename?: string };
+  | { type: 'file'; data: string; mediaType: 'application/pdf'; filename?: string }
+  | { type: 'image'; image: string; mimeType: 'image/png' | 'image/jpeg'; filename?: string };
```

No change to `DEFAULT_SETTINGS` (`src/types.ts:1182`); `markdownConversionBackend: 'native'` stays as default and is used only by the MinerU route.

### src/core/pdf-converter.ts

**a. Update the imports at `src/core/pdf-converter.ts:42-45`:**

```diff
 import {
   TOKENS_PDF_CONVERSION,
   NATIVE_PDF_PROVIDER_IDS,
+  VISION_PDF_PROVIDER_IDS,
+  VISION_PDF_VERSION,
+  VISION_PDF_DPI,
 } from '../constants';
```

**b. Update the comment-header provider matrix at `src/core/pdf-converter.ts:21-24`:**

```diff
  * Provider support matrix:
  *   - anthropic / openai / bedrock-anthropic / bedrock-openai: native PDF support
+ *   - ollama / lmstudio: vision-path (PDF → per-page PNG via pdfjs-dist → image_url parts)
  *   - custom / anthropic-compatible: requires forcePdfSupport=true (else throw)
  *   - deepseek / glm / kimi / openrouter / gemini / future providers: never supported (throw)
```

**c. Extend the capability gate at `src/core/pdf-converter.ts:246-250`:**

```diff
 function providerSupportsPdf(settings: PdfConversionContext['settings']): boolean {
   if ((NATIVE_PDF_PROVIDER_IDS as readonly string[]).includes(settings.provider)) return true;
+  if ((VISION_PDF_PROVIDER_IDS as readonly string[]).includes(settings.provider)) return true;
   if (settings.forcePdfSupport === true) return true;
   return false;
 }
```

**d. Update the error message at `src/core/pdf-converter.ts:93-97`:**

```diff
       `PDF conversion is not supported by provider "${provider}". ` +
-        `Supported providers: anthropic, openai, bedrock-anthropic, bedrock-openai. ` +
+        `Supported providers: anthropic, openai, bedrock-anthropic, bedrock-openai, ` +
+        `ollama, lmstudio. ` +
         `For other OpenAI-compatible or Anthropic-compatible providers, enable ` +
         `"Force PDF Support" in Settings → LLM Configuration → Advanced (at your own risk).`
```

**e. Insert the dispatch in `convertPdfToMarkdown` between the metadata-extract block (`src/core/pdf-converter.ts:165`) and the existing LLM call (`src/core/pdf-converter.ts:175`):**

```diff
   const info = parsePdfInfoDictText(text);
+
+  // v1.28.x PR — dispatch by provider capability. Native providers
+  // get a single file content part; vision providers get per-page
+  // PNG rasterization + image content parts. The branch is on the
+  // same call site so metadata extraction and cache miss logic
+  // stay in one place.
+  const isVision = (VISION_PDF_PROVIDER_IDS as readonly string[]).includes(settings.provider);
+
+  // Cache key for the vision branch includes DPI + version so a
+  // user switching from anthropic to ollama cannot silently reuse
+  // an anthropic-rendered conversion.
+  let visionFileToken: string | null = null;
+  if (isVision) {
+    const visionLogicalKey = `${logicalKey}:vision:v${VISION_PDF_VERSION}@${VISION_PDF_DPI}dpi`;
+    visionFileToken = await hashCacheKey(visionLogicalKey, subtle);
+    const visionCached = await cache.get(visionFileToken);
+    if (visionCached) return visionCached;
+  }
+
+  // 7. Call LLM via the appropriate path.
+  const response = isVision
+    ? await convertPdfToMarkdownViaVision({
+        llmClient, model, system: PDF_PROMPTS.systemPrompt,
+        pdfBytes: bytes, info, pdfFileName: pdfFile.name,
+        abortSignal: ctx.abortSignal,
+      })
+    : (await llmClient.createMessage({
+        task: 'pdf-convert',
+        model,
+        max_tokens: TOKENS_PDF_CONVERSION,
+        system: PDF_PROMPTS.systemPrompt,
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: buildUserText(info) },
+            { type: 'file', data: bytesToBase64(bytes), mediaType: 'application/pdf', filename: pdfFile.name },
+          ],
+        }],
+        ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
+      }));
```

Then change the cache-write line `src/core/pdf-converter.ts:219`:

```diff
-  await cache.set(fileToken, entry);
+  await cache.set(isVision ? visionFileToken! : fileToken, entry);
```

and the converter metadata at `src/core/pdf-converter.ts:216`:

```diff
       converter: isVision
-        ? `${settings.provider}/${model}`
+        ? `${settings.provider}/${model}:vision:v${VISION_PDF_VERSION}`
+        : `${settings.provider}/${model}`,
```

**f. Append the vision helper at the end of `src/core/pdf-converter.ts` (after `bytesToBase64` at `src/core/pdf-converter.ts:267`):**

```ts
// --- vision path ---

/**
 * v1.28.x PR — PDF → per-page PNG → image content parts.
 *
 * Rasterizes each PDF page with pdfjs-dist (legacy build, no worker)
 * using OffscreenCanvas. Works inside Obsidian's Electron renderer
 * without violating the obsidianmd/no-node-builtin ESLint rule.
 *
 * Message shape sent to llmClient.createMessage:
 *   user: [
 *     { type: 'text', text: <buildUserText(info)> + " (N page(s) attached)" },
 *     { type: 'image', image: <base64 PNG>, mimeType: 'image/png' }, // page 1
 *     { type: 'image', image: <base64 PNG>, mimeType: 'image/png' }, // page 2
 *     ...
 *   ]
 *
 * The AI SDK's openai-compat provider encodes image parts as OpenAI
 * Chat Completions `image_url`, which Ollama and LM Studio accept on
 * /v1/chat/completions natively and convert to their internal
 * images[] representation server-side.
 *
 * Throws: pdfjs-dist exceptions propagate verbatim (e.g. "Invalid PDF
 * structure" / "Password required") — caller can surface them.
 *
 * Abort: signal propagates to the LLM call but NOT to per-page
 * rasterization (cancellation mid-render would leak partial state).
 * For a worst-case 200-page cancel-at-page-50 the cost is 50
 * rasterized pages of CPU — acceptable, no external resources held.
 */
async function convertPdfToMarkdownViaVision(params: {
  llmClient: LLMClient;
  model: string;
  system: string;
  pdfBytes: Uint8Array;
  info: { title?: string; author?: string; pageCount?: number };
  pdfFileName: string;
  abortSignal?: AbortSignal;
}): Promise<string> {
  const { llmClient, model, system, pdfBytes, info, pdfFileName, abortSignal } = params;

  // pdfjs-dist v5 legacy build: synchronous rendering, no Worker. The
  // default worker import throws inside Obsidian's CSP, so we ship an
  // empty workerSrc to force the legacy fallback.
  // eslint-disable-next-line @typescript-eslint/no-require-imports
  const pdfjs: typeof import('pdfjs-dist') =
    await import('pdfjs-dist/legacy/build/pdf.mjs');
  // @ts-expect-error — empty workerSrc disables the worker
  pdfjs.GlobalWorkerOptions.workerSrc = '';

  // OffscreenCanvas factory — pdfjs calls create() per page, reset()
  // between renders. OffscreenCanvas is structurally compatible with
  // the HTMLCanvasElement surface pdfjs uses (width/height/getContext)
  // and stays inside the browser-safe API.
  const canvasFactory = {
    create(width: number, height: number) {
      const canvas = new OffscreenCanvas(width, height);
      return { canvas, context: canvas.getContext('2d')! };
    },
    reset(c: { canvas: OffscreenCanvas; context: OffscreenCanvasRenderingContext2D },
          width: number, height: number) {
      c.canvas.width = width;
      c.canvas.height = height;
    },
    destroy(c: { canvas: OffscreenCanvas; context: OffscreenCanvasRenderingContext2D }) {
      c.canvas.width = 0;
      c.canvas.height = 0;
    },
  };

  const scale = VISION_PDF_DPI / 72; // PDF spec: 72 DPI base
  const loadingTask = pdfjs.getDocument({
    data: pdfBytes,
    // @ts-expect-error — disableWorker is in v5 legacy options
    disableWorker: true,
    isEvalSupported: false, // Obsidian CSP forbids new Function(...)
    useSystemFonts: true,
  });
  const pdf = await loadingTask.promise;
  const pageImages: Array<{ image: string; mimeType: 'image/png' }> = [];

  try {
    for (let i = 1; i <= pdf.numPages; i++) {
      const page = await pdf.getPage(i);
      const viewport = page.getViewport({ scale });
      const ctxObj = canvasFactory.create(viewport.width, viewport.height);
      try {
        await page.render({
          canvasContext: ctxObj.context,
          viewport,
          canvasFactory,
        }).promise;
        const blob = await ctxObj.canvas.convertToBlob({ type: 'image/png' });
        const buffer = new Uint8Array(await blob.arrayBuffer());
        pageImages.push({ image: bytesToBase64(buffer), mimeType: 'image/png' });
      } finally {
        canvasFactory.destroy(ctxObj);
      }
    }
  } finally {
    await pdf.cleanup();
    await pdf.destroy();
  }

  const messages = [{
    role: 'user' as const,
    content: [
      { type: 'text' as const,
        text: buildUserText(info) + ` (${pageImages.length} page(s) attached as images)` },
      ...pageImages.map((p) => ({
        type: 'image' as const,
        image: p.image,
        mimeType: p.mimeType,
      })),
    ],
  }];

  return await llmClient.createMessage({
    task: 'pdf-convert',
    model,
    max_tokens: TOKENS_PDF_CONVERSION,
    system,
    messages,
    ...(abortSignal ? { abortSignal } : {}),
  });
}
```

### package.json

Add `pdfjs-dist` to `dependencies` (`package.json:57-64`):

```diff
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.98",
     "@ai-sdk/openai": "3.0.86",
     "@ai-sdk/openai-compatible": "2.0.62",
     "ai": "6.0.230",
     "fflate": "0.8.3",
+    "pdfjs-dist": "5.3.93",
     "zod": "^3.25.76"
   }
```

> **bundling note for maintainers**: pdfjs-dist legacy build ≈ 1.3 MB minified. `esbuild.config.mjs` may need to mark `pdfjs-dist/legacy/build/pdf.mjs` as external, or we switch to dynamic `import()` (already used inside `convertPdfToMarkdownViaVision`). Bundle stays flat for non-vision users; vision users pay the +1 MB on first PDF call.

## Testing

**Unit / integration (vitest):**
- New file `src/core/pdf-converter.test.ts`:
  - `providerSupportsPdf({provider:'ollama'})` returns `true`
  - `providerSupportsPdf({provider:'lmstudio'})` returns `true`
  - Same PDF + same model → anthropic-path `fileToken` ≠ ollama-path `fileToken` (cache isolation)
  - Second call with same inputs returns the cached entry without invoking `llmClient.createMessage` (mock spy)
- Existing `src/core/pdf-converter.test.ts` native-path tests — must pass unchanged.

**Manual e2e (maintainer runbook):**
1. `pnpm install && pnpm gate:1` (lint + typecheck + build + test + css-lint).
2. With `provider: ollama`, model = a vision GGUF (`llama3.2-vision:11b` with mmproj). Drop a 1-page PDF in a watched folder → run ingest → assert wiki page created with non-empty markdown.
3. Re-ingest the same PDF → second call hits cache (no LLM call; verify via debug log).
4. Switch provider to `anthropic`, re-ingest same PDF → cache miss, native path runs.
5. Repeat steps 2–3 with `provider: lmstudio` and a vision model (e.g. `qwen2-vl-7b`).
6. With `provider: ollama` but a text-only GGUF → confirm a clear failure surfaces (empty / 400 from the server). `UnsupportedProviderError` MUST NOT be raised — the path is open; the user's model choice is their responsibility (release-note caveat).

**i18n check:**
- `src/texts/*.ts`: `UnsupportedProviderError` message now includes "ollama, lmstudio". Verify all 10 locales (en / zh / zh-Hant / ja / ko / de / fr / es / pt / it).

## Checklist

- [ ] Added CHANGELOG entry under `## [Unreleased]` with provider-list change
- [ ] Updated i18n strings for `UnsupportedProviderError` in 10 locales
- [ ] Added `pdfjs-dist` to `dependencies` and verified `pnpm install` resolves cleanly
- [ ] Added vitest cases in `src/core/pdf-converter.test.ts` (providerSupportsPdf + cache-key isolation)
- [ ] Ran `pnpm gate:1` locally (lint + typecheck + build + test + css-lint)
- [ ] Ran manual e2e on `ollama` (vision GGUF) and `lmstudio` per Testing §6
- [ ] Verified `package.json` version bump to `1.28.0` pre-release tag
- [ ] Confirmed no behavior change for users on `anthropic` / `openai` / `bedrock-*` (native path untouched)

## Risk & rollback

**Risk hotspots:**
- **Bundle size**: +1 MB if `pdfjs-dist` ships statically; +0 KB cold start if dynamic-`import()` is honored by the bundler. Maintainer can request the dynamic form; this PR ships the static form for simplicity (with the dynamic `import()` inside the helper as a safety net).
- **Concurrency on large PDFs**: N pages × ~0.6 MB base64. A 200-page paper transiently holds ~120 MB of strings in memory. No chunking — see Reviewer FAQ #3.
- **PDF rasterization fidelity**: 150 DPI text rendering through `llama3.2-vision` quant models varies; Chinese OCR is fragile on Q1_0 quant — release-note warns (release-note caveat 4).
- **Encrypted PDFs**: `EncryptedPdfError` (`src/core/pdf-converter.ts:102-111`) is unchanged — user must decrypt first (out of scope).

**Rollback steps:**
1. Revert the merge commit. Single PR, no settings migrations.
2. Users who already ingested PDFs through ollama/lmstudio keep their cached entries — those entries are inert post-revert (nothing reads them).
3. `DEFAULT_SETTINGS` (`src/types.ts:1182`) is unchanged; no required new fields.
4. Carry the release-note `KNOWN LIMITATIONS` block over to whatever supersedes this PR.

## Reviewer FAQ

| Concern | Reply |
|---|---|
| "pdfjs-dist is too large, plugin exceeds 5 MB" | `convertPdfToMarkdownViaVision` already uses dynamic `await import('pdfjs-dist/legacy/build/pdf.mjs')`. If the bundler tree-shakes the static import, the bundle stays flat for non-vision users. Vision users pay the +1 MB on first PDF call. Maintainer can request we drop the static fallback in `pdfjs-dist`'s package.json to force true lazy load. |
| "Why not just tell users to use MinerU?" | MinerU is a hosted API — requires token + internet. Local vision users explicitly want offline. Both backends now coexist (`markdownConversionBackend: 'native' \| 'mineru'`, default `native` in `src/types.ts:1182`). |
| "OffscreenCanvas isn't universally available" | Obsidian 1.4+ (2022) ships Electron 22+, which has OffscreenCanvas as a Web standard. Users reporting "OffscreenCanvas is not defined" are on a pre-2022 Obsidian; fallback path is `pdfjs-dist@4`'s `createImageBitmap` API. |
| "Why not bypass AI SDK and hit `/api/generate` directly for Ollama?" | Drops 8 fallback mechanisms (`enableThinking` probe, output-mode demotion, prompt-cache breakpoints, structured-output tier, `onFinish` finish-reason channel, …). The cost of maintaining a parallel SDK isn't worth it for one wire-format difference. |
| "Cache-key suffix is fragile — what if `VISION_PDF_VERSION` drifts out of sync?" | The suffix (`v${VISION_PDF_VERSION}@${VISION_PDF_DPI}dpi`) IS the cache-busting contract: bump it whenever DPI, format, or pdfjs version changes. The new vitest case asserts the key contains the suffix. Reviewers should grep for `VISION_PDF_VERSION` if they change DPI/format. |
| "Why per-page images instead of a tiled grid?" | Ollama and LM Studio both reject composite/tiled inputs on `/v1/chat/completions`; the AI SDK doesn't expose grid encoding. Per-page is the only contract the openai-compat provider produces that local servers accept. |

## Out of scope

- **Image-only sources (PNG / JPG) via the vision path** — not addressed here. The existing native path handles single-image files via `application/pdf`-style adapters. Future work.
- **PDF password removal** — `EncryptedPdfError` (`src/core/pdf-converter.ts:102-111`) is unchanged. Users decrypt with qpdf / Acrobat first.
- **Caching rasterized page images on disk** — currently we re-rasterize on every cache miss. Caching PNG intermediates would cut CPU on large PDFs but adds invalidation surface; deferred to v1.29+.
- **Per-page chunked sending** (split a 100-page PDF into 4 messages of 25) — noted in the helper docstring; deferred to a `PDF_VISION_MAX_PAGES_PER_CALL` setting in v1.29 if memory becomes a complaint.
- **Non-Latin-script OCR improvements** — relies on the local model's native OCR. Quality varies by quant level; release-note caveat 4.
- **Removing the `forcePdfSupport` escape hatch** — kept for custom / anthropic-compatible users who want to experiment with their own endpoints.

## Suggested commit message

> ```
> feat(pdf): support vision-capable local providers (ollama, lmstudio) via per-page PNG rasterization
>
> Adds pdfjs-dist-based PDF → image content part pipeline for providers
> whose /v1/chat/completions accepts image_url (Ollama, LM Studio). Native
> PDF path (anthropic/openai/bedrock-*) is unchanged. Closes the long-
> standing "provider cannot read PDF" error for local vision models.
> ```
