### PR TITLE
fix(task-policy): reject duplicate __proto__ entries (#543)

### DIFF
--- a/src/__tests__/core/task-policy.test.ts
+++ b/src/__tests__/core/task-policy.test.ts
@@ -178,6 +178,17 @@ describe('parseTaskPolicySpec — bounded thinking', () => {
       .toThrow(/"extract" is set twice/);
   });
 
+  // #543: the duplicate-task guard relied on `Object.prototype.hasOwnProperty.call`
+  // against a plain object literal, which leaves `__proto__` as an inherited
+  // accessor — `policies['__proto__'] = ...` never becomes an own property, so
+  // a second `__proto__=...` entry passed the guard and silently mutated the
+  // object's prototype instead. The contract "a task named twice is an error"
+  // must hold for every key the parser accepts as a task name.
+  it('rejects a __proto__ entry set twice (closes the hasOwnProperty.call bypass, #543)', () => {
+    expect(() => parseTaskPolicySpec('__proto__=text:on,__proto__=schema:off'))
+      .toThrow(/"__proto__" is set twice/);
+  });
+
   it('rejects a repeated wildcard too', () => {
     expect(() => parseTaskPolicySpec('*=text,*=schema')).toThrow(/set twice/);
   });

--- a/src/core/task-policy.ts
+++ b/src/core/task-policy.ts
@@ -165,7 +165,13 @@ const THINKING_ALIASES: Readonly<Record<string, TaskThinking>> = {
  * never matches. Give the labels one home and this becomes a two-line check.
  */
 export function parseTaskPolicySpec(spec: string): TaskPolicyMap {
-  const policies: Record<string, TaskPolicy> = {};
+  // #543: a null-prototype map. `policies['__proto__'] = ...` on a plain
+  // object literal invokes the inherited accessor instead of setting an
+  // own property, so a second `__proto__=...` entry bypassed the duplicate
+  // guard and silently mutated the object's prototype. `hasOwnProperty.call`
+  // on a null-proto object still reports whatever string was assigned, and
+  // `__proto__` becomes a normal own key like any other.
+  const policies: Record<string, TaskPolicy> = Object.create(null) as Record<string, TaskPolicy>;
   for (const rawEntry of spec.split(',')) {
     const entry = rawEntry.trim();
     if (entry === '') continue;


### PR DESCRIPTION
## Summary

`parseTaskPolicySpec`'s duplicate-task guard used `Object.prototype.hasOwnProperty.call(policies, task)` against a plain object literal — one key defeats it: `__proto__`. `policies['__proto__'] = ...` invokes the inherited accessor setter instead of defining an own property, so a second `__proto__=...` entry passes the guard and silently mutates the object's prototype instead of throwing.

Switching the map to a null prototype (`Object.create(null)`) makes `__proto__` a normal own key: `hasOwnProperty.call` reports it, and the "a task named twice is an error" invariant (#525 review) now holds for every key the parser accepts.

## Changes

- `src/core/task-policy.ts`: one-line map construction change (+ comment)
- `src/__tests__/core/task-policy.test.ts`: new test asserting `__proto__=text:on,__proto__=schema:off` throws

## Verification

- RED: new test fails against unfixed code (no throw — the bug)
- GREEN: all 21 tests pass after fix
- Gate 1 (lint + tsc + build + test + css-lint): all green, 3691 tests pass

Closes #543