### PR TITLE
fix(repetition-loop): require consecutive source occurrences for echo (#542)

### DIFF
--- a/src/__tests__/core/repetition-loop.test.ts
+++ b/src/__tests__/core/repetition-loop.test.ts
@@ -100,12 +100,20 @@ describe('findRepetitionLoop', () => {
 
 // #525 review: halving changes how many items are asked for, never the note,
 // so a loop the note itself carries is reproduced by every retry.
+// #542: the source check has to mirror the response detector — the response
+// detector requires 4 *consecutive* repeats (LOOP_RE `\1{3,}`), so a faithful
+// echo is also a *consecutive* pattern in the note, not 4 scattered mentions.
+// A stopword scattered through ordinary prose ("und die " ×25 in a German
+// note) is not the note's pattern to repeat; spending the halve-retry on it
+// drops the only recovery attempt #524 provided for a damaged batch.
 describe('isSourceBorneLoop', () => {
   const REFRAIN = 'Und täglich grüßt das Murmeltier. ';
 
-  it('recognises a refrain the note states at least four times', () => {
+  it('recognises a refrain the note states at least four times consecutively', () => {
     const loop = findRepetitionLoop(REFRAIN.repeat(10))!;
-    const note = (REFRAIN + 'Dazwischen anderer Text. ').repeat(6);
+    // REFRAIN×4 back-to-back, then intervening prose, then REFRAIN×2: the
+    // 4-consecutive run at the start is the refrain pattern.
+    const note = `${REFRAIN.repeat(4)} Dazwischen anderer Text. ${REFRAIN.repeat(2)}`;
     expect(isSourceBorneLoop(loop, note)).toBe(true);
   });
 
@@ -119,6 +127,25 @@ describe('isSourceBorneLoop', () => {
     expect(isSourceBorneLoop(loop, 'Ein Text über Ferritin und Eisen.')).toBe(false);
   });
 
+  // #542 failure mode: a stopword ("und die ") appears many times scattered
+  // through ordinary German prose. The pre-#542 guard's `>= 4 scattered` check
+  // returned true and suppressed the halve-retry — the loop unit was 25× in
+  // the note, but never as a refrain; the response's 80× was degeneration,
+  // not echo. After the fix: scattered mentions don't satisfy the
+  // consecutive-run check, so the retry fires.
+  it('does not fire on a stopword scattered through the note (#542)', () => {
+    const loop = findRepetitionLoop('und die '.repeat(80))!;
+    const note = [
+      'Ein gewöhnlicher Text über Sprache. Die ist ein Wort. Die kommt oft vor.',
+      'Die und die Bedeutung und die Form. Die ist ein Wort. Die ist häufig.',
+      'und die Verbindung. und die Form. und die Syntax. und die Bedeutung.',
+      'und die Syntax, und die Semantik, und die Pragmatik.',
+    ].join(' ');
+    // "und die " appears many times scattered, never ≥4 consecutive.
+    expect(note.split('und die ').length - 1).toBeGreaterThanOrEqual(8);
+    expect(isSourceBorneLoop(loop, note)).toBe(false);
+  });
+
   // The trap this exists to avoid: `unit` is shortened for log lines, so a
   // unit over 40 characters would never be found in the note if the lookup
   // used it. The check has to read `rawUnit`.
@@ -128,5 +155,14 @@ describe('isSourceBorneLoop', () => {
     const loop = findRepetitionLoop(long.repeat(8))!;
     expect(loop.unit).toContain('…');
     expect(isSourceBorneLoop(loop, long.repeat(5))).toBe(true);
+  });
+
+  // #542 acceptance criterion #1: pin the consecutive-run boundary. Exactly
+  // 4 → true (the threshold), exactly 3 → false. A `>= 3 → false` mutation
+  // (changing the threshold) must NOT pass these tests.
+  it('requires exactly 4 consecutive occurrences (boundary pinned, #542)', () => {
+    const loop = findRepetitionLoop(REFRAIN.repeat(10))!;
+    expect(isSourceBorneLoop(loop, `${REFRAIN.repeat(3)} Dazwischen Text.`)).toBe(false);
+    expect(isSourceBorneLoop(loop, `${REFRAIN.repeat(4)} Dazwischen Text.`)).toBe(true);
   });
 });

--- a/src/__tests__/wiki/source-analyzer.test.ts
+++ b/src/__tests__/wiki/source-analyzer.test.ts
@@ -537,8 +537,14 @@ describe('SourceAnalyzer — repetition loop guard (#524)', () => {
 describe('SourceAnalyzer — source-borne repetition (#525 review)', () => {
   const REFRAIN = 'Und täglich grüßt das Murmeltier. ';
   // The note itself states the refrain far more often than the detector's
-  // four-repeat threshold, which is what makes the echo faithful.
-  const REFRAIN_NOTE = '# Refrain\n' + (REFRAIN + 'Dazwischen steht anderer Text. ').repeat(30);
+  // Four consecutive occurrences at the start (#542: scattered mentions are
+  // not a refrain — the new contract requires back-to-back occurrences, like
+  // the response detector's `LOOP_RE` `\1{3,}`). The trailing scattered
+  // mentions remain to confirm the count-based path is no longer the
+  // trigger; only the consecutive run at the head of the note is.
+  const REFRAIN_NOTE = '# Refrain\n' + REFRAIN.repeat(4)
+    + ' Dazwischen steht anderer Text. '
+    + (REFRAIN + 'Dazwischen steht anderer Text. ').repeat(30);
   const ECHO = JSON.stringify({
     source_title: 'Refrain',
     summary: 'A refrain.',

--- a/src/core/repetition-loop.ts
+++ b/src/core/repetition-loop.ts
@@ -82,17 +82,29 @@ export function findRepetitionLoop(
  * carries is therefore reproduced by every retry, so the budget is spent on a
  * certainty.
  *
- * Why "repeats it four times" and not "contains it once", which is the cheaper
- * reading: the two errors are not symmetric. Skipping the retry on a batch that
- * really is damaged costs items silently; spending it on a source-borne loop
- * costs one call. So the test has to be the conservative one, and a unit that
+ * Why "four times" and not "contains it once", which is the cheaper reading:
+ * the two errors are not symmetric. Skipping the retry on a batch that really
+ * is damaged costs items silently; spending it on a source-borne loop costs
+ * one call. So the test has to be the conservative one, and a unit that
  * appears once in a long note is no evidence at all — `Vitamin D, ` occurs in
- * half the vault and would suppress the retry for every genuine loop built from
- * it. A unit the note states four times is a refrain.
+ * half the vault and would suppress the retry for every genuine loop built
+ * from it. A unit the note states four times is a refrain.
+ *
+ * #542: the threshold is *consecutive* occurrences, mirroring the response
+ * detector's `LOOP_RE` `\1{3,}`. The previous check counted any non-
+ * overlapping occurrence, which let a stopword scattered through ordinary
+ * prose (`"und die "` ×25 in a German note, never as a refrain) suppress
+ * the retry for genuine token-level degeneration. The scatter is not the
+ * note's pattern to repeat — it is how the language works. Consecutive
+ * runs are the refrain shape; the detector's contract has to match it.
  */
 export function isSourceBorneLoop(loop: RepetitionLoop, sourceText: string): boolean {
   if (!loop.rawUnit) return false;
-  // split() counts non-overlapping occurrences, which is the conservative
-  // direction: it can undercount a self-overlapping unit, never overcount.
-  return sourceText.split(loop.rawUnit).length - 1 >= REPETITION_LOOP_MIN_REPEATS;
+  // Escape the unit for the repeat quantifier so a unit containing regex
+  // metacharacters (a quoted phrase, a path with a slash) still matches
+  // literally. The unit is already on the response side verbatim, so this
+  // is a literal-vs-regex question, not a normalisation question.
+  const escaped = loop.rawUnit.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?:${escaped}){${REPETITION_LOOP_MIN_REPEATS},}`);
+  return re.test(sourceText);
 }


### PR DESCRIPTION
## Summary

The pre-fix guard counted any non-overlapping occurrence of the loop unit in the source, so a stopword scattered through ordinary prose (`"und die "` ×25 in a German note) suppressed the halve-retry for the very token-level degeneration the response detector (#524) was built to catch. A loop the note carries is reproduced by every retry, but a stopword is not the note's pattern to repeat — it is how the language works.

Symmetric with the response detector's `LOOP_RE` `\1{3,}`: require ≥4 *consecutive* occurrences in the source, not ≥4 scattered mentions. The asymmetry is what let the scattered check through — closing it re-establishes the response/source symmetry at the four-repeat threshold.

## Changes

- `src/core/repetition-loop.ts`: `isSourceBorneLoop` now tests a consecutive-run regex (escaped unit, `{4,}` quantifier) instead of a scattered split count
- `src/__tests__/core/repetition-loop.test.ts`: new stopword-scattered test (the bug), boundary-pin test (exactly 4 → true / 3 → false), refrain fixture updated to back-to-back shape
- `src/__tests__/wiki/source-analyzer.test.ts`: `REFRAIN_NOTE` anchored with a consecutive run at the head, preserving the echo-path assertion

## Verification

- RED: stopword-scattered test fails against unfixed code (returns true — the bug)
- GREEN: all tests pass after fix (16 unit + integration)
- Gate 1 (lint + tsc + build + test + css-lint): all green, 3692 tests pass

Closes #542