### PR TITLE
docs(pdf): correct the Fallback claim that local servers accept PDF file parts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Feature planning and improvement proposals
 
-**Latest shipped:** v1.27.0 MINOR (2026-08-27). See [CHANGELOG.md §1.27.0](./CHANGELOG.md#1270---2026-08-27) for the canonical composition record. | **Updated:** 2026-08-27
+**Latest shipped:** v1.27.0 MINOR (2026-08-27). See [CHANGELOG.md §1.27.0](./CHANGELOG.md#1270---2026-08-27) for the canonical composition record. | **Updated:** 2026-08-28 (post v1.27.0 PATCH triage — 5 new items + simplify/code-review pass on PR #569)
 
 **v1.26.5 PATCH CANCELLED 2026-08-19** — folded into v1.27.0 MINOR to amortize release-cycle overhead (per user direction).
 
@@ -73,6 +73,61 @@ Follow-ups filed from #517 adjacent findings: **#533** (`isUrlError` treats mode
 
 Open follow-ups from review threads: alias-floor unification (#537×#532), bounded type-repair concurrency (#528), zh/ja candidate-gate measurement (#521 debt), plus from the #525 scan — codex-client `outputModeOverride` honoring (extract stays JSON-mode on that provider despite the builtin pin), source-borne loop pre-check before spending the halve-retry, exhaustion-arm test, hardcoded-EN placeholder i18n.
 
+---
+
+## v1.27.x PATCH cycle — current scope (2026-08-28)
+
+**Triggered by:** v1.27.0 MINOR shipped 2026-08-27 (`3464cce`). PATCH backlog is the union of (a) v1.27.0 ship-day bugs from architect-level triage (4 PRs already shipped 2026-08-27: #559 / #564 / #557 + #566 owner-passby), (b) deferred items from v1.27.0 review threads, (c) post-MINOR new Issues filed by @DocTpoint 2026-08-28 (#567 / #568) + PR #569.
+
+### Active backlog (priority × ROI)
+
+| # | Issue | What | Why now | Owner | Status |
+|---|-------|------|---------|-------|--------|
+| 1 | **#543** | `parseTaskPolicySpec` — `__proto__` entry bypasses the duplicate-task guard | 1-line + 1 test; closes `Object.prototype` pollution class | green-dalii (owner-self) | Ready, not yet PR |
+| 2 | **#567** | `customEntityLimit` / `customConceptLimit` ceiling-vs-denominator coupling reduces yield as limit rises | Real user pain (11-50 default range); recommended contract: ceiling-only + stop gets own signal sibling to `checkEmptyBatch` | green-dalii (owner-self) | Issue open; needs contract decision then PR |
+| 3 | **#568 / #569** | Domain-axis write side — `domains:` frontmatter key, validated against vault tag vocabulary | #91 read-side prerequisite; PR #569 has 6 pre-merge bugs (B1-B6) concentrated in fold-aware dedup inconsistency (3 writers vs validator) + empty-`wikiFolder` edge case + 3 test gaps | DocTpoint | PR open; **CHANGES_REQUESTED 2026-08-28**; author fix needed |
+| 4 | **#542** | `isSourceBorneLoop` suppresses halve-retry for common-word degenerate cases | Reaffirmed by #525 follow-up review (source-borne loop pre-check before spending halve-retry) | green-dalii (owner-self) | Issue open; small fix |
+| 5 | **#407 Stage 2** | 7 silent-failure sites in `conversation-ingest.ts:337` et al (one PR per blast radius) | High-ROI bug series, blast-radius split per `feedback_*` lessons | green-dalii (owner-self) | Open; split into ~3 PRs |
+| 6 | **#528** | Type-repair fan-out — bound concurrency to 2-4 chunks | Review-thread follow-up from #528 merged (PR #526/#528); no hot spot today | DocTpoint | Open; defer to mid-PATCH |
+| 7 | **#539 follow-ups** | codex-client `outputModeOverride` honoring + exhaustion-arm test + hardcoded-EN placeholder i18n | 6 filed items from simplify pass on PR #539 (merged `4c15cc5`); quality items | green-dalii (owner-self) | Open; mid-PATCH |
+
+### Recently shipped into v1.27.x PATCH (2026-08-27, pre-triage batch)
+
+| PR | Issue | What | Why |
+|----|-------|------|-----|
+| **#559** (`92f2f8c`) | #537 × #532 | `minAliasLength` floor threaded to the create path; cross-page alias gate wired at path resolution | Alias-floor unification from v1.27.0 review thread |
+| **#564** (`1a56a9d`) | #562 | `parenSpans` no longer treats wikilink markup brackets as aside | Gate link markup misread |
+| **#557** (`bd992f8c`) | #556 | `pnpm.overrides` deprecation → move to `pnpm-workspace.yaml` | pnpm 11+ silently drops the `pnpm` field |
+| **#566** (`a4c90c4`) | #560 follow-up | dev-instrument relative links converted to absolute https URLs | Path-changing PR must sync-audit `readme-links` guard |
+
+### Review-thread debts carried into v1.27.x PATCH
+
+- **#528** type-repair fan-out (concurrent → 2-4 chunks)
+- **#521** zh/ja candidate-gate measurement on a Chinese vault (DocTpoint → maintainer follow-up)
+- Alias-floor unification (#537×#532) — **DONE via PR #559**, but `filterRedundantAliases` cross-page gate still needs the wiring follow-up tracked separately
+- codex-client `outputModeOverride` honoring + exhaustion arm + i18n placeholders (from PR #525 / #539 review)
+
+### Research bookmarks (NOT in PATCH cycle)
+
+- **#479** Coverage measurement denominator — "no edge" readability (DocTpoint, 2026-08-18): 30.1% omission rate measured; on `v1.27.0+ research` milestone 2026-08-28; reopen when LLM-side probe ready
+- **#480** "PPR ≈ kNN" is a property of co-occurrence edges — depends on typed relations #285 emitting before re-test meaningful; on `v1.27.0+ research` milestone 2026-08-28
+
+### Recommended cycle cadence
+
+| Phase | Items | ETA |
+|-------|-------|-----|
+| **Early PATCH** (urgent + self-contained) | #543 + #567 + merge #569 (post B1-B6 + T1-T3) | ~1 day |
+| **Mid PATCH** (consolidation) | #542 + first PR of #407 Stage 2 + #539 follow-ups | ~3 days |
+| **Late PATCH** (research-grade) | #528 type-repair chunking + #521 zh/ja measurement | ~5 days |
+
+### Triage discipline notes (post-triage 2026-08-28)
+
+- 5 new items triaged: 4 from @DocTpoint (3 architect-level + 2 future-work bookmarks) + 1 PR. Total open issues 21 + 1 PR.
+- AND-rule (eyes + label both present) skipped #542 / #543 — those had previous maintainer 👀 + label, but the work is still pending; visible in backlog above.
+- PR review policy per CLAUDE.md "Mandatory merge sequence": `gh pr review` (formal review event) precedes any `gh pr merge`. PR #569 received `CHANGES_REQUESTED` review event 2026-08-28 with B1-B6 + T1-T3 as pre-merge scope.
+
+---
+
 ### Other follow-ups
 
 - **#407 Stages 2** — `conversation-ingest.ts:337` and remaining 7 silent-failure sites, one PR per blast radius.
@@ -119,7 +174,7 @@ Open follow-ups from review threads: alias-floor unification (#537×#532), bound
 - Obsidian Bases for index (#184) — Obsidian Bases still experimental; post-PPR integration
 - OKF Bundle export (#285) — typed-edges output standard; community-pending
 - 'auto' granularity mapping (#168) — needs benchmark + equation; community-pending
-- PPR ≈ kNN co-occurrence (#480) — research bookmark
-- Coverage measurement denominator (#479) — research bookmark
+- **PPR ≈ kNN co-occurrence (#480)** — research bookmark; reopened 2026-08-28 with self-correction on symmetric-vs-directed adjacency; re-test only meaningful after typed relations #285
+- **Coverage measurement denominator (#479)** — research bookmark; reopened 2026-08-28 with 30.1% omission rate measured; needs LLM-side per-edge probe before instrumentation
 - Lint details in user README — partial via Advanced settings UI; full section TBD
 - OS-async observation window policy — formalize SecretStorage 5-version stabilization pattern

--- a/docs/PDF-OCR-GUIDE.md
+++ b/docs/PDF-OCR-GUIDE.md
@@ -105,15 +105,13 @@ OCR models are all relatively lightweight — you don't need a multi-tier table.
 
 ### Fallback: any local multimodal LLM
 
-If oMLX/Markitdown is unavailable (Linux/Windows or older Macs without M-series), point **Force PDF Support** at any local multimodal LLM that accepts PDF file parts:
+If oMLX/Markitdown is unavailable (Linux/Windows or older Macs without M-series), you can point **Force PDF Support** at a local multimodal LLM — **but first check whether your server actually accepts PDF file parts**. The OpenAI-compatible `/v1/chat/completions` wire format carries `text` and `image` content parts; a PDF `file` part is not part of that standard and most local servers do not consume it:
 
+- **Ollama** — accepts only text and base64-image parts. A PDF file part is rejected (400 from the server).
+- **LM Studio** — likewise validates image blocks as real image binaries; a PDF sent as an image block is rejected.
+- **llama.cpp / vLLM** — support varies by build and model. Verify against your own server before relying on this path; if it works, set the plugin's Base URL to the server's endpoint and pick the multimodal model name.
 
-- **llama.cpp with a multimodal GGUF** (Qwen3-VL, Llama 3.2 Vision, Pixtral, Gemma 3 vision variants)
-- **Ollama with a multimodal model tag** (`ollama pull qwen3-vl:4b`, `ollama pull llama3.2-vision`)
-- **LM Studio** with a vision-capable GGUF loaded and the OpenAI-compatible server running
-- **vLLM with a dedicated OCR model** (`deepseek-ocr-2`, `glm-ocr`) — talk the standard OpenAI multimodal API
-
-Whichever you pick, set the plugin's Base URL to the server's endpoint and the model picker to the multimodal model name. The plugin's cache key includes the model, so switching models invalidates stale entries automatically.
+For local servers that reject PDF parts, the reliable pattern is to **convert the PDF before the LLM call** — the oMLX + Markitdown stack above, or any external converter (MinerU extractor, `markitdown` CLI, marker) — and ingest the resulting Markdown as a regular text source. The plugin's cache key includes the model, so switching models invalidates stale entries automatically.
 
 ---
 

--- a/docs/PDF-OCR-GUIDE_CN.md
+++ b/docs/PDF-OCR-GUIDE_CN.md
@@ -104,14 +104,13 @@ OCR 模型都相对轻量 —— 不需要多档位表格。两个带宽覆盖�
 
 ### 备选：任意本地多模态 LLM
 
-如果 oMLX / Markitdown 不可用（Linux/Windows 或不带 M 系列的旧 Mac），把 **Force PDF Support** 指向任意接受 PDF 文件部分的本地多模态 LLM：
+如果 oMLX / Markitdown 不可用（Linux/Windows 或不带 M 系列的旧 Mac），可以把 **Force PDF Support** 指向本地多模态 LLM —— **但先确认你的服务器真的接受 PDF 文件部分**。OpenAI 兼容的 `/v1/chat/completions` wire 格式只携带 `text` 和 `image` 两种 content part；PDF `file` part 不属于该标准，大多数本地服务器不会消费它：
 
-- **llama.cpp 配多模态 GGUF**（Qwen3-VL、Llama 3.2 Vision、Pixtral、Gemma 3 视觉变体）
-- **Ollama 配多模态模型 tag**（`ollama pull qwen3-vl:4b`、`ollama pull llama3.2-vision`）
-- **LM Studio** 加载支持视觉的 GGUF 并跑 OpenAI 兼容服务器
-- **vLLM 配专用 OCR 模型**（`deepseek-ocr-2`、`glm-ocr`）—— 走标准 OpenAI 多模态 API
+- **Ollama** —— 只接受 text 和 base64 图片 part。发 PDF file part 会被服务器拒绝（400）。
+- **LM Studio** —— 同样会校验 image 块必须是真实的图片二进制；把 PDF 当 image 块发会被拒绝。
+- **llama.cpp / vLLM** —— 支持情况因构建版本和模型而异。先在自己的服务器上验证再依赖这条路；如果可用，把插件的 Base URL 指向该服务器端点，模型选择器选多模态模型名。
 
-无论选哪个，把插件的 Base URL 指向该服务器的端点，模型选择器选多模态模型名字。插件的缓存 key 包含模型，所以切换模型会自动让陈旧条目失效。
+对拒绝 PDF part 的本地服务器，可靠的做法是**在 LLM 调用前先把 PDF 转好** —— 用上面的 oMLX + Markitdown 栈，或任何外部转换器（MinerU extractor、`markitdown` CLI、marker）—— 再把得到的 Markdown 作为普通文本源摄入。插件的缓存 key 包含模型，所以切换模型会自动让陈旧条目失效。
 
 ---
 


### PR DESCRIPTION
## Summary

PDF-OCR-GUIDE (EN + CN) stated that Ollama / LM Studio accept PDF file parts via Force PDF Support. Verified against the OpenAI-compatible wire format and both servers: /v1/chat/completions carries text and image content parts only — Ollama rejects a PDF file part (400), LM Studio rejects a PDF sent as an image block. The llama.cpp / vLLM row is reworded to 'verify against your server' instead of a blanket claim.

## Changes

- `docs/PDF-OCR-GUIDE.md` — Fallback section rewritten
- `docs/PDF-OCR-GUIDE_CN.md` — Fallback section rewritten (CN parity)

The Fallback section now points local-server users to the reliable pattern: convert the PDF before the LLM call (oMLX + Markitdown, MinerU extractor, markitdown CLI, marker) and ingest the resulting Markdown as a regular text source.

## Verification

- docs-only change; no Gate 1 impact
- shazam_verify PASS

Found during the PR #570 evaluation. The PR itself is not affected — this fix is independent.