### PR TITLE
fix(triage): give item-level contradictions a lane — the contradictions: marker was prompt-unreachable (#575)

### DIFF
--- a/src/__tests__/core/contradicted-marker.test.ts
+++ b/src/__tests__/core/contradicted-marker.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   appendContradictedByMarker,
+  appendContradictionNotes,
   CONTRADICTIONS_KEY,
 } from '../../core/contradicted-marker';
 
@@ -87,5 +88,29 @@ Body.
     // No marker emitted; the rest of the frontmatter survives intact.
     expect(result).toContain('type: concept');
     expect(result).not.toContain(`${CONTRADICTIONS_KEY}:`);
+  });
+});
+
+
+describe('appendContradictionNotes', () => {
+  const item = { content: 'Dose is 10mg', target_section: '## Dosage', reason: 'page states 5mg' };
+
+  it('returns the body unchanged for an empty item list', () => {
+    expect(appendContradictionNotes('# Page\n\nBody.', [], 'note')).toBe('# Page\n\nBody.');
+  });
+
+  it('appends an attributed conflict block with the manager heading', () => {
+    const out = appendContradictionNotes('# Page\n\nBody.', [item], 'my-note');
+    expect(out).toContain('## ⚠️ Potential Contradiction');
+    expect(out).toContain('**Source claim** (from my-note): Dose is 10mg');
+    expect(out).toContain('**Conflicts with** (## Dosage): page states 5mg');
+    expect(out.startsWith('# Page\n\nBody.')).toBe(true);
+  });
+
+  it('renders one block per item under a single heading', () => {
+    const out = appendContradictionNotes('B', [item, { content: 'X', target_section: '## A' }], 'n');
+    expect(out.match(/## ⚠️ Potential Contradiction/g)?.length).toBe(1);
+    expect(out.match(/\*\*Source claim\*\*/g)?.length).toBe(2);
+    expect(out).toContain('**Conflicts with**: ## A');
   });
 });

--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -401,3 +401,27 @@ describe('mergePage — note excerpt window (payload fix)', () => {
     expect(client.prompts[1]).not.toContain('{{source_excerpt}}');
   });
 });
+
+describe('mergePage — item-level contradiction lane stamps marker and appends attributed block', () => {
+  it('routes kind=contradictory items to the deterministic conflict block, not the section append', async () => {
+    const triage = JSON.stringify({
+      strategy: 'complementary',
+      reason: 'one conflicting claim',
+      items: [
+        { kind: 'contradictory', content: 'Dose is 10mg', target_section: '## Description', reason: 'page states 5mg' },
+      ],
+    });
+    // Only ONE LLM response: the triage. A per-section append call for the
+    // conflicting item would consume a second response and integrate the
+    // claim as if it were a fact.
+    const ctx = makeCtx(makeClient([triage]));
+    await mergePage(ctx, createMockEntity({ name: 'Caching' }), 'entity', { path: 'note.md', basename: 'note' }, EXISTING, [], 'wiki/entities/caching.md');
+    const written = ctx.written.get('wiki/entities/caching.md');
+    expect(written).toBeDefined();
+    expect(written).toContain('## Description\nOld text.');
+    expect(written).toContain('## ⚠️ Potential Contradiction');
+    expect(written).toContain('**Source claim** (from note): Dose is 10mg');
+    expect(written).toContain('contradictions:');
+    expect(written).toContain('note.md');
+  });
+});

--- a/src/__tests__/wiki/page-factory/merge-triage.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-triage.test.ts
@@ -389,3 +389,45 @@ describe('classifyMergeNeed — typed-output path (createMessageWithOutput)', ()
     expect(seenSchema).toBeDefined();
   });
 });
+
+describe('classifyMergeNeed — item-level contradiction lane', () => {
+  it('carries kind=contradictory through validation', async () => {
+    const ctx = makeCtx({
+      createMessage: async () =>
+        JSON.stringify({
+          strategy: 'complementary',
+          reason: 'mixed batch',
+          items: [
+            { kind: 'complementary', content: 'new fact', target_section: '## Background', reason: 'expands' },
+            { kind: 'contradictory', content: 'conflicting claim', target_section: '## Background', reason: 'conflicts with the stated dose' },
+          ],
+        }),
+    });
+    const result = await classifyMergeNeed(
+      ctx,
+      createMockEntity({ name: 'X' }),
+      'entity',
+      { path: 'p.md', basename: 'p.md' },
+      '# existing',
+    );
+    expect(result.items.map(i => i.kind)).toEqual(['complementary', 'contradictory']);
+  });
+
+  it('defaults an unknown kind to complementary', async () => {
+    const ctx = makeCtx({
+      createMessage: async () =>
+        JSON.stringify({
+          strategy: 'complementary',
+          items: [{ kind: 'novel', content: 'fact', target_section: '## A' }],
+        }),
+    });
+    const result = await classifyMergeNeed(
+      ctx,
+      createMockEntity({ name: 'X' }),
+      'entity',
+      { path: 'p.md', basename: 'p.md' },
+      '# x',
+    );
+    expect(result.items[0]?.kind).toBe('complementary');
+  });
+});

--- a/src/core/contradicted-marker.ts
+++ b/src/core/contradicted-marker.ts
@@ -65,3 +65,42 @@ function normalizeSource(s: string): string {
   return s.trim().replace(/^\[\[|\]\]$/g, '').trim().toLowerCase();
 }
 
+
+/**
+ * A triage item flagged `kind: 'contradictory'` — the shape the
+ * deterministic body append below consumes. Mirrors the fields of
+ * `ComplementaryItem` (merge-triage.ts) without importing it, so this
+ * module stays dependency-free.
+ */
+export interface ContradictionNoteItem {
+  content: string;
+  target_section: string;
+  reason?: string;
+}
+
+/**
+ * Append an attributed conflict block for item-level contradictions.
+ *
+ * Deterministic on purpose: a conflicting claim must never be handed to
+ * the per-section append LLM, which would integrate it as if it were a
+ * fact — the poison would land exactly where it blends in best. The
+ * heading is byte-identical to the one `ContradictionManager` writes so
+ * downstream tooling has ONE string to scan for both flag paths.
+ *
+ * Pure, no IO. Returns the body unchanged when `items` is empty.
+ */
+export function appendContradictionNotes(
+  body: string,
+  items: readonly ContradictionNoteItem[],
+  sourceBasename: string,
+): string {
+  if (items.length === 0) return body;
+  const date = new Date().toISOString().split('T')[0];
+  const blocks = items.map(item => {
+    const reason = item.reason?.trim()
+      ? `\n\n**Conflicts with** (${item.target_section}): ${item.reason.trim()}`
+      : `\n\n**Conflicts with**: ${item.target_section}`;
+    return `**Source claim** (from ${sourceBasename}): ${item.content}${reason}`;
+  });
+  return `${body}\n\n## ⚠️ Potential Contradiction\n\n${blocks.join('\n\n')}\n\n---\n*Flagged: ${date}*`;
+}

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -44,7 +44,7 @@ import {
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter, parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { incomingTypeTag } from '../../core/tag-vocab';
-import { appendContradictedByMarker } from '../../core/contradicted-marker';
+import { appendContradictedByMarker, appendContradictionNotes } from '../../core/contradicted-marker';
 import { injectMentionsSection } from '../../core/mentions-injector';
 import { renderTemplate } from '../../core/template-renderer';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
@@ -164,16 +164,29 @@ export async function mergePage(
         );
         shouldSkip = true;
       } else if (strategy === 'complementary' && triage.items.length > 0) {
+        // Item-level contradiction lane: a piece that conflicts with an
+        // existing statement must not ride the per-section append (which
+        // integrates it as if it were a fact). It becomes an attributed
+        // conflict block, and the page gets the same frontmatter marker
+        // as the page-level 'contradictory' strategy.
+        const appendItems = triage.items.filter(i => i.kind !== 'contradictory');
+        const conflictItems = triage.items.filter(i => i.kind === 'contradictory');
         console.debug(
-          `[mergePage] triage=complementary items=${triage.items.length} — appending to existing sections for ${path}`,
+          `[mergePage] triage=complementary items=${appendItems.length} conflicts=${conflictItems.length} — appending to existing sections for ${path}`,
         );
-        complementaryBody = await applyComplementaryAppends(
-          ctx,
-          triage.items,
-          existingBody,
-          info,
-          sourceFile,
-        );
+        complementaryBody = appendItems.length > 0
+          ? await applyComplementaryAppends(
+              ctx,
+              appendItems,
+              existingBody,
+              info,
+              sourceFile,
+            )
+          : existingBody;
+        if (conflictItems.length > 0) {
+          complementaryBody = appendContradictionNotes(complementaryBody, conflictItems, sourceFile.basename);
+          contradictedSourcePath = sourceFile.path;
+        }
         if (complementaryBody === existingBody) {
           console.debug(
             `[mergePage] complementary path produced no per-section appends — falling back to body-merge for ${path}`,
@@ -199,9 +212,14 @@ export async function mergePage(
 
     if (shouldSkip) {
       const bodyToWrite = complementaryBody ?? existingBody;
+      // Item-level contradictions reach this path (complementary write):
+      // stamp the same frontmatter marker the rewrite path stamps below.
+      const fmToWrite = contradictedSourcePath
+        ? appendContradictedByMarker(frontmatter, contradictedSourcePath)
+        : frontmatter;
       await ctx.createOrUpdateFile(
         path,
-        await assembleFinalContent(ctx, frontmatter, bodyToWrite, info, sourceFile, existingBody),
+        await assembleFinalContent(ctx, fmToWrite, bodyToWrite, info, sourceFile, existingBody),
       );
       return path;
     }

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -31,9 +31,15 @@ import { MergeTriageSchema, type MergeTriage } from '../../llm-sdk/output-schema
 /** Strategy selected by the LLM for handling new information vs. an existing page. */
 export type MergeStrategy = 'merge' | 'skip' | 'complementary' | 'contradictory';
 
-/** A single complementary append item (only populated when strategy === 'complementary'). */
+/**
+ * A single triage item (only populated when strategy === 'complementary').
+ * `kind: 'contradictory'` marks a piece that conflicts with a specific
+ * existing statement — it is appended as an attributed conflict note and
+ * stamps the `contradictions:` frontmatter marker, instead of being
+ * integrated as if it were a fact.
+ */
 export interface ComplementaryItem {
-  kind: 'complementary';
+  kind: 'complementary' | 'contradictory';
   content: string;
   target_section: string;
   reason?: string;
@@ -166,7 +172,9 @@ export async function classifyMergeNeed(
         throw new Error('merge triage: invalid complementary item');
       }
       items.push({
-        kind: 'complementary',
+        // Unknown/missing kinds default to 'complementary' so older or
+        // sloppier model outputs keep today's behavior.
+        kind: item.kind === 'contradictory' ? 'contradictory' : 'complementary',
         content: item.content,
         target_section: item.target_section,
         reason: typeof item.reason === 'string' ? item.reason : undefined,

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -45,20 +45,20 @@ export const MERGE_PROMPTS = {
 Examine the new information and classify each piece into ONE of the four strategies:
 
 - "skip" — every piece is already fully present in the existing page. No new content to add. \`items\` MUST be an empty array.
-- "merge" — substantial restructuring needed (e.g. a new section is required, the existing structure is wrong, or the new info contradicts existing). The full body-rewrite path will be used. \`items\` MUST be an empty array.
-- "complementary" — each piece adds new facts that fit into one of the existing sections. Populate \`items\` with one entry per new fact:
-  - \`kind\` = "complementary"
-  - \`content\` = the specific new fact to append (verbatim from the source if possible, otherwise a concise paraphrase)
-  - \`target_section\` = EXACTLY one name from the available sections list (this is critical for i18n matching)
-  - \`reason\` = one-sentence justification
-- "contradictory" — new info conflicts with existing facts. The full body-rewrite path will handle attribution. \`items\` MUST be an empty array.
+- "merge" — substantial restructuring needed (e.g. a new section is required, or the existing structure is wrong). The full body-rewrite path will be used. \`items\` MUST be an empty array.
+- "complementary" — each piece adds new facts that fit into one of the existing sections, or conflicts with a specific existing statement. Populate \`items\` with one entry per piece:
+  - \`kind\` = "complementary" for a new fact, "contradictory" for a piece that CONFLICTS with a specific statement already on the page
+  - \`content\` = the specific new fact or conflicting claim (verbatim from the source if possible, otherwise a concise paraphrase)
+  - \`target_section\` = EXACTLY one name from the available sections list (for "contradictory": the section containing the contradicted statement)
+  - \`reason\` = one-sentence justification (for "contradictory": name the existing statement it conflicts with)
+- "contradictory" — the new info AS A WHOLE conflicts with the page's core claims (not just single statements — use a "contradictory" item inside "complementary" for those). The full body-rewrite path will handle attribution. \`items\` MUST be an empty array.
 
 Output JSON format (ONLY this object, no other text):
 {
   "strategy": "skip" | "merge" | "complementary" | "contradictory",
   "items": [
     {
-      "kind": "complementary",
+      "kind": "complementary" | "contradictory",
       "content": "Specific new fact text",
       "target_section": "Exact section name from the available sections list",
       "reason": "Why this belongs in target section (one sentence)"


### PR DESCRIPTION
Fixes #575.

The `contradictions:` frontmatter marker (v1.25.10 §4) was prompt-unreachable: the `merge` definition claimed contradictions for itself ("or the new info contradicts existing"), and the one-strategy-per-page shape gave a single conflicting statement no lane — it rode the per-section append into the page as if it were a fact. Measured over one live 58-triage ingest run: 51 complementary / 5 merge / 2 skip / **0 contradictory**.

## Changes

- **Prompt** (`mergeAnalysis`): "contradicts" removed from the `merge` definition; `items` may now carry `kind: "contradictory"` for a piece that conflicts with a specific existing statement (`target_section` = the section holding it, `reason` names the contradicted statement); page-level `contradictory` is scoped to wholesale conflict.
- **merge-triage**: `ComplementaryItem.kind` widened to `'complementary' | 'contradictory'`. Unknown or missing kinds default to `complementary`, so older model outputs keep today's behavior byte-for-byte.
- **merge-page**: contradictory items bypass the section append and become a deterministic attributed conflict block — deliberately no LLM call, so the conflicting claim cannot be integrated where it blends in best. The block reuses the exact heading `ContradictionManager` writes (`## ⚠️ Potential Contradiction`), so downstream tooling has one string to scan for both flag paths. The page gets the same `contradictions:` marker as the page-level strategy — now on the complementary write path too.
- **No schema change**: `MergeTriageSchema.items[].kind` is already `z.string().optional()`.

## Known limitation (shared with ContradictionManager)

The appended conflict block lives in the body, and a later full body-rewrite can drop it via `stripUnknownSections` — the same blind spot ContradictionManager's sections have today. The frontmatter marker survives re-touches (unknown-field passthrough) and is the durable signal; the block is the human-visible one.

## Verification

- Gate 1: lint + tsc + build + test green — **3696 tests** (6 new: kind validation ×2, deterministic block ×3, mergePage integration ×1)
- The integration test pins the load-bearing property: a `kind: "contradictory"` item consumes **no** second LLM response (the per-section append would), and the written page carries block + marker.
