### PR TITLE
feat(lint): read the contentHash back — flag source notes changed since ingest (#220 Tier 0, read half)

### DIFF
--- a/src/__tests__/wiki/lint/report-builder.test.ts
+++ b/src/__tests__/wiki/lint/report-builder.test.ts
@@ -22,6 +22,7 @@ function makeFindings(overrides: Partial<ProgrammaticFindings> = {}): Programmat
     deadLinks: [],
     ungroundedQuotes: [],
     hubLinkDensityIssues: [],
+    sourceDriftIssues: [],
     sourcesNormalizedFiles: 0,
     sourcesNormalizedEntries: 0,
     doubleNestFixes: 0,
@@ -145,3 +146,39 @@ describe('buildLintReport', () => {
   });
 });
 
+
+describe('source drift section (Issue #220 Tier 0)', () => {
+  it('renders drifted pages and keeps the no-issues message suppressed', () => {
+    const report = buildLintReport({
+      settings: makeSettings(),
+      findings: makeFindings({
+        sourceDriftIssues: [{
+          sourcePage: 'wiki/sources/butyrat.md',
+          note: 'Notizen/Butyrat.md',
+          storedHash: '22-aaaaaaaa',
+          currentHash: '25-bbbbbbbb',
+        }],
+      }),
+      duplicates: [],
+      contradictionsReport: '',
+      elapsedSeconds: 1,
+      totalPages: 10,
+    });
+    expect(report).toContain('Source notes changed since ingest [1]');
+    expect(report).toContain('[[sources/butyrat]]');
+    expect(report).toContain('[[Notizen/Butyrat]]');
+    expect(report).not.toContain('No issues found');
+  });
+
+  it('omits the section when nothing drifted', () => {
+    const report = buildLintReport({
+      settings: makeSettings(),
+      findings: makeFindings(),
+      duplicates: [],
+      contradictionsReport: '',
+      elapsedSeconds: 1,
+      totalPages: 10,
+    });
+    expect(report).not.toContain('Source notes changed since ingest');
+  });
+});

--- a/src/__tests__/wiki/lint/scanners.test.ts
+++ b/src/__tests__/wiki/lint/scanners.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildKnownTargets, detectAliasDeficiency, scanDeadLinks, scanOrphans, scanTagViolations, ScannerPage } from '../../../wiki/lint/scanners';
+import { buildKnownTargets, detectAliasDeficiency, scanDeadLinks, scanOrphans, scanTagViolations, scanSourceDrift, ScannerPage } from '../../../wiki/lint/scanners';
+import { hashBody } from '../../../core/source-requirements';
 import { LLMWikiSettings } from '../../../types';
 
 // ── buildKnownTargets ─────────────────────────────────────────
@@ -453,5 +454,127 @@ describe('scanTagViolations', () => {
     ]);
     const result = scanTagViolations(pm, baseSettings);
     expect(result[0].title).toBe('Test');
+  });
+});
+
+// ── scanSourceDrift (Issue #220 Tier 0, read half) ─────────────
+
+describe('scanSourceDrift', () => {
+  const folder = 'wiki';
+  const noteBody = 'Original note body about butyrate.';
+  const page = (path: string, fmLines: string[]): [string, ScannerPage] => [
+    path,
+    { path, basename: path.split('/').pop()!, content: `---\n${fmLines.join('\n')}\n---\n\nSummary.` },
+  ];
+
+  const hashOf = (body: string) => hashBody(body);
+
+  it('flags a source page whose origin note changed since ingest', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/butyrat.md', [
+        'type: source',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - "[[Notizen/Butyrat.md]]"',
+      ]),
+    ]);
+    const notes = new Map([['Notizen/Butyrat.md', 'Revised note body — the claim changed.']]);
+    const issues = scanSourceDrift(pageMap, notes, folder);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].sourcePage).toBe('wiki/sources/butyrat.md');
+    expect(issues[0].note).toBe('Notizen/Butyrat.md');
+    expect(issues[0].storedHash).toBe(hashOf(noteBody));
+    expect(issues[0].currentHash).toBe(hashOf('Revised note body — the claim changed.'));
+  });
+
+  it('does not flag when the note body still matches (whitespace-insensitive)', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/butyrat.md', [
+        'type: source',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - Notizen/Butyrat.md',
+      ]),
+    ]);
+    const notes = new Map([['Notizen/Butyrat.md', '  Original   note body\nabout butyrate.  ']]);
+    expect(scanSourceDrift(pageMap, notes, folder)).toHaveLength(0);
+  });
+
+  it('strips note frontmatter before hashing, matching the write side', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/butyrat.md', [
+        'type: source',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - Notizen/Butyrat.md',
+      ]),
+    ]);
+    const notes = new Map([['Notizen/Butyrat.md', `---\ntags:\n  - Sorte/Stoff\n---\n\n${noteBody}`]]);
+    expect(scanSourceDrift(pageMap, notes, folder)).toHaveLength(0);
+  });
+
+  it('skips pages without contentHash (pre-#164) and pages outside sources/', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/alt.md', ['type: source', 'sources:', '  - Notizen/Alt.md']),
+      page('wiki/entities/butyrat.md', [
+        'type: entity',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - Notizen/Butyrat.md',
+      ]),
+    ]);
+    const notes = new Map([
+      ['Notizen/Alt.md', 'changed'],
+      ['Notizen/Butyrat.md', 'changed'],
+    ]);
+    expect(scanSourceDrift(pageMap, notes, folder)).toHaveLength(0);
+  });
+
+  it('skips pages whose note is unreadable — absence of evidence is not drift', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/butyrat.md', [
+        'type: source',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - Notizen/Verschwunden.md',
+      ]),
+    ]);
+    expect(scanSourceDrift(pageMap, new Map(), folder)).toHaveLength(0);
+  });
+
+  it('multi-source page: not flagged while ANY listed note still matches the stored hash', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/multi.md', [
+        'type: source',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - Notizen/Geaendert.md',
+        '  - Notizen/Original.md',
+      ]),
+    ]);
+    const notes = new Map([
+      ['Notizen/Geaendert.md', 'edited elsewhere'],
+      ['Notizen/Original.md', noteBody],
+    ]);
+    expect(scanSourceDrift(pageMap, notes, folder)).toHaveLength(0);
+  });
+
+  it('multi-source page: flagged with the first mismatching note when none match', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/sources/multi.md', [
+        'type: source',
+        `contentHash: ${hashOf(noteBody)}`,
+        'sources:',
+        '  - Notizen/A.md',
+        '  - Notizen/B.md',
+      ]),
+    ]);
+    const notes = new Map([
+      ['Notizen/A.md', 'changed A'],
+      ['Notizen/B.md', 'changed B'],
+    ]);
+    const issues = scanSourceDrift(pageMap, notes, folder);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].note).toBe('Notizen/A.md');
   });
 });

--- a/src/__tests__/wiki/lint/scanners.test.ts
+++ b/src/__tests__/wiki/lint/scanners.test.ts
@@ -578,3 +578,23 @@ describe('scanSourceDrift', () => {
     expect(issues[0].note).toBe('Notizen/A.md');
   });
 });
+
+describe('scanSourceDrift — canonical source_file frontmatter', () => {
+  it('reads the scalar source_file wikilink written by the generation template', () => {
+    const noteBody = 'Original note body.';
+    const pageMap = new Map<string, ScannerPage>([
+      ['wiki/sources/geh-test.md', {
+        path: 'wiki/sources/geh-test.md',
+        basename: 'geh-test.md',
+        content: `---\ntype: source\nsource_file: "[[Notizen/6-Minuten-Gehtest.md]]"\ncontentHash: ${hashBody(noteBody)}\n---\n\nSummary.`,
+      }],
+    ]);
+    const changed = new Map([['Notizen/6-Minuten-Gehtest.md', 'Edited body.']]);
+    const issues = scanSourceDrift(pageMap, changed, 'wiki');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].note).toBe('Notizen/6-Minuten-Gehtest.md');
+
+    const unchanged = new Map([['Notizen/6-Minuten-Gehtest.md', noteBody]]);
+    expect(scanSourceDrift(pageMap, unchanged, 'wiki')).toHaveLength(0);
+  });
+});

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -657,6 +657,8 @@ export const DE_TEXTS = {
     lintContradictionSection: 'Widersprüche (erkannt)',
     lintDuplicateSection: 'Doppelte Seiten (erkannt)',
     lintNoIssuesFound: 'Keine Duplikate, defekten Links, leeren Seiten, verwaisten Seiten oder unbelegten Zitate erkannt.',
+    lintSourceDriftSection: 'Quellnotizen seit dem Ingest geändert [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — Ursprungsnotiz [[{note}]] wurde nach dem Ingest bearbeitet; die Seite ist womöglich veraltet',
     lintQuoteGroundingSection: 'Unbelegte Zitate (erkannt) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (Seite existiert nicht){dupFlag}',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -669,6 +669,8 @@ export const EN_TEXTS = {
     lintSourcesNormalizedSection: 'Sources normalized (auto-fixed) [{files} files / {entries} entries]',
     lintSourcesNormalizedItem: 'Cleaned {entries} polluted sources entries across {files} file(s) (external paths, .md extensions, alias pipes removed and deduplicated).',
     lintNoIssuesFound: 'No duplicates, dead links, empty pages, orphan pages, or ungrounded quotes detected.',
+    lintSourceDriftSection: 'Source notes changed since ingest [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — origin note [[{note}]] was edited after ingest; the page may be stale',
     lintQuoteGroundingSection: 'Ungrounded quotes (detected) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (page does not exist){dupFlag}',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -655,6 +655,8 @@ export const ES_TEXTS = {
     lintContradictionSection: 'Contradicciones (detectadas)',
     lintDuplicateSection: 'Páginas duplicadas (detectadas)',
     lintNoIssuesFound: 'No se detectaron duplicados, enlaces rotos, páginas vacías, páginas huérfanas ni citas sin fuente.',
+    lintSourceDriftSection: 'Notas fuente modificadas desde la ingesta [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — la nota de origen [[{note}]] fue editada después de la ingesta; la página puede estar desactualizada',
     lintQuoteGroundingSection: 'Citas sin fuente (detectadas) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (la página no existe){dupFlag}',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -611,6 +611,8 @@ export const FR_TEXTS = {
     lintContradictionSection: 'Contradictions (détectées)',
     lintDuplicateSection: 'Pages dupliquées (détectées)',
     lintNoIssuesFound: 'Aucun doublon, lien cassé, page vide, page orpheline ou citation non fondée détecté.',
+    lintSourceDriftSection: 'Notes sources modifiées depuis l\'ingestion [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — la note d\'origine [[{note}]] a été modifiée après l\'ingestion ; la page peut être obsolète',
     lintQuoteGroundingSection: 'Citations non fondées (détectées) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: « {quote} »',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (la page n\'existe pas){dupFlag}',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -669,6 +669,8 @@ export const IT_TEXTS = {
     lintSourcesNormalizedSection: 'Sorgenti normalizzate (corrette automaticamente) [{files} file / {entries} voci]',
     lintSourcesNormalizedItem: 'Pulite {entries} voci sorgenti inquinate in {files} file (percorsi esterni, estensioni .md, pipe degli alias rimossi e deduplicati).',
     lintNoIssuesFound: 'Nessun duplicato, collegamento interrotto, pagina vuota, pagina orfana o citazione non fondata rilevato.',
+    lintSourceDriftSection: 'Note sorgente modificate dopo l\'ingestione [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — la nota di origine [[{note}]] è stata modificata dopo l\'ingestione; la pagina potrebbe non essere aggiornata',
     lintQuoteGroundingSection: 'Citazioni non fondate (rilevate) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (la pagina non esiste){dupFlag}',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -607,6 +607,8 @@ export const JA_TEXTS = {
     lintContradictionSection: '矛盾（検出済み）',
     lintDuplicateSection: '重複ページ（検出済み）',
     lintNoIssuesFound: '重複、リンク切れ、空ページ、孤立ページ、または根拠のない引用は検出されませんでした。',
+    lintSourceDriftSection: '取り込み後に変更されたソースノート [{count} 件]',
+    lintSourceDriftItem: '- [[{page}]] — 元ノート [[{note}]] が取り込み後に編集されました。ページが古い可能性があります',
     lintQuoteGroundingSection: '根拠のない引用（検出）[{count} 件]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: 「{quote}」',
     lintDeadLinkItem: '- [[{source}]] → **{target}**（ページが存在しません）{dupFlag}',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -658,6 +658,8 @@ export const KO_TEXTS = {
     lintContradictionSection: '모순 (감지됨)',
     lintDuplicateSection: '중복 페이지 (감지됨)',
     lintNoIssuesFound: '중복, 깨진 링크, 빈 페이지, 고아 페이지 또는 출처 없는 인용이 감지되지 않았습니다.',
+    lintSourceDriftSection: '수집 후 변경된 소스 노트 [{count}개]',
+    lintSourceDriftItem: '- [[{page}]] — 원본 노트 [[{note}]]가 수집 후 수정되었습니다. 페이지가 오래되었을 수 있습니다',
     lintQuoteGroundingSection: '출처 없는 인용 (감지됨) [{count}개]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (페이지가 존재하지 않음){dupFlag}',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -655,6 +655,8 @@ export const PT_TEXTS = {
     lintContradictionSection: 'Contradições (detectadas)',
     lintDuplicateSection: 'Páginas duplicadas (detectadas)',
     lintNoIssuesFound: 'Nenhuma duplicata, link quebrado, página vazia, página órfã ou citação sem fonte detectada.',
+    lintSourceDriftSection: 'Notas de origem alteradas desde a ingestão [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — a nota de origem [[{note}]] foi editada após a ingestão; a página pode estar desatualizada',
     lintQuoteGroundingSection: 'Citações sem fonte (detectadas) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (página inexistente){dupFlag}',

--- a/src/texts/ru.ts
+++ b/src/texts/ru.ts
@@ -650,6 +650,8 @@ export const RU_TEXTS = {
     lintSourcesNormalizedSection: 'Источники нормализованы (авто-исправлено) [{files} файлов / {entries} записей]',
     lintSourcesNormalizedItem: 'Очищено {entries} загрязнённых записей источников в {files} файл(ах) (внешние пути, расширения .md, псевдонимы pipes удалены и дедуплицированы).',
     lintNoIssuesFound: 'Дубликатов, мёртвых ссылок, пустых страниц, висячих страниц или неподтверждённых цитат не обнаружено.',
+    lintSourceDriftSection: 'Исходные заметки изменены после импорта [{count}]',
+    lintSourceDriftItem: '- [[{page}]] — исходная заметка [[{note}]] была изменена после импорта; страница может быть устаревшей',
     lintQuoteGroundingSection: 'Неподтверждённые цитаты (обнаружено) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: «{quote}»',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (страница не существует){dupFlag}',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -619,6 +619,8 @@ export const ZH_HANT_TEXTS = {
     lintHubLinkDensitySummary: '摘要：{strip} 個頁面建議剝離，{review} 個頁面建議覆核。',
     lintHubLinkDensityNoRelated: ' （未找到 ## Related 區塊）',
     lintNoIssuesFound: '未檢測到重複、斷鏈、空洞、孤立頁面或無來源引證。',
+    lintSourceDriftSection: '匯入後已變更的來源筆記 [共 {count} 個]',
+    lintSourceDriftItem: '- [[{page}]] — 原始筆記 [[{note}]] 在匯入後被編輯，頁面內容可能已過時',
     lintQuoteGroundingSection: '無來源引證（程式檢測）[共 {count} 個]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}："{quote}"',
     lintContradictionOpen: '未解決的矛盾：{count} 個',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -627,6 +627,8 @@ export const ZH_TEXTS = {
     lintHubLinkDensitySummary: '摘要：{strip} 个页面建议剥离，{review} 个页面建议复核。',
     lintHubLinkDensityNoRelated: ' （未找到 ## Related 区块）',
     lintNoIssuesFound: '未检测到重复、断链、空洞、孤立页面或无来源引证。',
+    lintSourceDriftSection: '导入后已变更的来源笔记 [共 {count} 个]',
+    lintSourceDriftItem: '- [[{page}]] — 原始笔记 [[{note}]] 在导入后被编辑，页面内容可能已过时',
     lintQuoteGroundingSection: '无来源引证（程序检测）[共 {count} 个]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}："{quote}"',
     lintContradictionOpen: '未解决的矛盾：{count} 个',

--- a/src/wiki/lint/phases/programmatic.ts
+++ b/src/wiki/lint/phases/programmatic.ts
@@ -1,5 +1,6 @@
-import { detectAliasDeficiency, scanOrphans, scanTagViolations, scanDeadLinks, scanQuoteGrounding, scanHubLinkDensity, collectCitedRawNoteTargets } from '../scanners';
+import { detectAliasDeficiency, scanOrphans, scanTagViolations, scanDeadLinks, scanQuoteGrounding, scanHubLinkDensity, scanSourceDrift, collectCitedRawNoteTargets } from '../scanners';
 import { detectPollutedPages } from '../utils';
+import { parseFrontmatter } from '../../../core/frontmatter';
 import { getText } from '../../../core/i18n';
 import { getSectionLabels } from '../../system-prompts';
 import type { Graph } from '../../../core/monte-carlo-ppr';
@@ -113,6 +114,36 @@ export async function runProgrammaticPhase(
   });
   console.debug(`lintWiki: ${hubLinkDensityIssues.length} hub pages with link density issues`);
 
+  // 8. Source drift (Issue #220 Tier 0, read half) — every `sources/` page
+  // carries a `contentHash` of the note body it was built from (#164), but
+  // nothing reads it back. Read each origin note once (same bounded-read
+  // pattern as the quote-grounding notes above) and flag pages whose note
+  // has changed since ingest. Report-only: re-ingest is additive, so the
+  // finding routes to the user, not to an automatic action.
+  const driftNoteContents = new Map<string, string>();
+  for (const [path, page] of input.pageMap) {
+    if (!path.startsWith(`${ctx.settings.wikiFolder}/sources/`)) continue;
+    const fm = parseFrontmatter(page.content);
+    if (!Array.isArray(fm?.sources)) continue;
+    for (const s of fm.sources) {
+      const trimmed = String(s).trim();
+      const notePath = trimmed.startsWith('[[') && trimmed.endsWith(']]')
+        ? trimmed.slice(2, -2).trim()
+        : trimmed;
+      if (!notePath || driftNoteContents.has(notePath)) continue;
+      const abstract = ctx.app.vault.getAbstractFileByPath(notePath);
+      if (!abstract) continue;
+      try {
+        const content = await (ctx.app.vault as unknown as { read: (f: unknown) => Promise<string> }).read(abstract);
+        driftNoteContents.set(notePath, content);
+      } catch {
+        /* unreadable note — stays out; absence of evidence is not drift */
+      }
+    }
+  }
+  const sourceDriftIssues = scanSourceDrift(input.pageMap, driftNoteContents, ctx.settings.wikiFolder);
+  console.debug(`lintWiki: ${sourceDriftIssues.length} source page(s) with drifted origin notes`);
+
   return {
     aliasDeficientPages,
     emptyPages: [],
@@ -122,6 +153,7 @@ export async function runProgrammaticPhase(
     deadLinks,
     ungroundedQuotes,
     hubLinkDensityIssues,
+    sourceDriftIssues,
     sourcesNormalizedFiles: 0, // populated by preparation phase caller
     sourcesNormalizedEntries: 0,
     doubleNestFixes: 0,

--- a/src/wiki/lint/phases/programmatic.ts
+++ b/src/wiki/lint/phases/programmatic.ts
@@ -124,9 +124,15 @@ export async function runProgrammaticPhase(
   for (const [path, page] of input.pageMap) {
     if (!path.startsWith(`${ctx.settings.wikiFolder}/sources/`)) continue;
     const fm = parseFrontmatter(page.content);
-    if (!Array.isArray(fm?.sources)) continue;
-    for (const s of fm.sources) {
-      const trimmed = String(s).trim();
+    if (!fm) continue;
+    // Same field precedence as scanSourceDrift: scalar `source_file:`
+    // (canonical on sources/ pages) plus any `sources:` list entries.
+    const refs: string[] = [];
+    const sourceFile = (fm as Record<string, unknown>).source_file;
+    if (typeof sourceFile === 'string') refs.push(sourceFile);
+    if (Array.isArray(fm.sources)) refs.push(...fm.sources.map(s => String(s)));
+    for (const s of refs) {
+      const trimmed = s.trim();
       const notePath = trimmed.startsWith('[[') && trimmed.endsWith(']]')
         ? trimmed.slice(2, -2).trim()
         : trimmed;

--- a/src/wiki/lint/report-builder.ts
+++ b/src/wiki/lint/report-builder.ts
@@ -34,6 +34,7 @@ export function buildLintReport(input: ReportInput): string {
   const hubLinkDensityIssues: HubLinkDensityIssue[] = findings.hubLinkDensityIssues;
   const sourcesNormalizedFiles = findings.sourcesNormalizedFiles;
   const sourcesNormalizedEntries = findings.sourcesNormalizedEntries;
+  const sourceDriftIssues = findings.sourceDriftIssues;
 
   // Compute deadLinkFromDup / orphanFromDup counts
   const duplicatePaths = new Set<string>();
@@ -200,8 +201,22 @@ export function buildLintReport(input: ReportInput): string {
     progReport += '\n';
   }
 
+  // 8c. Source drift (Issue #220 Tier 0, read half) — origin notes edited
+  // since their source page was built. Report-only: re-ingest is additive,
+  // so the decision what to do with a revision stays editorial.
+  if (sourceDriftIssues.length > 0) {
+    progReport += `## ${t.lintSourceDriftSection.replace('{count}', String(sourceDriftIssues.length))}\n\n`;
+    for (const d of sourceDriftIssues) {
+      const rel = d.sourcePage.replace(folder + '/', '').replace('.md', '');
+      progReport += t.lintSourceDriftItem
+        .replace('{page}', rel)
+        .replace('{note}', d.note.replace('.md', '')) + '\n';
+    }
+    progReport += '\n';
+  }
+
   // 9. No issues message
-  if (!duplicates.length && !deadLinks.length && !emptyPages.length && !orphans.length && !ungroundedQuotes.length && !hubLinkDensityIssues.length) {
+  if (!duplicates.length && !deadLinks.length && !emptyPages.length && !orphans.length && !ungroundedQuotes.length && !hubLinkDensityIssues.length && !sourceDriftIssues.length) {
     progReport += `${t.lintNoIssuesFound}\n\n`;
   }
 

--- a/src/wiki/lint/scanners.ts
+++ b/src/wiki/lint/scanners.ts
@@ -508,16 +508,27 @@ export function scanSourceDrift(
     if (!fm) continue;
     const storedHash = (fm as Record<string, unknown>).contentHash;
     if (typeof storedHash !== 'string' || !storedHash) continue;
-    if (!Array.isArray(fm.sources) || fm.sources.length === 0) continue;
 
-    const notePaths = fm.sources
+    // Canonical source pages carry a scalar `source_file:` wikilink
+    // (generation.ts template); a `sources:` list only appears on pages
+    // written through the entity/concept path. Read the scalar first and
+    // fall back to the list — reading only `sources:` would make the
+    // scanner blind on every canonical page (found by probing a real
+    // vault: 35/35 source pages carried source_file, none sources:).
+    const rawRefs: string[] = [];
+    const sourceFile = (fm as Record<string, unknown>).source_file;
+    if (typeof sourceFile === 'string') rawRefs.push(sourceFile);
+    if (Array.isArray(fm.sources)) rawRefs.push(...fm.sources.map(s => String(s)));
+
+    const notePaths = rawRefs
       .map(s => {
-        const trimmed = String(s).trim();
+        const trimmed = s.trim();
         return trimmed.startsWith('[[') && trimmed.endsWith(']]')
           ? trimmed.slice(2, -2).trim()
           : trimmed;
       })
       .filter(p => p.length > 0);
+    if (notePaths.length === 0) continue;
 
     let anyReadable = false;
     let anyMatch = false;

--- a/src/wiki/lint/scanners.ts
+++ b/src/wiki/lint/scanners.ts
@@ -1,7 +1,8 @@
 // Lint scanner functions — extracted from lint-controller.ts for testability.
 // These have no Obsidian API dependencies and can be unit tested directly.
 
-import { parseFrontmatter } from '../../core/frontmatter';
+import { parseFrontmatter, extractBody } from '../../core/frontmatter';
+import { hashBody } from '../../core/source-requirements';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from '../../core/tag-vocab';
 import { normalizeQuote, isQuoteGrounded } from './utils';
 import { LLMWikiSettings } from '../../types';
@@ -467,3 +468,81 @@ export function scanTagViolations(
 // makes the algorithm unit-testable without an Obsidian dependency.
 
 export { scanHubLinkDensity, type HubLinkDensityIssue, type HubLinkDensityOptions } from '../../core/hub-link-distinctiveness';
+
+// ── Source drift scanner (Issue #220 Tier 0, read half) ──────────────────────
+
+export interface SourceDriftIssue {
+  /** Wiki source page whose stored fingerprint no longer matches. */
+  sourcePage: string;
+  /** Origin note (first listed, normalized) whose current body was compared. */
+  note: string;
+  storedHash: string;
+  currentHash: string;
+}
+
+/**
+ * Detect source drift: a `sources/` page stores the `contentHash` of the note
+ * body it was built from (#164). When the note is edited afterwards, nothing
+ * re-reads that hash — the wiki silently keeps summarizing a body that no
+ * longer exists (Issue #220, Tier 0). This scanner is the read half: recompute
+ * the fingerprint of each origin note and flag mismatches.
+ *
+ * Report-only by design — a re-ingest is additive, so acting on drift
+ * automatically would duplicate content rather than revise it. Conservative on
+ * multi-source pages: the stored hash belongs to whichever note was written
+ * last, so a page is only flagged when NO listed, readable note matches it.
+ * Pages without a `contentHash` (pre-#164) and notes that cannot be read are
+ * skipped — absence of evidence is not drift.
+ */
+export function scanSourceDrift(
+  pageMap: Map<string, ScannerPage>,
+  noteContents: Map<string, string>,
+  wikiFolder: string,
+): SourceDriftIssue[] {
+  const issues: SourceDriftIssue[] = [];
+  const sourcesPrefix = `${wikiFolder}/sources/`;
+
+  for (const [path, page] of pageMap) {
+    if (!path.startsWith(sourcesPrefix)) continue;
+    const fm = parseFrontmatter(page.content);
+    if (!fm) continue;
+    const storedHash = (fm as Record<string, unknown>).contentHash;
+    if (typeof storedHash !== 'string' || !storedHash) continue;
+    if (!Array.isArray(fm.sources) || fm.sources.length === 0) continue;
+
+    const notePaths = fm.sources
+      .map(s => {
+        const trimmed = String(s).trim();
+        return trimmed.startsWith('[[') && trimmed.endsWith(']]')
+          ? trimmed.slice(2, -2).trim()
+          : trimmed;
+      })
+      .filter(p => p.length > 0);
+
+    let anyReadable = false;
+    let anyMatch = false;
+    let firstMismatch: { note: string; currentHash: string } | null = null;
+    for (const notePath of notePaths) {
+      const noteContent = noteContents.get(notePath);
+      if (noteContent === undefined) continue;
+      anyReadable = true;
+      const currentHash = hashBody(extractBody(noteContent));
+      if (currentHash === storedHash) {
+        anyMatch = true;
+        break;
+      }
+      if (!firstMismatch) firstMismatch = { note: notePath, currentHash };
+    }
+
+    if (anyReadable && !anyMatch && firstMismatch) {
+      issues.push({
+        sourcePage: path,
+        note: firstMismatch.note,
+        storedHash,
+        currentHash: firstMismatch.currentHash,
+      });
+    }
+  }
+
+  return issues;
+}

--- a/src/wiki/lint/types.ts
+++ b/src/wiki/lint/types.ts
@@ -105,6 +105,8 @@ export interface ProgrammaticFindings {
   ungroundedQuotes: import('./scanners').QuoteGroundingIssue[];
   /** v1.23.0 P1-6 — hub pages with redundant links in ## Related (Issue #157 / #175). */
   hubLinkDensityIssues: import('./scanners').HubLinkDensityIssue[];
+  /** Issue #220 Tier 0 (read half) — source pages whose origin note changed since ingest. */
+  sourceDriftIssues: import('./scanners').SourceDriftIssue[];
   sourcesNormalizedFiles: number;
   sourcesNormalizedEntries: number;
   doubleNestFixes: number;


### PR DESCRIPTION
Since #164 every `sources/` page stores a `contentHash` of the note body it was built from, but nothing ever read it back — the ingest skip is existence-based (`isAlreadyIngested`), so editing a note after ingest leaves its wiki pages silently stale. This PR adds the read half of #220 Tier 0 as a report-only lint check.

**What it does**
- `scanSourceDrift` (pure function, `scanners.ts`): recomputes `hashBody` over each origin note's body and flags source pages where no listed, readable note matches the stored hash.
- Programmatic phase step 8: one bounded read per origin note, same pattern as the quote-grounding reads.
- New report section + `lintSourceDriftSection`/`Item` keys in all 11 locales.

**What it deliberately does not do**
- No automatic re-ingest on drift: re-ingest is additive with no retraction of superseded content, so acting automatically would duplicate rather than revise. The finding routes to the user.
- No ingest-time notice split ("skipped vs. skipped-but-revised") — kept out to keep the diff reviewable; happy to follow up if wanted.
- Conservative on edge cases: pages without a `contentHash` (pre-#164), unreadable notes, and multi-source pages with one surviving match are skipped — absence of evidence is not drift.

Tests: 9 new (7 scanner, 2 report), full suite 3699 passing, tsc and eslint clean.
