### PR TITLE
feat(lint): surface the contradictions: marker — the lane's read half (#575)

### DIFF
--- a/src/__tests__/wiki/lint/report-builder.test.ts
+++ b/src/__tests__/wiki/lint/report-builder.test.ts
@@ -23,6 +23,7 @@ function makeFindings(overrides: Partial<ProgrammaticFindings> = {}): Programmat
     ungroundedQuotes: [],
     hubLinkDensityIssues: [],
     sourceDriftIssues: [],
+    contradictionMarkerIssues: [],
     sourcesNormalizedFiles: 0,
     sourcesNormalizedEntries: 0,
     doubleNestFixes: 0,
@@ -180,5 +181,38 @@ describe('source drift section (Issue #220 Tier 0)', () => {
       totalPages: 10,
     });
     expect(report).not.toContain('Source notes changed since ingest');
+  });
+});
+
+describe('contradiction marker section (#575 read half)', () => {
+  it('renders marked pages with their conflicting sources', () => {
+    const report = buildLintReport({
+      settings: makeSettings(),
+      findings: makeFindings({
+        contradictionMarkerIssues: [
+          { path: 'wiki/entities/butyrat.md', sources: ['Notizen/Neue-Studie.md'] },
+        ],
+      }),
+      duplicates: [],
+      contradictionsReport: '',
+      elapsedSeconds: 1,
+      totalPages: 10,
+    });
+    expect(report).toContain('Pages flagged with contradictions (merge triage) [1]');
+    expect(report).toContain('[[entities/butyrat]]');
+    expect(report).toContain('[[Notizen/Neue-Studie]]');
+    expect(report).not.toContain('No issues found');
+  });
+
+  it('omits the section when no page carries the marker', () => {
+    const report = buildLintReport({
+      settings: makeSettings(),
+      findings: makeFindings(),
+      duplicates: [],
+      contradictionsReport: '',
+      elapsedSeconds: 1,
+      totalPages: 10,
+    });
+    expect(report).not.toContain('Pages flagged with contradictions');
   });
 });

--- a/src/__tests__/wiki/lint/scanners.test.ts
+++ b/src/__tests__/wiki/lint/scanners.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildKnownTargets, detectAliasDeficiency, scanDeadLinks, scanOrphans, scanTagViolations, scanSourceDrift, ScannerPage } from '../../../wiki/lint/scanners';
+import { buildKnownTargets, detectAliasDeficiency, scanDeadLinks, scanOrphans, scanTagViolations, scanSourceDrift, scanContradictionMarkers, ScannerPage } from '../../../wiki/lint/scanners';
 import { hashBody } from '../../../core/source-requirements';
 import { LLMWikiSettings } from '../../../types';
 
@@ -596,5 +596,35 @@ describe('scanSourceDrift — canonical source_file frontmatter', () => {
 
     const unchanged = new Map([['Notizen/6-Minuten-Gehtest.md', noteBody]]);
     expect(scanSourceDrift(pageMap, unchanged, 'wiki')).toHaveLength(0);
+  });
+});
+
+// ── scanContradictionMarkers (#575 read half) ─────────────
+
+describe('scanContradictionMarkers', () => {
+  const page = (path: string, content: string): [string, ScannerPage] => [
+    path,
+    { path, basename: path.split('/').pop()!, content },
+  ];
+
+  it('surfaces pages with a non-empty contradictions: list', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/entities/butyrat.md',
+        '---\ntype: entity\ncontradictions:\n  - Notizen/Neue-Studie.md\n  - Notizen/Alte-Studie.md\n---\n\nBody'),
+      page('wiki/entities/clean.md', '---\ntype: entity\n---\n\nBody'),
+    ]);
+    const issues = scanContradictionMarkers(pageMap);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('wiki/entities/butyrat.md');
+    expect(issues[0].sources).toEqual(['Notizen/Neue-Studie.md', 'Notizen/Alte-Studie.md']);
+  });
+
+  it('ignores empty lists, blank entries, and non-list values', () => {
+    const pageMap = new Map<string, ScannerPage>([
+      page('wiki/entities/empty.md', '---\ntype: entity\ncontradictions:\n---\n\nBody'),
+      page('wiki/entities/blank.md', '---\ntype: entity\ncontradictions:\n  - ""\n---\n\nBody'),
+      page('wiki/entities/nofm.md', 'Body without frontmatter'),
+    ]);
+    expect(scanContradictionMarkers(pageMap)).toHaveLength(0);
   });
 });

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -659,6 +659,8 @@ export const DE_TEXTS = {
     lintNoIssuesFound: 'Keine Duplikate, defekten Links, leeren Seiten, verwaisten Seiten oder unbelegten Zitate erkannt.',
     lintSourceDriftSection: 'Quellnotizen seit dem Ingest geändert [{count}]',
     lintSourceDriftItem: '- [[{page}]] — Ursprungsnotiz [[{note}]] wurde nach dem Ingest bearbeitet; die Seite ist womöglich veraltet',
+    lintContradictionMarkerSection: 'Seiten mit Widerspruchs-Marker (Merge-Triage) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — widersprechende Quelle(n): {sources}; nach der Sichtung den contradictions:-Marker entfernen',
     lintQuoteGroundingSection: 'Unbelegte Zitate (erkannt) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (Seite existiert nicht){dupFlag}',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -671,6 +671,8 @@ export const EN_TEXTS = {
     lintNoIssuesFound: 'No duplicates, dead links, empty pages, orphan pages, or ungrounded quotes detected.',
     lintSourceDriftSection: 'Source notes changed since ingest [{count}]',
     lintSourceDriftItem: '- [[{page}]] — origin note [[{note}]] was edited after ingest; the page may be stale',
+    lintContradictionMarkerSection: 'Pages flagged with contradictions (merge triage) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — conflicting source(s): {sources}; review and remove the contradictions: marker when settled',
     lintQuoteGroundingSection: 'Ungrounded quotes (detected) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (page does not exist){dupFlag}',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -657,6 +657,8 @@ export const ES_TEXTS = {
     lintNoIssuesFound: 'No se detectaron duplicados, enlaces rotos, páginas vacías, páginas huérfanas ni citas sin fuente.',
     lintSourceDriftSection: 'Notas fuente modificadas desde la ingesta [{count}]',
     lintSourceDriftItem: '- [[{page}]] — la nota de origen [[{note}]] fue editada después de la ingesta; la página puede estar desactualizada',
+    lintContradictionMarkerSection: 'Páginas marcadas con contradicciones (triaje de fusión) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — fuente(s) en conflicto: {sources}; tras revisar, elimine el marcador contradictions:',
     lintQuoteGroundingSection: 'Citas sin fuente (detectadas) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (la página no existe){dupFlag}',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -613,6 +613,8 @@ export const FR_TEXTS = {
     lintNoIssuesFound: 'Aucun doublon, lien cassé, page vide, page orpheline ou citation non fondée détecté.',
     lintSourceDriftSection: 'Notes sources modifiées depuis l\'ingestion [{count}]',
     lintSourceDriftItem: '- [[{page}]] — la note d\'origine [[{note}]] a été modifiée après l\'ingestion ; la page peut être obsolète',
+    lintContradictionMarkerSection: 'Pages marquées de contradictions (triage de fusion) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — source(s) en conflit : {sources} ; après examen, retirez le marqueur contradictions:',
     lintQuoteGroundingSection: 'Citations non fondées (détectées) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: « {quote} »',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (la page n\'existe pas){dupFlag}',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -671,6 +671,8 @@ export const IT_TEXTS = {
     lintNoIssuesFound: 'Nessun duplicato, collegamento interrotto, pagina vuota, pagina orfana o citazione non fondata rilevato.',
     lintSourceDriftSection: 'Note sorgente modificate dopo l\'ingestione [{count}]',
     lintSourceDriftItem: '- [[{page}]] — la nota di origine [[{note}]] è stata modificata dopo l\'ingestione; la pagina potrebbe non essere aggiornata',
+    lintContradictionMarkerSection: 'Pagine contrassegnate con contraddizioni (triage di unione) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — fonte/i in conflitto: {sources}; dopo la revisione rimuovere il marcatore contradictions:',
     lintQuoteGroundingSection: 'Citazioni non fondate (rilevate) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (la pagina non esiste){dupFlag}',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -609,6 +609,8 @@ export const JA_TEXTS = {
     lintNoIssuesFound: '重複、リンク切れ、空ページ、孤立ページ、または根拠のない引用は検出されませんでした。',
     lintSourceDriftSection: '取り込み後に変更されたソースノート [{count} 件]',
     lintSourceDriftItem: '- [[{page}]] — 元ノート [[{note}]] が取り込み後に編集されました。ページが古い可能性があります',
+    lintContradictionMarkerSection: '矛盾マーカー付きページ（マージトリアージ）[{count} 件]',
+    lintContradictionMarkerItem: '- [[{page}]] — 矛盾するソース: {sources}。確認後に contradictions: マーカーを削除してください',
     lintQuoteGroundingSection: '根拠のない引用（検出）[{count} 件]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: 「{quote}」',
     lintDeadLinkItem: '- [[{source}]] → **{target}**（ページが存在しません）{dupFlag}',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -660,6 +660,8 @@ export const KO_TEXTS = {
     lintNoIssuesFound: '중복, 깨진 링크, 빈 페이지, 고아 페이지 또는 출처 없는 인용이 감지되지 않았습니다.',
     lintSourceDriftSection: '수집 후 변경된 소스 노트 [{count}개]',
     lintSourceDriftItem: '- [[{page}]] — 원본 노트 [[{note}]]가 수집 후 수정되었습니다. 페이지가 오래되었을 수 있습니다',
+    lintContradictionMarkerSection: '모순 마커가 있는 페이지 (병합 분류) [{count}개]',
+    lintContradictionMarkerItem: '- [[{page}]] — 충돌하는 소스: {sources}. 검토 후 contradictions: 마커를 제거하세요',
     lintQuoteGroundingSection: '출처 없는 인용 (감지됨) [{count}개]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (페이지가 존재하지 않음){dupFlag}',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -657,6 +657,8 @@ export const PT_TEXTS = {
     lintNoIssuesFound: 'Nenhuma duplicata, link quebrado, página vazia, página órfã ou citação sem fonte detectada.',
     lintSourceDriftSection: 'Notas de origem alteradas desde a ingestão [{count}]',
     lintSourceDriftItem: '- [[{page}]] — a nota de origem [[{note}]] foi editada após a ingestão; a página pode estar desatualizada',
+    lintContradictionMarkerSection: 'Páginas marcadas com contradições (triagem de mesclagem) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — fonte(s) em conflito: {sources}; após a revisão, remova o marcador contradictions:',
     lintQuoteGroundingSection: 'Citações sem fonte (detectadas) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: "{quote}"',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (página inexistente){dupFlag}',

--- a/src/texts/ru.ts
+++ b/src/texts/ru.ts
@@ -652,6 +652,8 @@ export const RU_TEXTS = {
     lintNoIssuesFound: 'Дубликатов, мёртвых ссылок, пустых страниц, висячих страниц или неподтверждённых цитат не обнаружено.',
     lintSourceDriftSection: 'Исходные заметки изменены после импорта [{count}]',
     lintSourceDriftItem: '- [[{page}]] — исходная заметка [[{note}]] была изменена после импорта; страница может быть устаревшей',
+    lintContradictionMarkerSection: 'Страницы с маркером противоречий (триаж слияния) [{count}]',
+    lintContradictionMarkerItem: '- [[{page}]] — конфликтующие источники: {sources}; после проверки удалите маркер contradictions:',
     lintQuoteGroundingSection: 'Неподтверждённые цитаты (обнаружено) [{count}]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}: «{quote}»',
     lintDeadLinkItem: '- [[{source}]] → **{target}** (страница не существует){dupFlag}',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -621,6 +621,8 @@ export const ZH_HANT_TEXTS = {
     lintNoIssuesFound: '未檢測到重複、斷鏈、空洞、孤立頁面或無來源引證。',
     lintSourceDriftSection: '匯入後已變更的來源筆記 [共 {count} 個]',
     lintSourceDriftItem: '- [[{page}]] — 原始筆記 [[{note}]] 在匯入後被編輯，頁面內容可能已過時',
+    lintContradictionMarkerSection: '帶有矛盾標記的頁面（合併分流）[共 {count} 個]',
+    lintContradictionMarkerItem: '- [[{page}]] — 衝突來源：{sources}；審閱後請移除 contradictions: 標記',
     lintQuoteGroundingSection: '無來源引證（程式檢測）[共 {count} 個]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}："{quote}"',
     lintContradictionOpen: '未解決的矛盾：{count} 個',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -629,6 +629,8 @@ export const ZH_TEXTS = {
     lintNoIssuesFound: '未检测到重复、断链、空洞、孤立页面或无来源引证。',
     lintSourceDriftSection: '导入后已变更的来源笔记 [共 {count} 个]',
     lintSourceDriftItem: '- [[{page}]] — 原始笔记 [[{note}]] 在导入后被编辑，页面内容可能已过时',
+    lintContradictionMarkerSection: '带有矛盾标记的页面（合并分流）[共 {count} 个]',
+    lintContradictionMarkerItem: '- [[{page}]] — 冲突来源：{sources}；审阅后请移除 contradictions: 标记',
     lintQuoteGroundingSection: '无来源引证（程序检测）[共 {count} 个]',
     lintQuoteGroundingItem: '- [[{page}]]{sourceHint}："{quote}"',
     lintContradictionOpen: '未解决的矛盾：{count} 个',

--- a/src/wiki/lint/phases/programmatic.ts
+++ b/src/wiki/lint/phases/programmatic.ts
@@ -1,4 +1,4 @@
-import { detectAliasDeficiency, scanOrphans, scanTagViolations, scanDeadLinks, scanQuoteGrounding, scanHubLinkDensity, scanSourceDrift, collectCitedRawNoteTargets } from '../scanners';
+import { detectAliasDeficiency, scanOrphans, scanTagViolations, scanDeadLinks, scanQuoteGrounding, scanHubLinkDensity, scanSourceDrift, scanContradictionMarkers, collectCitedRawNoteTargets } from '../scanners';
 import { detectPollutedPages } from '../utils';
 import { parseFrontmatter } from '../../../core/frontmatter';
 import { getText } from '../../../core/i18n';
@@ -150,6 +150,14 @@ export async function runProgrammaticPhase(
   const sourceDriftIssues = scanSourceDrift(input.pageMap, driftNoteContents, ctx.settings.wikiFolder);
   console.debug(`lintWiki: ${sourceDriftIssues.length} source page(s) with drifted origin notes`);
 
+  // 9. Contradiction markers (#575 read half) — pages the merge triage
+  // stamped with `contradictions:` when it routed a conflicted rewrite.
+  // Pure frontmatter read, zero IO, zero LLM; complements the
+  // contradiction-phase folder records, which only cover conflicts the
+  // lint's own LLM pass detected.
+  const contradictionMarkerIssues = scanContradictionMarkers(input.pageMap);
+  console.debug(`lintWiki: ${contradictionMarkerIssues.length} page(s) carrying a contradictions: marker`);
+
   return {
     aliasDeficientPages,
     emptyPages: [],
@@ -160,6 +168,7 @@ export async function runProgrammaticPhase(
     ungroundedQuotes,
     hubLinkDensityIssues,
     sourceDriftIssues,
+    contradictionMarkerIssues,
     sourcesNormalizedFiles: 0, // populated by preparation phase caller
     sourcesNormalizedEntries: 0,
     doubleNestFixes: 0,

--- a/src/wiki/lint/report-builder.ts
+++ b/src/wiki/lint/report-builder.ts
@@ -35,6 +35,7 @@ export function buildLintReport(input: ReportInput): string {
   const sourcesNormalizedFiles = findings.sourcesNormalizedFiles;
   const sourcesNormalizedEntries = findings.sourcesNormalizedEntries;
   const sourceDriftIssues = findings.sourceDriftIssues;
+  const contradictionMarkerIssues = findings.contradictionMarkerIssues;
 
   // Compute deadLinkFromDup / orphanFromDup counts
   const duplicatePaths = new Set<string>();
@@ -215,8 +216,23 @@ export function buildLintReport(input: ReportInput): string {
     progReport += '\n';
   }
 
+  // 8d. Contradiction markers (#575 read half) — pages stamped by the merge
+  // triage. Shown next to the contradiction-phase records so the two
+  // detection paths (merge-time vs. lint-time) land in one review surface.
+  if (contradictionMarkerIssues.length > 0) {
+    progReport += `## ${t.lintContradictionMarkerSection.replace('{count}', String(contradictionMarkerIssues.length))}\n\n`;
+    for (const c of contradictionMarkerIssues) {
+      const rel = c.path.replace(folder + '/', '').replace('.md', '');
+      const src = c.sources.map(s2 => `[[${s2.replace('.md', '')}]]`).join(', ');
+      progReport += t.lintContradictionMarkerItem
+        .replace('{page}', rel)
+        .replace('{sources}', src) + '\n';
+    }
+    progReport += '\n';
+  }
+
   // 9. No issues message
-  if (!duplicates.length && !deadLinks.length && !emptyPages.length && !orphans.length && !ungroundedQuotes.length && !hubLinkDensityIssues.length && !sourceDriftIssues.length) {
+  if (!duplicates.length && !deadLinks.length && !emptyPages.length && !orphans.length && !ungroundedQuotes.length && !hubLinkDensityIssues.length && !sourceDriftIssues.length && !contradictionMarkerIssues.length) {
     progReport += `${t.lintNoIssuesFound}\n\n`;
   }
 

--- a/src/wiki/lint/scanners.ts
+++ b/src/wiki/lint/scanners.ts
@@ -3,6 +3,7 @@
 
 import { parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { hashBody } from '../../core/source-requirements';
+import { CONTRADICTIONS_KEY } from '../../core/contradicted-marker';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from '../../core/tag-vocab';
 import { normalizeQuote, isQuoteGrounded } from './utils';
 import { LLMWikiSettings } from '../../types';
@@ -554,6 +555,44 @@ export function scanSourceDrift(
       });
     }
   }
+  return issues;
+}
 
+// ── Contradiction marker scanner (#575 read half) ──────────────────────
+
+export interface ContradictionMarkerIssue {
+  /** Wiki page carrying a non-empty `contradictions:` frontmatter list. */
+  path: string;
+  /** Source paths whose triage flagged a conflict with this page. */
+  sources: string[];
+}
+
+/**
+ * Surface pages whose frontmatter carries the `contradictions:` marker that
+ * the merge triage stamps when it routes a conflicted rewrite (#575). The
+ * marker module wrote the field for exactly this consumer ("Lint can later
+ * scan this field to surface pages that need editorial review") — without
+ * this scanner the durable half of the contradiction lane is write-only.
+ *
+ * Pure and IO-free: the marker accumulates across re-touches, so this is a
+ * frontmatter read over the pages the lint already holds. A page leaves the
+ * report when the user removes the marker after review — the inline
+ * "Potential Contradiction" body block is NOT required to still exist (it
+ * falls to section pruning on later rewrites; the frontmatter is the
+ * durable signal).
+ */
+export function scanContradictionMarkers(
+  pageMap: Map<string, ScannerPage>,
+): ContradictionMarkerIssue[] {
+  const issues: ContradictionMarkerIssue[] = [];
+  for (const [path, page] of pageMap) {
+    const fm = parseFrontmatter(page.content);
+    if (!fm) continue;
+    const raw = (fm as Record<string, unknown>)[CONTRADICTIONS_KEY];
+    if (!Array.isArray(raw)) continue;
+    const sources = raw.map(s => String(s).trim()).filter(s => s.length > 0);
+    if (sources.length === 0) continue;
+    issues.push({ path, sources });
+  }
   return issues;
 }

--- a/src/wiki/lint/types.ts
+++ b/src/wiki/lint/types.ts
@@ -107,6 +107,8 @@ export interface ProgrammaticFindings {
   hubLinkDensityIssues: import('./scanners').HubLinkDensityIssue[];
   /** Issue #220 Tier 0 (read half) — source pages whose origin note changed since ingest. */
   sourceDriftIssues: import('./scanners').SourceDriftIssue[];
+  /** #575 read half — pages carrying the triage-stamped `contradictions:` marker. */
+  contradictionMarkerIssues: import('./scanners').ContradictionMarkerIssue[];
   sourcesNormalizedFiles: number;
   sourcesNormalizedEntries: number;
   doubleNestFixes: number;


### PR DESCRIPTION
Stacked on #576 — the first commit is that PR's; **review only the top commit** (`77e4f1c`).

#576 gives item-level contradictions a lane: the merge triage stamps conflicted rewrites with a durable `contradictions:` frontmatter marker. The marker module already names its intended consumer — "Lint can later scan this field to surface pages that need editorial review" — but that consumer didn't exist yet. Without it the lane is write-only: the inline "Potential Contradiction" body block falls to section pruning on later rewrites (as disclosed in #576), and nothing ever routes the durable signal to a human.

**What it does**
- `scanContradictionMarkers` (pure function, `scanners.ts`): pages whose frontmatter carries a non-empty `contradictions:` list, with the conflicting source paths.
- Programmatic phase step: zero IO, zero LLM — a frontmatter read over pages the lint already holds.
- Report section placed next to the contradiction-phase records, so merge-time and lint-time detection land in one review surface; `lintContradictionMarkerSection`/`Item` keys in all 11 locales.

**Review model:** the marker accumulates across re-touches and is removed by the user once the conflict is settled — a page leaves the report exactly then. No auto-resolution; deciding the conflict stays editorial.

Tests: 4 new (2 scanner, 2 report), full suite 3700 passing, tsc and eslint clean.
