### PR TITLE
feat(merge): give merge calls the note's own paragraphs — the payload was a constant

### DIFF
--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -304,3 +304,100 @@ describe('mergePage — H1 survives a rewrite that omits it', () => {
     expect(written).toContain('Merged body.');
   });
 });
+
+describe('mergePage — note excerpt window (payload fix)', () => {
+  function makeCapturingClient(responses: string[]): LLMClient & { prompts: string[] } {
+    let i = 0;
+    const prompts: string[] = [];
+    return {
+      prompts,
+      createMessage: async (req: { messages: Array<{ content: string }> }) => {
+        prompts.push(req.messages[0].content);
+        return responses[i++] ?? 'NO_NEW_CONTENT';
+      },
+    } as LLMClient & { prompts: string[] };
+  }
+
+  const NOTE = [
+    '---',
+    'tags:',
+    '  - Thema/Test',
+    '---',
+    'Einleitung ohne den Begriff.',
+    '',
+    'Caching beschleunigt wiederholte Zugriffe erheblich und senkt die Latenz.',
+    '',
+    'Ein Absatz über etwas völlig anderes.',
+  ].join('\n');
+
+  it('passes the matching note paragraphs to triage AND body merge', async () => {
+    const client = makeCapturingClient([
+      JSON.stringify({ strategy: 'merge', reason: 'restructure' }),
+      '## Description\nNew merged text.\n',
+    ]);
+    const ctx = makeCtx(client);
+    ctx.written.set('Notizen/Some-Note.md', NOTE);
+    await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'Notizen/Some-Note.md', basename: 'Some-Note' },
+      EXISTING,
+      [],
+      'wiki/entities/Caching.md',
+    );
+    expect(client.prompts.length).toBe(2);
+    // Triage prompt carries the excerpt block…
+    expect(client.prompts[0]).toContain('says about "Caching"');
+    expect(client.prompts[0]).toContain('senkt die Latenz');
+    expect(client.prompts[0]).not.toContain('völlig anderes');
+    // …and so does the body-merge prompt.
+    expect(client.prompts[1]).toContain('senkt die Latenz');
+    // Note frontmatter is stripped before matching/excerpting.
+    expect(client.prompts[1]).not.toContain('Thema/Test');
+  });
+
+  it('lemma case: the note that IS the page delivers its full body', async () => {
+    const client = makeCapturingClient([
+      JSON.stringify({ strategy: 'merge', reason: 'own lemma' }),
+      '## Description\nNew merged text.\n',
+    ]);
+    const ctx = makeCtx(client);
+    ctx.written.set('Notizen/Caching.md', NOTE);
+    await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'Notizen/Caching.md', basename: 'Caching' },
+      EXISTING,
+      [],
+      'wiki/entities/Caching.md',
+      undefined,
+      { sourceTitle: 'Caching', summary: 'A note about caching.', sourcePath: 'Notizen/Caching.md' },
+    );
+    // Full-note mode: even the non-matching paragraphs travel.
+    expect(client.prompts[0]).toContain('völlig anderes');
+    expect(client.prompts[0]).toContain('Einleitung ohne den Begriff');
+  });
+
+  it('no prose about the page → prompts carry no excerpt block (prompt-invariant)', async () => {
+    const client = makeCapturingClient([
+      JSON.stringify({ strategy: 'merge', reason: 'x' }),
+      '## Description\nNew merged text.\n',
+    ]);
+    const ctx = makeCtx(client);
+    ctx.written.set('Notizen/Other.md', 'Nur fremde Themen.\n\nNichts über die Seite.');
+    await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'Notizen/Other.md', basename: 'Other' },
+      EXISTING,
+      [],
+      'wiki/entities/Caching.md',
+    );
+    expect(client.prompts[0]).not.toContain('says about');
+    expect(client.prompts[1]).not.toContain('says about');
+    expect(client.prompts[1]).not.toContain('{{source_excerpt}}');
+  });
+});

--- a/src/__tests__/wiki/page-factory/note-window.test.ts
+++ b/src/__tests__/wiki/page-factory/note-window.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { buildNoteExcerpt, renderNoteExcerptBlock, EXCERPT_MAX_CHARS } from '../../../wiki/page-factory/note-window';
+
+describe('buildNoteExcerpt', () => {
+  const body = [
+    'Intro paragraph about the topic in general.',
+    'Die Cholesterin-Hypothese hält sich hartnäckig, obwohl Statine primärpräventiv überschätzt sind.',
+    'Ein Absatz über Vitamin D und die Endocrine Society.',
+    'Schlussabsatz ohne Namen.',
+  ].join('\n\n');
+
+  it('selects only paragraphs mentioning the page name', () => {
+    const out = buildNoteExcerpt(body, { pageName: 'Statine' });
+    expect(out).toContain('Cholesterin-Hypothese');
+    expect(out).not.toContain('Vitamin D');
+    expect(out).not.toContain('Intro paragraph');
+  });
+
+  it('matches hyphen/space variants of slugged page names', () => {
+    const prose = 'Die Sugar Industry bezahlte Forscher.\n\nAnderes Thema.';
+    expect(buildNoteExcerpt(prose, { pageName: 'Sugar-Industry' })).toContain('bezahlte Forscher');
+  });
+
+  it('matches via aliases, case-insensitively', () => {
+    const prose = 'Der LDL-Wert allein trägt nicht das ganze Bild.\n\nAnderes.';
+    expect(buildNoteExcerpt(prose, { pageName: 'Low-Density-Lipoprotein', aliases: ['ldl'] }))
+      .toContain('ganze Bild');
+  });
+
+  it('returns "" when nothing matches — callers keep the prompt unchanged', () => {
+    expect(buildNoteExcerpt(body, { pageName: 'Quantenphysik' })).toBe('');
+    expect(renderNoteExcerptBlock('', 'Quantenphysik')).toBe('');
+  });
+
+  it('ignores needles shorter than 3 chars instead of matching everything', () => {
+    expect(buildNoteExcerpt(body, { pageName: 'D', aliases: ['ie'] })).toBe('');
+  });
+
+  it('full-note mode returns the whole body and caps with a truncation mark', () => {
+    expect(buildNoteExcerpt(body, { pageName: 'Egal', fullNote: true })).toBe(body);
+    const long = 'x'.repeat(50);
+    const out = buildNoteExcerpt(long, { pageName: 'Egal', fullNote: true, maxChars: 10 });
+    expect(out.startsWith('xxxxxxxxxx')).toBe(true);
+    expect(out).toContain('[…]');
+  });
+
+  it('caps the matched window and marks the cut', () => {
+    const para = 'Statine sind relevant. ' + 'y'.repeat(300);
+    const many = Array.from({ length: 30 }, () => para).join('\n\n');
+    const out = buildNoteExcerpt(many, { pageName: 'Statine', maxChars: 1000 });
+    expect(out.length).toBeLessThanOrEqual(1000 + 10);
+    expect(out).toContain('[…]');
+  });
+
+  it('default cap constant is used for the window mode', () => {
+    expect(EXCERPT_MAX_CHARS).toBe(4000);
+  });
+});
+
+describe('renderNoteExcerptBlock', () => {
+  it('wraps the excerpt in a labeled prompt block', () => {
+    const block = renderNoteExcerptBlock('Fakt eins.', 'Statine');
+    expect(block).toContain('"Statine"');
+    expect(block).toContain('Fakt eins.');
+    expect(block.startsWith('\n\n**')).toBe(true);
+  });
+});

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -42,7 +42,7 @@ import {
   stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
-import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
+import { mergeFrontmatter, parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { incomingTypeTag } from '../../core/tag-vocab';
 import { appendContradictedByMarker } from '../../core/contradicted-marker';
 import { injectMentionsSection } from '../../core/mentions-injector';
@@ -54,6 +54,7 @@ import { classifyMergeNeed, isSourceOwnPageLemma } from './merge-triage';
 import { assembleFinalContent } from './mentions-integration';
 import { applyComplementaryAppends } from './complementary-appends';
 import { firstQuotesForPrompt, isConversationSource, mergeError } from './contextualize';
+import { buildNoteExcerpt, renderNoteExcerptBlock } from './note-window';
 
 /**
  * Minimal context contract required by mergePage / appendToReviewedPage.
@@ -112,6 +113,26 @@ export async function mergePage(
       sourceContext,
     });
 
+    // Note excerpt window — the merge payload was a constant (item summary +
+    // two quotes) regardless of how much the note says about this page;
+    // measured on a real ingest, 5 of 7 merges added nothing but links. Give
+    // both merge consumers the note's own paragraphs about the page — and
+    // the page whose lemma the note carries gets the whole note, because a
+    // note about X is THE source for page X. Deterministic, bounded, and ''
+    // (prompt-invariant) when the note never discusses the page in prose.
+    const noteRaw = await ctx.tryReadFile(sourceFile.path);
+    const noteExcerpt = noteRaw
+      ? buildNoteExcerpt(extractBody(noteRaw), {
+          pageName: pageBasename,
+          aliases: [
+            info.name,
+            ...(info.aliases ?? []),
+            ...(Array.isArray(existingAliases) ? existingAliases : []),
+          ],
+          fullNote: sourceOwnsPage,
+        })
+      : '';
+
     // 1. v1.24.0 #216 — classify-then-route triage.
     let shouldSkip = false;
     let complementaryBody: string | null = null;
@@ -121,7 +142,7 @@ export async function mergePage(
     // not classified.
     let contradictedSourcePath: string | null = null;
     try {
-      const triage = await classifyMergeNeed(ctx, info, pageType, sourceFile, existingBody, sourceContext);
+      const triage = await classifyMergeNeed(ctx, info, pageType, sourceFile, existingBody, sourceContext, noteExcerpt);
 
       // #312 part 2: a page's own primary source must not be dropped on a
       // novelty judgement — that is how an incidental mention keeps a
@@ -196,6 +217,7 @@ export async function mergePage(
       related_entities: info.related_entities?.join(', ') || '',
       related_concepts: info.related_concepts?.join(', ') || '',
       key_details: firstQuotesForPrompt(info),
+      source_excerpt: renderNoteExcerptBlock(noteExcerpt, pageBasename),
     });
 
     // #328 Phase 1 follow-up: user-layer tag-vocab removed — system layer injects once.
@@ -297,12 +319,29 @@ export async function appendToReviewedPage(
       incomingTypeTag(ctx.settings, pageKind, info.type),
     );
 
-    // 2. Minimal LLM check for genuinely new content.
+    // 2. Minimal LLM check for genuinely new content. Same note-excerpt
+    // window as mergePage (matched paragraphs only — no lemma full-note
+    // here, the reviewed body is locked anyway and only a small block is
+    // drafted): the draft should see what the note says, not just two quotes.
+    const reviewedPageBasename = path.split('/').pop()?.replace(/\.md$/i, '') ?? '';
+    const reviewedAliases = parseFrontmatter(existingContent)?.aliases;
+    const reviewedNoteRaw = await ctx.tryReadFile(sourceFile.path);
+    const reviewedExcerpt = reviewedNoteRaw
+      ? buildNoteExcerpt(extractBody(reviewedNoteRaw), {
+          pageName: reviewedPageBasename,
+          aliases: [
+            info.name,
+            ...(info.aliases ?? []),
+            ...(Array.isArray(reviewedAliases) ? reviewedAliases : []),
+          ],
+        })
+      : '';
     const prompt = renderTemplate(PROMPTS.appendToReviewedPage, {
       existing_body: existingBody,
       new_source: sourceFile.basename,
       entity_summary: info.summary,
       key_details: firstQuotesForPrompt(info),
+      source_excerpt: renderNoteExcerptBlock(reviewedExcerpt, reviewedPageBasename),
       constraints: UNIVERSAL_LINK_CONSTRAINTS,
     });
 

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -24,6 +24,7 @@ import { TOKENS_MERGE_TRIAGE } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { getSectionLabels, applySectionLabels } from '../system-prompts';
 import { firstQuotesForPrompt } from './contextualize';
+import { renderNoteExcerptBlock } from './note-window';
 import { renderTemplate } from '../../core/template-renderer';
 import { MergeTriageSchema, type MergeTriage } from '../../llm-sdk/output-schemas';
 
@@ -80,6 +81,7 @@ export async function classifyMergeNeed(
   sourceFile: TFile | { path: string; basename: string },
   existingContent: string,
   sourceContext?: SourceContext,
+  sourceExcerpt?: string,
 ): Promise<MergeTriageResult> {
   const client = ctx.getClient();
   if (!client) throw new Error('LLM client not initialized');
@@ -95,6 +97,7 @@ export async function classifyMergeNeed(
     page_type: pageType,
     existing_content: existingContent,
     new_info: buildNewInfoSummary(info, sourceFile),
+    source_excerpt: renderNoteExcerptBlock(sourceExcerpt ?? '', info.name),
     source_context: renderSourceContextBlock(sourceContext),
     source_ownership_rule: renderSourceOwnershipRule(sourceContext),
     section_labels: `- ${sectionLabelsList}`,

--- a/src/wiki/page-factory/note-window.ts
+++ b/src/wiki/page-factory/note-window.ts
@@ -1,0 +1,116 @@
+// Note excerpt window for merge calls — the payload half of the merge
+// thinness problem.
+//
+// Why this exists
+// ---------------
+// Both merge consumers — the #216 triage (`buildNewInfoSummary`) and the
+// body-merge prompt — see only the extracted item: a few-sentence summary
+// plus the first two quotes. The source note itself never reaches a merge
+// call, so a note rich in facts about an existing page merges as links and
+// a quote, and the facts land nowhere (observed: 2 of 7 merges carried any
+// substance; the note's own lemma page got nothing). The payload of a call
+// may be a function of the NOTE — here it was a constant.
+//
+// This module selects, deterministically and bounded, the note paragraphs
+// that mention the page (by name or alias), so the merge finally sees what
+// the note actually says about its subject. For the page whose lemma the
+// note carries (#312 `isSourceOwnPageLemma`), the whole note body is the
+// excerpt — a note about X is THE source for page X.
+//
+// Pure: no IO, no Obsidian imports, no LLM.
+
+/** Options for {@link buildNoteExcerpt}. */
+export interface NoteExcerptOptions {
+  /** Page name the merge is targeting (`info.name`). */
+  pageName: string;
+  /** Extraction aliases and curated note aliases; matched like the name. */
+  aliases?: string[];
+  /**
+   * True when the note carries the page's own lemma (#312): the whole body
+   * is returned (capped) instead of matching paragraphs.
+   */
+  fullNote?: boolean;
+  /** Hard cap on the excerpt, in characters. */
+  maxChars?: number;
+}
+
+/** Default cap for the matched-paragraph window. */
+export const EXCERPT_MAX_CHARS = 4000;
+/** Default cap for the lemma full-note case. */
+export const EXCERPT_FULL_NOTE_MAX_CHARS = 12000;
+
+const TRUNCATION_MARK = '\n[…]';
+
+/**
+ * Name-form variants a paragraph is searched for: the raw form, the
+ * hyphen↔space swaps (slugged page names like "Sugar-Industry" must match
+ * the prose form "Sugar Industry" and vice versa). Case-insensitive
+ * matching is applied by the caller via toLowerCase.
+ */
+function nameVariants(name: string): string[] {
+  const forms = new Set<string>();
+  const trimmed = name.trim();
+  if (!trimmed) return [];
+  forms.add(trimmed);
+  forms.add(trimmed.replace(/-/g, ' '));
+  forms.add(trimmed.replace(/ /g, '-'));
+  return [...forms];
+}
+
+/**
+ * Build the note excerpt for one merge call.
+ *
+ * Paragraphs are blank-line-separated blocks; a block is included when it
+ * contains the page name or any alias (case-insensitive, hyphen/space
+ * tolerant). Blocks are joined in note order up to `maxChars`; when the cap
+ * cuts, a truncation mark is appended so the prompt does not present a
+ * partial window as the whole story. Returns '' when nothing matches —
+ * callers render no excerpt block in that case, keeping today's prompt
+ * byte-identical for pages the note only names in passing lists.
+ */
+export function buildNoteExcerpt(noteBody: string, opts: NoteExcerptOptions): string {
+  const body = noteBody.trim();
+  if (!body) return '';
+
+  const maxChars = opts.maxChars ?? (opts.fullNote ? EXCERPT_FULL_NOTE_MAX_CHARS : EXCERPT_MAX_CHARS);
+
+  if (opts.fullNote) {
+    if (body.length <= maxChars) return body;
+    return body.slice(0, maxChars) + TRUNCATION_MARK;
+  }
+
+  const needles = [opts.pageName, ...(opts.aliases ?? [])]
+    .flatMap(nameVariants)
+    .map(v => v.toLowerCase())
+    .filter(v => v.length >= 3);
+  if (needles.length === 0) return '';
+
+  const blocks = body.split(/\n\s*\n/);
+  const matched: string[] = [];
+  for (const block of blocks) {
+    const lower = block.toLowerCase();
+    if (needles.some(n => lower.includes(n))) matched.push(block.trim());
+  }
+  if (matched.length === 0) return '';
+
+  let out = '';
+  for (const block of matched) {
+    const next = out ? `${out}\n\n${block}` : block;
+    if (next.length > maxChars) {
+      return out ? out + TRUNCATION_MARK : block.slice(0, maxChars) + TRUNCATION_MARK;
+    }
+    out = next;
+  }
+  return out;
+}
+
+/**
+ * Render the excerpt as a prompt block, or '' when there is no excerpt.
+ * Shared by the triage and the body-merge prompts so both consumers see
+ * the same window — enriching only the merge would leave the triage
+ * routing to "skip" on the thin payload before the merge can act.
+ */
+export function renderNoteExcerptBlock(excerpt: string, pageName: string): string {
+  if (!excerpt) return '';
+  return `\n\n**What the source note itself says about "${pageName}" (verbatim excerpt):**\n${excerpt}`;
+}

--- a/src/wiki/prompts/merge.ts
+++ b/src/wiki/prompts/merge.ts
@@ -36,7 +36,7 @@ export const MERGE_PROMPTS = {
 {{existing_content}}
 
 **New Information from Source File:**
-{{new_info}}{{source_context}}
+{{new_info}}{{source_excerpt}}{{source_context}}
 
 **Available sections in the existing page (target_section MUST be one of these exact names):**
 {{section_labels}}
@@ -86,11 +86,11 @@ Rules:
 - Summary: {{entity_summary}}
 - Related entities: {{related_entities}}
 - Related concepts: {{related_concepts}}
-- Key details: {{key_details}}
+- Key details: {{key_details}}{{source_excerpt}}
 
 **Integration Requirements:**
 1. STRUCTURE: Follow the schema sections exactly. If a section exists, update it; if missing, create it.
-2. DESCRIPTION: Integrate new facts naturally. Do NOT duplicate existing information.
+2. DESCRIPTION: Integrate new facts naturally. When a verbatim excerpt block is present, it is the authoritative payload: integrate EVERY fact in it that concerns this page, not only the summary lines. Do NOT duplicate existing information.
 3. RELATED: Update "{{section_related_entities}}" and "{{section_related_concepts}}" sections with new relationships.
 4. CONTRADICTIONS: If new info conflicts with existing, preserve BOTH with clear attribution.
 5. LINKS: Write [[Name]] as you would say the name. Do NOT write or guess a folder path — the system resolves every name to its real page after the merge, against the whole wiki. A display name is optional.
@@ -123,11 +123,11 @@ Output ONLY the body content (no frontmatter):
 - Summary: {{concept_summary}}
 - Related concepts: {{related_concepts}}
 - Related entities: {{related_entities}}
-- Key details: {{key_details}}
+- Key details: {{key_details}}{{source_excerpt}}
 
 **Integration Requirements:**
 1. STRUCTURE: Follow the schema sections exactly. Update existing, create missing.
-2. DESCRIPTION: Integrate new understanding coherently with existing.
+2. DESCRIPTION: Integrate new understanding coherently with existing. When a verbatim excerpt block is present, it is the authoritative payload: integrate EVERY fact in it that concerns this concept, not only the summary lines.
 3. RELATED CONCEPTS: Update links — add new ones, preserve existing.
 4. RELATED ENTITIES: Update links — add new ones from this source.
 5. CONTRADICTIONS: If new info conflicts, preserve both with attribution.
@@ -155,7 +155,7 @@ Output ONLY the body content (no frontmatter):
 
 **New Information from Source "{{new_source}}":**
 - Summary: {{entity_summary}}
-- Key details: {{key_details}}
+- Key details: {{key_details}}{{source_excerpt}}
 
 **Task:**
 1. Compare new information against existing content


### PR DESCRIPTION
Both merge consumers — the #216 triage (`buildNewInfoSummary`) and the body-merge prompt — see only the extracted item: a few-sentence summary plus the first two quotes. The source note itself never reaches a merge call, so a note rich in facts about an existing page merges as links and a quote. Measured on a real ingest (7 existing pages touched): 5 of 7 merges added nothing but frontmatter and links, and the note's own lemma page absorbed none of its facts — the Cochrane numbers, the NCEP panel, the historical case studies all landed on newly created pages or nowhere.

**Fix, deterministic and bounded:** `note-window.ts` (pure) selects the note paragraphs mentioning the page (name or alias, hyphen/space tolerant), capped at 4k chars; the page whose lemma the note carries (#312 `isSourceOwnPageLemma`) gets the whole body (capped 12k) — a note about X is THE source for page X. Wired into **both** consumers, because enriching only the merge would leave the triage routing to "skip" on the thin payload before the merge can act. Returns '' for passing mentions, keeping today's prompts byte-identical in that case. The reviewed-append path gets the same window (matched paragraphs only).

Tests: 12 new (9 note-window, 3 mergePage prompt-capture), full suite 3702 passing, tsc and eslint clean.
