### PR TITLE
fix(markdown): preamble cut eats the first section of responses that start with a heading

### DIFF
--- a/src/__tests__/core/markdown.test.ts
+++ b/src/__tests__/core/markdown.test.ts
@@ -196,3 +196,36 @@ describe('stripTrailingSeparators (#310)', () => {
   });
 });
 
+
+// Fix: the preamble cut must not eat a legitimate first section.
+describe('cleanMarkdownResponse — preamble cut guards', () => {
+  it('keeps the first section when the response starts with a heading', () => {
+    const resp = [
+      '## Description',
+      'New merged description with the source facts.',
+      '',
+      '## Related Entities',
+      '- [[AHA]]',
+    ].join('\n');
+    const out = cleanMarkdownResponse(resp);
+    expect(out).toContain('## Description');
+    expect(out).toContain('source facts');
+  });
+
+  it('still strips chat preamble before the first heading', () => {
+    const resp = [
+      'Here is the merged page:',
+      '',
+      '## Description',
+      'Body text.',
+    ].join('\n');
+    const out = cleanMarkdownResponse(resp);
+    expect(out.startsWith('## Description')).toBe(true);
+    expect(out).not.toContain('Here is the merged page');
+  });
+
+  it('leaves frontmatter-carrying responses alone (original guard)', () => {
+    const resp = '---\ntype: entity\n---\n\n# Title\n\n## Description\nBody.';
+    expect(cleanMarkdownResponse(resp)).toContain('type: entity');
+  });
+});

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -16,7 +16,19 @@ export function cleanMarkdownResponse(response: string): string {
 
   let cleaned = stripThinkingBlocks(response.trim());
 
-  if (cleaned.indexOf('\n---\n') === -1) {
+  // Preamble cut: strip chat prose the model put before the first heading
+  // ("Here is the merged page:", …). Guarded twofold:
+  //   - a response carrying frontmatter is left alone (original guard), and
+  //   - a response that already STARTS with a `#`/`##` heading is left alone.
+  // The second guard is the fix for a silent first-section eater: the search
+  // pattern requires a leading newline, so on a body that opens with
+  // `## Description` the first MATCH was the SECOND heading — and the cut
+  // deleted the entire first section. Downstream, preserveExistingSections
+  // then restored the OLD section, so every body-merge looked like it never
+  // touched the description while Related/Mentions arrived. Measured on a
+  // real ingest: description-bearing first sections were dropped from
+  // merge-body responses on every touched page.
+  if (cleaned.indexOf('\n---\n') === -1 && !/^#{1,6} /.test(cleaned)) {
     const headerMatch = cleaned.match(/\n#{1,2} \S/);
     if (headerMatch) {
       const cutIdx = cleaned.indexOf(headerMatch[0]);


### PR DESCRIPTION
`cleanMarkdownResponse` strips chat preamble by cutting everything before the first `\n#{1,2} ` match. On a body-merge response that correctly **starts** with `## Description`, the leading heading has no preceding newline — so the first match is the *second* heading, and the cut deletes the entire first section. Downstream, `preserveExistingSections` restores the old section, making the loss doubly invisible: every body merge looks like it never touched the description, while Related/Mentions arrive normally. Measured on a real ingest: the description-bearing first section was dropped from merge-body responses on every touched page. Repro: a canonical two-section body loses section one (test included).

Guard: skip the cut when the response already starts with a heading — there is no preamble to strip. Chat-preamble stripping and the frontmatter guard are unchanged, pinned by tests. 3 new tests, full suite 3693 passing, tsc and eslint clean.
