### PR TITLE
feat(markdown): normalize heading spacing and blank-line runs at the write gate

### DIFF
--- a/src/__tests__/core/markdown-spacing.test.ts
+++ b/src/__tests__/core/markdown-spacing.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeHeadingSpacing } from '../../core/markdown-spacing';
+
+describe('normalizeHeadingSpacing', () => {
+  it('inserts a blank line between a heading and its glued content', () => {
+    expect(normalizeHeadingSpacing('## Definition\nDer 6MWT ist ein Feldtest.'))
+      .toBe('## Definition\n\nDer 6MWT ist ein Feldtest.');
+  });
+
+  it('keeps normalized content unchanged and stays idempotent (same reference)', () => {
+    const ok = '# Titel\n\n## Definition\n\nText.\n';
+    expect(normalizeHeadingSpacing(ok)).toBe(ok);
+    const once = normalizeHeadingSpacing('## A\nText');
+    expect(normalizeHeadingSpacing(once)).toBe(once);
+  });
+
+  it('collapses runs of blank lines to a single one', () => {
+    expect(normalizeHeadingSpacing('---\ntype: concept\n---\n\n\n\n# Titel\n\nText.'))
+      .toBe('---\ntype: concept\n---\n\n# Titel\n\nText.');
+  });
+
+  it('leaves the frontmatter block untouched', () => {
+    const fm = '---\ntags:\n  - "Thema/Diagnostik"\n---\n\n# Titel\n\nText.';
+    expect(normalizeHeadingSpacing(fm)).toBe(fm);
+  });
+
+  it('leaves fenced code blocks untouched', () => {
+    const fenced = 'Text.\n\n```\n# kein Heading\ncode\n```\n\nWeiter.';
+    expect(normalizeHeadingSpacing(fenced)).toBe(fenced);
+  });
+
+  it('treats a heading followed by a blank line as already correct', () => {
+    const ok = '## Anwendungen\n\n- Punkt eins.';
+    expect(normalizeHeadingSpacing(ok)).toBe(ok);
+  });
+
+  it('handles a heading as the last line without appending anything', () => {
+    expect(normalizeHeadingSpacing('Text.\n\n## Offen')).toBe('Text.\n\n## Offen');
+  });
+});

--- a/src/core/markdown-spacing.ts
+++ b/src/core/markdown-spacing.ts
@@ -1,0 +1,66 @@
+// Heading/blank-line spacing normalization for generated wiki pages.
+//
+// Generated pages frequently carry headings glued to their first content
+// line (`## Definition\nText …`) and stray runs of blank lines (e.g.
+// between the frontmatter block and the H1). Both render fine but make the
+// source view inconsistent. The spacing is pure syntax — machine-checkable
+// — so the write gate normalizes it instead of asking the model to:
+//   1. exactly one blank line after every ATX heading, and
+//   2. runs of two or more blank lines collapsed to one,
+// both outside the YAML frontmatter block and fenced code blocks.
+
+const HEADING = /^#{1,6}\s/;
+const FENCE = /^(```|~~~)/;
+
+/**
+ * Normalize heading spacing and collapse blank-line runs. Idempotent;
+ * content already normalized is returned unchanged (same reference, so
+ * callers can cheaply detect no-ops).
+ */
+export function normalizeHeadingSpacing(content: string): string {
+  const lines = content.split('\n');
+  const out: string[] = [];
+  let i = 0;
+  let changed = false;
+
+  // Pass the frontmatter block through untouched.
+  if (lines[0] === '---') {
+    out.push(lines[0]);
+    i = 1;
+    while (i < lines.length && lines[i] !== '---') out.push(lines[i++]);
+    if (i < lines.length) out.push(lines[i++]);
+  }
+
+  let inFence = false;
+  while (i < lines.length) {
+    const line = lines[i];
+    out.push(line);
+
+    if (FENCE.test(line)) {
+      inFence = !inFence;
+      i++;
+      continue;
+    }
+    if (inFence) {
+      i++;
+      continue;
+    }
+
+    if (line.trim() === '') {
+      // Collapse a run of blank lines to this single one.
+      let j = i + 1;
+      while (j < lines.length && lines[j].trim() === '') j++;
+      if (j > i + 1) changed = true;
+      i = j;
+      continue;
+    }
+
+    if (HEADING.test(line) && i + 1 < lines.length && lines[i + 1].trim() !== '') {
+      out.push('');
+      changed = true;
+    }
+    i++;
+  }
+
+  return changed ? out.join('\n') : content;
+}

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_SOURCE_TAG,
 } from '../types';
 import { PROMPTS } from '../prompts';
+import { normalizeHeadingSpacing } from '../core/markdown-spacing';
 import { getText } from '../core/i18n';
 import { buildRepetitionPenaltyHint } from '../core/repetition-penalty-hint';
 import { formatTaskUsage, snapshotTaskUsage, taskUsageSince } from '../core/llm-task-usage';
@@ -1567,6 +1568,13 @@ export class WikiEngine {
     if (sourcesFix.fixed > 0) {
       console.warn(`createOrUpdateFile: normalized polluted sources field in ${path}`);
       content = sourcesFix.content;
+    }
+
+    // Cosmetic spacing: one blank line after each heading, blank-line runs
+    // collapsed (see core/markdown-spacing.ts). Wiki content pages only —
+    // log/schema writes pass through untouched.
+    if (this.isInWikiContentFolder(path, this.settings.wikiFolder)) {
+      content = normalizeHeadingSpacing(content);
     }
 
     for (let attempt = 0; attempt < 3; attempt++) {


### PR DESCRIPTION
Generated pages often come out of the model with a heading glued to its first content line (`## Definition\nText …`), and assembly can leave runs of blank lines (for example three between the frontmatter block and the H1). Both render fine in reading view, but the source view ends up inconsistent from page to page.

The spacing is pure syntax — machine-checkable — so this PR lets the write gate own it instead of asking the model to be tidy. `createOrUpdateFile` now normalizes wiki content pages before writing:

1. exactly one blank line after every ATX heading, and
2. runs of two or more blank lines collapsed to one.

The YAML frontmatter block and fenced code blocks pass through untouched, and the function is idempotent (already-normalized content is returned by reference, so no-ops are cheap to detect). The check is scoped with `isInWikiContentFolder`, so `log.md` and other non-content writes are not affected.

Observed on a live rebuild: 14 of 24 freshly generated pages carried at least one glued heading or a blank-line run; after normalization the set is uniform. Covered by 7 unit tests; full suite, typecheck and lint green.