### PR TITLE
fix(ingest): a cancelled ingest must not read as a completed one — trash the summary page on abort

### DIFF
--- a/src/__tests__/__support__/wiki-engine-harness.ts
+++ b/src/__tests__/__support__/wiki-engine-harness.ts
@@ -31,6 +31,8 @@ export interface WikiEngineHarness {
   stats: { llmCalls: number; vaultMarkdownScans: number };
   /** Filenames delivered to `onIngestionStart` (status-bar text hooks). */
   startedFilenames: string[];
+  /** Paths handed to fileManager.trashFile, in order. */
+  trashedPaths: string[];
   /** Progress messages delivered to `onProgress` (PDF "Reading PDF: …"). */
   progressMessages: string[];
 }
@@ -42,6 +44,9 @@ export interface HarnessOptions {
   /** Paths where getAbstractFileByPath returns null despite the file existing.
    *  Simulates macOS NFC/NFD normalization mismatch (Issue #173 Symptom A). */
   nfcNfdPaths?: string[];
+  /** Invoked before every stubbed LLM call with the 0-based call index.
+   *  Throwing here simulates the SDK propagating an abort/failure mid-run. */
+  beforeLLMCall?: (callIndex: number) => void;
 }
 
 function mkFile(path: string): TFile {
@@ -61,6 +66,7 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
   const writtenPaths: string[] = [];
   const reports: IngestReport[] = [];
   const stats = { llmCalls: 0, vaultMarkdownScans: 0 };
+  const trashedPaths: string[] = [];
   let llmIdx = 0;
 
   const app = {
@@ -92,6 +98,12 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
       getMarkdownFiles: () => { stats.vaultMarkdownScans++; return [...files.keys()].filter(p => p.endsWith('.md')).map(mkFile); },
       getFiles: () => [...files.keys()].map(mkFile),
     },
+    fileManager: {
+      trashFile: async (f: { path: string }) => {
+        files.delete(f.path);
+        trashedPaths.push(f.path);
+      },
+    },
     metadataCache: {
       // Reflect stored frontmatter from the in-memory vault so content-hash
       // dedup (buildIngestedHashes) behaves like the real cached metadata.
@@ -106,6 +118,7 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
 
   const client: LLMClient = {
     createMessage: async params => {
+      opts.beforeLLMCall?.(stats.llmCalls);
       stats.llmCalls++;
       llmRequests.push(params);
       return opts.llmResponses?.[llmIdx++] ?? '{"entities":[],"concepts":[]}';
@@ -139,7 +152,7 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
     () => { /* onEnd: nothing to capture */ },
   );
 
-  return { engine, llmRequests, writtenPaths, reports, files, stats, startedFilenames, progressMessages };
+  return { engine, llmRequests, writtenPaths, reports, files, stats, startedFilenames, progressMessages, trashedPaths };
 }
 
 /** True if any written path is a wiki entity/concept/source page (the #164 symptom). */

--- a/src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts
+++ b/src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts
@@ -1,0 +1,93 @@
+// Cancelled ingest must not read as a completed one.
+//
+// The summary page doubles as the completion marker: isAlreadyIngested
+// checks its existence, and it is written in Stage 2 — before the content
+// pages, the index, and the log. A cancellation after Stage 2 therefore
+// used to leave a half-finished ingest that every later trigger skipped as
+// "already ingested", with the log and index blind to it. The fix trashes
+// the summary page in the AbortError branch so the next trigger re-ingests
+// the source cleanly.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+
+const SOURCE_NOTE_PATH = 'Notizen/act-note.md';
+
+function sourceFile(): TFile {
+  return Object.assign(new TFile(), {
+    path: SOURCE_NOTE_PATH,
+    name: 'act-note.md',
+    basename: 'act-note',
+    extension: 'md',
+  });
+}
+
+const ANALYSIS_RESPONSE = JSON.stringify({
+  source_title: 'ACT Note',
+  summary: 'Acceptance and Commitment Therapy.',
+  entities: [{ name: 'Steven Hayes', type: 'person', summary: 'founder', mentions_in_source: [] }],
+  concepts: [{ name: 'Psychological Flexibility', summary: 'core construct', mentions_in_source: [] }],
+  contradictions: [],
+  related_pages: [],
+  key_points: [],
+});
+
+const SUMMARY_RESPONSE = 'Auto-generated source page.\n\n## Zusammenfassung\n\nACT.';
+
+function summaryPageWritten(files: Map<string, string>): string | undefined {
+  return [...files.keys()].find(p => /(^|\/)sources\//.test(p) && p.endsWith('.md') && p !== SOURCE_NOTE_PATH);
+}
+
+describe('WikiEngine.ingestSource — cancellation removes the completion marker', () => {
+  async function cancelledRun() {
+    // The real cancel is a flag: cancelIngestion() aborts the controller and
+    // the next checkCancelled() checkpoint (before each Stage-3/4 batch)
+    // throws the AbortError. The hook flips the flag on the first LLM call
+    // after the summary page exists — i.e. mid Stage 3, exactly where a
+    // user-clicked cancel lands in practice.
+    let h: ReturnType<typeof createWikiEngineHarness> | null = null;
+    h = createWikiEngineHarness({
+      files: { [SOURCE_NOTE_PATH]: '# ACT\n\nBody text.' },
+      llmResponses: [ANALYSIS_RESPONSE, SUMMARY_RESPONSE],
+      beforeLLMCall: () => {
+        if (h && summaryPageWritten(h.files)) h.engine.cancelIngestion();
+      },
+    });
+    await h.engine.ingestSource(sourceFile());
+    return h;
+  }
+
+  it('trashes the summary page so the source re-ingests on the next trigger', async () => {
+    const h = await cancelledRun();
+
+    expect(h.trashedPaths).toHaveLength(1);
+    expect(h.trashedPaths[0]).toMatch(/(^|\/)sources\//);
+    expect(summaryPageWritten(h.files)).toBeUndefined();
+  });
+
+  it('reports cancelled without listing the removed summary page as created', async () => {
+    const h = await cancelledRun();
+
+    expect(h.reports).toHaveLength(1);
+    const report = h.reports[0];
+    expect(report.cancelled).toBe(true);
+    expect(report.success).toBe(false);
+    expect(report.createdPages.some(p => /(^|\/)sources\//.test(p))).toBe(false);
+  });
+
+  it('a cancellation before Stage 2 trashes nothing', async () => {
+    let h: ReturnType<typeof createWikiEngineHarness> | null = null;
+    h = createWikiEngineHarness({
+      files: { [SOURCE_NOTE_PATH]: '# ACT\n\nBody text.' },
+      llmResponses: [ANALYSIS_RESPONSE],
+      // Cancel during the very first call: the post-Stage-1 checkpoint
+      // throws before any summary page exists.
+      beforeLLMCall: () => { h?.engine.cancelIngestion(); },
+    });
+    await h.engine.ingestSource(sourceFile());
+
+    expect(h.trashedPaths).toHaveLength(0);
+    expect(h.reports[0]?.cancelled).toBe(true);
+  });
+});

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -995,6 +995,9 @@ export class WikiEngine {
 
     const failedItems: Array<{ type: 'entity' | 'concept'; name: string; reason: string }> = [];
     let analysis: SourceAnalysis | null = null;
+    // Path of the summary page written in Stage 2, tracked outside the try so
+    // the cancellation path can remove it — see the AbortError branch below.
+    let summaryPagePath: string | null = null;
 
     try {
       await this.ensureWikiStructure();
@@ -1082,6 +1085,7 @@ export class WikiEngine {
       const summaryTime = Date.now() - summaryStart;
       console.debug(`[Time] Summary page generation: ${summaryTime}ms`);
       analysis.created_pages.push(summaryPage);
+      summaryPagePath = summaryPage;
 
       // Stage 3: Entity/Concept Page Generation
       // v1.25.1 Phase C-PR1: retry + rate-limit template extracted to
@@ -1334,13 +1338,30 @@ export class WikiEngine {
       if (error instanceof DOMException && error.name === 'AbortError') {
         this.wasCancelled = true;
         console.debug('=== Ingestion cancelled by user ===');
+
+        // A cancelled ingest must not read as a completed one: the summary
+        // page doubles as the completion marker (isAlreadyIngested checks its
+        // existence), so leaving it behind freezes the half-finished ingest as
+        // done and every later trigger skips the source. Trash it — the next
+        // trigger then re-ingests cleanly. Content pages stay: a re-ingest
+        // merges them additively.
+        if (summaryPagePath) {
+          try {
+            await this.deleteFile(summaryPagePath);
+            console.debug('Cancelled ingest: removed summary page so the source re-ingests:', summaryPagePath);
+          } catch (cleanupError) {
+            console.warn('Cancelled ingest: could not remove summary page:', summaryPagePath, cleanupError);
+          }
+        }
+        const reportedCreated = createdPages.filter(p => p !== summaryPagePath);
+
         new Notice(getText(this.settings.language, 'ingestionCancelled'), NOTICE_NORMAL);
         this.onDone?.({
           sourceFile: file.path,
-          createdPages,
+          createdPages: reportedCreated,
           updatedPages: analysis?.updated_pages || [],
-          entitiesCreated: createdPages.filter(p => p.includes('/entities/')).length,
-          conceptsCreated: createdPages.filter(p => p.includes('/concepts/')).length,
+          entitiesCreated: reportedCreated.filter(p => p.includes('/entities/')).length,
+          conceptsCreated: reportedCreated.filter(p => p.includes('/concepts/')).length,
           failedItems,
           contradictionsFound: analysis?.contradictions?.length || 0,
           success: false,


### PR DESCRIPTION
Fixes #582.

The summary page doubles as the completion marker: it is written in Stage 2, and `isAlreadyIngested` checks its existence. A cancellation after Stage 2 therefore froze the half-finished ingest as "done" — later triggers skipped the source, while `log.md` and `index.md` (Stage 6) never learned about the pages that were written.

This PR makes the `AbortError` branch trash the summary page (via the existing `deleteFile`, so it goes to the trash and stays recoverable). Its absence re-arms the existing re-ingest mechanism; content pages written before the cancel stay, since a re-ingest merges them additively. The cancel report no longer lists the removed page as created.

Three unit tests cover the mid-Stage-3 cancel (page trashed, report filtered) and the pre-Stage-2 cancel (nothing to trash). The test harness gained a `fileManager.trashFile` mock and an optional `beforeLLMCall` hook — both additive.

One adjacent observation, out of scope here: a cancel that lands while the Stage-1 LLM call is in flight surfaces as a generic connection error rather than as a cancellation, because `analyzeSource` wraps every error into its connection-hint message. Worth a separate look.