### PR TITLE
fix(llm-sdk): don't launder a runaway think into page content — gate the reasoning prepend on the #470 predicate

### DIFF
--- a/src/__tests__/llm-sdk/openai-compat-sdk-client.test.ts
+++ b/src/__tests__/llm-sdk/openai-compat-sdk-client.test.ts
@@ -293,6 +293,53 @@ describe('OpenAICompatSdkClient', () => {
       expect(text).toContain('"name":"A"');
     });
 
+    // S143: the prepend rescue is for answers that arrived through the
+    // reasoning channel (finish=stop). A think that ran into the token limit
+    // with empty content never produced an answer — prepending it would
+    // launder the runaway reasoning into a "valid" response that downstream
+    // merges into wiki pages (observed: 7 pages with 30K-char English
+    // think-plans as body). The #470 guard must fire instead.
+    it('createMessage: does NOT launder a runaway think (empty content at length)', async () => {
+      mockGenerateText.mockReset();
+      const runaway = {
+        ...(makeResultWithReasoning('', '*   Target: Update the "Burnout" wiki page…') as object),
+        finishReason: 'length',
+        usage: { inputTokens: 9000, outputTokens: 32767, totalTokens: 41767, reasoningTokens: 32765, cachedInputTokens: undefined },
+      } as Awaited<ReturnType<typeof generateText>>;
+      mockGenerateText.mockResolvedValue(runaway);
+      const client = new OpenAICompatSdkClient({
+        apiKey: 'sk-test',
+        baseURL: 'http://localhost:1234/v1',
+        provider: 'lmstudio',
+      });
+      await expect(client.createMessage({
+        model: 'gemma-4-26b',
+        max_tokens: 32767,
+        messages: [{ role: 'user', content: 'merge' }],
+      })).rejects.toThrow(/max_tokens/);
+    });
+
+    it('createMessageWithOutput: same runaway gate on the typed path', async () => {
+      mockGenerateText.mockReset();
+      const runaway = {
+        ...(makeResultWithReasoning('', 'endless format rumination…') as object),
+        finishReason: 'length',
+        usage: { inputTokens: 9000, outputTokens: 16000, totalTokens: 25000, reasoningTokens: 15997, cachedInputTokens: undefined },
+      } as Awaited<ReturnType<typeof generateText>>;
+      mockGenerateText.mockResolvedValue(runaway);
+      const client = new OpenAICompatSdkClient({
+        apiKey: 'sk-test',
+        baseURL: 'http://localhost:1234/v1',
+        provider: 'lmstudio',
+      });
+      await expect(client.createMessageWithOutput({
+        model: 'gemma-4-26b',
+        max_tokens: 16000,
+        messages: [{ role: 'user', content: 'analyze' }],
+        response_format: { type: 'json_object', schema: {} },
+      })).rejects.toThrow(/reasoning/);
+    });
+
     it('does NOT prepend when reasoning is empty (cloud providers unaffected)', async () => {
       mockGenerateText.mockReset();
       mockGenerateText.mockResolvedValue(

--- a/src/llm-sdk/finish-reason.ts
+++ b/src/llm-sdk/finish-reason.ts
@@ -116,20 +116,41 @@ export function extractReasoningText(reasoning: unknown): string {
  *     provider to have said what the tokens went to; without it, "empty at
  *     length" is just truncation, which is #305's signal, not this one.
  */
+/**
+ * S143: the predicate of assertNotReasoningOnly, reusable BEFORE the
+ * reasoning-channel prepend. When it holds, the reasoning is a runaway think
+ * that never reached the answer — prepending it would hand 30K chars of
+ * reasoning prose to markdown-consuming callers (merge/create), which have
+ * no parse gate and write it into pages. Callers skip the prepend so the
+ * assert below sees the empty answer and throws. When the provider reports
+ * no reasoning breakdown, this stays false and the legacy prepend applies
+ * (#544: a truncated JSON in the reasoning channel still reaches the
+ * parse-and-retry path downstream).
+ */
+export function isReasoningRunaway(
+  text: string,
+  raw: unknown,
+  usage: LLMUsage | undefined,
+): boolean {
+  if (text.trim().length > 0) return false;
+  if (normalizeFinishReason(raw) !== 'length') return false;
+  const outputTokens = usage?.outputTokens ?? 0;
+  const reasoningTokens = usage?.reasoningTokens;
+  if (reasoningTokens === undefined || outputTokens <= 0) return false;
+  return reasoningTokens / outputTokens >= 0.5;
+}
+
 export function assertNotReasoningOnly(
   text: string,
   raw: unknown,
   usage: LLMUsage | undefined,
 ): void {
-  if (text.trim().length > 0) return;
-  if (normalizeFinishReason(raw) !== 'length') return;
+  if (!isReasoningRunaway(text, raw, usage)) return;
   const outputTokens = usage?.outputTokens ?? 0;
   const reasoningTokens = usage?.reasoningTokens;
-  if (reasoningTokens === undefined || outputTokens <= 0) return;
-  if (reasoningTokens / outputTokens < 0.5) return;
   throw new Error(
     `The model returned empty content after spending ${reasoningTokens} of `
     + `${outputTokens} output tokens on reasoning. Disable thinking for this `
-    + `model, or raise the token limit so the answer fits after it.`,
+    + `model, or raise the token limit (max_tokens) so the answer fits after it.`,
   );
 }

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -39,7 +39,7 @@ import {
 import { TokenKeyProber } from './token-key-probe';
 import { ReasoningStripProber } from './reasoning-strip-probe';
 import { OutputModeProber, type OutputMode } from './output-mode-prober';
-import { assertNotReasoningOnly, normalizeUsage, reportFinish, extractReasoningText } from './finish-reason';
+import { assertNotReasoningOnly, isReasoningRunaway, normalizeUsage, reportFinish, extractReasoningText } from './finish-reason';
 import { buildSamplingArgs } from './sampling-args';
 import { buildOutputArgs } from './output-args';
 import { JSON_ENFORCEMENT_SYSTEM_PREFIX, forcedTextPromptSystem } from './json-prompt-prefix';
@@ -374,13 +374,20 @@ export class OpenAICompatSdkClient implements LLMClient {
       } catch {
         /* No reasoning field on this provider. */
       }
+      // S143: the reasoning-channel rescue below exists for backends that put
+      // the ANSWER into `reasoning_content`. When the usage says the budget
+      // went to reasoning and content is empty at `length`, the reasoning is
+      // a runaway think, not an answer — skip the prepend so the #470 assert
+      // sees the empty answer and throws (see isReasoningRunaway).
+      const usage = normalizeUsage(result.usage);
       const finalText = reasoningContent
+          && !isReasoningRunaway(result.text, result.finishReason, usage)
         ? prependReasoningForParse(reasoningContent, result.text)
         : result.text;
       // Issue #470: empty answer + `length` + the budget spent on reasoning is
       // a thinking-control failure, not a parse failure. Checked on finalText
       // so the reasoning-channel prepend above counts as content.
-      assertNotReasoningOnly(finalText, result.finishReason, normalizeUsage(result.usage));
+      assertNotReasoningOnly(finalText, result.finishReason, usage);
       return finalText;
     } catch (err) {
       // v1.26.3 PATCH Path 2 fix (DocTpoint CHANGES_REQUESTED
@@ -939,10 +946,12 @@ export class OpenAICompatSdkClient implements LLMClient {
       } catch {
         /* No reasoning field on this provider. */
       }
+      // S143: same runaway gate as the plain path — see createMessage.
+      const usage = normalizeUsage(result.usage);
       const text = reasoningContent
+          && !isReasoningRunaway(result.text, result.finishReason, usage)
         ? prependReasoningForParse(reasoningContent, result.text)
         : result.text;
-      const usage = normalizeUsage(result.usage);
       recoveredText = text;
       recoveredUsage = usage;
       recoveredFinishReason = result.finishReason;


### PR DESCRIPTION
Closes #584.

The #443 prepend exists for backends that put the answer into `reasoning_content`. A think that ran into the token limit with empty content is the opposite case: there is no answer. Prepending it hands 30K characters of reasoning prose to markdown-consuming callers (merge-body, page-generate), which have no parse gate and write it into pages — observed on 7 pages in one ingest (details in #584).

Changes:

- `isReasoningRunaway` in `finish-reason.ts` — the `assertNotReasoningOnly` predicate, extracted so the prepend gate and the assert share one definition. The assert now delegates to it.
- Both prepend sites in `openai-compat-sdk-client.ts` skip the prepend when the predicate holds; the #470 assert then sees the empty answer and throws, so the caller gets a visible failure instead of corrupted content.
- The assert message now names `max_tokens`, so `source-analyzer`'s truncation predicate routes the throw into the existing halve-and-retry lane instead of a terminal batch failure.
- Calls without a reasoning breakdown in `usage` keep the current prepend — the #544 recovery contract (truncated JSON in the reasoning channel) is untouched, and its test still passes.

Tests: two new cases (plain and typed path) asserting the runaway is refused; 82/82 in the two touched llm-sdk suites, typecheck and lint clean.
