### PR TITLE
fix(ingest): the truncation retry must raise max_tokens toward retryCap, not only halve the batch

### DIFF
--- a/src/__tests__/wiki/source-analyzer-truncation-retry.test.ts
+++ b/src/__tests__/wiki/source-analyzer-truncation-retry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { createMockContext, createMockFile } from '../__support__/engine-context';
 import { SourceAnalyzer } from '../../wiki/source-analyzer';
 import { normalizeFinishReason } from '../../llm-sdk/finish-reason';
+import { SOURCE_ANALYZER_RETRY_MULTIPLIER } from '../../constants';
 import type { LLMClient, LLMFinishReason } from '../../types';
 import { TFile } from 'obsidian';
 
@@ -50,9 +51,11 @@ function scriptedClient(replies: ScriptedReply[], opts: { repair?: (broken: stri
   client: LLMClient;
   prompts: string[];
   repairPrompts: string[];
+  maxTokens: number[];
 } {
   const prompts: string[] = [];
   const repairPrompts: string[] = [];
+  const maxTokens: number[] = [];
   let idx = 0;
   let lastText = '';
   const client: LLMClient = {
@@ -64,6 +67,7 @@ function scriptedClient(replies: ScriptedReply[], opts: { repair?: (broken: stri
         return opts.repair ? opts.repair(lastText) : lastText;
       }
       prompts.push(prompt);
+      maxTokens.push(params.max_tokens as number);
       const reply = replies[idx++];
       if (!reply) throw new Error(`unscripted extraction call #${idx}`);
       if (reply.finishReason) params.onFinish?.({ finishReason: reply.finishReason });
@@ -71,7 +75,7 @@ function scriptedClient(replies: ScriptedReply[], opts: { repair?: (broken: stri
       return reply.text;
     },
   };
-  return { client, prompts, repairPrompts };
+  return { client, prompts, repairPrompts, maxTokens };
 }
 
 function analyzerWith(client: LLMClient): SourceAnalyzer {
@@ -113,6 +117,23 @@ describe('SourceAnalyzer truncation retry (#305)', () => {
     const mainPrompts = prompts.filter(p => batchSizeOf(p) !== null);
     expect(mainPrompts.length).toBeGreaterThanOrEqual(2);
     expect(batchSizeOf(mainPrompts[1])!).toBeLessThan(batchSizeOf(mainPrompts[0])!);
+  });
+
+  it('raises max_tokens to the retry cap on the truncation retry', async () => {
+    // S143: a reasoning model can spend the entire budget thinking, so the
+    // retry must offer more room — halving only lowers the item ceiling in
+    // the prompt, which cannot shorten a think-phase that never reached the
+    // items.
+    const { client, maxTokens } = scriptedClient([
+      { text: TRUNCATED, finishReason: 'length' },
+      { text: VALID, finishReason: 'stop' },
+    ]);
+
+    const result = await run(analyzerWith(client));
+
+    expect(result).not.toBeNull();
+    expect(maxTokens.length).toBeGreaterThanOrEqual(2);
+    expect(maxTokens[1]).toBe(maxTokens[0] * SOURCE_ANALYZER_RETRY_MULTIPLIER);
   });
 
   it('does not retry when the parse failed for a reason other than truncation', async () => {

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -214,6 +214,13 @@ export class SourceAnalyzer {
     let currentBatchSize = limits.initialBatchSize;
     let batchSizeHalved = false;
     let retryingBatch = false; // one retry on truncation: halve batch size
+    // S143: halving lowers only the item ceiling inside the prompt. A
+    // reasoning model that spent the whole budget thinking never reached the
+    // items, so a smaller ceiling cannot shorten the retry — and
+    // Math.max(baseMaxTokens, …) could only shrink the budget back to base.
+    // The retry must also raise the budget to retryCap, which until now was
+    // only ever passed as a ceiling nothing climbed toward.
+    let escalateMaxTokens = false;
     // v1.26.x PATCH follow-up (#443 LMStudio + Qwen3.5): a reasoning-mode
     // model under grammar constraint emits `{"": ""}` (minimum valid JSON
     // object) as a placeholder when its thinking budget is tight. The
@@ -241,7 +248,8 @@ export class SourceAnalyzer {
     const halveBatchAndRetry = (batchLabel: string, cause: string): boolean => {
       if (!canHalveBatch()) return false;
       currentBatchSize = Math.max(limits.minBatchSize, Math.floor(currentBatchSize * 0.5));
-      console.warn(`${batchLabel} Truncation detected (${cause}), halving batch size to ${currentBatchSize} and retrying`);
+      escalateMaxTokens = true;
+      console.warn(`${batchLabel} Truncation detected (${cause}), halving batch size to ${currentBatchSize} and raising max_tokens to ${retryCap} for the retry`);
       retryingBatch = true;
       return true;
     };
@@ -358,7 +366,9 @@ export class SourceAnalyzer {
       try {
         const systemPrompt = await this.ctx.buildSystemPrompt('analyze');
         // Scale max_tokens with current batch size to avoid truncation.
-        const batchMaxTokens = Math.max(baseMaxTokens, currentBatchSize * TOKENS_PER_ITEM_BUDGET);
+        const batchMaxTokens = escalateMaxTokens
+          ? retryCap
+          : Math.max(baseMaxTokens, currentBatchSize * TOKENS_PER_ITEM_BUDGET);
         // v1.24.0 #208: route through resolveModelForTask so the debug
         // log reflects the ACTUAL model used (per-task override), not
         // the unified setting. Without this, e2e verification of
@@ -563,6 +573,7 @@ export class SourceAnalyzer {
         // complete while missing that batch's items. Resetting here, on the
         // success path, gives each batch its own retry budget.
         retryingBatch = false;
+        escalateMaxTokens = false;
 
         const { validity, data: norm } = normalizeBatchResponse(analysisData);
 
@@ -691,6 +702,7 @@ export class SourceAnalyzer {
           continue;
         }
         retryingBatch = false;
+        escalateMaxTokens = false;
         console.warn(`[Batch ${batchNum + 1}] Non-first-round failure, keeping extracted items`);
         break;
       }


### PR DESCRIPTION
`retryCap` (3× base, from `SOURCE_ANALYZER_RETRY_MULTIPLIER`) is computed and passed only as the `maxTokensPerCall` ceiling — nothing ever requests it. On `finish_reason: length` the #305 retry halves the batch size, but that changes almost nothing on the wire: the prompt keeps its full text (only the item ceiling shrinks) and the `max_tokens` formula can only fall back to base. A reasoning model that spent the whole budget thinking re-enters an essentially identical draw.

Observed with LM Studio + Gemma (thinking on, `text_prompt`): first call `finish=length` with `reasoning_tokens` 15997 of 15999; the halved retry failed identically, four times out of four across two runs. With this change the retry requests `retryCap`, and the same batch completed whenever the draw finished thinking at all.

One honest limit: LM Studio caps a single generation at 32768 output tokens, so a `retryCap` above that is not reachable there — the escalation still triples the effective room (16k → 32k).

Changes: an `escalateMaxTokens` flag with the same lifecycle as `retryingBatch` (set on the truncation retry, reset once a batch parses); a test asserting the retry call requests `retryCap`. 44/44 in the two analyzer suites, typecheck and lint clean.

Related context: #584 is the write-side hole for the same runaway class; this PR is about giving the retry a real chance before that point.
