### PR TITLE
fix(dedup): route cross-folder designators through the semantic call — the folder never decides (#588)

### DIFF
--- a/src/__tests__/core/conflict-resolver.test.ts
+++ b/src/__tests__/core/conflict-resolver.test.ts
@@ -155,3 +155,32 @@ describe('ConflictResolver — ambiguous designators', () => {
     expect(second.candidates).toHaveLength(2);
   });
 });
+
+describe('ConflictResolver — cross-folder claims (#472 both ways)', () => {
+  it('reports an opposite-folder title claim on a create', () => {
+    const r = new ConflictResolver(WIKI_FOLDER, pages(['concepts/Stress.md']));
+    const result = r.resolve({ name: 'Stress', slug: 'Stress', pageType: 'entity' });
+    // The claim never decides: the action stays 'create', the caller routes it.
+    expect(result.action).toBe('create');
+    expect(result.targetPath).toBe('wiki/entities/Stress.md');
+    expect(result.crossFolderCandidates?.map(p => p.path)).toEqual(['wiki/concepts/Stress.md']);
+  });
+
+  it('reports an opposite-folder alias claim alongside a same-type merge', () => {
+    const r = new ConflictResolver(WIKI_FOLDER, [
+      { path: 'wiki/concepts/Koronare-Herzkrankheit.md', title: 'Koronare-Herzkrankheit', aliases: ['KHK'] },
+      { path: 'wiki/entities/Ketohexokinase.md', title: 'Ketohexokinase', aliases: ['KHK'] },
+    ]);
+    const result = r.resolve({ name: 'KHK', slug: 'KHK', pageType: 'concept' });
+    expect(result.action).toBe('merge');
+    expect(result.targetPath).toBe('wiki/concepts/Koronare-Herzkrankheit.md');
+    expect(result.crossFolderCandidates?.map(p => p.path)).toEqual(['wiki/entities/Ketohexokinase.md']);
+  });
+
+  it('reports no cross-folder field when the opposite folder is silent', () => {
+    const r = new ConflictResolver(WIKI_FOLDER, pages(['entities/foo.md', 'concepts/bar.md']));
+    const result = r.resolve({ name: 'Foo', slug: 'foo', pageType: 'entity' });
+    expect(result.action).toBe('merge');
+    expect(result.crossFolderCandidates).toBeUndefined();
+  });
+});

--- a/src/__tests__/schema/task-sections-delivery.test.ts
+++ b/src/__tests__/schema/task-sections-delivery.test.ts
@@ -130,7 +130,13 @@ describe('TASK_SECTIONS delivery matrix (#491 — oversight reading)', () => {
       'Naming Conventions',
       'Classification Rules',
     ]);
-    expect(headingsOf(await mgr.getSchemaContext('index'))).toEqual(['Wiki Structure']);
+    // 'index' feeds the semantic dedup, which re-decides the entity/concept
+    // classification on a cross-folder match — the user's Classification
+    // Rules are the ruler for that decision.
+    expect(headingsOf(await mgr.getSchemaContext('index'))).toEqual([
+      'Wiki Structure',
+      'Classification Rules',
+    ]);
     expect(headingsOf(await mgr.getSchemaContext('lint'))).toEqual(['Maintenance Policies']);
   });
 

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -291,8 +291,11 @@ describe('resolvePagePath — LLM semantic dedup fallback', () => {
   });
 });
 
-describe('resolvePagePath — the opposite type is a different designator (#472)', () => {
-  it('creates in its own folder when only the opposite folder holds the name', async () => {
+describe('resolvePagePath — a cross-folder designator goes to the semantic call (#472 both ways)', () => {
+  // No client: nothing can decide the cross-folder question, so the page is
+  // created in its own folder. The twin is the visible failure; a merge across
+  // the folder without a decision would be the silent one.
+  it('creates in its own folder when only the opposite folder holds the name and no client can decide', async () => {
     const ctx = makeCtx({
       files: {
         'wiki/concepts/Cross.md': '# concept exists',
@@ -300,5 +303,94 @@ describe('resolvePagePath — the opposite type is a different designator (#472)
     });
     const result = await resolvePagePath(ctx, 'Cross', 'entity', 'desc');
     expect(result.path).toBe('wiki/entities/Cross.md');
+  });
+
+  const twinVault = {
+    files: {
+      'wiki/concepts/Stress.md': '---\ntitle: Stress\n---\n\n# the concept page',
+    },
+    mockVault: {
+      getMarkdownFiles: () => [{ path: 'wiki/concepts/Stress.md', basename: 'Stress' }],
+    },
+  };
+
+  it('shows the opposite-folder page to the model and merges into it on a confirmed match', async () => {
+    let prompt = '';
+    const ctx = makeCtx({
+      ...twinVault,
+      client: {
+        createMessage: async (args: unknown) => {
+          prompt = (args as { messages: Array<{ content: string }> }).messages[0].content;
+          return JSON.stringify({ match: true, path: 'wiki/concepts/Stress.md' });
+        },
+      },
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'chronic load reaction');
+    expect(result.path).toBe('wiki/concepts/Stress.md');
+    expect(prompt).toContain('wiki/concepts/Stress.md');
+  });
+
+  it('creates the page in its own folder when the model says the referents differ', async () => {
+    const ctx = makeCtx({
+      ...twinVault,
+      client: { createMessage: async () => JSON.stringify({ match: false }) },
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'mechanical stress on materials');
+    expect(result.path).toBe('wiki/entities/Stress.md');
+  });
+
+  // The measured twins include pairs born seconds apart from one note: the
+  // second item resolved before the page index listed the first item's page.
+  // The direct file probe is the backstop for exactly that window.
+  it('reaches the semantic call even when the page index does not list the opposite page yet', async () => {
+    const ctx = makeCtx({
+      files: { 'wiki/concepts/Stress.md': '---\ntitle: Stress\n---\n\n# just written' },
+      // mockVault default: getMarkdownFiles() returns [] — the index lags.
+      client: {
+        createMessage: async () => JSON.stringify({ match: true, path: 'wiki/concepts/Stress.md' }),
+      },
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'chronic load reaction');
+    expect(result.path).toBe('wiki/concepts/Stress.md');
+  });
+
+  // #472's damaging case: the designator lives in BOTH folders with different
+  // meanings. The deterministic same-type match must not stand unquestioned —
+  // the model sees both sides and may move the item across the folder.
+  const khkVault = {
+    files: {
+      'wiki/concepts/Koronare-Herzkrankheit.md': '---\naliases:\n  - KHK\n---\nheart disease',
+      'wiki/entities/Ketohexokinase.md': '---\naliases:\n  - KHK\n---\nthe enzyme',
+    },
+    mockVault: {
+      getMarkdownFiles: () => [
+        { path: 'wiki/concepts/Koronare-Herzkrankheit.md', basename: 'Koronare-Herzkrankheit' },
+        { path: 'wiki/entities/Ketohexokinase.md', basename: 'Ketohexokinase' },
+      ],
+    },
+  };
+
+  it('routes a same-type alias merge to the model when the opposite folder also claims the designator', async () => {
+    let prompt = '';
+    const ctx = makeCtx({
+      ...khkVault,
+      client: {
+        createMessage: async (args: unknown) => {
+          prompt = (args as { messages: Array<{ content: string }> }).messages[0].content;
+          return JSON.stringify({ match: true, path: 'wiki/entities/Ketohexokinase.md' });
+        },
+      },
+    });
+    const result = await resolvePagePath(ctx, 'KHK', 'concept', 'fructose-metabolizing enzyme');
+    expect(result.path).toBe('wiki/entities/Ketohexokinase.md');
+    // Both claimants lead the rendered list.
+    expect(prompt).toContain('wiki/concepts/Koronare-Herzkrankheit.md');
+    expect(prompt).toContain('wiki/entities/Ketohexokinase.md');
+  });
+
+  it('keeps the deterministic same-type target when no client can decide the both-folders case', async () => {
+    const ctx = makeCtx({ ...khkVault, client: null });
+    const result = await resolvePagePath(ctx, 'KHK', 'concept', 'fructose-metabolizing enzyme');
+    expect(result.path).toBe('wiki/concepts/Koronare-Herzkrankheit.md');
   });
 });

--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -394,3 +394,112 @@ describe('resolvePagePath — a cross-folder designator goes to the semantic cal
     expect(result.path).toBe('wiki/concepts/Koronare-Herzkrankheit.md');
   });
 });
+
+describe('resolvePagePath — a cross-folder match re-decides the classification', () => {
+  // The matched page's folder is the first ingest's draw; the dedup call
+  // answers the classification question against the Classification Rules and
+  // the page moves when the answer disagrees with its address. The move is
+  // link-safe (fileManager.renameFile); the decision is ratcheted with
+  // `type_confirmed: true` so it is taken at most once per page.
+  function makeMovableCtx(opts: {
+    files: Record<string, string>;
+    indexed: string[];
+    reply: Record<string, unknown>;
+    withRename?: boolean;
+  }) {
+    const renamed: Array<[string, string]> = [];
+    const ctx = makeCtx({
+      files: opts.files,
+      mockVault: {
+        getMarkdownFiles: () =>
+          opts.indexed.map(p => ({ path: p, basename: p.split('/').pop()!.replace('.md', '') })),
+      },
+      client: { createMessage: async () => JSON.stringify(opts.reply) },
+    });
+    const app = ctx.app as Record<string, unknown>;
+    (app.vault as Record<string, unknown>).getAbstractFileByPath = (p: string) =>
+      ctx.written.has(p) ? { path: p } : null;
+    if (opts.withRename !== false) {
+      app.fileManager = {
+        renameFile: async (file: { path: string }, newPath: string) => {
+          renamed.push([file.path, newPath]);
+          ctx.written.set(newPath, ctx.written.get(file.path)!);
+          ctx.written.delete(file.path);
+        },
+      };
+    }
+    return { ctx, renamed };
+  }
+
+  it('moves the matched page when the decided classification disagrees with its folder', async () => {
+    const { ctx, renamed } = makeMovableCtx({
+      files: { 'wiki/concepts/Stress.md': '---\ntype: concept\ncreated: 2026-08-31\n---\n\nbody' },
+      indexed: ['wiki/concepts/Stress.md'],
+      reply: { match: true, path: 'wiki/concepts/Stress.md', classification: 'entity' },
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'the hormone-level state');
+    expect(result.path).toBe('wiki/entities/Stress.md');
+    expect(renamed).toEqual([['wiki/concepts/Stress.md', 'wiki/entities/Stress.md']]);
+    const moved = ctx.written.get('wiki/entities/Stress.md')!;
+    expect(moved).toContain('type: entity');
+    expect(moved).toContain('type_confirmed: true');
+    // Untouched fields survive the line-based update.
+    expect(moved).toContain('created: 2026-08-31');
+  });
+
+  it('confirms in place when the decided classification agrees with the folder', async () => {
+    const { ctx, renamed } = makeMovableCtx({
+      files: { 'wiki/concepts/Stress.md': '---\ntype: concept\n---\n\nbody' },
+      indexed: ['wiki/concepts/Stress.md'],
+      reply: { match: true, path: 'wiki/concepts/Stress.md', classification: 'concept' },
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'desc');
+    expect(result.path).toBe('wiki/concepts/Stress.md');
+    expect(renamed).toEqual([]);
+    expect(ctx.written.get('wiki/concepts/Stress.md')).toContain('type_confirmed: true');
+  });
+
+  it('never re-decides a page whose classification is already confirmed', async () => {
+    const before = '---\ntype: concept\ntype_confirmed: true\n---\n\nbody';
+    const { ctx, renamed } = makeMovableCtx({
+      files: { 'wiki/concepts/Stress.md': before },
+      indexed: ['wiki/concepts/Stress.md'],
+      reply: { match: true, path: 'wiki/concepts/Stress.md', classification: 'entity' },
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'desc');
+    expect(result.path).toBe('wiki/concepts/Stress.md');
+    expect(renamed).toEqual([]);
+    expect(ctx.written.get('wiki/concepts/Stress.md')).toBe(before);
+  });
+
+  it('marks the conflict instead of moving when the target address is occupied', async () => {
+    const { ctx, renamed } = makeMovableCtx({
+      files: {
+        'wiki/concepts/Stress.md': '---\ntype: concept\naliases:\n  - Psychischer Stress\n---\n\nbody',
+        'wiki/entities/Stress.md': '---\ntype: entity\n---\n\nthe twin',
+      },
+      indexed: ['wiki/concepts/Stress.md', 'wiki/entities/Stress.md'],
+      reply: { match: true, path: 'wiki/concepts/Stress.md', classification: 'entity' },
+    });
+    const result = await resolvePagePath(ctx, 'Psychischer Stress', 'entity', 'desc');
+    expect(result.path).toBe('wiki/concepts/Stress.md');
+    expect(renamed).toEqual([]);
+    const marked = ctx.written.get('wiki/concepts/Stress.md')!;
+    expect(marked).toContain('type_conflict: entity');
+    // The question stays open for the run after the twin is healed.
+    expect(marked).not.toContain('type_confirmed');
+  });
+
+  it('marks the conflict when the host offers no link-safe rename', async () => {
+    const { ctx, renamed } = makeMovableCtx({
+      files: { 'wiki/concepts/Stress.md': '---\ntype: concept\n---\n\nbody' },
+      indexed: ['wiki/concepts/Stress.md'],
+      reply: { match: true, path: 'wiki/concepts/Stress.md', classification: 'entity' },
+      withRename: false,
+    });
+    const result = await resolvePagePath(ctx, 'Stress', 'entity', 'desc');
+    expect(result.path).toBe('wiki/concepts/Stress.md');
+    expect(renamed).toEqual([]);
+    expect(ctx.written.get('wiki/concepts/Stress.md')).toContain('type_conflict: entity');
+  });
+});

--- a/src/core/conflict-resolver.ts
+++ b/src/core/conflict-resolver.ts
@@ -46,6 +46,16 @@ export interface ConflictResolution {
    * resolves the same way on every page order.
    */
   candidates?: PageRef[];
+  /**
+   * Issue #472 both ways: opposite-folder pages whose title or alias carries
+   * this designator, ranked. They never decide — the folder can be wrong in
+   * either direction (a mis-typed extraction next to a same-referent page, or
+   * two genuinely different designators sharing letters), so the caller routes
+   * the resolution through the semantic dedup call with these pages in the
+   * candidate list instead of merging or creating deterministically. Set on
+   * any action when non-empty.
+   */
+  crossFolderCandidates?: PageRef[];
 }
 
 // ── Helpers ───────────────────────────────────────────────────────
@@ -111,19 +121,33 @@ export class ConflictResolver {
    */
   resolve(check: ConflictCheck): ConflictResolution {
     const folder = folderOf(check.pageType);
+    const oppositeFolder = folderOf(check.pageType === 'entity' ? 'concept' : 'entity');
     const sameTypePages = this.allPages.filter(p => p.path.includes(`/${folder}/`));
     const checkKey = check.slug.toLowerCase();
+
+    // Issue #472 both ways: pages in the opposite folder that carry the
+    // designator as title or alias. Detected here, decided nowhere — the
+    // resolution below attaches them so the caller can put the question to the
+    // semantic dedup call instead of trusting the extraction's typing.
+    const crossMatches = rankByTagOverlap(
+      this.allPages
+        .filter(p => p.path.includes(`/${oppositeFolder}/`))
+        .filter(p => slugMatchKeys(p).has(checkKey)),
+      check.tags,
+    );
+    const withCross = (r: ConflictResolution): ConflictResolution =>
+      crossMatches.length > 0 ? { ...r, crossFolderCandidates: crossMatches } : r;
 
     // 1. Same-type match: exact path match or slug/alias match
     const exactPath = `${this.wikiFolder}/${folder}/${check.slug}.md`;
     let match = sameTypePages.find(p => p.path === exactPath);
     if (match) {
-      return {
+      return withCross({
         action: 'merge',
         targetPath: match.path,
         confidence: 'high',
         reason: `Same-type exact path match: ${exactPath}`,
-      };
+      });
     }
     // Issue #446: a short designator is a title or an alias on more than one
     // page often enough to matter (23 of them in a 2838-page vault). `find`
@@ -133,31 +157,31 @@ export class ConflictResolver {
     const slugMatches = sameTypePages.filter(p => slugMatchKeys(p).has(checkKey));
     if (slugMatches.length === 1) {
       const only = slugMatches[0];
-      return {
+      return withCross({
         action: 'merge',
         targetPath: only.path,
         confidence: 'high',
         reason: `Same-type slug/alias match: title=${only.title} slug=${check.slug}`,
-      };
+      });
     }
     if (slugMatches.length > 1) {
       const ranked = rankByTagOverlap(slugMatches, check.tags);
-      return {
+      return withCross({
         action: 'disambiguate',
         targetPath: ranked[0].path,
         candidates: ranked,
         confidence: 'low',
         reason: `Ambiguous designator: ${ranked.length} same-type pages match slug=${check.slug} (${ranked.map(p => p.title).join(', ')})`,
-      };
+      });
     }
 
     // 2. No match — create new
-    return {
+    return withCross({
       action: 'create',
       targetPath: `${this.wikiFolder}/${folder}/${check.slug}.md`,
       confidence: 'high',
       reason: 'No conflict found',
-    };
+    });
   }
 
   // ── Interactive query helpers (for future use) ──────────────────

--- a/src/llm-sdk/output-schemas.ts
+++ b/src/llm-sdk/output-schemas.ts
@@ -292,6 +292,12 @@ export type SchemaSuggestionLLM = z.infer<typeof SchemaSuggestionLLMSchema>;
 export const PathResolutionLLMSchema = z.object({
   match: z.boolean().optional(),
   path: z.string().nullable().optional(),
+  // #472 both ways: on a cross-folder match the call also re-decides the
+  // entity/concept classification against the Classification Rules — the
+  // matched page's folder is the first ingest's draw, not a fact about the
+  // referent. Optional: only consumed when cross-folder candidates were
+  // seeded and the matched page's classification is not yet confirmed.
+  classification: z.enum(['entity', 'concept']).optional(),
 }).passthrough();
 export type PathResolutionLLM = z.infer<typeof PathResolutionLLMSchema>;
 

--- a/src/schema/schema-manager.ts
+++ b/src/schema/schema-manager.ts
@@ -125,7 +125,12 @@ const TASK_SECTIONS: Record<SchemaTask, string[]> = {
   concept: ['Concept Page Template', 'Naming Conventions', 'Classification Rules', 'Mentions Format', 'Content Rules'],
   related: ['Naming Conventions', 'Classification Rules'],
   conversation: ['Wiki Structure', 'Entity Page Template', 'Concept Page Template', 'Naming Conventions', 'Classification Rules'],
-  index: ['Wiki Structure'],
+  // 'index' has a single caller: the semantic dedup in
+  // page-factory/path-resolution.ts. Classification Rules ride along because
+  // that call now re-decides the entity/concept classification on a
+  // cross-folder match — the user's own definitions are the ruler for that
+  // decision, and this is the only way they reach it.
+  index: ['Wiki Structure', 'Classification Rules'],
   lint: ['Maintenance Policies'],
   merge: ['Entity Page Template', 'Concept Page Template', 'Naming Conventions', 'Classification Rules', 'Multi-Source Merge Rules', 'Date Fields'],
   full: ['Wiki Structure', 'Entity Page Template', 'Concept Page Template', 'Naming Conventions', 'Classification Rules', 'Maintenance Policies'],

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -32,6 +32,7 @@ import { normalizeLLMPath } from '../../core/prompt-builders';
 import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { appendAliases, aliasClaimsFromPages, type AliasesContext } from './aliases';
+import { parseFrontmatter } from '../../core/frontmatter';
 import { PathResolutionLLMSchema } from '../../llm-sdk/output-schemas';
 import { callLlm } from '../../core/llm-dispatch';
 
@@ -97,9 +98,11 @@ export interface PathResolutionContext extends AliasesContext {
  * Determine the actual file path for a new entity/concept, using slug-based
  * matching first and falling back to LLM semantic resolution.
  *
- * Issue #472: the opposite folder is never consulted. A page there carrying
- * the same letters is a different designator, so it can neither be a merge
- * target nor a reason to withhold this one.
+ * Issue #472 both ways: the opposite folder never decides deterministically.
+ * A cross-folder slug/alias claim routes the resolution through the semantic
+ * dedup call, which decides identity — and, on a confirmed cross-folder
+ * match, re-decides the entity/concept classification against the vault's
+ * Classification Rules (see `applyClassificationDecision`).
  */
 export async function resolvePagePath(
   ctx: PathResolutionContext,
@@ -305,16 +308,28 @@ export async function resolvePagePath(
       return { path: fallbackPath };
     }
 
-    const result = parsed.value as { match?: boolean; path?: string | null };
+    const result = parsed.value as {
+      match?: boolean;
+      path?: string | null;
+      classification?: string;
+    };
 
     if (result.match && result.path) {
       const normalizedPath = normalizeLLMPath(result.path, ctx.settings.wikiFolder);
       console.debug(`Entity resolution: "${name}" matched existing page "${normalizedPath}"`);
+      // On a cross-folder-routed match the reply also re-decided the
+      // entity/concept classification; act on it (possibly moving the page)
+      // before the alias append, which must target the final address.
+      let finalPath = normalizedPath;
+      if (crossCandidates.length > 0) {
+        finalPath = await applyClassificationDecision(ctx, normalizedPath, result.classification);
+      }
       // Append the new name as an alias to the existing page to prevent future
       // duplicates — through the same cross-page gate as the deterministic
-      // merge above (`allPages` is still in scope here).
-      await appendAliases(ctx, normalizedPath, [name], aliasClaimsFromPages(allPages, normalizedPath));
-      return { path: normalizedPath };
+      // merge above (`allPages` is still in scope here; the claims are
+      // computed against the pre-move address, the one `allPages` lists).
+      await appendAliases(ctx, finalPath, [name], aliasClaimsFromPages(allPages, normalizedPath));
+      return { path: finalPath };
     }
   } catch (error) {
     console.debug(`Entity resolution for "${name}" failed, using ${fallbackPath}:`, error);
@@ -325,4 +340,127 @@ export async function resolvePagePath(
   // name that is already an alias twice, so it resolves to the top-ranked
   // candidate instead. For every other call `fallbackPath` is `slugPath`.
   return { path: fallbackPath };
+}
+
+/**
+ * #472 both ways, second half: a cross-folder match re-decides the
+ * entity/concept classification once. The matched page's folder is the first
+ * ingest's draw — made from whatever context that call happened to have, on a
+ * page that may have been born from a passing mention — not a fact about the
+ * referent. The dedup call answers the classification question against the
+ * vault's Classification Rules (delivered via the 'index' schema context)
+ * with both summaries in view.
+ *
+ * Ratchet: the answer is written back as `type_confirmed: true`, so the
+ * question is asked at most once per page and the page cannot ping-pong
+ * between the folders on later draws. A page already confirmed keeps its
+ * address unconditionally.
+ *
+ * The move goes through `app.fileManager.renameFile`, which rewrites inbound
+ * links (Obsidian in production; a CLI host must provide the same contract).
+ * Deliberately NOT moved — and marked instead: when the decided folder
+ * differs but the target address is occupied (an existing twin: healing that
+ * is a merge, not a move) or the host offers no link-safe rename, the page
+ * gets `type_conflict: <classification>` in its frontmatter. The conflict is
+ * then a greppable artifact for a lint or a later pass, not a log line that
+ * scrolled away — and `type_confirmed` stays absent, so the question is
+ * re-asked once the obstacle is gone.
+ */
+async function applyClassificationDecision(
+  ctx: PathResolutionContext,
+  pagePath: string,
+  classification: string | undefined,
+): Promise<string> {
+  const content = await ctx.tryReadFile(pagePath);
+  if (!content) return pagePath;
+  // parseFrontmatter coerces only `reviewed` to a boolean; every other value
+  // stays a string, so the ratchet must accept both spellings.
+  const fm = parseFrontmatter(content);
+  if (fm && (fm.type_confirmed === true || fm.type_confirmed === 'true')) return pagePath;
+  if (classification !== 'entity' && classification !== 'concept') return pagePath;
+
+  const decidedFolder =
+    classification === 'entity' ? WIKI_SUBFOLDERS.entities : WIKI_SUBFOLDERS.concepts;
+  const currentFolder = pagePath.includes(`/${WIKI_SUBFOLDERS.entities}/`)
+    ? WIKI_SUBFOLDERS.entities
+    : WIKI_SUBFOLDERS.concepts;
+
+  if (decidedFolder === currentFolder) {
+    await writeTypeDecision(ctx, pagePath, content, { type: classification, confirmed: true });
+    return pagePath;
+  }
+
+  const newPath = pagePath.replace(`/${currentFolder}/`, `/${decidedFolder}/`);
+  if ((await ctx.tryReadFile(newPath)) !== null) {
+    console.debug(
+      `Entity resolution: "${pagePath}" is classified as ${classification} but ${newPath} already exists — marking the conflict, leaving both for a merge pass`,
+    );
+    await writeTypeDecision(ctx, pagePath, content, { conflict: classification });
+    return pagePath;
+  }
+
+  const app = ctx.app as {
+    vault?: { getAbstractFileByPath?: (p: string) => unknown };
+    fileManager?: { renameFile?: (file: unknown, newPath: string) => Promise<void> };
+  };
+  const file = app.vault?.getAbstractFileByPath?.(pagePath);
+  const rename = app.fileManager?.renameFile;
+  if (!file || !rename) {
+    console.debug(
+      `Entity resolution: "${pagePath}" is classified as ${classification} but the host offers no link-safe rename — marking the conflict, leaving the page in place`,
+    );
+    await writeTypeDecision(ctx, pagePath, content, { conflict: classification });
+    return pagePath;
+  }
+
+  await rename.call(app.fileManager, file, newPath);
+  const moved = await ctx.tryReadFile(newPath);
+  if (moved === null) {
+    console.error(
+      `Entity resolution: rename of "${pagePath}" to "${newPath}" reported success but the target is unreadable — resolving to the original path`,
+    );
+    return pagePath;
+  }
+  await writeTypeDecision(ctx, newPath, moved, { type: classification, confirmed: true });
+  console.debug(
+    `Entity resolution: moved "${pagePath}" → "${newPath}" per classification decision`,
+  );
+  return newPath;
+}
+
+/**
+ * Line-based frontmatter update in the appendAliases style: only the named
+ * lines change, everything else in the file is untouched. No-op on a page
+ * without frontmatter delimiters (corrupt file).
+ */
+async function writeTypeDecision(
+  ctx: PathResolutionContext,
+  pagePath: string,
+  content: string,
+  decision: { type?: 'entity' | 'concept'; confirmed?: boolean; conflict?: 'entity' | 'concept' },
+): Promise<void> {
+  const lines = content.split('\n');
+  if (lines[0]?.trim() !== '---') return;
+  const end = lines.indexOf('---', 1);
+  if (end === -1) return;
+
+  const upserts: Array<[RegExp, string]> = [];
+  if (decision.type) upserts.push([/^type:/, `type: ${decision.type}`]);
+  if (decision.confirmed) upserts.push([/^type_confirmed:/, 'type_confirmed: true']);
+  if (decision.conflict) upserts.push([/^type_conflict:/, `type_conflict: ${decision.conflict}`]);
+
+  const toInsert: string[] = [];
+  for (const [pattern, line] of upserts) {
+    let found = false;
+    for (let i = 1; i < end; i++) {
+      if (pattern.test(lines[i])) {
+        lines[i] = line;
+        found = true;
+        break;
+      }
+    }
+    if (!found) toInsert.push(line);
+  }
+  lines.splice(end, 0, ...toInsert);
+  await ctx.createOrUpdateFile(pagePath, lines.join('\n'));
 }

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -7,10 +7,14 @@
 //
 // Behavior (v1.24.1 Phase 2 refactor — preserved verbatim):
 //   - resolvePagePath: exact-slug fast path → ConflictResolver (same-type
-//     slug/alias match) → LLM semantic dedup fallback. Issue #472: matching is
-//     scoped to the item's own type throughout — a designator is `(letters,
-//     type)`, so the same letters in the opposite folder denote a different
-//     thing and are never consulted.
+//     slug/alias match) → LLM semantic dedup fallback. Issue #472 both ways:
+//     the opposite folder never decides deterministically — in neither
+//     direction. A cross-folder slug/alias hit routes the resolution through
+//     the semantic dedup call with that page in the candidate list: merging on
+//     it blindly mistakes a shared designator for a shared referent (the KHK
+//     case), ignoring it blindly mints a twin page whenever the extraction
+//     types the same referent differently across notes (measured: 18 twin
+//     pairs in one 83-note batch, every one the same referent).
 //   - buildPagesListForPrompt: filters out sources/ by default (#234) and
 //     polluted basenames (L2); caps at MAX_PAGES=50 with entity/concept
 //     bias based on includePaths; emits a "(truncated)" suffix when the cap
@@ -147,13 +151,39 @@ export async function resolvePagePath(
     const resolver = new ConflictResolver(ctx.settings.wikiFolder, allPages);
     const cr = resolver.resolve({ name, slug, pageType, tags });
 
+    // Issue #472 both ways: opposite-folder pages carrying the designator.
+    // The resolver reports slug/alias claims from the page index; the direct
+    // file probe backstops it for a page created moments ago in this same run
+    // that the index may not list yet — the measured twins include pairs born
+    // seconds apart from one note.
+    const oppositeFolder = pageType === 'entity' ? WIKI_SUBFOLDERS.concepts : WIKI_SUBFOLDERS.entities;
+    const oppositeSlugPath = `${ctx.settings.wikiFolder}/${oppositeFolder}/${slug}.md`;
+    const crossCandidates: DedupCandidatePage[] = [...(cr.crossFolderCandidates ?? [])];
+    if (
+      !crossCandidates.some(p => p.path === oppositeSlugPath) &&
+      (await ctx.tryReadFile(oppositeSlugPath)) !== null
+    ) {
+      crossCandidates.push({ path: oppositeSlugPath, title: name });
+    }
+
     if (cr.action === 'merge') {
-      // f9a680e's cross-page gate, fed for the first time: `allPages` is
-      // already in scope, so the name is only appended when no OTHER page's
-      // basename or alias claims it — a duplicated claim would silently merge
-      // every future occurrence of the name into whichever page matches first.
-      await appendAliases(ctx, cr.targetPath, [name], aliasClaimsFromPages(allPages, cr.targetPath));
-      return { path: cr.targetPath };
+      if (crossCandidates.length === 0) {
+        // f9a680e's cross-page gate, fed for the first time: `allPages` is
+        // already in scope, so the name is only appended when no OTHER page's
+        // basename or alias claims it — a duplicated claim would silently merge
+        // every future occurrence of the name into whichever page matches first.
+        await appendAliases(ctx, cr.targetPath, [name], aliasClaimsFromPages(allPages, cr.targetPath));
+        return { path: cr.targetPath };
+      }
+      // The designator lives in BOTH folders (#472's damaging case): the
+      // deterministic same-type match may be about something else entirely, so
+      // the question goes to the semantic call with both sides seeded. On
+      // no-decision the same-type target stands — that is the pre-existing
+      // behaviour, kept so a failure never crosses the folder on its own.
+      fallbackPath = cr.targetPath;
+      console.debug(
+        `Entity resolution: "${name}" matches ${cr.targetPath} but ${crossCandidates[0].path} also carries the designator — routing to semantic dedup`,
+      );
     }
 
     // Issue #446: more than one same-type page carries this designator. The
@@ -168,8 +198,27 @@ export async function resolvePagePath(
       console.debug(`Entity resolution: ${cr.reason}`);
     }
 
-    const sameTypePages = allPages
-      .filter(p => p.path.includes(`/${folder}/`))
+    // Pages that demonstrably carry the designator lead the rendered list:
+    // the same-type merge target when a cross-folder claim forced it here,
+    // the ranked ambiguous candidates, then the cross-folder claims. For a
+    // create-with-cross-claim the fallback stays `slugPath`: only a positive
+    // match from the model crosses the folder, a failure to decide creates the
+    // page in its own folder where the miss is at least visible as a twin.
+    const seeded: DedupCandidatePage[] = [
+      ...(cr.action === 'merge' ? allPages.filter(p => p.path === cr.targetPath) : []),
+      ...ambiguous,
+      ...crossCandidates,
+    ].filter((p, i, arr) => arr.findIndex(q => q.path === p.path) === i);
+
+    // Both wiki folders feed the window (#472 both ways): the folder is the
+    // extraction's guess, not a property of the referent, so a near-name twin
+    // in the opposite folder must be able to reach the model too.
+    const wikiPages = allPages
+      .filter(
+        p =>
+          p.path.includes(`/${WIKI_SUBFOLDERS.entities}/`) ||
+          p.path.includes(`/${WIKI_SUBFOLDERS.concepts}/`),
+      )
       .filter(p => {
         // Purge polluted entries from LLM input (L2)
         const bn = p.title || '';
@@ -186,14 +235,12 @@ export async function resolvePagePath(
     // Same-type slug/alias match is handled above by ConflictResolver.
     // Remaining path: LLM-based semantic dedup for pages that don't match by slug/alias.
 
-    if (sameTypePages.length === 0) return { path: slugPath };
+    if (wikiPages.length === 0 && seeded.length === 0) return { path: fallbackPath };
 
-    const selected = selectDedupCandidates(name, summary, sameTypePages);
+    const selected = selectDedupCandidates(name, summary, wikiPages);
     // The pages that actually carry the designator lead the list; the lexical
     // pre-filter supplies the rest as context.
-    const pagesList = (ambiguous.length > 0
-      ? [...ambiguous, ...selected.filter(p => !ambiguous.some(c => c.path === p.path))]
-      : selected)
+    const pagesList = [...seeded, ...selected.filter(p => !seeded.some(c => c.path === p.path))]
       .map(p => {
         const aliasBlock = p.aliases?.length
           ? `\n  aliases: ${p.aliases.join(', ')}`

--- a/src/wiki/prompts/ingestion.ts
+++ b/src/wiki/prompts/ingestion.ts
@@ -129,8 +129,10 @@ export const INGESTION_PROMPTS = {
 
 The list can hold pages from both the entities/ and the concepts/ folder. The folder does not decide identity: a page in the other folder is a match when it denotes the same thing (the folder reflects an earlier classification, which may differ for the same referent). But sharing a name is not identity either — an abbreviation can stand for two different things; match only when the summaries describe the same referent. Never match a page about a related, broader, narrower, or component thing — a relationship is not sameness.
 
+When you output a match, also output "classification": whether the referent itself is an entity or a concept under the Classification Rules in the system prompt. Judge this from the definitions alone — not from the folder the matched page currently sits in, which records an earlier call's guess.
+
 **Output JSON:**
-- If it matches an existing page, output: {"match": true, "path": "{{wikiFolder}}/entities/existing-slug.md"}
+- If it matches an existing page, output: {"match": true, "path": "{{wikiFolder}}/entities/existing-slug.md", "classification": "entity" or "concept"}
 - If no match exists, output: {"match": false, "path": null}
 
 Do NOT create a new name — only match against the existing pages listed above.`,

--- a/src/wiki/prompts/ingestion.ts
+++ b/src/wiki/prompts/ingestion.ts
@@ -113,7 +113,7 @@ export const INGESTION_PROMPTS = {
   // ~200 chars and forfeits the cache entirely.
   resolveEntityDedup: `You are an entity resolution engine. Given a newly extracted entity/concept and a list of existing wiki pages, determine if it is semantically equivalent to any existing page.
 
-**Existing {{page_type}} pages:**
+**Existing wiki pages (entities and concepts):**
 {{existing_pages}}
 
 **New entity/concept:**
@@ -126,6 +126,8 @@ export const INGESTION_PROMPTS = {
 - Abbreviations and full names (e.g. "MIT" = "Massachusetts Institute of Technology")
 - Alternative phrasings (e.g. "Supervised Learning" = "Supervised ML")
 - Spelling variations
+
+The list can hold pages from both the entities/ and the concepts/ folder. The folder does not decide identity: a page in the other folder is a match when it denotes the same thing (the folder reflects an earlier classification, which may differ for the same referent). But sharing a name is not identity either — an abbreviation can stand for two different things; match only when the summaries describe the same referent. Never match a page about a related, broader, narrower, or component thing — a relationship is not sameness.
 
 **Output JSON:**
 - If it matches an existing page, output: {"match": true, "path": "{{wikiFolder}}/entities/existing-slug.md"}

--- a/tools/dev-instrument/src/vault-fs.ts
+++ b/tools/dev-instrument/src/vault-fs.ts
@@ -238,6 +238,54 @@ export class NodeVault {
     this.writes.push({ path: file.path, action: 'delete' });
   }
 
+  /**
+   * Move a file and rewrite inbound wiki-links across every markdown file —
+   * the headless stand-in for Obsidian's link-safe `fileManager.renameFile`.
+   * Generated pages link wiki-folder-relative (`[[entities/X|X]]`); some
+   * writers emit the wiki-folder prefix too. Both forms are rewritten, in
+   * bodies and in quoted frontmatter alike, with the link target bounded by
+   * `]`, `|` or `#` so `entities/Stress` never rewrites
+   * `entities/Stress-Resilienz`.
+   */
+  async renameWithLinkRewrite(file: TFile, newPath: string): Promise<void> {
+    const key = normalizePath(newPath);
+    if (this.files.has(key)) throw new Error(`File already exists: ${key}`);
+    const parent = parentPathOf(key);
+    if (parent !== '' && !this.folders.has(parent)) {
+      throw new Error(`Folder does not exist: ${parent}`);
+    }
+    const oldPath = file.path;
+    await this.modules.nodeFsPromises.rename(this.absolute(oldPath), this.absolute(key));
+    this.unregisterFile(file);
+    this.registerFile(key);
+    this.writes.push({ path: oldPath, action: 'delete' });
+    this.writes.push({ path: key, action: 'create' });
+
+    const noExt = (p: string): string => p.replace(/\.md$/, '');
+    const tail = (p: string): string => p.split('/').slice(1).join('/');
+    const pairs: Array<[string, string]> = [
+      [noExt(oldPath), noExt(key)],
+      [tail(noExt(oldPath)), tail(noExt(key))],
+    ].filter(([from]) => from.length > 0) as Array<[string, string]>;
+
+    for (const md of this.getMarkdownFiles()) {
+      let content: string;
+      try {
+        content = this.readSync(md.path);
+      } catch {
+        continue;
+      }
+      let updated = content;
+      for (const [from, to] of pairs) {
+        const esc = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        updated = updated.replace(new RegExp(`\\[\\[${esc}(?=[\\]|#|\\|])`, 'g'), `[[${to}`);
+      }
+      if (updated !== content) {
+        await this.writeContent(md.path, updated, 'update');
+      }
+    }
+  }
+
   // ── DataAdapter ──────────────────────────────────────────────────
   //
   // Obsidian's adapter is the raw filesystem view: it reaches paths the file
@@ -311,7 +359,10 @@ export class NodeVault {
 export interface VaultApp {
   vault: NodeVault;
   metadataCache: { getFileCache: (file: TFile) => { frontmatter: Record<string, unknown> } | null; on: () => { unload: () => void } };
-  fileManager: { trashFile: (file: TFile) => Promise<void> };
+  fileManager: {
+    trashFile: (file: TFile) => Promise<void>;
+    renameFile: (file: TFile, newPath: string) => Promise<void>;
+  };
 }
 
 export async function createVaultApp(root: string): Promise<VaultApp> {
@@ -328,6 +379,7 @@ export async function createVaultApp(root: string): Promise<VaultApp> {
     },
     fileManager: {
       trashFile: (file: TFile) => vault.trash(file),
+      renameFile: (file: TFile, newPath: string) => vault.renameWithLinkRewrite(file, newPath),
     },
   };
 }


### PR DESCRIPTION
Closes #588. Builds on the #472 resolution rather than reverting it: deterministic merges stay same-type only.

## First commit — the folder never decides identity

- `ConflictResolver` now reports opposite-folder slug/alias claims as `crossFolderCandidates` on any action — detected there, decided nowhere.
- `resolvePagePath` routes any such claim through the semantic dedup call, claimants seeded at the head of the list. A direct file probe of the opposite slug path backstops the page index for a twin written moments ago in the same run (the measured pairs include ones born seconds apart).
- The candidate window draws from both wiki folders, so near-name twins (`Brainfog` next to `Brain-Fog` in the same batch) reach the model too.
- The prompt states that the folder reflects an earlier classification and does not decide identity — and that a related, broader, narrower, or component thing is not a match.
- Conservative fallbacks: on no-decision a create stays a create (the twin is the visible failure; an undecided cross-folder merge would be the silent one), and a deterministic same-type match stays the target — a failure never crosses the folder on its own.

## Second commit — the classification is re-decided, once

The matched page's folder is the first ingest's draw, made on whatever context that call had — possibly a passing mention that produced little more than a name. Letting it stand unquestioned makes the classification a function of ingest order.

- On a cross-folder-routed match the dedup call also answers the classification question, judged against the vault's own **Classification Rules** — the `index` schema context now delivers that section to its single caller, so the user's definitions are the ruler.
- The decision is ratcheted: written back as `type_confirmed: true`, asked at most once per page, so a page cannot ping-pong between the folders on later draws.
- A page whose decided classification disagrees with its address moves via `app.fileManager.renameFile` (link-safe in Obsidian); the dev-instrument shim gains an equivalent `renameWithLinkRewrite` (file move plus inbound wiki-link rewrite, bounded by `]`/`|`/`#` so `entities/Stress` never rewrites `entities/Stress-Resilienz`).
- Where the move is impossible — target address occupied by an existing twin (healing that is a merge, not a move), or no link-safe rename on the host — the page gets `type_conflict: <classification>` in its frontmatter: the disagreement becomes a greppable artifact a lint or a later pass can surface, and `type_confirmed` stays absent so the question is re-asked once the obstacle is gone.

## Deliberately out of scope

- The same-type exact-slug fast path still returns early without consulting the opposite folder: once both twins exist, re-ingests keep merging same-type. Healing existing twins is a merge over two full pages, not a resolution decision — separate pass.
- `fix-dead-link.ts` builds its page list inline and is untouched.

Both #472 directions are covered by tests (twin case, KHK case, index-lag case, move/ratchet/conflict-marker cases). Pre-checks: tsc clean (main and tools), 3703/3703 tests, eslint clean, and one real instrument start against a live vault.
