### PR TITLE
fix(ingest): resolve ingest ownership from source_file, not sources (#595)

### DIFF
--- a/src/__tests__/main-commands/ingest-skip.test.ts
+++ b/src/__tests__/main-commands/ingest-skip.test.ts
@@ -1,0 +1,94 @@
+// The batch-ingest skip check must answer one question: has THIS note
+// already been ingested?
+//
+// `isAlreadyIngested` locates the summary page by slug and then verifies
+// ownership by looking for the note's path in the page's frontmatter. It
+// reads `sources:` for that path. But `sources:` is a list of
+// `[[sources/X]]` wikilinks by contract — the Issue #81 normalizer removes
+// or remaps any `[[Notizen/X.md]]` entry it finds there. The path being
+// searched for is therefore the one shape the field can never hold, and
+// every summary page that carries a `sources:` list reads as "not
+// ingested".
+//
+// The canonical owner is the scalar `source_file:` written by the
+// generation template. `scanSourceDrift` (#577) already resolves ownership
+// that way: scalar first, list as a fallback.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { ingestCommands, type IngestHost } from '../../main-commands/ingest-commands';
+
+const NOTE_PATH = 'Notizen/ATP-Produktion.md';
+
+function note(path = NOTE_PATH): TFile {
+  const basename = path.split('/').pop()!.replace(/\.md$/, '');
+  return Object.assign(new TFile(), { path, basename, extension: 'md' });
+}
+
+/** Minimal host: `isAlreadyIngested` only touches the vault and two settings. */
+function host(pages: Record<string, string>): IngestHost {
+  return {
+    app: {
+      vault: {
+        getAbstractFileByPath: (p: string) =>
+          p in pages ? Object.assign(new TFile(), { path: p }) : null,
+        read: async (f: { path: string }) => pages[f.path],
+      },
+    },
+    settings: { wikiFolder: 'wiki', slugCase: 'preserve' },
+  } as unknown as IngestHost;
+}
+
+const call = (h: IngestHost, f: TFile) =>
+  ingestCommands.isAlreadyIngested.call(h, f);
+
+// A real page from the vault. The canonical scalar names the origin note.
+// `sources:` names the OTHER notes whose later ingest extended this page —
+// the multi-source merge, which also stamps "Erweitert durch: [[sources/X]]"
+// into the body. It is by design the one field that never names the origin.
+const MULTI_SOURCE_PAGE = `---
+type: source
+source_file: "[[Notizen/ATP-Produktion.md]]"
+contentHash: 11a3-6a586cb9
+sources:
+  - "[[sources/Coenzym-Q10]]"
+  - "[[sources/Magnesium]]"
+---
+
+Summary.`;
+
+const SINGLE_SOURCE_PAGE = `---
+type: source
+source_file: "[[Notizen/ATP-Produktion.md]]"
+contentHash: 11a3-6a586cb9
+---
+
+Summary.`;
+
+describe('isAlreadyIngested — ownership comes from source_file', () => {
+  it('skips a note whose summary page carries a sources: list', async () => {
+    const h = host({ 'wiki/sources/ATP-Produktion.md': MULTI_SOURCE_PAGE });
+    // Today: false. The note path is compared against `[[sources/…]]`
+    // entries and never matches, so the batch re-ingests the note.
+    expect(await call(h, note())).toBe(true);
+  });
+
+  it('skips a note whose summary page has no sources: list', async () => {
+    const h = host({ 'wiki/sources/ATP-Produktion.md': SINGLE_SOURCE_PAGE });
+    expect(await call(h, note())).toBe(true);
+  });
+
+  it('ingests a note that has no summary page', async () => {
+    expect(await call(host({}), note())).toBe(false);
+  });
+
+  it('ingests a same-slug note from another folder', async () => {
+    // Two notes slugify to one page path. The page belongs to the note
+    // named in `source_file:`; the other one has not been ingested.
+    // Today: true — the ownership check falls through to `return true`
+    // whenever `sources:` is absent, so the second note is silently
+    // skipped and never ingested at all.
+    const h = host({ 'wiki/sources/ATP-Produktion.md': SINGLE_SOURCE_PAGE });
+    expect(await call(h, note('Archiv/ATP-Produktion.md'))).toBe(false);
+  });
+});

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -101,6 +101,40 @@ export function parseFrontmatter(content: string): FrontmatterData | null {
   return result;
 }
 
+/**
+ * The origin notes a `sources/` page was built from, normalized to vault
+ * paths.
+ *
+ * Two fields can name them and they are not interchangeable. The scalar
+ * `source_file:` is the canonical owner, written by the generation
+ * template. The `sources:` list records the multi-source merge: the other
+ * ingests that later extended this page. It holds `[[sources/X]]`
+ * wikilinks by contract — the Issue #81 normalizer removes or remaps any
+ * external `[[Notizen/X.md]]` entry that lands there — so a note path
+ * found in it is the exception, not the rule. Read the scalar first and
+ * fall back to the list, which is the resolution `scanSourceDrift` (#577)
+ * already uses.
+ *
+ * Returns an empty array when neither field is present: a page with no
+ * recorded origin proves nothing about ownership, and callers must decide
+ * for themselves what absence means.
+ */
+export function originNoteRefs(fm: FrontmatterData): string[] {
+  const raw: string[] = [];
+  const sourceFile = fm.source_file;
+  if (typeof sourceFile === 'string') raw.push(sourceFile);
+  if (Array.isArray(fm.sources)) raw.push(...fm.sources.map(s => String(s)));
+
+  return raw
+    .map(entry => {
+      const trimmed = entry.trim();
+      return trimmed.startsWith('[[') && trimmed.endsWith(']]')
+        ? trimmed.slice(2, -2).trim()
+        : trimmed;
+    })
+    .filter(entry => entry.length > 0);
+}
+
 /** Serialize value to YAML format for frontmatter */
 function yamlStringify(value: unknown): string {
   if (Array.isArray(value)) {

--- a/src/main-commands/ingest-commands.ts
+++ b/src/main-commands/ingest-commands.ts
@@ -24,7 +24,7 @@ import type { BatchProgress } from '../core/status-bar';
 import { TEXTS } from '../texts';
 import { getText } from '../core/i18n';
 import { slugify } from '../core/slug';
-import { parseFrontmatter } from '../core/frontmatter';
+import { parseFrontmatter, originNoteRefs } from '../core/frontmatter';
 import { isIngestableSource } from '../core/folder-scope';
 import { COMPATIBLE_SOURCE_EXTENSIONS, NOTICE_NORMAL, NOTICE_ERROR } from '../constants';
 import { FileSuggestModal, FolderSuggestModal, MultiFileSuggestModal, IngestReportModal } from '../ui/modals';
@@ -65,17 +65,20 @@ export const ingestCommands = {
       try {
         const content = await this.app.vault.read(file);
         const fm = parseFrontmatter(content);
-        if (fm && fm.sources) {
-          const normalizedSources = fm.sources.map(s => {
-            const trimmed = s.trim();
-            if (trimmed.startsWith('[[') && trimmed.endsWith(']]')) {
-              return trimmed.slice(2, -2).trim();
-            }
-            return trimmed;
-          });
-          return normalizedSources.includes(sourceFile.path);
-        }
-        return true;
+        if (!fm) return true;
+        // Ownership: the page found by slug belongs to this note only if
+        // the note is one of its recorded origins. Reading `sources:`
+        // alone never established that — it holds `[[sources/X]]` links
+        // by contract, so the note path being searched for is the one
+        // shape it cannot contain, and every multi-source page read as
+        // "not ingested". The scalar `source_file:` is the canonical
+        // owner; `originNoteRefs` reads it first.
+        const origins = originNoteRefs(fm);
+        // No recorded origin (pre-#164 pages): fall back to existence,
+        // the pre-existing behaviour. Absence of evidence is not proof
+        // of a different owner.
+        if (origins.length === 0) return true;
+        return origins.includes(sourceFile.path);
       } catch {
         return true;
       }

--- a/src/wiki/lint/scanners.ts
+++ b/src/wiki/lint/scanners.ts
@@ -1,7 +1,7 @@
 // Lint scanner functions — extracted from lint-controller.ts for testability.
 // These have no Obsidian API dependencies and can be unit tested directly.
 
-import { parseFrontmatter, extractBody } from '../../core/frontmatter';
+import { parseFrontmatter, extractBody, originNoteRefs } from '../../core/frontmatter';
 import { hashBody } from '../../core/source-requirements';
 import { CONTRADICTIONS_KEY } from '../../core/contradicted-marker';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from '../../core/tag-vocab';
@@ -512,23 +512,12 @@ export function scanSourceDrift(
 
     // Canonical source pages carry a scalar `source_file:` wikilink
     // (generation.ts template); a `sources:` list only appears on pages
-    // written through the entity/concept path. Read the scalar first and
-    // fall back to the list — reading only `sources:` would make the
-    // scanner blind on every canonical page (found by probing a real
-    // vault: 35/35 source pages carried source_file, none sources:).
-    const rawRefs: string[] = [];
-    const sourceFile = (fm as Record<string, unknown>).source_file;
-    if (typeof sourceFile === 'string') rawRefs.push(sourceFile);
-    if (Array.isArray(fm.sources)) rawRefs.push(...fm.sources.map(s => String(s)));
-
-    const notePaths = rawRefs
-      .map(s => {
-        const trimmed = s.trim();
-        return trimmed.startsWith('[[') && trimmed.endsWith(']]')
-          ? trimmed.slice(2, -2).trim()
-          : trimmed;
-      })
-      .filter(p => p.length > 0);
+    // written through the entity/concept path. `originNoteRefs` reads the
+    // scalar first and falls back to the list — reading only `sources:`
+    // would make the scanner blind on every canonical page (found by
+    // probing a real vault: 35/35 source pages carried source_file, none
+    // sources:).
+    const notePaths = originNoteRefs(fm);
     if (notePaths.length === 0) continue;
 
     let anyReadable = false;


### PR DESCRIPTION
Fixes #595.

## The problem

`isAlreadyIngested` locates a note's summary page by slug and then confirms the page belongs to that note by looking for the note's vault path in `sources:`.

`sources:` records the multi-source merge — the other ingests that later extended the page — and holds `[[sources/X]]` wikilinks by contract, since the Issue #81 normalizer removes or remaps any external `[[Notizen/X.md]]` entry that lands there. The path being searched for is the one shape the field cannot hold, so the comparison could not succeed. The origin lives in the scalar `source_file:`.

## Measured

On a 230-page vault:

| | pages |
|---|---|
| summary pages | 230 |
| carry `source_file:`, resolving to an existing note | 230 |
| also carry a `sources:` list | 103 |
| of those, own note path present in `sources:` | **0** |

The affected set is exactly the pages a second ingest has extended: of the 127 pages without a `sources:` list, 0 have ever been rewritten after creation; of the 103 with one, 49 carry a later `updated:`. It grows with the vault and singles out the pages holding the most content — and a re-ingest is additive rather than revising.

## The fix

`originNoteRefs` (in `core/frontmatter.ts`) reads the canonical scalar first and falls back to the list — the resolution `scanSourceDrift` (#577) already uses. `isAlreadyIngested` now answers from it.

Behaviour is unchanged for pages with no recorded origin: they keep the existing existence-based answer, so pre-#164 pages are not suddenly re-ingested.

The fix also closes the inverse case the old `return true` fallback hid: two notes in different folders that slugify to one page path both read as ingested, so the second was skipped and never ingested at all.

## Tests

New `src/__tests__/main-commands/ingest-skip.test.ts`, four cases driving `isAlreadyIngested` against a real page's frontmatter:

- summary page with a `sources:` list → skip (failed before: reported "not ingested")
- summary page without one → skip
- no summary page → ingest
- same-slug note from another folder → ingest (failed before: reported "ingested")

Two of the four fail on `main`. Full suite 3745/3745, lint and typecheck clean, `build` + `css-lint` green.

## On the second commit

`refactor(lint): read origin notes through the shared resolver` points `scanSourceDrift` at the same helper. It is deliberately a separate commit: the duplication is what let the two readers drift apart in the first place, but it touches code you merged recently, so drop the commit if you would rather leave the scanner alone. The fix does not depend on it.

## Not included

I did not run a batch ingest to observe a duplicate in the wild — the evidence is the code path, the frontmatter counts, and the failing tests.
