### PR TITLE
feat(gate): three-outcome table — dissent between the gate halves births a stub, not a drop (#485, #514)

### DIFF
--- a/src/__tests__/core/candidate-gate.test.ts
+++ b/src/__tests__/core/candidate-gate.test.ts
@@ -244,17 +244,64 @@ describe('classifyCandidate — link markup is not a parenthesis', () => {
     expect(classifyCandidate(t, 'Mitochondrium')).toBe('prose');
   });
 
-  // The rule cuts both ways: markup changes nothing, so a parenthesis that
-  // merely CONTAINS a link is still a parenthesis.
-  it('leaves a real parenthesis an aside even when it holds a link', () => {
-    const t = 'Hormonelle Dysregulation (z. B. Leptin-Resistenz, [[Insulinresistenz]]) ist typisch.';
-    expect(classifyCandidate(t, 'Insulinresistenz')).toBe('aside');
+  // S135 inverts the S132 half-rule: the author's link outranks the bracket
+  // around it. The UNLINKED neighbour in the same parenthesis stays an aside.
+  it('reads a linked name as prose even inside a real parenthesis', () => {
+    const t = 'Hormonelle Dysregulation (Leptin-Resistenz und auch [[Insulinresistenz]]) ist typisch.';
+    expect(classifyCandidate(t, 'Insulinresistenz')).toBe('prose');
+    expect(classifyCandidate(t, 'Leptin-Resistenz')).toBe('aside');
   });
 
   // A citation in square brackets carries no `(url)` and stays an aside.
   it('leaves a bare bracketed citation an aside', () => {
     const t = 'Die Methodik folgt dem Standard [ATS Statement: Guidelines 2002].';
     expect(classifyCandidate(t, 'ATS Statement: Guidelines 2002')).toBe('aside');
+  });
+});
+
+// S135: three parenthesis rescues, measured together on 20 German notes and
+// two independent draws — 159 aside verdicts, 68 move to prose (32 exemplar,
+// 19 linked occurrence, 19 gloss), none the other way, every case reviewed.
+describe('classifyCandidate — exemplar lists, glosses and linked occurrences (S135)', () => {
+  it('exemplar marker: members of the group named before the parenthesis are prose', () => {
+    const t = 'Medikamentös sind Stimulanzien (Methylphenidat als First-Line in Deutschland, alternativ Amphetamine wie Lisdexamfetamin) die Therapie der Wahl.';
+    expect(classifyCandidate(t, 'Methylphenidat')).toBe('prose');
+    expect(classifyCandidate(t, 'Lisdexamfetamin')).toBe('prose');
+  });
+
+  it('exemplar marker: `z. B.` and `etc.`', () => {
+    const t1 = 'Für Patienten auf Antikoagulanzien (z. B. Warfarin) ist Vorsicht geboten.';
+    expect(classifyCandidate(t1, 'Warfarin')).toBe('prose');
+    const t2 = 'Non-Stimulanzien (Atomoxetin, Guanfacin etc.) kommen bei Kontraindikationen zum Einsatz.';
+    expect(classifyCandidate(t2, 'Atomoxetin')).toBe('prose');
+    expect(classifyCandidate(t2, 'Guanfacin')).toBe('prose');
+  });
+
+  it('a parenthesis without a marker stays an aside', () => {
+    const t = 'Es steigt bei Entzündung (CRP erhöht) deutlich an.';
+    expect(classifyCandidate(t, 'CRP')).toBe('aside');
+  });
+
+  it('gloss: a parenthesis holding nothing but the name introduces the term', () => {
+    const t1 = 'Die Glykolyse führt zur Übersäuerung (Azidose) des Gewebes.';
+    expect(classifyCandidate(t1, 'Azidose')).toBe('prose');
+    const t2 = 'Häufig genannt wird **Maca** (*Lepidium meyenii*) in Studien.';
+    expect(classifyCandidate(t2, 'Lepidium meyenii')).toBe('prose');
+  });
+
+  it('gloss needs full cover: a compound around the name is no gloss', () => {
+    const t = 'Die Entfernung geschädigter Zellen (p53-abhängig) verhindert Tumoren.';
+    expect(classifyCandidate(t, 'p53')).toBe('aside');
+  });
+
+  it('the gloss rule decides pages, not identity: a member gloss is prose too', () => {
+    const t = 'Grüntee-Polyphenole (EGCG) aktivieren Caspasen und modulieren die Bcl-2-Familie.';
+    expect(classifyCandidate(t, 'EGCG')).toBe('prose');
+  });
+
+  it('a profile without exemplar markers keeps the strict reading', () => {
+    const t = 'Pour les anticoagulants (Warfarin notamment) la prudence est requise.';
+    expect(classify(t, 'Warfarin', GATE_LANGUAGE_PROFILES.fr)).toBe('aside');
   });
 });
 

--- a/src/__tests__/core/candidate-gate.test.ts
+++ b/src/__tests__/core/candidate-gate.test.ts
@@ -412,3 +412,98 @@ describe('applyCoverageThreshold with isKnownPage (#620 parity)', () => {
     expect(r.linkedAnyway).toEqual([]);
   });
 });
+
+// S135: the three-outcome table. Measured over 1,153 items across three runs:
+// its full-page set equals exactly the serial gates' keep set; dissent
+// (prose+named / aside+covered) births stubs instead of drops.
+import { applyOutcomeTable, type StubIdentity } from '../../core/candidate-gate';
+
+describe('applyOutcomeTable (S135)', () => {
+  const mk = (name: string, coverage?: string, related: string[] = []): EntityInfo =>
+    ({ name, type: 'other', summary: 's', mentions_in_source: [], related_entities: related, ...(coverage ? { coverage } : {}) } as unknown as EntityInfo);
+  const mkC = (name: string, coverage?: string, related: string[] = []): ConceptInfo =>
+    ({ name, type: 'term', summary: 's', mentions_in_source: [], related_concepts: related, ...(coverage ? { coverage } : {}) } as unknown as ConceptInfo);
+  const none = (): StubIdentity => 'none';
+
+  // TEXT (top of file): Ferritin/Entzündung prose · CRP/Malabsorption aside ·
+  // Eisenstoffwechsel absent.
+
+  it('agreement cells: prose+covered keeps, aside+named and absent drop', () => {
+    const r = applyOutcomeTable({
+      entities: [mk('Ferritin', 'discussed'), mk('CRP', 'named')],
+      concepts: [mkC('Eisenstoffwechsel', 'discussed')],
+    }, TEXT, 'de', none);
+    expect(r.applied).toBe(true);
+    expect(r.entities.map(e => e.name)).toEqual(['Ferritin']);
+    expect(r.concepts).toEqual([]);
+    expect(r.stubs).toEqual([]);
+    expect(r.dropped).toEqual([
+      { name: 'CRP', kind: 'entity', verdict: 'aside+named' },
+      { name: 'Eisenstoffwechsel', kind: 'concept', verdict: 'absent' },
+    ]);
+  });
+
+  it('dissent cells birth stubs: prose+named and aside+covered', () => {
+    const r = applyOutcomeTable({
+      entities: [mk('Ferritin', 'named'), mk('CRP', 'discussed')],
+      concepts: [],
+    }, TEXT, 'de', none);
+    expect(r.entities).toEqual([]);
+    expect(r.stubs.map(s => ({ name: s.item.name, cell: s.cell }))).toEqual([
+      { name: 'Ferritin', cell: 'prose+named' },
+      { name: 'CRP', cell: 'aside+covered' },
+    ]);
+    expect(r.dropped).toEqual([]);
+  });
+
+  it('a missing coverage value counts as covered (same contract as the threshold)', () => {
+    const r = applyOutcomeTable({ entities: [mk('Ferritin'), mk('CRP')], concepts: [] }, TEXT, 'de', none);
+    expect(r.entities.map(e => e.name)).toEqual(['Ferritin']);
+    expect(r.stubs.map(s => s.item.name)).toEqual(['CRP']);
+  });
+
+  it("the author's link outranks both gates", () => {
+    const text = 'Es steigt bei Entzündung ([[CRP]] erhöht) an.';
+    const r = applyOutcomeTable({ entities: [mk('CRP', 'named')], concepts: [] }, text, 'de', none);
+    expect(r.entities.map(e => e.name)).toEqual(['CRP']);
+    expect(r.stubs).toEqual([]);
+  });
+
+  it('a dissent name an existing page answers gets no stub and stays linkable', () => {
+    const r = applyOutcomeTable({
+      entities: [mk('Ferritin', 'discussed', ['CRP'])],
+      concepts: [mkC('CRP', 'discussed')],
+    }, TEXT, 'de', () => 'match');
+    expect(r.stubs).toEqual([]);
+    expect(r.existing).toEqual([{ name: 'CRP', kind: 'concept', cell: 'aside+covered' }]);
+    // NOT pruned: the existing page takes the edge.
+    expect(r.entities[0].related_entities).toEqual(['CRP']);
+  });
+
+  it('an ambiguous dissent name gets no stub and IS pruned', () => {
+    const r = applyOutcomeTable({
+      entities: [mk('Ferritin', 'discussed', ['CRP'])],
+      concepts: [mkC('CRP', 'discussed')],
+    }, TEXT, 'de', () => 'ambiguous');
+    expect(r.stubs).toEqual([]);
+    expect(r.dropped).toEqual([{ name: 'CRP', kind: 'concept', verdict: 'ambiguous' }]);
+    expect(r.entities[0].related_entities).toEqual([]);
+  });
+
+  it('stub names are not pruned from the survivors\' related_* lists', () => {
+    const r = applyOutcomeTable({
+      entities: [mk('Ferritin', 'discussed', ['CRP']), mk('CRP', 'discussed')],
+      concepts: [],
+    }, TEXT, 'de', none);
+    expect(r.stubs.map(s => s.item.name)).toEqual(['CRP']);
+    expect(r.entities[0].related_entities).toEqual(['CRP']);
+  });
+
+  it('no language profile: input untouched, applied false', () => {
+    const input = { entities: [mk('Ferritin', 'named')], concepts: [] };
+    const r = applyOutcomeTable(input, TEXT, 'sv', none);
+    expect(r.applied).toBe(false);
+    expect(r.entities).toBe(input.entities);
+    expect(r.stubs).toEqual([]);
+  });
+});

--- a/src/__tests__/core/candidate-gate.test.ts
+++ b/src/__tests__/core/candidate-gate.test.ts
@@ -348,6 +348,39 @@ describe('applyCoverageThreshold (domain axis stage 3, #568)', () => {
     expect(r.entities).toBe(entities);
     expect(r.dropped).toEqual([]);
   });
+
+  // S135: the author's link outranks the model's `named` — measured twice in
+  // one day ([[Reis]] in Arsen, [[Blei]] in Reis, both hand-linked, both
+  // dropped by the threshold before this rule).
+  describe('linked names survive the threshold', () => {
+    const text = [
+      'Hauptquellen sind Nahrungsmittel ([[Reis]] nimmt Arsen stark auf).',
+      'Spuren von [[Blei|Bleibelastung]] und die [[Notizen/HPA-Axis|Stressachse]] spielen mit.',
+      'Details im [ATS Statement](https://example.org/ats).',
+    ].join('\n');
+
+    it('keeps a `named` candidate whose name is a wikilink target, pipe alias, or markdown link text', () => {
+      const r = applyCoverageThreshold({
+        entities: [mk('Reis', 'named'), mk('Bleibelastung', 'named'), mk('ATS Statement', 'named')],
+        concepts: [mkC('HPA-Axis', 'named')],
+      }, text);
+      expect(r.entities.map(e => e.name)).toEqual(['Reis', 'Bleibelastung', 'ATS Statement']);
+      expect(r.concepts.map(c => c.name)).toEqual(['HPA-Axis']);
+      expect(r.dropped).toEqual([]);
+    });
+
+    it('still drops a `named` candidate the note never linked — and everything without sourceText', () => {
+      const r = applyCoverageThreshold({ entities: [mk('Arsen', 'named')], concepts: [] }, text);
+      expect(r.dropped.map(d => d.name)).toEqual(['Arsen']);
+      const r2 = applyCoverageThreshold({ entities: [mk('Reis', 'named')], concepts: [] });
+      expect(r2.dropped.map(d => d.name)).toEqual(['Reis']);
+    });
+
+    it('the link is an exact claim: a compound or inflected form does not inherit it', () => {
+      const r = applyCoverageThreshold({ entities: [mk('Reisprodukte', 'named')], concepts: [] }, text);
+      expect(r.dropped.map(d => d.name)).toEqual(['Reisprodukte']);
+    });
+  });
 });
 
 describe('applyCoverageThreshold with isKnownPage (#620 parity)', () => {

--- a/src/__tests__/core/candidate-gate.test.ts
+++ b/src/__tests__/core/candidate-gate.test.ts
@@ -393,6 +393,7 @@ describe('applyCoverageThreshold with isKnownPage (#620 parity)', () => {
         entities: [mk('Ferritin', 'defined', ['CRP', 'Eisen']), mk('CRP', 'named')],
         concepts: [],
       },
+      undefined,
       name => name === 'CRP', // vault has a CRP page
     );
     expect(r.entities[0].related_entities).toEqual(['CRP', 'Eisen']);
@@ -406,6 +407,7 @@ describe('applyCoverageThreshold with isKnownPage (#620 parity)', () => {
         entities: [mk('Ferritin', 'defined', ['CRP', 'Eisen']), mk('CRP', 'named')],
         concepts: [],
       },
+      undefined,
       () => false,
     );
     expect(r.entities[0].related_entities).toEqual(['Eisen']);

--- a/src/__tests__/wiki/lint/fix-dead-link.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link.test.ts
@@ -31,6 +31,16 @@ describe('fixDeadLink stub construction (#197 — honest placeholders)', () => {
       expect(out).toContain('generation_complete: false');
     });
 
+    it('emits stub: true — the marker that survives the write (S135)', () => {
+      const out = buildStubContent({
+        title: 'EntityX',
+        stubType: 'entity',
+        wikiFolder: 'wiki',
+        referringPageRel: 'entities/SomeSource',
+      });
+      expect(out).toContain('stub: true');
+    });
+
     it('body is the placeholder template, NOT LLM-generated content', () => {
       const out = buildStubContent({
         title: 'EntityX',

--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -505,50 +505,5 @@ describe('mergePage — the triage lane reports what it records (onContradiction
     ctx.onContradiction = c => seen.push(c);
     await mergePage(ctx, createMockEntity({ name: 'Caching' }), 'entity', { path: 'note.md', basename: 'note' }, EXISTING, [], 'wiki/entities/caching.md');
     expect(seen).toEqual([]);
-=======
-// S135 — a stub (frontmatter `stub: true`, dissent-born or Fix-Dead-Links)
-// must never be skip-frozen, and a write that fills it strips the marker.
-describe('mergePage — a stub page overrides triage=skip and is promoted (S135)', () => {
-  const EXISTING_STUB = `---\ntype: entity\ncreated: 2026-08-28\nsources:\n  - "[[sources/adhs]]"\ntags: [other]\nstub: true\ngeneration_complete: true\n---\n# Methylphenidat\n\n> Stub created by the ingest candidate gate (prose+named) — [[sources/adhs]] names this without treating it. Will be filled by the next ingest of a source that does.\n`;
-
-  it('routes skip to the body merge and strips the stub marker with the write', async () => {
-    const ctx = makeCtx(makeClient([
-      JSON.stringify({ strategy: 'skip', reason: 'stub body carries nothing new' }),
-      '## Description\nFilled body.',
-    ]));
-
-    const result = await mergePage(
-      ctx,
-      createMockEntity({ name: 'Methylphenidat' }),
-      'entity',
-      { path: 'Notes/Stimulanzien.md', basename: 'Stimulanzien' },
-      EXISTING_STUB,
-      [],
-      'wiki/entities/methylphenidat.md',
-    );
-
-    expect(result).toBe('wiki/entities/methylphenidat.md');
-    const written = ctx.written.get('wiki/entities/methylphenidat.md')!;
-    expect(written).toContain('Filled body.');
-    expect(written).not.toContain('stub: true');
-  });
-
-  it('a non-stub page keeps the plain skip behaviour', async () => {
-    const ctx = makeCtx(makeClient([
-      JSON.stringify({ strategy: 'skip', reason: 'no new info' }),
-      '## Description\nMerged text.',
-    ]));
-    await mergePage(
-      ctx,
-      createMockEntity({ name: 'Caching' }),
-      'entity',
-      { path: 'Notes/Distributed Systems.md', basename: 'Distributed Systems' },
-      EXISTING,
-      [],
-      'wiki/entities/caching.md',
-    );
-    const written = ctx.written.get('wiki/entities/caching.md')!;
-    expect(written).toContain('Old text.');
-    expect(written).not.toContain('Merged text.');
   });
 });

--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -505,5 +505,50 @@ describe('mergePage — the triage lane reports what it records (onContradiction
     ctx.onContradiction = c => seen.push(c);
     await mergePage(ctx, createMockEntity({ name: 'Caching' }), 'entity', { path: 'note.md', basename: 'note' }, EXISTING, [], 'wiki/entities/caching.md');
     expect(seen).toEqual([]);
+=======
+// S135 — a stub (frontmatter `stub: true`, dissent-born or Fix-Dead-Links)
+// must never be skip-frozen, and a write that fills it strips the marker.
+describe('mergePage — a stub page overrides triage=skip and is promoted (S135)', () => {
+  const EXISTING_STUB = `---\ntype: entity\ncreated: 2026-08-28\nsources:\n  - "[[sources/adhs]]"\ntags: [other]\nstub: true\ngeneration_complete: true\n---\n# Methylphenidat\n\n> Stub created by the ingest candidate gate (prose+named) — [[sources/adhs]] names this without treating it. Will be filled by the next ingest of a source that does.\n`;
+
+  it('routes skip to the body merge and strips the stub marker with the write', async () => {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({ strategy: 'skip', reason: 'stub body carries nothing new' }),
+      '## Description\nFilled body.',
+    ]));
+
+    const result = await mergePage(
+      ctx,
+      createMockEntity({ name: 'Methylphenidat' }),
+      'entity',
+      { path: 'Notes/Stimulanzien.md', basename: 'Stimulanzien' },
+      EXISTING_STUB,
+      [],
+      'wiki/entities/methylphenidat.md',
+    );
+
+    expect(result).toBe('wiki/entities/methylphenidat.md');
+    const written = ctx.written.get('wiki/entities/methylphenidat.md')!;
+    expect(written).toContain('Filled body.');
+    expect(written).not.toContain('stub: true');
+  });
+
+  it('a non-stub page keeps the plain skip behaviour', async () => {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({ strategy: 'skip', reason: 'no new info' }),
+      '## Description\nMerged text.',
+    ]));
+    await mergePage(
+      ctx,
+      createMockEntity({ name: 'Caching' }),
+      'entity',
+      { path: 'Notes/Distributed Systems.md', basename: 'Distributed Systems' },
+      EXISTING,
+      [],
+      'wiki/entities/caching.md',
+    );
+    const written = ctx.written.get('wiki/entities/caching.md')!;
+    expect(written).toContain('Old text.');
+    expect(written).not.toContain('Merged text.');
   });
 });

--- a/src/__tests__/wiki/page-factory/stub-page.test.ts
+++ b/src/__tests__/wiki/page-factory/stub-page.test.ts
@@ -1,0 +1,178 @@
+// Module-level unit tests for page-factory/stub-page.ts (S135).
+//
+// Pins: the deterministic identity resolver (match / ambiguous / none, titles
+// outrank aliases, only entities/+concepts/ count), the stub content format
+// (frontmatter marker set, body from the paid-for extraction), the promotion
+// helpers, and the birth run (existing paths and in-run slug collisions are
+// skipped, never overwritten).
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildStubIdentityResolver,
+  buildDissentStubContent,
+  createDissentStubs,
+  stubPath,
+  isStubPage,
+  stripStubMarker,
+} from '../../../wiki/page-factory/stub-page';
+import { parseFrontmatter } from '../../../core/frontmatter';
+import type { EntityInfo } from '../../../types';
+import type { StubCandidate } from '../../../core/candidate-gate';
+
+const PAGES = [
+  { path: 'wiki/entities/Ferritin.md', title: 'Ferritin', aliases: ['Eisenspeicherprotein'] },
+  { path: 'wiki/concepts/Butyrat.md', title: 'Butyrat', aliases: ['SCFA'] },
+  { path: 'wiki/entities/Propionat.md', title: 'Propionat', aliases: ['SCFA'] },
+  { path: 'wiki/sources/ferritin-note.md', title: 'Ferritin', aliases: [] },
+  { path: 'elsewhere/entities/Ferritin.md', title: 'Zink', aliases: [] },
+];
+
+describe('buildStubIdentityResolver', () => {
+  const resolve = buildStubIdentityResolver(PAGES, 'wiki');
+
+  it('a title match is a match, case-folded', () => {
+    expect(resolve('Ferritin')).toBe('match');
+    expect(resolve('ferritin')).toBe('match');
+  });
+
+  it('a unique curated alias is a match', () => {
+    expect(resolve('Eisenspeicherprotein')).toBe('match');
+  });
+
+  it('an alias two pages claim is ambiguous (the #446 lesson)', () => {
+    expect(resolve('SCFA')).toBe('ambiguous');
+  });
+
+  it('a name the vault does not know is none', () => {
+    expect(resolve('Methylphenidat')).toBe('none');
+  });
+
+  it('titles outrank aliases: a title claim beats a contested alias', () => {
+    const resolveWithTitle = buildStubIdentityResolver(
+      [...PAGES, { path: 'wiki/entities/SCFA.md', title: 'SCFA', aliases: [] }],
+      'wiki',
+    );
+    expect(resolveWithTitle('SCFA')).toBe('match');
+  });
+
+  it('sources/ pages and pages outside the wiki folder never claim a name', () => {
+    // 'Zink' appears only as the title of a page outside wikiFolder.
+    expect(resolve('Zink')).toBe('none');
+  });
+});
+
+const ITEM: EntityInfo = {
+  name: 'Methylphenidat',
+  type: 'other',
+  summary: 'First-Line-Stimulans bei ADHS.',
+  mentions_in_source: ['Medikamentös sind Stimulanzien (Methylphenidat …) die Therapie der Wahl.'],
+  domains: ['Pharmakologie'],
+};
+
+describe('buildDissentStubContent', () => {
+  const content = buildDissentStubContent({
+    item: ITEM,
+    stubType: 'entity',
+    sourceSlug: 'adhs',
+    cell: 'prose+named',
+  });
+
+  it('carries the stub marker, the #170 birth stamp, and the quoted sources wikilink', () => {
+    expect(content).toContain('stub: true');
+    expect(content).toContain('generation_complete: false');
+    expect(content).toContain('- "[[sources/adhs]]"');
+    expect(content).toContain('tags: [other]');
+    expect(content).toContain('domains:\n  - Pharmakologie');
+  });
+
+  it('body is the paid-for extraction: summary, one mention, the cell named', () => {
+    expect(content).toContain('# Methylphenidat');
+    expect(content).toContain('First-Line-Stimulans bei ADHS.');
+    expect(content).toContain('prose+named');
+    expect(content).toContain('"Medikamentös sind Stimulanzien (Methylphenidat …) die Therapie der Wahl." — [[sources/adhs]]');
+  });
+
+  it('parses as frontmatter the rest of the pipeline can read', () => {
+    const fm = parseFrontmatter(content);
+    expect(fm?.type).toBe('entity');
+    expect(isStubPage(fm)).toBe(true);
+  });
+
+  it('no summary, no quote: the stub still stands on its provenance line', () => {
+    const bare = buildDissentStubContent({
+      item: { name: 'X', type: 'other', summary: '', mentions_in_source: [] },
+      stubType: 'concept',
+      sourceSlug: 's',
+      cell: 'aside+covered',
+    });
+    expect(bare).toContain('# X');
+    expect(bare).toContain('tags: [other]');
+    expect(bare).not.toContain('" — [[sources/s]]');
+  });
+});
+
+describe('isStubPage / stripStubMarker', () => {
+  it('recognises the parsed string form and the boolean form', () => {
+    expect(isStubPage({ stub: 'true' })).toBe(true);
+    expect(isStubPage({ stub: true })).toBe(true);
+    expect(isStubPage({ stub: 'false' })).toBe(false);
+    expect(isStubPage({})).toBe(false);
+    expect(isStubPage(null)).toBe(false);
+  });
+
+  it('stripStubMarker removes exactly the marker line', () => {
+    const fm = '---\ntype: entity\nstub: true\ntags: [other]\n---';
+    expect(stripStubMarker(fm)).toBe('---\ntype: entity\ntags: [other]\n---');
+    expect(stripStubMarker('---\ntype: entity\n---')).toBe('---\ntype: entity\n---');
+  });
+});
+
+describe('createDissentStubs', () => {
+  const mkStub = (name: string): StubCandidate => ({
+    kind: 'entity',
+    cell: 'prose+named',
+    item: { name, type: 'other', summary: '', mentions_in_source: [] },
+  });
+  const mkDeps = (existing: string[] = []) => {
+    const written = new Map<string, string>();
+    return {
+      written,
+      deps: {
+        wikiFolder: 'wiki',
+        preserveCase: false,
+        normalizePath: (p: string) => p,
+        fileExists: (p: string) => existing.includes(p),
+        createOrUpdateFile: async (p: string, c: string) => { written.set(p, c); },
+      },
+    };
+  };
+
+  it('writes each stub to its slug path and reports it created', async () => {
+    const { written, deps } = mkDeps();
+    const r = await createDissentStubs(deps, [mkStub('Methylphenidat')], 'adhs');
+    expect(r.created).toEqual(['wiki/entities/methylphenidat.md']);
+    expect(written.get('wiki/entities/methylphenidat.md')).toContain('stub: true');
+  });
+
+  it('an occupied path is skipped, never overwritten (slug collision)', async () => {
+    const { written, deps } = mkDeps(['wiki/entities/methylphenidat.md']);
+    const r = await createDissentStubs(deps, [mkStub('Methylphenidat')], 'adhs');
+    expect(r.created).toEqual([]);
+    expect(r.skipped).toEqual(['wiki/entities/methylphenidat.md']);
+    expect(written.size).toBe(0);
+  });
+
+  it('two stubs folding to one slug in the same run: first wins', async () => {
+    const { written, deps } = mkDeps();
+    const r = await createDissentStubs(deps, [mkStub('Maca'), mkStub('MACA')], 's');
+    expect(r.created).toEqual(['wiki/entities/maca.md']);
+    expect(r.skipped).toEqual(['wiki/entities/maca.md']);
+    expect(written.size).toBe(1);
+  });
+
+  it('stubPath places entities and concepts in their folders', () => {
+    const deps = { wikiFolder: 'wiki', preserveCase: false, normalizePath: (p: string) => p };
+    expect(stubPath(deps, mkStub('Maca'))).toBe('wiki/entities/maca.md');
+    expect(stubPath(deps, { ...mkStub('Maca'), kind: 'concept' })).toBe('wiki/concepts/maca.md');
+  });
+});

--- a/src/__tests__/wiki/page-factory/stub-page.test.ts
+++ b/src/__tests__/wiki/page-factory/stub-page.test.ts
@@ -81,8 +81,10 @@ describe('buildDissentStubContent', () => {
     expect(content).toContain('stub: true');
     expect(content).toContain('generation_complete: false');
     expect(content).toContain('- "[[sources/adhs]]"');
-    expect(content).toContain('tags: [other]');
-    expect(content).toContain('domains:\n  - Pharmakologie');
+    // Tag-Achse Stufe 4 (S137): one field — identity value + belonging values
+    // share `tags:`, no `domains:` block is born.
+    expect(content).toContain('tags: [other, Pharmakologie]');
+    expect(content).not.toContain('domains:');
   });
 
   it('body is the paid-for extraction: summary, one mention, the cell named', () => {

--- a/src/__tests__/wiki/page-factory/stub-page.test.ts
+++ b/src/__tests__/wiki/page-factory/stub-page.test.ts
@@ -16,7 +16,7 @@ import {
   stripStubMarker,
 } from '../../../wiki/page-factory/stub-page';
 import { parseFrontmatter } from '../../../core/frontmatter';
-import type { EntityInfo } from '../../../types';
+import type { EntityInfo, ConceptInfo } from '../../../types';
 import type { StubCandidate } from '../../../core/candidate-gate';
 
 const PAGES = [
@@ -176,5 +176,44 @@ describe('createDissentStubs', () => {
     const deps = { wikiFolder: 'wiki', preserveCase: false, normalizePath: (p: string) => p };
     expect(stubPath(deps, mkStub('Maca'))).toBe('wiki/entities/maca.md');
     expect(stubPath(deps, { ...mkStub('Maca'), kind: 'concept' })).toBe('wiki/concepts/maca.md');
+  });
+});
+
+describe('buildDissentStubContent — identity tag faces the harvest (S142)', () => {
+  const VOCAB = ['Sorte/Botenstoffe', 'Thema/Diagnostik'] as const;
+
+  it('drops a settings-typelist identity the vocabulary does not carry', () => {
+    const content = buildDissentStubContent({
+      item: { name: 'Israel Brekhman', type: 'person', summary: 's', mentions_in_source: [] },
+      stubType: 'entity',
+      sourceSlug: 'adaptogen',
+      cell: 'prose+named',
+      vocabulary: VOCAB,
+    });
+    expect(content).toContain('tags: []');
+    expect(content).not.toContain('person');
+  });
+
+  it('keeps an identity value the vocabulary carries', () => {
+    const content = buildDissentStubContent({
+      item: { name: 'Prostaglandin', type: 'method', summary: 's', mentions_in_source: [], domains: ['Thema/Diagnostik'] } as unknown as ConceptInfo,
+      stubType: 'concept',
+      sourceSlug: 'ass',
+      cell: 'prose+named',
+      vocabulary: [...VOCAB, 'method'],
+    });
+    expect(content).toContain('tags: [method, Thema/Diagnostik]');
+  });
+
+  it('writes no other/term fallback under a vocabulary — empty stays empty', () => {
+    const content = buildDissentStubContent({
+      item: { name: 'Herzfrequenz', summary: 's', mentions_in_source: [] } as unknown as ConceptInfo,
+      stubType: 'concept',
+      sourceSlug: 'sechs-minuten-gehtest',
+      cell: 'aside+covered',
+      vocabulary: VOCAB,
+    });
+    expect(content).toContain('tags: []');
+    expect(content).not.toContain('term');
   });
 });

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -3,9 +3,11 @@
 // The extraction names candidates; this decides the clear cases before any
 // further call is spent on them. A candidate whose name never appears in the
 // source text, or appears only inside parentheses, enumerations or short list
-// items, gets no page — the brackets of link markup do not count as
-// parentheses, so a name the author wikilinked or hyperlinked is not an
-// aside — and is removed from the other candidates' related_*
+// items, gets no page — link markup does not count against a name (neither
+// its brackets as parentheses nor a parenthesis around the link: a name the
+// author linked is prose wherever it stands), and neither does a parenthesis
+// that is an exemplar list (profile markers) or a gloss of the name itself
+// — and is removed from the other candidates' related_*
 // lists so the gate never manufactures a dead link. Measured on a German
 // sample (10 notes, 115 candidates): 9.6 % absent, 19.1 % aside, 71.3 % prose
 // with the rules below (a first rule — plain substring, any sentence with two
@@ -89,6 +91,15 @@ export interface GateLanguageProfile {
    * bounded by one of them is an enumeration entry regardless of length.
    */
   enumerationMarks?: readonly string[];
+  /**
+   * Regex alternatives (no anchors) that mark a round parenthesis as an
+   * exemplar list rather than an aside: `Antikoagulanzien (z. B. Warfarin)`
+   * names members of the group it follows, with real predication —
+   * `(Methylphenidat als First-Line in Deutschland)` — and the members are
+   * exactly what a reader would look up. A profile without markers keeps the
+   * strict reading: every parenthesis stays an aside.
+   */
+  exemplarMarkers?: readonly string[];
 }
 
 /**
@@ -103,11 +114,13 @@ export const GATE_LANGUAGE_PROFILES: Readonly<Record<string, GateLanguageProfile
   de: {
     inflection: ['e', 's', 'n', 'en', 'es', 'er', 'em', 'ern', 'nen'],
     connectives: new Set(['und', 'oder', 'sowie', 'bzw.']),
+    exemplarMarkers: ['\\bz\\.\\s?B\\.', '\\bwie\\b', '\\betwa\\b', '\\balternativ\\b', '\\bals\\b', '\\betc\\b', '\\bu\\.\\s?a\\.', '\\binkl\\b'],
   },
-  // estimated — plural -s/-es, possessive
+  // estimated — plural -s/-es, possessive; exemplar markers unmeasured
   en: {
     inflection: ['s', 'es', "'s"],
     connectives: new Set(['and', 'or']),
+    exemplarMarkers: ['\\be\\.\\s?g\\.', '\\bsuch as\\b', '\\blike\\b', '\\bincluding\\b', '\\bincl\\b', '\\betc\\b'],
   },
   // estimated — plural -s/-x, feminine -e/-es; under-matches -al → -aux
   fr: {
@@ -215,25 +228,59 @@ function linkSpans(text: string): Array<[number, number]> {
  * candidate may carry either. Collapsing a link to its display text instead
  * turned 7 of 87 measured `aside` verdicts into `absent`.
  *
- * A parenthesis that merely CONTAINS a link stays an aside: `(e.g. [[X]])`
- * reads as an aside without the brackets of the link too. Markup changes
- * nothing in either direction. A bare bracketed citation carries no `(url)`
- * and stays an aside as well.
+ * A parenthesis that merely CONTAINS a link is still an aside as a span —
+ * but the linked name itself is rescued one level up: an occurrence inside
+ * link markup is never an aside (see classifyCandidate). A bare bracketed
+ * citation carries no `(url)` and stays an aside as well.
  *
  * Measured on a German vault, 16 notes and 321 candidates: 32 verdicts move
  * `aside` → `prose`, none the other way.
+ *
+ * A round parenthesis whose content carries one of the profile's exemplar
+ * markers (`z. B.`, `wie`, `als`, …) is no aside either: `Antikoagulanzien
+ * (z. B. Warfarin)` and `Stimulanzien (Methylphenidat als First-Line)` name
+ * the members of the group they follow — dropping them cost a medical vault
+ * exactly its pharmacology. Measured on 20 German notes, two independent
+ * draws, 159 `aside` verdicts: the marker rule moves 32 `aside` → `prose`,
+ * the link-occurrence rule 19, the gloss rule (isGlossSpan) 19 — 68 combined,
+ * no verdict moves toward `aside`, and every rescued case was reviewed.
  */
-function parenSpans(text: string): Array<[number, number]> {
+function parenSpans(text: string, profile?: GateLanguageProfile): Array<[number, number]> {
   const links = linkSpans(text);
+  const markers = profile?.exemplarMarkers?.length
+    ? new RegExp(profile.exemplarMarkers.join('|'), 'iu')
+    : null;
   const spans: Array<[number, number]> = [];
   const re = new RegExp(PAREN_RE.source, 'g');
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
     const start = m.index, end = start + m[0].length;
     if (links.some(([a, b]) => start >= a && end <= b)) continue;
+    if (markers && (text[start] === '(' || text[start] === '（') && markers.test(m[0].slice(1, -1))) continue;
     spans.push([start, end]);
   }
   return spans;
+}
+
+/**
+ * A parenthesis whose content is nothing but the name is a gloss, not an
+ * aside — the text introduces the term there: a synonym (`Übersäuerung
+ * (Azidose)`), a translation or botanical name (`Maca (Lepidium meyenii)`),
+ * an expanded acronym (`TWI (tolerierbare wöchentliche Aufnahmemenge)`).
+ * Emphasis markup around the name does not count; partial cover does not
+ * qualify (`(p53-abhängig)` glosses nothing). The rule decides only whether
+ * the name earns a page — it asserts no identity between the name and what
+ * precedes the parenthesis: `Grüntee-Polyphenole (EGCG)` glosses a member,
+ * not a synonym, and telling those apart is a typed-relation question, not
+ * a bracket question. Round parentheses only — a square-bracketed citation
+ * that consists of the name is still a citation.
+ */
+function isGlossSpan(text: string, span: [number, number], needle: RegExp): boolean {
+  if (text[span[0]] !== '(' && text[span[0]] !== '（') return false;
+  const inner = text.slice(span[0] + 1, span[1] - 1).replace(/[*_`]/g, ' ').trim();
+  const re = new RegExp(needle.source, needle.flags);
+  const m = re.exec(inner);
+  return m !== null && m.index <= 1 && m.index + m[0].length >= inner.length - 1;
 }
 
 function lineAt(text: string, pos: number): string {
@@ -313,15 +360,23 @@ export function classifyCandidate(text: string, name: string, profile: GateLangu
   const t = nfc(text);
   const needle = needleOf(name, profile);
   if (!needle) return 'absent';
-  const spans = parenSpans(t);
+  const links = linkSpans(t);
+  const spans = parenSpans(t, profile);
   let sawAside = false;
   let m: RegExpExecArray | null;
   while ((m = needle.exec(t)) !== null) {
-    const pos = m.index;
+    const pos = m.index, end = pos + m[0].length;
     if (m[0].length === 0) { needle.lastIndex++; continue; }
+    // A name inside link markup was linked by the author — the most explicit
+    // relevance statement a note makes, prose wherever the link stands.
+    if (links.some(([a, b]) => pos >= a && end <= b)) return 'prose';
     const line = lineAt(t, pos);
     if (/^\s*#{1,6}\s/.test(line)) return 'prose';
-    if (spans.some(([a, b]) => a <= pos && pos < b)) { sawAside = true; continue; }
+    const covering = spans.find(([a, b]) => a <= pos && pos < b);
+    if (covering) {
+      if (isGlossSpan(t, covering, needle)) return 'prose';
+      sawAside = true; continue;
+    }
     const item = /^\s*[-*•]\s+/.exec(line);
     if (item) {
       if (chunkLength(line.slice(item[0].length), profile) <= listItemMax(profile)) { sawAside = true; continue; }

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -426,7 +426,13 @@ export function classifyCandidate(text: string, name: string, profile: GateLangu
 export const COVERAGE_BELOW_THRESHOLD: ReadonlySet<string> = new Set(['named']);
 
 /** Why a candidate got no page: where the text put it, or what the model observed. */
-export type DropReason = Exclude<GateVerdict, 'prose'> | 'named';
+export type DropReason =
+  | Exclude<GateVerdict, 'prose'>
+  | 'named'
+  // Outcome-table drops (S135): both gates below threshold, or a dissent name
+  // whose identity is ambiguous in the vault (an alias two pages claim).
+  | 'aside+named'
+  | 'ambiguous';
 
 /**
  * Parameterised on the reason so each gate's result says what that gate can
@@ -566,4 +572,106 @@ export function applyCoverageThreshold(
   const concepts = keep(analysis.concepts, 'concept');
   if (dropped.length === 0) return { entities: analysis.entities, concepts: analysis.concepts, dropped, linkedAnyway: [], applied: true };
   return { ...pruneDroppedNames(entities, concepts, dropped, isKnownPage), dropped, applied: true };
+}
+
+// ---------------------------------------------------------------------------
+// S135: the three-outcome table. The position gate (deterministic: where the
+// text puts the name) and the coverage observation (the model: how the text
+// treats it) measure different things, and their dissent is mixed content —
+// neither may hold a veto alone. Measured over 1,153 items across three
+// ingest runs: the full-page set of this table equals exactly the keep set of
+// the two serial gates above, so the table is a pure extension — it converts
+// about half of today's drops into stubs and demotes nothing.
+
+/** The two dissent cells. Agreement cells need no name: full page or nothing. */
+export type StubCell = 'prose+named' | 'aside+covered';
+
+export interface StubCandidate {
+  kind: 'entity' | 'concept';
+  cell: StubCell;
+  item: EntityInfo | ConceptInfo;
+}
+
+/**
+ * What the vault already says about a dissent name. Supplied by the caller
+ * (the gate is pure and has no vault): 'match' = exactly one page carries the
+ * name as title or curated alias — no stub, the name stays linkable and the
+ * existing page takes the edge; 'ambiguous' = two pages claim it — no stub
+ * and the name is pruned (a stub born onto a contested name would buy back
+ * the dedup cost this gate exists to save); 'none' = a stub is born.
+ */
+export type StubIdentity = 'none' | 'match' | 'ambiguous';
+
+export interface OutcomeTableResult extends GateResult {
+  /** Dissent names with no page yet: stub births, in analysis order. */
+  stubs: StubCandidate[];
+  /** Dissent names an existing page already answers: no page work, name kept. */
+  existing: Array<{ name: string; kind: 'entity' | 'concept'; cell: StubCell }>;
+}
+
+/**
+ * Route every candidate through the decision table instead of the two serial
+ * gates above:
+ *
+ *   hand-linked name            → full page   (the author's link outranks both gates)
+ *   prose  + covered            → full page
+ *   prose  + named              → stub        (dissent: the model under-read the text)
+ *   aside  + covered            → stub        (dissent: the position rule over-read it)
+ *   aside  + named              → nothing
+ *   absent                      → nothing
+ *
+ * A missing/unknown `coverage` value counts as covered, exactly as in
+ * applyCoverageThreshold. Stub and existing-match names are NOT pruned from
+ * the survivors' related_* lists — their pages exist (or will), so the links
+ * resolve; only the nothing-cells are pruned. Pure, same no-profile contract
+ * as gateCandidates (`applied: false`, input untouched).
+ */
+export function applyOutcomeTable(
+  analysis: Pick<SourceAnalysis, 'entities' | 'concepts'>,
+  sourceText: string,
+  language: string | undefined | null,
+  resolveIdentity: (name: string) => StubIdentity,
+): OutcomeTableResult {
+  const profile = gateProfileFor(language);
+  if (!profile) {
+    return { entities: analysis.entities, concepts: analysis.concepts, dropped: [], stubs: [], existing: [], applied: false };
+  }
+  const linked = linkedNames(sourceText);
+  const dropped: DroppedCandidate[] = [];
+  const stubs: StubCandidate[] = [];
+  const existing: OutcomeTableResult['existing'] = [];
+  const route = <T extends EntityInfo | ConceptInfo>(items: T[], kind: StubCandidate['kind']): T[] =>
+    items.filter(item => {
+      if (linked.has(nfc(item.name).trim().toLowerCase())) return true;
+      const position = classifyCandidate(sourceText, item.name, profile);
+      const cov = typeof item.coverage === 'string' ? item.coverage.trim().toLowerCase() : '';
+      const covered = !COVERAGE_BELOW_THRESHOLD.has(cov);
+      if (position === 'prose' && covered) return true;
+      if (position === 'absent') {
+        dropped.push({ name: item.name, kind, verdict: 'absent' });
+        return false;
+      }
+      if (position === 'aside' && !covered) {
+        dropped.push({ name: item.name, kind, verdict: 'aside+named' });
+        return false;
+      }
+      const cell: StubCell = position === 'prose' ? 'prose+named' : 'aside+covered';
+      const identity = resolveIdentity(item.name);
+      if (identity === 'match') {
+        existing.push({ name: item.name, kind, cell });
+        return false;
+      }
+      if (identity === 'ambiguous') {
+        dropped.push({ name: item.name, kind, verdict: 'ambiguous' });
+        return false;
+      }
+      stubs.push({ kind, cell, item });
+      return false;
+    });
+  const entities = route(analysis.entities, 'entity');
+  const concepts = route(analysis.concepts, 'concept');
+  if (dropped.length === 0) {
+    return { entities, concepts, dropped, stubs, existing, applied: true };
+  }
+  return { ...pruneDropped(entities, concepts, dropped), dropped, stubs, existing, applied: true };
 }

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -204,6 +204,31 @@ function needleOf(name: string, profile: GateLanguageProfile): RegExp | null {
 /** Link markup, whose brackets are syntax: `[[wikilink]]`, `![[embed]]`, `[text](url)`. */
 const LINK_RE = /!?\[\[[^\]\n]*\]\]|!?\[[^[\]\n]*\]\([^)\n]*\)/g;
 
+/**
+ * Every name the note's own link markup asserts: wikilink targets (folder
+ * prefix and `#anchor` stripped), pipe aliases, and markdown link texts —
+ * case-folded, NFC. Exact names, no inflection: a link is an exact claim.
+ */
+function linkedNames(text: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  const add = (s: string) => { const n = nfc(s).trim().toLowerCase(); if (n) names.add(n); };
+  const t = nfc(text);
+  const re = new RegExp(LINK_RE.source, 'g');
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(t)) !== null) {
+    const wiki = /^!?\[\[([^\]]*)\]\]$/.exec(m[0]);
+    if (wiki) {
+      const [target, alias] = wiki[1].split('|');
+      add((target ?? '').split('#')[0].split('/').pop() ?? '');
+      if (alias) add(alias);
+      continue;
+    }
+    const md = /^!?\[([^\]]*)\]/.exec(m[0]);
+    if (md) add(md[1]);
+  }
+  return names;
+}
+
 function linkSpans(text: string): Array<[number, number]> {
   const spans: Array<[number, number]> = [];
   const re = new RegExp(LINK_RE.source, 'g');
@@ -510,16 +535,30 @@ function pruneDroppedNames<R extends DropReason>(
  *
  * `isKnownPage` mirrors gateCandidates (#620): a dropped name the vault
  * already has a page for keeps its edge in the survivors' related_* lists.
+ *
+ * With `sourceText` given (the raw note body), a candidate whose exact name
+ * the note's own link markup carries — wikilink target, pipe alias, or
+ * markdown link text — survives a `named` verdict (#607): the author linking
+ * a name is a stronger statement about relevance than the model's reading of
+ * how the text treats it.
  */
 export function applyCoverageThreshold(
   analysis: Pick<SourceAnalysis, 'entities' | 'concepts'>,
   isKnownPage?: (name: string) => boolean,
+  sourceText?: string,
 ): GateResult<'named'> {
+  const linked = sourceText === undefined ? null : linkedNames(sourceText);
   const dropped: DroppedCandidate<'named'>[] = [];
   const keep = <T extends { name: string; coverage?: string }>(items: T[], kind: DroppedCandidate['kind']): T[] =>
     items.filter(item => {
       const cov = typeof item.coverage === 'string' ? item.coverage.trim().toLowerCase() : '';
       if (!COVERAGE_BELOW_THRESHOLD.has(cov)) return true;
+      // Author's link outranks coverage (#607): `[[Reis]]` in Arsen, `[[Blei]]`
+      // in Reis were both hand-linked and both dropped as `named` without this.
+      if (linked?.has(nfc(item.name).trim().toLowerCase())) return true;
+      // Vault-page parity (#620): a dropped name the vault already has a page
+      // for keeps its edge in the survivors' related_* lists.
+      if (isKnownPage?.(item.name) === true) return true;
       dropped.push({ name: item.name, kind, verdict: 'named' });
       return false;
     });

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -550,8 +550,8 @@ function pruneDroppedNames<R extends DropReason>(
  */
 export function applyCoverageThreshold(
   analysis: Pick<SourceAnalysis, 'entities' | 'concepts'>,
-  isKnownPage?: (name: string) => boolean,
   sourceText?: string,
+  isKnownPage?: (name: string) => boolean,
 ): GateResult<'named'> {
   const linked = sourceText === undefined ? null : linkedNames(sourceText);
   const dropped: DroppedCandidate<'named'>[] = [];
@@ -562,9 +562,9 @@ export function applyCoverageThreshold(
       // Author's link outranks coverage (#607): `[[Reis]]` in Arsen, `[[Blei]]`
       // in Reis were both hand-linked and both dropped as `named` without this.
       if (linked?.has(nfc(item.name).trim().toLowerCase())) return true;
-      // Vault-page parity (#620): a dropped name the vault already has a page
-      // for keeps its edge in the survivors' related_* lists.
-      if (isKnownPage?.(item.name) === true) return true;
+      // #620 parity is in pruneDroppedNames below, NOT here: a known page
+      // name still belongs in `dropped` so the caller can log it, but its
+      // edge stays in the survivors' related_* lists.
       dropped.push({ name: item.name, kind, verdict: 'named' });
       return false;
     });
@@ -635,7 +635,7 @@ export function applyOutcomeTable(
 ): OutcomeTableResult {
   const profile = gateProfileFor(language);
   if (!profile) {
-    return { entities: analysis.entities, concepts: analysis.concepts, dropped: [], stubs: [], existing: [], applied: false };
+    return { entities: analysis.entities, concepts: analysis.concepts, dropped: [], stubs: [], existing: [], linkedAnyway: [], applied: false };
   }
   const linked = linkedNames(sourceText);
   const dropped: DroppedCandidate[] = [];
@@ -672,7 +672,7 @@ export function applyOutcomeTable(
   const entities = route(analysis.entities, 'entity');
   const concepts = route(analysis.concepts, 'concept');
   if (dropped.length === 0) {
-    return { entities, concepts, dropped, stubs, existing, applied: true };
+    return { entities, concepts, dropped, stubs, existing, linkedAnyway: [], applied: true };
   }
   return { ...pruneDroppedNames(entities, concepts, dropped, isKnownPage), dropped, stubs, existing, applied: true };
 }

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -631,6 +631,7 @@ export function applyOutcomeTable(
   sourceText: string,
   language: string | undefined | null,
   resolveIdentity: (name: string) => StubIdentity,
+  isKnownPage?: (name: string) => boolean,
 ): OutcomeTableResult {
   const profile = gateProfileFor(language);
   if (!profile) {
@@ -673,5 +674,5 @@ export function applyOutcomeTable(
   if (dropped.length === 0) {
     return { entities, concepts, dropped, stubs, existing, applied: true };
   }
-  return { ...pruneDropped(entities, concepts, dropped), dropped, stubs, existing, applied: true };
+  return { ...pruneDroppedNames(entities, concepts, dropped, isKnownPage), dropped, stubs, existing, applied: true };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -502,6 +502,18 @@ export interface LLMWikiSettings {
   skipMentionOnlyCandidates?: boolean;
 
   /**
+   * S135 outcome table: when the candidate gate is on, a candidate the two
+   * gate halves disagree on (prose+named / aside+covered) becomes a stub
+   * page built from the extraction's own summary — no LLM call — instead of
+   * being dropped. Off by default: more pages is a behaviour change. Takes
+   * effect only with `skipMentionOnlyCandidates` on, because the table needs
+   * the position verdict that setting opts into; the full-page set is
+   * unchanged either way (the table is a pure extension of the two serial
+   * gates, measured over 1,153 items across three runs).
+   */
+  gateDissentStubs?: boolean;
+
+  /**
    * Issue #485: whether Fix Dead Links writes an empty placeholder page when
    * a link resolves to nothing (both branches — the model's create_stub
    * answer and the deterministic fallback). On by default: that is the
@@ -1293,6 +1305,8 @@ export const DEFAULT_SETTINGS: LLMWikiSettings = {
   lintDedupIncludeSources: undefined,
   // Issue #514: off by default — fewer pages is a behaviour change, opt in.
   skipMentionOnlyCandidates: false,
+  // S135: off by default — stubs from gate dissent are a behaviour change, opt in.
+  gateDissentStubs: false,
   // Issue #485: on by default — stub creation is the existing outcome;
   // turning it off is the user's choice. The use site also treats a
   // missing key as on (`!== false`), matching lintDedupIncludeSources.

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -87,7 +87,12 @@ export function buildStubContent(params: StubContentParams): string {
   // which makes Obsidian's Properties panel drop the property type and
   // the value becomes literal text (no link chip, no backlink, no graph
   // edge). Match `yamlStringify()` in src/core/frontmatter.ts (line 104).
-  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - "[[${referringPageRel}]]"\ntags: [${defaultTag}]\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
+  // S135: `stub: true` is the marker that actually carries "this is a stub" —
+  // `generation_complete: false` cannot (createOrUpdateFile flips it to `true`
+  // right after the write, and unflipped it would hand the page to the startup
+  // Phase-3 cleaner). merge-page.ts reads it to keep a stub from being
+  // skip-frozen, and strips it when a treating source fills the page.
+  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - "[[${referringPageRel}]]"\ntags: [${defaultTag}]\nstub: true\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referringPageRel}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
 }
 
 /**

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -48,6 +48,7 @@ import { collectActiveVocabulary } from '../../core/domain-axis';
 import { appendContradictedByMarker } from '../../core/contradicted-marker';
 import { buildContradictionRecord } from '../../core/contradiction-record';
 import { describeDemotion } from './contradiction-gates';
+import { isStubPage, stripStubMarker } from './stub-page';
 import { injectMentionsSection } from '../../core/mentions-injector';
 import { renderTemplate } from '../../core/template-renderer';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
@@ -112,7 +113,8 @@ export async function mergePage(
     // its curated aliases; slug comparison on both sides, so "Silent
     // Inflammation.md" matches the page "Silent-Inflammation".
     const pageBasename = path.split('/').pop()?.replace(/\.md$/i, '') ?? '';
-    const existingAliases = parseFrontmatter(existingContent)?.aliases;
+    const existingFm = parseFrontmatter(existingContent);
+    const existingAliases = existingFm?.aliases;
     const sourceOwnsPage = isSourceOwnPageLemma({
       pageName: pageBasename,
       pageAliases: Array.isArray(existingAliases) ? existingAliases : undefined,
@@ -140,6 +142,15 @@ export async function mergePage(
         })
       : '';
 
+    // S135: a stub (dissent-born or Fix-Dead-Links, both carry `stub: true`)
+    // must never be skip-frozen — its whole contract is that the next source
+    // treating the subject fills it. The triage sees a thin placeholder body
+    // and can honestly judge a real source as "nothing new"; that judgement
+    // is right about the body and wrong about the page. Same narrow shape as
+    // the #312 override below: only `skip` is rerouted. A write that adds
+    // content promotes the page: the marker is stripped below.
+    const existingIsStub = isStubPage(existingFm);
+
     // 1. v1.24.0 #216 — classify-then-route triage.
     let shouldSkip = false;
     let complementaryBody: string | null = null;
@@ -158,10 +169,12 @@ export async function mergePage(
       // Deliberately narrow: only `skip` is overridden. `complementary`
       // already writes the new facts, and rerouting it would trade a targeted
       // append for a full rewrite without cause.
-      const strategy = triage.strategy === 'skip' && sourceOwnsPage ? 'merge' : triage.strategy;
+      const strategy = triage.strategy === 'skip' && (sourceOwnsPage || existingIsStub) ? 'merge' : triage.strategy;
       if (strategy !== triage.strategy) {
         console.debug(
-          `[mergePage] triage=skip overridden to merge — "${sourceFile.basename}" carries this page's own lemma (#312) for ${path}`,
+          sourceOwnsPage
+            ? `[mergePage] triage=skip overridden to merge — "${sourceFile.basename}" carries this page's own lemma (#312) for ${path}`
+            : `[mergePage] triage=skip overridden to merge — ${path} is a stub (generation_complete: false), skip would freeze it (S135)`,
         );
       }
 
@@ -249,9 +262,15 @@ export async function mergePage(
       const bodyToWrite = complementaryBody ?? existingBody;
       // Item-level contradictions reach this path (complementary write):
       // stamp the same frontmatter marker the rewrite path stamps below.
-      const fmToWrite = contradictedSourcePath
+      let fmToWrite = contradictedSourcePath
         ? appendContradictedByMarker(frontmatter, contradictedSourcePath)
         : frontmatter;
+      // S135 promotion: a complementary append put real content onto a stub.
+      // A pure skip cannot reach a stub (the override above reroutes it), so
+      // the marker survives only untouched writes elsewhere.
+      if (existingIsStub && complementaryBody !== null) {
+        fmToWrite = stripStubMarker(fmToWrite);
+      }
       await ctx.createOrUpdateFile(
         path,
         await assembleFinalContent(ctx, fmToWrite, bodyToWrite, info, sourceFile, existingBody),
@@ -330,9 +349,11 @@ export async function mergePage(
         // routine merge. Unknown-field preservation (PR A Step 2) keeps the
         // marker across subsequent re-touches; the helper dedupes by
         // sourcePath so idempotent re-runs are safe.
+        // S135 promotion: the body merge below filled the stub with a source
+        // that treats its subject — the marker comes off with the same write.
         contradictedSourcePath
-          ? appendContradictedByMarker(frontmatter, contradictedSourcePath)
-          : frontmatter,
+          ? appendContradictedByMarker(existingIsStub ? stripStubMarker(frontmatter) : frontmatter, contradictedSourcePath)
+          : existingIsStub ? stripStubMarker(frontmatter) : frontmatter,
         titledBody,
         info,
         sourceFile,

--- a/src/wiki/page-factory/stub-page.ts
+++ b/src/wiki/page-factory/stub-page.ts
@@ -31,6 +31,7 @@
 import type { EntityInfo, ConceptInfo } from '../../types';
 import type { StubCandidate, StubIdentity } from '../../core/candidate-gate';
 import { slugify } from '../../core/slug';
+import { selectDomains } from '../../core/domain-axis';
 
 interface ExistingPageLike {
   path: string;
@@ -114,13 +115,23 @@ export function buildDissentStubContent(params: {
   stubType: 'entity' | 'concept';
   sourceSlug: string;
   cell: string;
+  /** Harvested tag vocabulary. When present, the identity value faces it like
+   *  every other writer's tags do (S139); when absent, legacy behavior. */
+  vocabulary?: readonly string[];
 }): string {
-  const { item, stubType, sourceSlug, cell } = params;
+  const { item, stubType, sourceSlug, cell, vocabulary } = params;
   const today = new Date().toISOString().split('T')[0];
   // Tag-Achse Stufe 4 (S137): one field — the identity value (the extraction
   // type) and the validated belonging values share `tags:`; no `domains:`.
-  const identity = item.type || (stubType === 'entity' ? 'other' : 'term');
-  const tagValues = [identity, ...(item.domains ?? []).filter(d => d !== identity)];
+  // S142: the identity fallback leaked the settings typelist (`person`,
+  // `theory`) into `tags:` — the same drift the S139 strips closed at
+  // create/merge/fill. With a vocabulary the identity faces the harvest:
+  // a value it does not carry is dropped, and an empty result stays empty —
+  // a visible gap beats a wrong value (the fill path rewrites tags anyway).
+  const identity = vocabulary
+    ? (item.type ? selectDomains([item.type], vocabulary).kept[0] ?? '' : '')
+    : item.type || (stubType === 'entity' ? 'other' : 'term');
+  const tagValues = [...(identity ? [identity] : []), ...(item.domains ?? []).filter(d => d !== identity)];
   const tag = tagValues.join(', ');
   const quote = item.mentions_with_provenance?.[0]?.quote ?? item.mentions_in_source?.[0];
   const summary = (item.summary ?? '').trim();
@@ -134,6 +145,8 @@ export interface StubBirthDeps {
   normalizePath: (p: string) => string;
   fileExists: (path: string) => boolean;
   createOrUpdateFile: (path: string, content: string) => Promise<void>;
+  /** Harvested tag vocabulary for the stub's identity tag (see buildDissentStubContent). */
+  vocabulary?: readonly string[];
 }
 
 export interface StubBirthResult {
@@ -175,6 +188,7 @@ export async function createDissentStubs(
       stubType: stub.kind,
       sourceSlug,
       cell: stub.cell,
+      vocabulary: deps.vocabulary,
     }));
     created.push(path);
   }

--- a/src/wiki/page-factory/stub-page.ts
+++ b/src/wiki/page-factory/stub-page.ts
@@ -1,0 +1,181 @@
+// page-factory/stub-page.ts — S135: stubs born from gate dissent.
+//
+// The outcome table in core/candidate-gate.ts routes a candidate the two
+// gates disagree on to a stub: a page built entirely from what the
+// extraction already paid for (summary, one mention, the item's domain
+// subset) — no LLM call. The format follows the Fix Dead Links stub
+// (fix-dead-link.ts, #197/#485), with one difference in body (a dead-link
+// stub has nothing to say — no extraction exists for it — a dissent stub
+// carries the summary the extraction produced) and one shared addition:
+// `stub: true` in the frontmatter.
+//
+// Why a dedicated marker and not `generation_complete: false`: that flag
+// cannot carry "this is a stub". The engine's createOrUpdateFile stamps
+// every wiki content page `generation_complete: true` right after the write
+// (markPageComplete, #170) — the `false` a stub is born with is flipped
+// before anyone reads it. And if it were NOT flipped, the startup QuickFixes
+// Phase 3 would trash the page as an interrupted write. `stub: true` rides
+// the #356 passthrough through every frontmatter merge and is stripped
+// exactly once: when a source that treats the subject fills the page
+// (merge-page.ts) — that is the stub's promotion.
+//
+// Identity is decided deterministically before birth (buildStubIdentityResolver):
+// exactly one existing page carrying the name as title or curated alias means
+// no stub — the edge lands on that page through normal link resolution. A
+// name two pages claim gets no stub either (the #446 lesson: an alias claimed
+// twice merges the next name into the wrong page); the outcome table prunes
+// it. Only an unclaimed name is born as a stub. No LLM near any of this —
+// a model call at stub birth would buy back the resolveEntityDedup cost the
+// gate exists to save.
+
+import type { EntityInfo, ConceptInfo } from '../../types';
+import type { StubCandidate, StubIdentity } from '../../core/candidate-gate';
+import { slugify } from '../../core/slug';
+
+interface ExistingPageLike {
+  path: string;
+  title: string;
+  aliases?: string[];
+}
+
+/**
+ * Build a name → StubIdentity resolver over the existing wiki pages.
+ * Keyed case-folded (`slugify(x, false)`) on both sides, per the contract at
+ * slug.ts: comparison callers must not pass `preserveCase`. Titles outrank
+ * aliases — a title is the page's own claim to a name, an alias is someone's
+ * cross-reference to it — matching the related-link corrector's index
+ * (related-link-corrector.ts). Only entities/ and concepts/ pages count:
+ * sources/ is never a link target and a stub never answers to one.
+ */
+export function buildStubIdentityResolver(
+  pages: ExistingPageLike[],
+  wikiFolder: string,
+): (name: string) => StubIdentity {
+  const prefix = wikiFolder + '/';
+  const pathByTitle = new Map<string, string>();
+  const pathByAlias = new Map<string, string>();
+  const ambiguousTitles = new Set<string>();
+  const ambiguousAliases = new Set<string>();
+  const register = (raw: string, relPath: string, into: Map<string, string>, clash: Set<string>) => {
+    const s = slugify(raw, false);
+    if (!s) return;
+    const prev = into.get(s);
+    if (prev && prev !== relPath) { clash.add(s); return; }
+    into.set(s, relPath);
+  };
+  for (const page of pages) {
+    if (!page.path.startsWith(prefix)) continue;
+    const relPath = page.path.slice(prefix.length).replace(/\.md$/, '');
+    if (!relPath.startsWith('entities/') && !relPath.startsWith('concepts/')) continue;
+    register(page.title, relPath, pathByTitle, ambiguousTitles);
+    for (const alias of page.aliases ?? []) {
+      register(alias, relPath, pathByAlias, ambiguousAliases);
+    }
+  }
+  return (name: string): StubIdentity => {
+    const s = slugify(name, false);
+    if (!s) return 'none';
+    if (ambiguousTitles.has(s)) return 'ambiguous';
+    if (pathByTitle.has(s)) return 'match';
+    if (ambiguousAliases.has(s)) return 'ambiguous';
+    if (pathByAlias.has(s)) return 'match';
+    return 'none';
+  };
+}
+
+/** Frontmatter key that marks a stub page. String-compared ('true') because
+ *  parseFrontmatter does no boolean coercion; boolean accepted defensively. */
+export function isStubPage(fm: Record<string, unknown> | null | undefined): boolean {
+  return fm?.stub === 'true' || fm?.stub === true;
+}
+
+/**
+ * Promotion: remove the `stub:` marker line from a rendered frontmatter
+ * block (or full page content — the regex is line-anchored and the key is
+ * frontmatter-only by construction). Called by merge-page.ts when a source
+ * that treats the subject fills the page.
+ */
+export function stripStubMarker(frontmatterBlock: string): string {
+  return frontmatterBlock.replace(/^stub:\s*(?:true|false)\s*\n?/m, '');
+}
+
+/**
+ * The stub page content. Frontmatter matches the Fix Dead Links stub
+ * (block-style quoted `sources:` wikilink — see the YAML notes in
+ * fix-dead-link.ts — and the #170 birth stamp), plus `stub: true` (see the
+ * module header) and what the extraction already knows: the item's type tag
+ * and its validated domain subset. The body is the paid-for extraction
+ * summary and one verbatim mention; the provenance line names the gate so a
+ * reader (and a later session) can tell a dissent stub from a dead-link
+ * stub.
+ */
+export function buildDissentStubContent(params: {
+  item: EntityInfo | ConceptInfo;
+  stubType: 'entity' | 'concept';
+  sourceSlug: string;
+  cell: string;
+}): string {
+  const { item, stubType, sourceSlug, cell } = params;
+  const today = new Date().toISOString().split('T')[0];
+  const tag = item.type || (stubType === 'entity' ? 'other' : 'term');
+  const domainsBlock = item.domains?.length
+    ? `domains:\n${item.domains.map(d => `  - ${d}`).join('\n')}\n`
+    : '';
+  const quote = item.mentions_with_provenance?.[0]?.quote ?? item.mentions_in_source?.[0];
+  const summary = (item.summary ?? '').trim();
+  const quoteBlock = quote ? `\n> "${quote.trim()}" — [[sources/${sourceSlug}]]\n` : '';
+  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - "[[sources/${sourceSlug}]]"\ntags: [${tag}]\n${domainsBlock}stub: true\ngeneration_complete: false\n---\n# ${item.name}\n\n> Stub created by the ingest candidate gate (${cell}) — [[sources/${sourceSlug}]] names this without treating it. Will be filled by the next ingest of a source that does.\n${summary ? `\n${summary}\n` : ''}${quoteBlock}`;
+}
+
+export interface StubBirthDeps {
+  wikiFolder: string;
+  preserveCase: boolean;
+  normalizePath: (p: string) => string;
+  fileExists: (path: string) => boolean;
+  createOrUpdateFile: (path: string, content: string) => Promise<void>;
+}
+
+export interface StubBirthResult {
+  created: string[];
+  /** Planned stubs whose file already existed (or collided in-run by slug): skipped, never overwritten. */
+  skipped: string[];
+}
+
+/** The vault path a stub for this candidate would occupy. */
+export function stubPath(deps: Pick<StubBirthDeps, 'wikiFolder' | 'preserveCase' | 'normalizePath'>, stub: StubCandidate): string {
+  const folder = stub.kind === 'entity' ? 'entities' : 'concepts';
+  return deps.normalizePath(`${deps.wikiFolder}/${folder}/${slugify(stub.item.name, deps.preserveCase)}.md`);
+}
+
+/**
+ * Write the stub pages. A path that already exists is skipped — identity was
+ * resolved against titles and aliases, so an existing file here means a slug
+ * collision (two names folding to one slug), and overwriting a page the
+ * resolver did not claim would be a silent merge into the wrong page. Two
+ * stubs folding to the same slug in one run: first one wins, same rule.
+ */
+export async function createDissentStubs(
+  deps: StubBirthDeps,
+  stubs: StubCandidate[],
+  sourceSlug: string,
+): Promise<StubBirthResult> {
+  const created: string[] = [];
+  const skipped: string[] = [];
+  const claimed = new Set<string>();
+  for (const stub of stubs) {
+    const path = stubPath(deps, stub);
+    if (claimed.has(path) || deps.fileExists(path)) {
+      skipped.push(path);
+      continue;
+    }
+    claimed.add(path);
+    await deps.createOrUpdateFile(path, buildDissentStubContent({
+      item: stub.item,
+      stubType: stub.kind,
+      sourceSlug,
+      cell: stub.cell,
+    }));
+    created.push(path);
+  }
+  return { created, skipped };
+}

--- a/src/wiki/page-factory/stub-page.ts
+++ b/src/wiki/page-factory/stub-page.ts
@@ -117,14 +117,15 @@ export function buildDissentStubContent(params: {
 }): string {
   const { item, stubType, sourceSlug, cell } = params;
   const today = new Date().toISOString().split('T')[0];
-  const tag = item.type || (stubType === 'entity' ? 'other' : 'term');
-  const domainsBlock = item.domains?.length
-    ? `domains:\n${item.domains.map(d => `  - ${d}`).join('\n')}\n`
-    : '';
+  // Tag-Achse Stufe 4 (S137): one field — the identity value (the extraction
+  // type) and the validated belonging values share `tags:`; no `domains:`.
+  const identity = item.type || (stubType === 'entity' ? 'other' : 'term');
+  const tagValues = [identity, ...(item.domains ?? []).filter(d => d !== identity)];
+  const tag = tagValues.join(', ');
   const quote = item.mentions_with_provenance?.[0]?.quote ?? item.mentions_in_source?.[0];
   const summary = (item.summary ?? '').trim();
   const quoteBlock = quote ? `\n> "${quote.trim()}" — [[sources/${sourceSlug}]]\n` : '';
-  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - "[[sources/${sourceSlug}]]"\ntags: [${tag}]\n${domainsBlock}stub: true\ngeneration_complete: false\n---\n# ${item.name}\n\n> Stub created by the ingest candidate gate (${cell}) — [[sources/${sourceSlug}]] names this without treating it. Will be filled by the next ingest of a source that does.\n${summary ? `\n${summary}\n` : ''}${quoteBlock}`;
+  return `---\ntype: ${stubType}\ncreated: ${today}\nsources:\n  - "[[sources/${sourceSlug}]]"\ntags: [${tag}]\nstub: true\ngeneration_complete: false\n---\n# ${item.name}\n\n> Stub created by the ingest candidate gate (${cell}) — [[sources/${sourceSlug}]] names this without treating it. Will be filled by the next ingest of a source that does.\n${summary ? `\n${summary}\n` : ''}${quoteBlock}`;
 }
 
 export interface StubBirthDeps {

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -35,7 +35,8 @@ import type { SourceRejection } from '../core/source-requirements';
 import { formatRateLimitNotice } from '../core/rate-limit';
 import { extractSourceTags } from '../core/arrays';
 import { buildVaultResolver } from '../core/related-link-corrector';
-import { gateCandidates, applyCoverageThreshold } from '../core/candidate-gate';
+import { gateCandidates, applyCoverageThreshold, applyOutcomeTable, type StubCandidate } from '../core/candidate-gate';
+import { buildStubIdentityResolver, createDissentStubs, stubPath } from './page-factory/stub-page';
 import { selectDomains, collectActiveVocabulary } from '../core/domain-axis'; // domain axis stages 3-5 (#568)
 import { getSourceLanguage, isCrossLanguage } from '../core/source-language';
 import { cleanMarkdownResponse } from '../core/markdown';
@@ -1050,10 +1051,58 @@ export class WikiEngine {
       // and is not gated; a wiki language without a profile is reported, not
       // silently skipped — the user turned this on.
       const rawSource = opts?.contentOverride ?? await this.app.vault.read(file);
-      if (this.settings.skipMentionOnlyCandidates === true) {
-        const wikiLang = this.settings.wikiLanguage || 'en';
-        const sourceLang = getSourceLanguage(file, this.app);
-        const translated = sourceLang !== null && isCrossLanguage(sourceLang, wikiLang);
+      const wikiLang = this.settings.wikiLanguage || 'en';
+      const sourceLang = getSourceLanguage(file, this.app);
+      const translated = sourceLang !== null && isCrossLanguage(sourceLang, wikiLang);
+
+      // S135 outcome table: with `gateDissentStubs` on, the two gate halves
+      // stop running in series (each with a veto) and become one decision
+      // table — agreement keeps or drops as before, dissent births a stub
+      // from the extraction's own summary (no LLM call). Requires the #514
+      // opt-in, because the table needs the position verdict that setting
+      // opts into; cross-language notes are not gated, same as below. The
+      // full-page set is identical to the serial path's keep set (measured
+      // over 1,153 items, three runs) — the table only converts drops.
+      let stubPlan: StubCandidate[] = [];
+      let tableApplied = false;
+      if (
+        this.settings.gateDissentStubs === true &&
+        this.settings.skipMentionOnlyCandidates === true &&
+        !translated
+      ) {
+        const pages = await getExistingWikiPages(this.app, this.settings.wikiFolder);
+        const table = applyOutcomeTable(
+          analysis,
+          extractBody(rawSource),
+          wikiLang,
+          buildStubIdentityResolver(pages, this.settings.wikiFolder),
+        );
+        // `!table.applied` (no language profile) falls through to the serial
+        // path, which reports the missing profile itself.
+        if (table.applied) {
+          tableApplied = true;
+          const total = analysis.entities.length + analysis.concepts.length;
+          if (table.dropped.length > 0) {
+            const list = table.dropped.map(d => `${d.name} (${d.kind}, ${d.verdict})`).join('; ');
+            console.warn(`[candidate-gate] ${file.path}: dropped ${table.dropped.length} of ${total} candidates — ${list}`);
+            this.onProgress?.(`Candidate gate: ${table.dropped.length} dropped — ${list}`);
+          }
+          if (table.existing.length > 0) {
+            const list = table.existing.map(d => `${d.name} (${d.kind}, ${d.cell})`).join('; ');
+            console.debug(`[candidate-gate] ${file.path}: ${table.existing.length} dissent name(s) an existing page answers — ${list}`);
+          }
+          if (table.stubs.length > 0) {
+            const list = table.stubs.map(s => `${s.item.name} (${s.kind}, ${s.cell})`).join('; ');
+            console.warn(`[candidate-gate] ${file.path}: ${table.stubs.length} dissent stub(s) planned — ${list}`);
+            this.onProgress?.(`Candidate gate: ${table.stubs.length} stub(s) from dissent — ${list}`);
+          }
+          analysis.entities = table.entities;
+          analysis.concepts = table.concepts;
+          stubPlan = table.stubs;
+        }
+      }
+
+      if (!tableApplied && this.settings.skipMentionOnlyCandidates === true) {
         if (!translated) {
           // A dropped name the vault already has a page for keeps its edge:
           // the gate judges whether this note earns the page, not whether a
@@ -1088,33 +1137,36 @@ export class WikiEngine {
       // is validated against the vault's tag vocabulary: a value no note
       // carries is dropped (logged), not written. Runs regardless of the #521
       // opt-in — the deterministic gate is upstream's setting, this half is
-      // the local domain-axis design.
+      // the local domain-axis design. Under the outcome table the threshold
+      // has already been folded into the routing, so only the domain
+      // validation runs — over the survivors AND the planned stubs, whose
+      // frontmatter carries the same validated subset.
       {
-        // #620 parity: a dropped name the vault already has a page for keeps
-        // its edge in the survivors' related_* lists. #607: the author's own
-        // link markup ([[X]] / [X](X)) in the note outranks a `named` coverage
-        // verdict — hand-linked names carry stronger intent than the model's
-        // reading of how the text treats them. Both predicates are passed;
-        // either one keeps the candidate.
-        const coverageResolve = buildVaultResolver({ wikiFolder: this.settings.wikiFolder, pages: await this.getExistingWikiPages() });
-        const covered = applyCoverageThreshold(
-          analysis,
-          name => coverageResolve(name) !== undefined,
-          rawSource,
-        );
-        if (covered.dropped.length > 0) {
-          const list = covered.dropped.map(d => `${d.name} (${d.kind}, ${d.verdict})`).join('; ');
-          const kept = covered.linkedAnyway.length > 0 ? ` — linked anyway (existing page): ${covered.linkedAnyway.join('; ')}` : '';
-          console.warn(`[candidate-gate] ${file.path}: dropped ${covered.dropped.length} of ${analysis.entities.length + analysis.concepts.length} candidates — ${list}${kept}`);
-          this.onProgress?.(`Candidate gate: ${covered.dropped.length} dropped — ${list}${kept}`);
-          analysis.entities = covered.entities;
-          analysis.concepts = covered.concepts;
+        if (!tableApplied) {
+          // #620 parity: a dropped name the vault already has a page for keeps
+          // its edge in the survivors' related_* lists. Without the predicate
+          // behaviour is unchanged. (The author's own link markup is folded
+          // into applyCoverageThreshold's own sourceText path — see candidate-gate.ts.)
+          const coverageResolve = buildVaultResolver({ wikiFolder: this.settings.wikiFolder, pages: await this.getExistingWikiPages() });
+          const covered = applyCoverageThreshold(
+            analysis,
+            name => coverageResolve(name) !== undefined,
+            extractBody(rawSource),
+          );
+          if (covered.dropped.length > 0) {
+            const list = covered.dropped.map(d => `${d.name} (${d.kind}, ${d.verdict})`).join('; ');
+            const kept = covered.linkedAnyway.length > 0 ? ` — linked anyway (existing page): ${covered.linkedAnyway.join('; ')}` : '';
+            console.warn(`[candidate-gate] ${file.path}: dropped ${covered.dropped.length} of ${analysis.entities.length + analysis.concepts.length} candidates — ${list}${kept}`);
+            this.onProgress?.(`Candidate gate: ${covered.dropped.length} dropped — ${list}${kept}`);
+            analysis.entities = covered.entities;
+            analysis.concepts = covered.concepts;
+          }
         }
         // Stage 5 (#568): validation accepts exactly what the declared source
         // folders and the wiki's own pages carry — new values are born by
         // tagging a note or a page, not by editing a settings list.
         const domainVocabulary = collectActiveVocabulary(this.app, this.settings);
-        for (const item of [...analysis.entities, ...analysis.concepts]) {
+        for (const item of [...analysis.entities, ...analysis.concepts, ...stubPlan.map(s => s.item)]) {
           const selection = selectDomains(item.domains, domainVocabulary);
           if (selection.rejected.length > 0) {
             console.debug(`[domain-axis] ${file.path}: "${item.name}" — dropped ${selection.rejected.length} value(s) the vocabulary does not carry: ${selection.rejected.join(', ')}`);
@@ -1135,6 +1187,11 @@ export class WikiEngine {
       for (const concept of analysis.concepts) {
         plannedPaths.push(normalizePath(`${this.settings.wikiFolder}/concepts/${slugify(concept.name, preserveCase)}.md`));
       }
+      // S135: stub pages will exist too — planned like any page, so links
+      // the summary makes to their names land on the canonical path.
+      for (const stub of stubPlan) {
+        plannedPaths.push(stubPath({ wikiFolder: this.settings.wikiFolder, preserveCase, normalizePath }, stub));
+      }
 
       this.onProgress?.(
         getText(this.settings.language, 'ingestCreatingSummary')
@@ -1147,6 +1204,31 @@ export class WikiEngine {
       // before any page is written, so the summary page, entity/concept backlinks,
       // and related pages all reference the same canonical [[sources/<slug>]].
       const sourceSlug = resolveSourceSlug(file.path, { preserveCase });
+
+      // S135: birth the dissent stubs — deterministic writes, no LLM call,
+      // before any generation so every page produced this run can already
+      // link to them. A path that exists is a slug collision and is skipped,
+      // never overwritten (identity was resolved against titles + aliases).
+      if (stubPlan.length > 0) {
+        const stubResult = await createDissentStubs(
+          {
+            wikiFolder: this.settings.wikiFolder,
+            preserveCase,
+            normalizePath,
+            fileExists: (p) => this.app.vault.getAbstractFileByPath(p) !== null,
+            createOrUpdateFile: (p, c) => this.createOrUpdateFile(p, c),
+          },
+          stubPlan,
+          sourceSlug,
+        );
+        analysis.created_pages.push(...stubResult.created);
+        if (stubResult.skipped.length > 0) {
+          console.warn(`[candidate-gate] ${file.path}: ${stubResult.skipped.length} stub(s) skipped (slug already occupied) — ${stubResult.skipped.join('; ')}`);
+        }
+        if (stubResult.created.length > 0) {
+          console.debug(`[candidate-gate] ${file.path}: ${stubResult.created.length} dissent stub(s) written — ${stubResult.created.join('; ')}`);
+        }
+      }
 
       // Stage 2: Summary Page Generation (contentOverride flows through opts)
       const summaryStart = Date.now();

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -1217,6 +1217,9 @@ export class WikiEngine {
             normalizePath,
             fileExists: (p) => this.app.vault.getAbstractFileByPath(p) !== null,
             createOrUpdateFile: (p, c) => this.createOrUpdateFile(p, c),
+            // S142: the stub's identity tag faces the harvest like every
+            // other writer's tags (the domains were validated above).
+            vocabulary: collectActiveVocabulary(this.app, this.settings),
           },
           stubPlan,
           sourceSlug,

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -1150,8 +1150,8 @@ export class WikiEngine {
           const coverageResolve = buildVaultResolver({ wikiFolder: this.settings.wikiFolder, pages: await this.getExistingWikiPages() });
           const covered = applyCoverageThreshold(
             analysis,
-            name => coverageResolve(name) !== undefined,
             extractBody(rawSource),
+            name => coverageResolve(name) !== undefined,
           );
           if (covered.dropped.length > 0) {
             const list = covered.dropped.map(d => `${d.name} (${d.kind}, ${d.verdict})`).join('; ');

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -1091,10 +1091,17 @@ export class WikiEngine {
       // the local domain-axis design.
       {
         // #620 parity: a dropped name the vault already has a page for keeps
-        // its edge in the survivors' related_* lists — the coverage gate must
-        // not prune what the deterministic gate was taught to keep.
+        // its edge in the survivors' related_* lists. #607: the author's own
+        // link markup ([[X]] / [X](X)) in the note outranks a `named` coverage
+        // verdict — hand-linked names carry stronger intent than the model's
+        // reading of how the text treats them. Both predicates are passed;
+        // either one keeps the candidate.
         const coverageResolve = buildVaultResolver({ wikiFolder: this.settings.wikiFolder, pages: await this.getExistingWikiPages() });
-        const covered = applyCoverageThreshold(analysis, name => coverageResolve(name) !== undefined);
+        const covered = applyCoverageThreshold(
+          analysis,
+          name => coverageResolve(name) !== undefined,
+          rawSource,
+        );
         if (covered.dropped.length > 0) {
           const list = covered.dropped.map(d => `${d.name} (${d.kind}, ${d.verdict})`).join('; ');
           const kept = covered.linkedAnyway.length > 0 ? ` — linked anyway (existing page): ${covered.linkedAnyway.join('; ')}` : '';


### PR DESCRIPTION
**Stacked on #569:** the first ten commits are that PR unchanged (rebased onto `7c4d144` today, head `d1e04a7`); only the last six belong here — the coverage observation this table consumes is commit 2 of #569. Once #569 merges, this PR's diff collapses to the six.

Follows up #514 (the deterministic gate) and closes the loop on #485's "leave it" outcome from the other side: a name the note carries without treating it gets a stub, not an empty page and not a dropped edge.

**The principle.** The position gate (deterministic: where the text puts the name) and the coverage observation (the model: how the text treats it) measure different things, and their disagreement is mixed content — neither half may hold a veto alone. Two serial vetoes become one decision table: agreement keeps (prose + covered) or drops (aside + named, absent) exactly as today; a hand-linked name outranks both halves; the two dissent cells (prose + named, aside + covered) birth a **stub** — a page built entirely from what the extraction already paid for (summary, one verbatim mention, validated tags, sources backlink), no LLM call anywhere near the path.

**Measured** over 1,153 items across three ingest runs on a German vault: the table's full-page set equals the serial gates' keep set exactly. It is a pure extension — it converts about half of today's drops into stubs (52 of 105 on the latest run) and demotes nothing.

**What the six commits do:**

1. **Three parenthesis rescues** (exemplar markers, glosses, occurrences inside link markup are not asides) — 70 of 159 aside verdicts move to prose across two independent draws, none the other way, every case reviewed. Extends the #564 rule, which stopped at the link's own brackets.
2. **The author's link outranks the coverage threshold** — `[[Reis]]` in one note and `[[Blei]]` in another were hand-linked and dropped as `named` on the same day. Exact names only: a link is an exact claim.
3. **`applyOutcomeTable`** — the table itself, with a caller-supplied deterministic identity verdict per dissent name: an existing page answers it (edge only), an ambiguous name (an alias two pages claim) is pruned — a stub born onto a contested name would merge the next mention into the wrong page — an unclaimed name becomes a stub. Stub and existing-match names stay in the survivors' `related_*` lists, so the gate keeps its no-manufactured-dead-links invariant.
4. **Stub birth and lifecycle.** Marker is a dedicated `stub: true` key on both birth paths (gate dissent and Fix Dead Links' third outcome), because `generation_complete: false` cannot carry it: `markPageComplete` flips it right after the write, and if it did not, startup QuickFixes would trash the page as an interrupted write. Two rules keep the stub honestly temporary: merge triage never freezes it (`skip` is rerouted to merge, same narrow shape as the #312 lemma override — the triage is right about the thin body and wrong about the page), and a write that fills it strips the marker in the same write.
5. **The stub follows the one-field tag axis** from #569 — identity and belonging values share `tags:`, no `domains:` block is born.
6. **The stub's identity tag faces the harvest** — with a vocabulary present, a type the vocabulary does not carry is dropped and an empty result stays empty; without one, the legacy fallback is unchanged.

**Opt-in:** `settings.gateDissentStubs`, default off (more pages is a behaviour change), effective only with `skipMentionOnlyCandidates` on because the table needs the position verdict that setting opts into. Deliberately not in the settings UI yet, same reasoning as #490. Cross-language notes and languages without a gate profile keep the serial-gate path unchanged.

**Not in this PR, named so nobody looks for it:** the extraction brake (names never proposed, #567) · typed relations (synonym vs. member — the gloss boundary, #285) · marker-less exemplar parentheses "(A, B, C)" stay asides and land as stubs via `discussed` · exemplar markers for languages beyond de/en (those profiles stay strict).

3841 tests passing (270 files); typecheck and lint clean on the rebased stack. Run end to end on a live vault (three instrumented batch runs) before the rebase.
