### PR TITLE
fix(dates): stamp vault dates from local time, not the UTC calendar

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { LLMWikiSettings } from '../../types';
 import { enforceFrontmatterConstraints, isBlankSource, mergeFrontmatter, mergeFrontmatterArrayField, parseFrontmatter, preserveFrontmatterReviewTag, replaceFrontmatterArrayField, serializeFrontmatter, upsertFrontmatterField } from '../../core/frontmatter';
+import { localDateStamp } from '../../core/format';
 
 describe('isBlankSource', () => {
   it('is true for empty or whitespace-only content', () => {
@@ -186,7 +187,7 @@ describe('enforceFrontmatterConstraints', () => {
     // must still be normalized to today. Safety > user intent on dates.
     const input = '---\ntype: entity\nreviewed: true\ncreated: 2025-13-99\nupdated: 2099-99-99\n---\n\nBody';
     const result = enforceFrontmatterConstraints(input, 'entity');
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(result).toContain('reviewed: true');
     expect(result).toContain(`created: ${today}`);
     expect(result).not.toContain('2025-13-99');
@@ -242,7 +243,7 @@ describe('enforceFrontmatterConstraints', () => {
     const result = enforceFrontmatterConstraints(input, 'entity', undefined, {
       preserveCreated: '2026-01-01',
     });
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(result).toContain('created: 2026-01-01');
     expect(result).not.toContain('created: 2024-11-03');
     expect(result).toContain(`updated: ${today}`);
@@ -292,7 +293,7 @@ describe('enforceFrontmatterConstraints', () => {
     const result = enforceFrontmatterConstraints(input, 'entity', undefined, {
       preserveCreated: '2025-03-20',
     });
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(result).toContain('created: 2025-03-20');
     expect(result).toContain(`updated: ${today}`);
     expect(result).not.toContain('updated: 2024-12-01');
@@ -301,7 +302,7 @@ describe('enforceFrontmatterConstraints', () => {
   it('adds created/updated when missing from frontmatter', () => {
     const input = '---\ntype: entity\n---\n\nBody';
     const result = enforceFrontmatterConstraints(input, 'entity');
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(result).toContain(`created: ${today}`);
     expect(result).toContain(`updated: ${today}`);
   });
@@ -314,14 +315,14 @@ describe('enforceFrontmatterConstraints', () => {
     // is invented by construction.
     const input = '---\ntype: entity\ncreated: 2024-11-03\n---\n\nBody';
     const result = enforceFrontmatterConstraints(input, 'entity');
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(result).toContain(`created: ${today}`);
     expect(result).not.toContain('2024-11-03');
   });
 
   it('ignores a caller value that is not an ISO date', () => {
     const input = '---\ntype: entity\n---\n\nBody';
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     for (const bogus of ['gestern', '2025-13-99x', '', '   ']) {
       const result = enforceFrontmatterConstraints(input, 'entity', undefined, {
         preserveCreated: bogus,
@@ -336,7 +337,7 @@ describe('enforceFrontmatterConstraints', () => {
     // every pass. With the value supplied it survives; without one the branch
     // behaves as before.
     const input = '---\ntype: entity\nreviewed: true\ncreated: 2024-11-03\nupdated: 2020-01-01\n---\n\nBody';
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
 
     const withValue = enforceFrontmatterConstraints(input, 'entity', undefined, {
       preserveCreated: '2026-01-05',
@@ -496,7 +497,7 @@ describe('serializeFrontmatter', () => {
 });
 
 describe('mergeFrontmatter', () => {
-  const today = new Date().toISOString().split('T')[0];
+  const today = localDateStamp();
 
   it('returns body as-is when no frontmatter exists', () => {
     const input = '# Just content\nNo frontmatter';

--- a/src/__tests__/core/local-date-stamp.test.ts
+++ b/src/__tests__/core/local-date-stamp.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { localDateStamp } from '../../core/format';
+
+describe('localDateStamp', () => {
+  it('formats the local calendar date as YYYY-MM-DD with zero padding', () => {
+    // Local components — the same wall-clock date in every time zone.
+    expect(localDateStamp(new Date(2026, 0, 5, 9, 15))).toBe('2026-01-05');
+    expect(localDateStamp(new Date(2026, 11, 31, 23, 59))).toBe('2026-12-31');
+  });
+
+  it('keeps the local date across the hours where the UTC date still lags', () => {
+    // 00:30 local on 3 Sep. In any zone east of UTC toISOString() still says
+    // 2 Sep here; the vault's dates are read in local time, so 3 Sep is right.
+    const justAfterMidnight = new Date(2026, 8, 3, 0, 30);
+    expect(localDateStamp(justAfterMidnight)).toBe('2026-09-03');
+  });
+
+  it('defaults to now', () => {
+    const now = new Date();
+    expect(localDateStamp()).toBe(localDateStamp(now));
+  });
+});

--- a/src/__tests__/wiki/engine-internals/log-writer.test.ts
+++ b/src/__tests__/wiki/engine-internals/log-writer.test.ts
@@ -57,6 +57,27 @@ describe('LogWriter', () => {
     expect(content).toContain(' · 4.3KB'); // 4400 bytes → 4.3KB
   });
 
+  it('appendIngest stamps the local calendar date, not the UTC one', async () => {
+    // 00:30 local on 3 Sep. East of UTC the ISO date is still 2 Sep at this
+    // hour; the log is read in local time, so the header must say 3 Sep.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 8, 3, 0, 30));
+    try {
+      const writeFile = vi.fn().mockResolvedValue(undefined);
+      const writer = new LogWriter({
+        wikiFolder: 'wiki',
+        wikiLanguage: 'en',
+        readFile: vi.fn().mockResolvedValue('# Wiki Operation Log\n'),
+        writeFile,
+      });
+      await writer.appendIngest('ingest', makeAnalysis(), {});
+      const [, content] = writeFile.mock.calls[0] as [string, string];
+      expect(content).toContain('## [2026-09-03 00:30] ingest');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('appendIngest with no metrics omits the suffix entirely', async () => {
     const writeFile = vi.fn().mockResolvedValue(undefined);
     const readFile = vi.fn().mockResolvedValue('# Header\n');

--- a/src/__tests__/wiki/lint/fill-empty-page-created.test.ts
+++ b/src/__tests__/wiki/lint/fill-empty-page-created.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { fillEmptyPage } from '../../../wiki/lint/fill-empty-page';
 import type { EngineContext } from '../../../types';
+import { localDateStamp } from '../../../core/format';
 
 // Issue #388 at the fill path. Unlike page creation, a real page exists here —
 // so the model's `created:` does not invent a date, it overwrites a true one.
@@ -35,7 +36,7 @@ describe('fillEmptyPage — created: provenance (Issue #388)', () => {
     await fillEmptyPage(ctx, PAGE);
 
     const written = files.get(PAGE)!;
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(written).toContain('created: 2026-07-30');
     expect(written).not.toContain('2024-11-03');
     expect(written).toContain(`updated: ${today}`);

--- a/src/__tests__/wiki/page-factory/create-page.test.ts
+++ b/src/__tests__/wiki/page-factory/create-page.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../wiki/page-factory/create-page';
 import { createMockEntity, createMockConcept } from '../../__support__/factories';
 import type { LLMWikiSettings, LLMClient } from '../../../types';
+import { localDateStamp } from '../../../core/format';
 
 const EXISTING_FM = `---\ncreated: 2026-07-10\nupdated: 2026-07-10\nsources:\n  - "[[existing]]"\ntags: []\n---\n\n## Description\nOld body.\n`;
 
@@ -446,7 +447,7 @@ describe('createNewPage — created: provenance (Issue #388)', () => {
       'wiki/entities/X.md',
     );
     const written = ctx.written.get('wiki/entities/X.md')!;
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     expect(written).toContain(`created: ${today}`);
     expect(written).not.toContain('2024-11-03');
   });

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -11,3 +11,20 @@ export function formatBytes(n: number): string {
   if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`;
   return `${n}B`;
 }
+
+/**
+ * Today's calendar date in the user's local time zone, as `YYYY-MM-DD`.
+ *
+ * `new Date().toISOString().slice(0, 10)` yields the UTC date, which in any
+ * zone east of UTC is still *yesterday* for the first hours after local
+ * midnight (until 08:00 in UTC+8, 02:00 in CEST). Every date stamp the plugin
+ * writes into the vault — `created:` / `updated:` frontmatter, the ingest
+ * log's `## [date time]` header, contradiction records — is read by a human
+ * in local time, so it must be built from local components.
+ */
+export function localDateStamp(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -1,6 +1,7 @@
 import { VALID_ENTITY_TAGS, VALID_CONCEPT_TAGS, VALID_SOURCE_TAGS, LLMWikiSettings } from '../types';
 import { getActiveEntityTags, getActiveConceptTags, getActiveSourceTags } from './tag-vocab';
 import { filterRedundantAliases, resolveMinAliasLength } from './slug';
+import { localDateStamp } from './format';
 
 export interface FrontmatterData {
   reviewed?: boolean;
@@ -544,8 +545,8 @@ export function mergeFrontmatter(
   sourceSet.add(newSourcePath);
   const mergedSources = Array.from(sourceSet).map(s => `[[${s}]]`);
 
-  const created = fm.created || new Date().toISOString().split('T')[0];
-  const updated = new Date().toISOString().split('T')[0];
+  const created = fm.created || localDateStamp();
+  const updated = localDateStamp();
 
   // Always emit a `tags:` line (bare when empty) to preserve prior behavior.
   // Issue #356 follow-up: also pass through unknown top-level fields
@@ -635,7 +636,7 @@ export function enforceFrontmatterConstraints(
   const fmText = content.substring(3, fmEnd);
 
   if (/^reviewed:\s*true\s*$/m.test(fmText)) {
-    const today = new Date().toISOString().split('T')[0];
+    const today = localDateStamp();
     const created = resolveCreated(options, today);
     return content
       .replace(/^created:\s*\d{4}-\d{2}-\d{2}\s*$/m, `created: ${created}`)
@@ -643,7 +644,7 @@ export function enforceFrontmatterConstraints(
   }
 
   let body = content.substring(fmEnd + 5);
-  const today = new Date().toISOString().split('T')[0];
+  const today = localDateStamp();
 
   const lines = fmText.split('\n');
   let collectedTags: string[] = [];

--- a/src/schema/auto-maintain.ts
+++ b/src/schema/auto-maintain.ts
@@ -15,6 +15,7 @@ import { isLocalNoKeyProvider } from '../core/local-no-key-provider';
 import { resolveProviderApiKey } from '../llm-sdk/provider-api-key-resolver';
 import type { LLMClient } from '../types';
 import { isIngestableSource } from '../core/folder-scope';
+import { localDateStamp } from '../core/format';
 
 export class AutoMaintainManager {
   private app: App;
@@ -632,7 +633,7 @@ export class AutoMaintainManager {
         createWelcomeNote: this.settings.createWelcomeNote,
       },
       targetLanguage: this.settings.wikiLanguage || 'en',
-      createdAt: new Date().toISOString().slice(0, 10),
+      createdAt: localDateStamp(),
       // smokeTestProbe wraps the sync probe in a resolved Promise so
       // the ensure-welcome-note signature is satisfied.
       smokeTestProbe: async () => this.probeLlm(),

--- a/src/schema/schema-manager.ts
+++ b/src/schema/schema-manager.ts
@@ -10,6 +10,7 @@ import { TOKENS_SCHEMA_SUGGESTION } from '../constants';
 import { renderTemplate } from '../core/template-renderer';
 import { SchemaSuggestionLLMSchema } from '../llm-sdk/output-schemas';
 import { callLlm } from '../core/llm-dispatch';
+import { localDateStamp } from '../core/format';
 
 const SCHEMA_FILENAME = 'schema/config.md';
 const SUGGESTIONS_FILENAME = 'schema/suggestions.md';
@@ -391,7 +392,7 @@ ${selectedBody}
       // Already exists
     }
 
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDateStamp();
     const body = buildDefaultSchemaBody(this.settings);
     const content = `---
 version: 1
@@ -410,7 +411,7 @@ ${body}`;
 
   async regenerateDefaultSchema(): Promise<void> {
     const path = this.getSchemaPath();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDateStamp();
     const body = buildDefaultSchemaBody(this.settings);
     const content = `---
 version: 1

--- a/src/wiki/contradictions.ts
+++ b/src/wiki/contradictions.ts
@@ -21,6 +21,7 @@ import {
   resolveContradictionTarget,
   ResolvedContradictionTarget,
 } from '../core/contradiction-record';
+import { localDateStamp } from '../core/format';
 
 export class ContradictionManager {
   constructor(private ctx: EngineContext) {}
@@ -74,7 +75,7 @@ export class ContradictionManager {
       // folder already exists
     }
 
-    const date = new Date().toISOString().split('T')[0];
+    const date = localDateStamp();
     const record = buildContradictionRecord(
       {
         claim: contradiction.claim,
@@ -151,7 +152,7 @@ export class ContradictionManager {
     }
     const updated = content.replace(/^status:\s*\S+/m, `status: ${newStatus}`);
     if (newStatus === 'resolved') {
-      const resolvedDate = new Date().toISOString().split('T')[0];
+      const resolvedDate = localDateStamp();
       if (updated.includes('resolved:')) {
         const final = updated.replace(
           /^resolved:\s*\S*/m,

--- a/src/wiki/conversation-ingest.ts
+++ b/src/wiki/conversation-ingest.ts
@@ -19,6 +19,7 @@ import { TOKENS_CONVERSATION_EXTRACTION, TOKENS_CONVERSATION_PAGE, TOKENS_PAGE_G
 import { PageFactory } from './page-factory';
 import { SourceAnalysisLLMSchema, ConversationDedupStatusLLMSchema } from '../llm-sdk/output-schemas';
 import { callLlm } from '../core/llm-dispatch';
+import { localDateStamp } from '../core/format';
 
 export interface ConversationOrchestration {
   ensureWikiStructure: () => Promise<void>;
@@ -66,7 +67,7 @@ export class ConversationIngestor {
     console.debug('=== Starting conversation extraction ===');
     this.ctx.onProgress?.(getText(this.ctx.settings.language, 'convAnalyzing'));
 
-    const actualDate = new Date().toISOString().split('T')[0];
+    const actualDate = localDateStamp();
     console.debug('[System time]', actualDate);
 
     const indexPath = `${this.ctx.settings.wikiFolder}/index.md`;

--- a/src/wiki/engine-internals/log-writer.ts
+++ b/src/wiki/engine-internals/log-writer.ts
@@ -30,7 +30,7 @@ import type { SourceAnalysis } from '../../types';
 import { TEXTS } from '../../texts';
 import { dedupPages } from './dedup-pages';
 import { buildLogHeader } from '../../core/log-header';
-import { formatBytes } from '../../core/format';
+import { formatBytes, localDateStamp } from '../../core/format';
 
 /** Metrics suffix for ingest log H2 line. */
 export interface IngestMetrics {
@@ -164,7 +164,7 @@ export class LogWriter {
   private timestamp(): { date: string; time: string } {
     const now = new Date();
     return {
-      date: now.toISOString().split('T')[0],
+      date: localDateStamp(now),
       time: now.toTimeString().slice(0, 5), // HH:MM
     };
   }

--- a/src/wiki/lint/fill-empty-page.ts
+++ b/src/wiki/lint/fill-empty-page.ts
@@ -16,6 +16,7 @@ import {
 } from '../../core/prompt-builders';
 import { normalizeFrontmatterDates, buildSectionLabelsHint, EMPTY_CONTENT_STRIP, MIN_SUBSTANTIVE_CHARS, STUB_MARKER } from './utils';
 import { WIKI_SUBFOLDERS } from '../../constants';
+import { localDateStamp } from '../../core/format';
 
 
 export async function fillEmptyPage(
@@ -90,7 +91,7 @@ export async function fillEmptyPage(
     );
   }
 
-  const dateStr = new Date().toISOString().split('T')[0];
+  const dateStr = localDateStamp();
   const withDates = normalizeFrontmatterDates(stubFree, dateStr);
   const pageTypeSingular = pageType === WIKI_SUBFOLDERS.entities ? 'entity' : pageType === WIKI_SUBFOLDERS.concepts ? 'concept' : 'source';
   // Issue #388: the page being filled already exists, so its real creation date

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -14,6 +14,7 @@ import {
 import { getExistingWikiPages } from './get-existing-pages';
 import { selectCandidateWindow, contextAround } from '../../core/candidate-window';
 import { FixDeadLinkSchema, type FixDeadLink } from '../../llm-sdk/output-schemas';
+import { localDateStamp } from '../../core/format';
 
 /** Characters to each side of the dead link that describe what it points to (300 in all, the dedup summary length). */
 const DEAD_LINK_CONTEXT_RADIUS = 150;
@@ -73,7 +74,7 @@ export interface StubContentParams {
 
 export function buildStubContent(params: StubContentParams): string {
   const { title, stubType, referringPageRel } = params;
-  const today = new Date().toISOString().split('T')[0];
+  const today = localDateStamp();
   const defaultTag = stubType === 'entity' ? 'other' : 'term';
   // Emit `sources:` as block-style so the v1.25.11 provenance-stamp
   // writer in create-page.ts's `appendSourceSlugToFrontmatter` (which

--- a/src/wiki/lint/merge-duplicates.ts
+++ b/src/wiki/lint/merge-duplicates.ts
@@ -9,6 +9,7 @@ import { cleanMarkdownResponse } from '../../core/markdown';
 import { renderTemplate } from '../../core/template-renderer';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { retargetLinksToPage } from '../../core/link-retarget';
+import { localDateStamp } from '../../core/format';
 
 export async function mergeDuplicatePages(
   ctx: EngineContext,
@@ -145,7 +146,7 @@ export async function mergeDuplicatePages(
     }
   }
 
-  const today = new Date().toISOString().split('T')[0];
+  const today = localDateStamp();
   const newContent = serializeFrontmatter(
     {
       type: targetFm?.type,

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -42,6 +42,7 @@ import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { mergePage } from './merge-page';
 import { appendToReviewedPage } from './merge-page';
 import { isConversationSource, contextualizeError } from './contextualize';
+import { localDateStamp } from '../../core/format';
 
 /**
  * Minimal context contract required by createOrUpdatePage / createNewPage.
@@ -196,7 +197,7 @@ export async function createNewPage(
       related_concepts: info.related_concepts?.join(', ') || 'No related concepts',
       related_content: 'No existing content',
       merge_strategy: 'New page, no merge needed.',
-      date: new Date().toISOString().split('T')[0],
+      date: localDateStamp(),
       // Issue #155: entity/concept pages cite the canonical source PAGE
       // ([[sources/<slug>]]), not the raw note path — so a collision-
       // disambiguated source slug is honored and the normalizer passes it

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -56,6 +56,7 @@ import { assembleFinalContent } from './mentions-integration';
 import { applyComplementaryAppends } from './complementary-appends';
 import { firstQuotesForPrompt, isConversationSource, mergeError } from './contextualize';
 import { buildNoteExcerpt, renderNoteExcerptBlock } from './note-window';
+import { localDateStamp } from '../../core/format';
 
 /**
  * Minimal context contract required by mergePage / appendToReviewedPage.
@@ -341,7 +342,7 @@ async function writeContradictionRecords(
     // folder already exists
   }
   const labels = getSectionLabels(ctx.settings);
-  const date = new Date().toISOString().split('T')[0];
+  const date = localDateStamp();
   const pageRelPath = pagePath.startsWith(`${wikiFolder}/`)
     ? pagePath.slice(wikiFolder.length + 1).replace(/\.md$/i, '')
     : pagePath.replace(/\.md$/i, '');

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -65,6 +65,7 @@ import { GraphCache, type GraphPageLoader } from './engine-internals/graph-cache
 import { IndexGenerator } from './engine-internals/index-generator';
 import { LogWriter } from './engine-internals/log-writer';
 import { dedupPages } from './engine-internals/dedup-pages';
+import { localDateStamp } from '../core/format';
 
 /**
  * Issue #173 Symptom B: drop exact-string duplicates from a page-path list
@@ -1470,7 +1471,7 @@ export class WikiEngine {
       analysis: JSON.stringify(analysis),
       created_pages_list: createdPagesList || '(none)',
       source_file: file.path,
-      date: new Date().toISOString().split('T')[0],
+      date: localDateStamp(),
       tags: tagsValue,
       constraints: UNIVERSAL_LINK_CONSTRAINTS,
     });


### PR DESCRIPTION
Fixes #611

## What

All 17 places that write a `YYYY-MM-DD` into the vault built it from `new Date().toISOString()`, the UTC calendar date. This PR routes them through one helper, `localDateStamp()` in `src/core/format.ts`, that uses the local calendar date. Details and the log excerpt are in #611.

## Why one helper and not one line

The visible symptom is the ingest log (`## [2026-09-02 01:56]` right after `## [2026-09-02 23:52]`, then `2026-09-03` from 02:00 on), but the log only made it visible because its time part was already local. `created:` / `updated:` on every generated page, the contradiction records, the stubs, the schema file and the welcome note all carried the same UTC date silently. Fixing the log alone would have left the log and the pages it lists disagreeing about which day it was.

## Changes

- `src/core/format.ts`: `localDateStamp(now = new Date())`.
- 14 source files: the 17 `toISOString().split('T')[0]` / `.slice(0, 10)` sites replaced by the helper. No other logic touched.
- 3 test files: expected dates computed via the helper instead of the UTC expression, so they stop being wrong in the same hours the code was.
- New: `src/__tests__/core/local-date-stamp.test.ts` (helper) and one case in `log-writer.test.ts` that fakes 00:30 local on 3 Sep and expects `## [2026-09-03 00:30]`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm test`: 3796 tests, 268 files, green.
- Negative control: the new log-writer case run against `upstream/main`'s `log-writer.ts` under `TZ=Asia/Shanghai` fails (`expected … to contain '## [2026-09-03 00:30] ingest'`); with the fix it passes under `TZ=Asia/Shanghai`, `TZ=America/Los_Angeles` and the default zone.

## Not in this PR

Full ISO timestamps (`convertedAt` in the converters, `apply-suggestion.ts`, `source-analyzer.ts`, `schema-manager.ts:492`) are instants and stay UTC. The history modal's day-range filter (`render-state.ts`) already treats an entry's date as a whole day, so the local date matches its intent; no change needed there.
