### PR TITLE
fix(related): a related page is an entity or concept — never the source page that shares its name

### DIFF
--- a/src/__tests__/wiki/page-factory/related-page.test.ts
+++ b/src/__tests__/wiki/page-factory/related-page.test.ts
@@ -417,3 +417,38 @@ describe('updateRelatedPage — H1 survives a rewrite that omits it', () => {
     expect(body.trimStart().startsWith('# X —')).toBe(true);
   });
 });
+
+describe('updateRelatedPage — only entity and concept pages are related targets', () => {
+  const SOURCE_PATH = 'wiki/sources/X.md';
+
+  // The stock mock resolves only PAGE_PATH; here both the source twin and the
+  // entity page must resolve, so a wrong pick writes to the wrong file
+  // instead of vanishing behind a null lookup.
+  function makeTwinCtx(pages: Array<{ path: string; basename: string }>) {
+    const ctx = makeCtx({ pageContent: EXISTING_FM, pages });
+    ctx.written.set(SOURCE_PATH, EXISTING_FM);
+    ctx.app.vault.getAbstractFileByPath = (p: string): unknown =>
+      p === PAGE_PATH || p === SOURCE_PATH
+        ? Object.assign(new TFile(), { path: p, basename: PAGE_TITLE })
+        : null;
+    return ctx;
+  }
+
+  it('rewrites the entity page when a source page shares its basename and is listed first', async () => {
+    const ctx = makeTwinCtx([
+      { path: SOURCE_PATH, basename: PAGE_TITLE },
+      { path: PAGE_PATH, basename: PAGE_TITLE },
+    ]);
+    const result = await updateRelatedPage(ctx, PAGE_TITLE, makeAnalysis(PAGE_TITLE), { path: 'p.md', basename: 'p' });
+    expect(result).toBe(true);
+    expect(ctx.written.get(PAGE_PATH)).toContain('new body');
+    expect(ctx.written.get(SOURCE_PATH)).toBe(EXISTING_FM);
+  });
+
+  it('returns false and writes nothing when only a source page carries the name', async () => {
+    const ctx = makeTwinCtx([{ path: SOURCE_PATH, basename: PAGE_TITLE }]);
+    const result = await updateRelatedPage(ctx, PAGE_TITLE, makeAnalysis(PAGE_TITLE), { path: 'p.md', basename: 'p' });
+    expect(result).toBe(false);
+    expect(ctx.written.get(SOURCE_PATH)).toBe(EXISTING_FM);
+  });
+});

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -16,7 +16,7 @@
 import { TFile } from 'obsidian';
 import type { SourceAnalysis, LLMWikiSettings, LLMClient } from '../../types';
 import { PROMPTS } from '../../prompts';
-import { TOKENS_PAGE_GENERATION } from '../../constants';
+import { TOKENS_PAGE_GENERATION, WIKI_SUBFOLDERS } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
@@ -69,7 +69,20 @@ export async function updateRelatedPage(
     ctx.app as never,
     ctx.settings.wikiFolder,
   );
-  const page = existingPages.find(p => p.title === pageName);
+  // A related page is an entity or concept page. The title index spans the
+  // whole wiki folder, and a source page shares its basename with the entity
+  // its note is about (`sources/Zytokine` next to `entities/Zytokine`), so a
+  // bare title lookup picked whichever the vault listed first — on a measured
+  // vault 573 of the rewrites landed on source pages, whose one-note summary
+  // then got the entity prompt, the entity's `new_info`, and the entity-page
+  // Mentions budget. Only the two entity folders are candidates here.
+  const relatedFolders = [
+    `${ctx.settings.wikiFolder}/${WIKI_SUBFOLDERS.entities}/`,
+    `${ctx.settings.wikiFolder}/${WIKI_SUBFOLDERS.concepts}/`,
+  ];
+  const page = existingPages.find(
+    p => p.title === pageName && relatedFolders.some(folder => p.path.startsWith(folder)),
+  );
 
   if (!page) {
     console.debug('Related page not found:', pageName);


### PR DESCRIPTION
Fixes #613

## What

`updateRelatedPage` now resolves its target among `entities/` and `concepts/` only. A source page that shares the basename (`sources/Zytokine` next to `entities/Zytokine`) is no longer a candidate; a name that exists solely as a source page returns "not found", as the function's contract says.

## Why

The title index spans the whole wiki folder and `title` is the basename, so the bare-title `find` returned whichever twin the vault listed first. Measured: 573 of the related-page body rewrites on a 413-note rebuild landed on source pages (numbers in #613). The source page then received the entity prompt and the entity's `new_info`, and the entity page the rewrite was meant for stayed as it was.

## Changes

- `src/wiki/page-factory/related-page.ts`: the lookup filters on the two entity folders (`WIKI_SUBFOLDERS`). Nothing else in the function changes.
- `src/__tests__/wiki/page-factory/related-page.test.ts`: two cases with both twins resolvable in the mock, so a wrong pick shows as a write to the wrong file rather than as a null lookup. (a) source listed first → entity rewritten, source byte-identical, returns true; (b) only the source exists → nothing written, returns false. Both fail against `main`.

## Verification

typecheck, lint, build, test: 3795 tests, 267 files, green.

## Not in this PR

The Mentions budget that made those misdirected rewrites visible (#614, separate PR). Repairing the already-rewritten source pages is a vault-side job.
