### PR TITLE
fix(mentions): re-emitting the union never shrinks the block already on the page

### DIFF
--- a/src/__tests__/wiki/page-factory/mentions-integration.test.ts
+++ b/src/__tests__/wiki/page-factory/mentions-integration.test.ts
@@ -198,3 +198,30 @@ describe('assembleFinalContent — frontmatter + body composition', () => {
     expect(out.startsWith('---\ntitle: X\n---\n\n# X')).toBe(true);
   });
 });
+describe('assembleFinalContent — re-emitting the union never shrinks the block', () => {
+  it('keeps every accumulated quote when the existing section already exceeds the fresh-page budget', async () => {
+    const source = makeSource('notes/late.md', 'late');
+    const info = createMockEntity({
+      name: 'Zytokine',
+      mentions_with_provenance: [
+        { quote: 'the new quote', source_path: 'notes/late.md', source_slug: '', extracted_at: '' },
+      ],
+    });
+    // Eight ~170-char bullets: ~1400 chars, the size a #496 source page or a
+    // multi-source entity page reaches. The fresh-page budget is 500.
+    const old = Array.from({ length: 8 }, (_, i) =>
+      `- "old quote number ${i} ${'x'.repeat(140)}" — [[sources/early|early]]`,
+    );
+    const existingBody = `# Zytokine\n\n${SECTION}\n\n${old.join('\n')}`;
+    const out = await assembleFinalContent(
+      CTX,
+      '---\ntitle: Zytokine\n---',
+      '# Zytokine\n\nBody.',
+      info,
+      source,
+      existingBody,
+    );
+    for (let i = 0; i < 8; i++) expect(out).toContain(`old quote number ${i} `);
+    expect(out).toContain('the new quote');
+  });
+});

--- a/src/core/mentions-formatter.ts
+++ b/src/core/mentions-formatter.ts
@@ -14,7 +14,14 @@
 
 import type { MentionWithProvenance } from '../types';
 
-const DEFAULT_MAX_CHARS = 500;
+/**
+ * Total character budget of one emitted section (header + bullets) when the
+ * caller passes no `maxChars`. Exported so a caller that re-emits a section
+ * already on the page can add this much headroom on top of what the page
+ * holds instead of re-capping the accumulated block at the fresh-page size.
+ */
+export const DEFAULT_MENTIONS_MAX_CHARS = 500;
+const DEFAULT_MAX_CHARS = DEFAULT_MENTIONS_MAX_CHARS;
 
 export interface FormatMentionsOptions {
   /** Override the 500-char total budget. Defaults to 500 (matches truncateMentions). */

--- a/src/core/mentions-parser.ts
+++ b/src/core/mentions-parser.ts
@@ -38,6 +38,8 @@ export interface ReingestMentionsResult {
   mentions: MentionWithProvenance[];
   /** Non-null ⇒ the existing block was hand-edited; caller preserves it verbatim and skips the union. */
   preserveRaw: string | null;
+  /** Character length of the block already on the page (0 when absent) — the floor for re-emitting it. */
+  existingLength: number;
 }
 
 export function computeReingestMentions(
@@ -47,8 +49,9 @@ export function computeReingestMentions(
   defaultSourcePath?: string,
 ): ReingestMentionsResult {
   const existing = parseMentionsSection(existingBody, sectionLabel);
+  const existingLength = existing.raw?.length ?? 0;
   if (existing.found && !existing.fullyParsed) {
-    return { mentions: [], preserveRaw: existing.raw ?? '' };
+    return { mentions: [], preserveRaw: existing.raw ?? '', existingLength };
   }
   const normalize = (m: MentionWithProvenance) => ({
     ...m,
@@ -60,6 +63,7 @@ export function computeReingestMentions(
       newMentions.map(normalize),
     ) ?? [],
     preserveRaw: null,
+    existingLength,
   };
 }
 

--- a/src/wiki/page-factory/mentions-integration.ts
+++ b/src/wiki/page-factory/mentions-integration.ts
@@ -20,6 +20,7 @@ import type { EntityInfo, ConceptInfo, MentionWithProvenance, LLMWikiSettings } 
 import { TFile } from 'obsidian';
 import { getSectionLabels } from '../system-prompts';
 import { injectMentionsSection } from '../../core/mentions-injector';
+import { DEFAULT_MENTIONS_MAX_CHARS } from '../../core/mentions-formatter';
 import { stripMentionsSection, computeReingestMentions } from '../../core/mentions-parser';
 import { isConversationSource } from './contextualize';
 
@@ -92,7 +93,7 @@ export async function assembleFinalContent(
         extracted_at: '',
       }));
 
-  const { mentions: unioned, preserveRaw } = computeReingestMentions(
+  const { mentions: unioned, preserveRaw, existingLength } = computeReingestMentions(
     existingBody,
     newMentions,
     labels.mentions_in_source,
@@ -111,10 +112,18 @@ export async function assembleFinalContent(
     return `${frontmatter}\n\n${preserved}`;
   }
 
+  // The formatter's budget is sized for a fresh page. Applied to the union it
+  // re-capped the accumulated block at that size on every rewrite: a source
+  // page written with the #496 budget (2000) came back at 500, an entity page
+  // that had grown past 500 across sources lost its oldest quotes — the
+  // "non-lossy" union of #267 was lossy exactly when it had something to keep.
+  // What the page already holds is the floor; the default budget is the
+  // headroom this source may add on top of it.
   const bodyWithMentions = injectMentionsSection(body, unioned, sourceFile.path, {
     sectionLabel: labels.mentions_in_source,
     conversationMode: false,
     conversationLabel: `Conversation: ${sourceFile.basename}`,
+    maxChars: existingLength + DEFAULT_MENTIONS_MAX_CHARS,
   });
   return `${frontmatter}\n\n${bodyWithMentions}`;
 }


### PR DESCRIPTION
Fixes #614

## What

When `assembleFinalContent` re-emits the union of a page's accumulated mentions with the new source's, the injector budget is now `existingLength + DEFAULT_MENTIONS_MAX_CHARS` instead of the formatter's fresh-page default. What the page already holds is the floor; the default budget is what this source may add on top. A fresh page (existing length 0) keeps the 500 it had.

## Why

The union was capped at 500 characters on every rewrite, so any block above that — source pages written with the #496 budget of 2000, entity pages grown across sources — came back at 500. On a measured rebuild that was the entire mention-loss signal: 180 of 180 audited losses, block 374–2029 characters before, 173–528 after (#614 has the table). The #267 union was lossy exactly when it had something to keep.

## Changes

- `src/core/mentions-formatter.ts`: `DEFAULT_MENTIONS_MAX_CHARS` exported; the private constant aliases it.
- `src/core/mentions-parser.ts`: `computeReingestMentions` returns `existingLength` (raw length of the block found, 0 when absent) alongside `mentions` and `preserveRaw`.
- `src/wiki/page-factory/mentions-integration.ts`: the union path passes `maxChars: existingLength + DEFAULT_MENTIONS_MAX_CHARS`. The conversation path and the `preserveRaw` fail-safe are untouched.
- `src/__tests__/wiki/page-factory/mentions-integration.test.ts`: eight ~170-character existing quotes plus one new quote come back as nine. Fails against `main` (three survive).

## Verification

typecheck, lint, build, test: 3795 tests, 267 files, green.

## Design note

Growth is bounded per write (one default budget per source), not per page. A per-page ceiling would reintroduce the same loss at a higher number; if one is wanted, it belongs in the formatter as an explicit cap with a log line, not as the fresh-page default applied to an accumulated block.

## Not in this PR

The misdirected related-page rewrites on source pages (#613, separate PR) — they are how source pages reached this path at all.
