### PR TITLE
fix(rewrite): a kept section that collapsed is a dropped section — restore it in place

### DIFF
--- a/src/__tests__/core/section-header-canonicalizer.test.ts
+++ b/src/__tests__/core/section-header-canonicalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  SECTION_SHRINK_MIN_CHARS,
   canonicalizeSectionHeaders,
   classifyHeader,
   preserveExistingSections,
@@ -401,5 +402,53 @@ describe('stripUnknownSections (drop prompt-scaffolding sections the model copie
     const r = stripUnknownSections(canon, DE);
     expect(r).toContain('## Erwähnungen in der Quelle');
     expect(r).not.toContain('Active Tag Vocabulary');
+  });
+});
+
+describe('preserveExistingSections — a kept section that collapsed is a dropped section', () => {
+  const DE = [
+    'Beschreibung', 'Hauptmerkmale', 'Verwandte Konzepte', 'Verwandte Entitäten',
+    'Erwähnungen in der Quelle', 'Neue Informationen',
+  ];
+  const M = 'Erwähnungen in der Quelle';
+  // Five footnoted paragraphs, the shape a description reaches after merges.
+  const paragraphs = Array.from({ length: 5 }, (_, i) =>
+    `Absatz ${i + 1}: ${'Belegter Inhalt aus einer Quelle. '.repeat(6)}^[Quelle: [[Q${i + 1}]]]`,
+  );
+  const longDescription = paragraphs.join('\n\n');
+
+  it('restores a section in place when the rewrite kept the header but a fraction of the content', () => {
+    const oldBody = `# Stress\n\n## Beschreibung\n${longDescription}\n\n## Hauptmerkmale\n- alt\n\n## Verwandte Konzepte\n- [[concepts/X|X]]`;
+    const newBody = `# Stress\n\n## Beschreibung\n${paragraphs[0]}\n\n## Hauptmerkmale\n- alt\n- neu\n\n## Verwandte Konzepte\n- [[concepts/X|X]]`;
+    const out = preserveExistingSections(oldBody, newBody, DE, M);
+    for (const p of paragraphs) expect(out).toContain(p);
+    // In place: the restored block sits between the H1 and Hauptmerkmale, and
+    // the model's other sections are untouched.
+    expect(out.indexOf('## Beschreibung')).toBeLessThan(out.indexOf('## Hauptmerkmale'));
+    expect(out).toContain('- neu');
+    expect(out.match(/## Beschreibung/g)).toHaveLength(1);
+  });
+
+  it('leaves a section alone when it shrank but stayed above the floor', () => {
+    const oldBody = `## Beschreibung\n${longDescription}`;
+    const kept = paragraphs.slice(0, 3).join('\n\n'); // 60 % of the content
+    const newBody = `## Beschreibung\n${kept}`;
+    expect(preserveExistingSections(oldBody, newBody, DE, M)).toBe(newBody);
+  });
+
+  it('leaves a short section alone however much it shrank — below the size threshold the wording is the model\'s call', () => {
+    const short = 'Kurzer Text. '.repeat(10).trim();
+    expect(short.length).toBeLessThan(SECTION_SHRINK_MIN_CHARS);
+    const oldBody = `## Beschreibung\n${short}`;
+    const newBody = '## Beschreibung\nKurz.';
+    expect(preserveExistingSections(oldBody, newBody, DE, M)).toBe(newBody);
+  });
+
+  it('guards a suffixed New Information block by identity', () => {
+    const oldBody = `## Neue Informationen (SIBO)\n${longDescription}`;
+    const newBody = `## Neue Informationen (SIBO)\nEin Satz.`;
+    const out = preserveExistingSections(oldBody, newBody, DE, M);
+    expect(out).toContain(paragraphs[4]);
+    expect(out).not.toContain('Ein Satz.');
   });
 });

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -179,12 +179,22 @@ function canonicalSectionBlocks(
  *
  * The schema, not the model, decides which sections must exist, so restore any
  * canonical section that carried content in `existingBody` and is wholly absent
- * from `rewrite`. Conservative by construction: it only ever APPENDS a dropped
- * section back (at the end, in first-seen order) — it never edits or removes
- * what the model produced, so a section the model legitimately rewrote (its
- * identity still present, however much its content changed) is left untouched.
- * The same non-lossy guarantee #267 gives the Mentions section, generalized to
- * the rest of the schema body.
+ * from `rewrite`: a dropped section is APPENDED back (at the end, in first-seen
+ * order). The same non-lossy guarantee #267 gives the Mentions section,
+ * generalized to the rest of the schema body.
+ *
+ * A section that is still there but collapsed is the same loss one header
+ * short of it. Measured on a rebuilt vault: nine `## Beschreibung` blocks of
+ * 800–8400 characters came back from a rewrite at under half their size —
+ * 5046 → 335 in the worst case, the first paragraph kept and five paragraphs
+ * of merged, footnoted content gone — while the prompt said "without deleting
+ * existing content" and the guard saw the header and called it kept. So a
+ * canonical section whose content shrinks below SECTION_SHRINK_FLOOR of what
+ * it held (once it held at least SECTION_SHRINK_MIN_CHARS) is treated like a
+ * dropped one: the previous block is put back IN PLACE of the collapsed one,
+ * and a warning names the section and both sizes. Below the size threshold
+ * or above the floor the content stays the model's call — a genuine rewrite
+ * changes wording, not an order of magnitude.
  *
  * Presence is decided per full identity (label + suffix), which matters for the
  * one section that repeats: emitting `## New Information (Source B)` must not
@@ -196,6 +206,15 @@ function canonicalSectionBlocks(
  * though the prompt body was mentions-stripped. assembleFinalContent re-attaches
  * it programmatically below — once, at the right anchor. Pure, O(lines × labels).
  */
+/** A kept section whose content falls below this fraction of its previous length is restored. */
+export const SECTION_SHRINK_FLOOR = 0.5;
+/** Sections shorter than this before the rewrite are never shrink-guarded — the model may reword them freely. */
+export const SECTION_SHRINK_MIN_CHARS = 400;
+
+function blockContentLength(block: string[]): number {
+  return block.slice(1).join('\n').trim().length;
+}
+
 export function preserveExistingSections(
   existingBody: string,
   rewrite: string,
@@ -208,16 +227,65 @@ export function preserveExistingSections(
   const newBlocks = canonicalSectionBlocks(strippedRewrite, canonicalLabels);
 
   const restored: string[] = [];
+  const collapsed = new Map<string, string[]>();
   for (const [key, block] of oldBlocks) {
-    if (newBlocks.has(key)) continue; // model kept the section — its call
+    const oldLen = blockContentLength(block);
+    const kept = newBlocks.get(key);
+    if (kept) {
+      const newLen = blockContentLength(kept);
+      if (oldLen >= SECTION_SHRINK_MIN_CHARS && newLen < oldLen * SECTION_SHRINK_FLOOR) {
+        console.warn(
+          `[preserveExistingSections] "${block[0]}" came back at ${newLen} of ${oldLen} chars — restoring the previous block`,
+        );
+        collapsed.set(key, block);
+      }
+      continue; // model kept the section at a plausible size — its call
+    }
     // Only restore sections that actually carried content; an empty scaffold the
     // model correctly omitted stays omitted.
-    if (block.slice(1).some(l => l.trim() !== '')) {
+    if (oldLen > 0) {
       restored.push(block.join('\n').replace(/\s+$/, ''));
     }
   }
-  if (restored.length === 0) return strippedRewrite;
-  return `${strippedRewrite.replace(/\s+$/, '')}\n\n${restored.join('\n\n')}\n`;
+
+  const body = collapsed.size === 0
+    ? strippedRewrite
+    : replaceSectionBlocks(strippedRewrite, collapsed, canonicalLabels);
+  if (restored.length === 0) return body;
+  return `${body.replace(/\s+$/, '')}\n\n${restored.join('\n\n')}\n`;
+}
+
+/**
+ * Swap whole canonical blocks in place: every section of `body` whose identity
+ * is in `replacements` is emitted from the replacement (header included) and
+ * the model's lines for that section are skipped up to the next `##`. Every
+ * other line — lead paragraph, foreign sections, H1 — passes through untouched.
+ * Same header walk as `canonicalSectionBlocks`, so the two cannot disagree on
+ * where a section starts.
+ */
+function replaceSectionBlocks(
+  body: string,
+  replacements: Map<string, string[]>,
+  canonicalLabels: string[],
+): string {
+  const out: string[] = [];
+  let skipping = false;
+  for (const line of body.split('\n')) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      skipping = false;
+      const id = classifyHeader(m[1], canonicalLabels);
+      const key = id ? (id.suffix === null ? id.label : `${id.label} (${id.suffix})`) : null;
+      const replacement = key !== null ? replacements.get(key) : undefined;
+      if (replacement) {
+        out.push(...replacement.join('\n').replace(/\s+$/, '').split('\n'), '');
+        skipping = true;
+        continue;
+      }
+    }
+    if (!skipping) out.push(line);
+  }
+  return out.join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
 /**


### PR DESCRIPTION
Fixes #617

## What

`preserveExistingSections` now also guards a canonical section the rewrite kept but collapsed. When a section that held at least `SECTION_SHRINK_MIN_CHARS` (400) comes back with less than `SECTION_SHRINK_FLOOR` (0.5) of its content, the previous block replaces the collapsed one in place, and a warning names the section and both sizes. Everything else the model produced — other sections, lead paragraph, H1, foreign sections — passes through untouched. Sections below the size threshold, or shrunk but above the floor, remain the model's call, exactly as before.

## Why

Measured on a rebuilt vault: nine `## Beschreibung` blocks of 800–8400 characters came back from a rewrite at under half their size, 5046 → 335 in the worst case, five merged and footnoted paragraphs gone while the neighbouring sections were byte-identical (numbers and the prompt wording in #617). The #419 guard restores what is absent; a header over one surviving paragraph is the same loss with a header on it.

## Changes

- `src/core/section-header-canonicalizer.ts`: the two constants (exported), the shrink check inside the existing loop, and `replaceSectionBlocks`, which re-walks the rewrite with the same header classification as `canonicalSectionBlocks` and swaps whole blocks by identity. The append path for wholly dropped sections is unchanged.
- `src/__tests__/core/section-header-canonicalizer.test.ts`: four cases — collapsed section restored in place with the other sections untouched and the header emitted once; shrunk to 60 % left alone; short section left alone however much it shrank; a suffixed `Neue Informationen (SIBO)` block guarded by identity. The first and last fail against `main`.

## Verification

typecheck, lint, build, test: 3796 tests, 267 files, green. Replay of the guard on the parked pre-rewrite version of `concepts/Stress` against the page as the rewrite left it: description back at 5046 characters, one `## Beschreibung`, `## Hauptmerkmale` intact.

## Design note

The floor is a dial, not a truth. Across the audit, 761 guarded-size sections (≥ 400 chars) have a next state: 662 grew or stayed, 75 lost under 20 %, 21 lost 20–50 %, 3 fell below half in a single write (the nine in #617 are cumulative over several writes). 0.5 catches the collapses and leaves the 21 partial shrinks to the model; raising the floor to 0.8 would also catch those at the price of overriding rewording that removed a fifth of a section — the constant is there to be moved once a vault says which side it wants. Restoring the previous block in place discards whatever the model integrated into the collapsed section on this write; that is the cheaper loss — the new source's facts are still in its mentions and its own pages, the five old paragraphs were not anywhere else.
