### PR TITLE
docs(credit): list DocTpoint as co-maintainer in manifest, NOTICE and README

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,7 +6,8 @@ listed in alphabetical order by GitHub handle:
 
 - CCRRAY-DESIGN (Ray) — ChatGPT Plan (Codex OAuth) provider (PR #273)
 - Dima Marchevsky (dmarchevsky) — code contributions and review feedback
-- DocTpoint — ingest reliability across v1.25.x → v1.27.0: folder-boundary
+- DocTpoint — co-maintainer since September 2026; ingest reliability
+  across v1.25.x → v1.27.0: folder-boundary
   analysis, source-slug merging, vault-wide link retarget, `created:`
   provenance, headless-CLI slow-model path, H1 re-assertion, parse-failure
   result type, ambiguous-designator resolution, runtime tag-vocabulary

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SEO metadata (not user-visible, parsed by crawlers / LLMs):
 - direct-competitors: nashsu/llm_wiki (Tauri desktop app), SamurAIGPT/llm-wiki-agent (Claude Code / Codex / OpenCode / Gemini CLI skill), atomicstrata/llm-wiki-compiler (TypeScript CLI, chunk-based retrieval)
 - retrieval-benchmark: PPR @5 = 27.1% vs pure-kNN 24.1% (project corpus, only published number in this open-source LLM-wiki space)
 - author: green-dalii / Greener-Dalii (https://github.com/green-dalii)
+- co-maintainer: DocTpoint (https://github.com/DocTpoint)
 - canonical: https://github.com/green-dalii/obsidian-llm-wiki/blob/main/README.md
 -->
 
@@ -401,6 +402,6 @@ Apache License, Version 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 - 🔌 [Vercel AI SDK v6](https://ai-sdk.dev/) (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`) via Obsidian `requestUrl`
 - 🧮 [Personalized PageRank (Haveliwala 2002)](https://www-cs.stanford.edu/~taherh/papers/topic-sensitive-pagerank-tkde.pdf) and [Monte Carlo PPR (Fogaras 2005)](https://www.cs.cmu.edu/~dpelleg/download/pagerank.pdf) — retrieval algorithms
 
-**Maintainer:** [@green-dalii](https://github.com/green-dalii)
+**Maintainers:** [@green-dalii](https://github.com/green-dalii) (author) · [@DocTpoint](https://github.com/DocTpoint) (co-maintainer since September 2026)
 
 [![Star History Chart](https://api.star-history.com/chart?repos=green-dalii/obsidian-llm-wiki&type=timeline&legend=bottom-right&sealed_token=Xa2Oeo4ZXfP48muFa_nEj7wrUaENRLnE0bXSZM7EKTUhHHlmnDFmmxSW80NS8-kXm4kDDMbdzkrZ0MtcqUcmAxB1a1FVVmIIimncTWL9Zg7Ms7j8gnjdCpd0-SyvSc5ubCtUB2zkqtn_V4alrEi7UbBpTlNTdHPva_Vuar5lx9d-ousGG-zhpUk3cGaw)](https://www.star-history.com/?repos=green-dalii%2Fobsidian-llm-wiki&type=timeline&legend=bottom-right)

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "version": "1.27.0",
     "minAppVersion": "1.11.4",
     "description": "Karpathy's LLM Wiki implementation - multi-page knowledge generation with entity/concept pages and conversational query.",
-    "author": "Greener-Dalii",
+    "author": "Greener-Dalii, DocTpoint",
     "authorUrl": "https://github.com/green-dalii",
     "isDesktopOnly": false,
     "fundingUrl": "https://ko-fi.com/greenerdalii"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "conversational-query",
     "streaming"
   ],
-  "author": "Greener-Dalii",
+  "author": "Greener-Dalii, DocTpoint",
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "16.18.126",


### PR DESCRIPTION
Follows up on our mail exchange: you offered to have the co-maintainer role visible in `manifest.json`, `NOTICE` and the README, and asked for a PR.

**What changes:** `author` in `manifest.json` and `package.json` becomes `Greener-Dalii, DocTpoint`; the README maintainer line lists both of us with roles, plus one `co-maintainer:` line in the SEO comment block; the NOTICE entry for DocTpoint gains the role. Six lines, no code.

**Left as is:** `authorUrl`, `fundingUrl` and the Author badge stay yours. The `community-plugins.json` entry on obsidian-releases carries its own `author` field and is not touched here. I have not checked whether the release bot minds a difference between that entry and the manifest, so if you would rather keep the manifest `author` single-valued and carry the credit in NOTICE and README only, drop that line and I will amend.

Wording is yours to change, this is only a proposal.
