### PR TITLE
fix(gate): a dropped candidate keeps its edge when the vault already has the page

### DIFF
--- a/src/__tests__/core/candidate-gate.test.ts
+++ b/src/__tests__/core/candidate-gate.test.ts
@@ -102,6 +102,29 @@ describe('gateCandidates', () => {
     expect(out.entities[0].related_concepts).toEqual(['Eisenmangel']);
     expect(out.concepts.map(x => x.name)).toEqual(['Eisenmangel']);
     expect(out.concepts[0].related_concepts).toEqual(['Ferritin']);
+    expect(out.linkedAnyway).toEqual([]);
+  });
+
+  it('keeps a dropped name in related_* lists when the vault already has a page for it', () => {
+    // Eisenstoffwechsel is absent from THIS note, so it earns no page here —
+    // but a page for it exists, and the edge to an existing page is not a
+    // dead link. CRP is not a candidate in this input, so it is never judged.
+    const known = (name: string) => name.toLowerCase() === 'eisenstoffwechsel';
+    const out = gate(
+      {
+        entities: [e('Ferritin', { related_entities: ['CRP', 'Transferrin'], related_concepts: ['Eisenstoffwechsel', 'Eisenmangel'] })],
+        concepts: [c('Eisenmangel', ['Eisenstoffwechsel', 'Ferritin']), c('Eisenstoffwechsel')],
+      },
+      TEXT,
+      'de',
+      known,
+    );
+    expect(out.concepts.map(x => x.name)).toEqual(['Eisenmangel']);
+    expect(out.dropped.map(d => d.name)).toEqual(['Eisenstoffwechsel']);
+    expect(out.entities[0].related_entities).toEqual(['CRP', 'Transferrin']);
+    expect(out.entities[0].related_concepts).toEqual(['Eisenstoffwechsel', 'Eisenmangel']);
+    expect(out.concepts[0].related_concepts).toEqual(['Eisenstoffwechsel', 'Ferritin']);
+    expect(out.linkedAnyway).toEqual(['Eisenstoffwechsel']);
   });
 
   it('is a no-op — input returned untouched — for a language without a profile, and resolves region codes', () => {

--- a/src/core/candidate-gate.ts
+++ b/src/core/candidate-gate.ts
@@ -342,6 +342,12 @@ export interface GateResult {
   entities: EntityInfo[];
   concepts: ConceptInfo[];
   dropped: DroppedCandidate[];
+  /**
+   * Dropped names that stayed in the survivors' related_* lists because the
+   * vault already has a page for them (`isKnownPage`). No page is written
+   * for them in this ingest; the edge to the existing page is kept.
+   */
+  linkedAnyway: string[];
   /** False when no profile exists for `language` — the input came back untouched. */
   applied: boolean;
 }
@@ -352,14 +358,23 @@ export interface GateResult {
  * pruned from related_* lists) and what was dropped, why. Pure; the caller
  * decides what to log and writes the result back. The cross-language check
  * (note declares another language) is the caller's — it needs the vault.
+ *
+ * `isKnownPage` answers whether a name already resolves to a wiki page
+ * (title or alias). The gate decides whether THIS note earns a page for a
+ * name; it cannot decide that a link to a page another note already earned
+ * is dead. Without the predicate every dropped name is pruned, which on a
+ * measured vault emptied the related sections of pages whose named
+ * neighbours existed — a passing mention of an existing page is exactly the
+ * edge the graph is for.
  */
 export function gateCandidates(
   analysis: Pick<SourceAnalysis, 'entities' | 'concepts'>,
   sourceText: string,
   language: string | undefined | null,
+  isKnownPage?: (name: string) => boolean,
 ): GateResult {
   const profile = gateProfileFor(language);
-  if (!profile) return { entities: analysis.entities, concepts: analysis.concepts, dropped: [], applied: false };
+  if (!profile) return { entities: analysis.entities, concepts: analysis.concepts, dropped: [], linkedAnyway: [], applied: false };
   const dropped: DroppedCandidate[] = [];
   const keep = <T extends { name: string }>(items: T[], kind: DroppedCandidate['kind']): T[] =>
     items.filter(item => {
@@ -370,11 +385,13 @@ export function gateCandidates(
     });
   const entities = keep(analysis.entities, 'entity');
   const concepts = keep(analysis.concepts, 'concept');
-  if (dropped.length === 0) return { entities: analysis.entities, concepts: analysis.concepts, dropped, applied: true };
+  if (dropped.length === 0) return { entities: analysis.entities, concepts: analysis.concepts, dropped, linkedAnyway: [], applied: true };
 
-  const gone = new Set(dropped.map(d => nfc(d.name).trim().toLowerCase()));
+  const key = (n: string) => nfc(n).trim().toLowerCase();
+  const linkedAnyway = dropped.filter(d => isKnownPage?.(d.name) === true).map(d => d.name);
+  const gone = new Set(dropped.filter(d => !linkedAnyway.includes(d.name)).map(d => key(d.name)));
   const prune = (names: string[] | undefined): string[] | undefined =>
-    names?.filter(n => !gone.has(nfc(n).trim().toLowerCase()));
+    names?.filter(n => !gone.has(key(n)));
   return {
     entities: entities.map(e => ({
       ...e,
@@ -387,6 +404,7 @@ export function gateCandidates(
       ...(c.related_entities ? { related_entities: prune(c.related_entities) } : {}),
     })),
     dropped,
+    linkedAnyway,
     applied: true,
   };
 }

--- a/src/core/related-link-corrector.ts
+++ b/src/core/related-link-corrector.ts
@@ -44,30 +44,28 @@ export interface ExistingPageRef {
  * An alias claimed by two pages resolves to neither (the #446 lesson): the
  * ambiguity goes to the typed-list fallback rather than to a coin flip.
  */
-export function correctRelatedLinkPrefixes(
-  content: string,
-  relatedEntities: string[] | undefined,
-  relatedConcepts: string[] | undefined,
-  relatedEntitiesLabel: string,
-  relatedConceptsLabel: string,
+/**
+ * Full-vault name → path resolver. Titles outrank aliases: a title is the page's
+ * own claim to a name, an alias is someone's cross-reference to it. A name two
+ * pages claim resolves to neither. Returns the path relative to the wiki folder
+ * (`entities/X`), or undefined for a name the vault does not know.
+ *
+ * The index is keyed case-folded — `slugify(x, false)` — on both sides, per the
+ * contract stated at slug.ts: comparison callers must not pass `preserveCase`,
+ * so slugs stay comparable whatever the user's `slugCase` setting is. Under
+ * `slugCase: 'preserve'` a case-sensitive key would make this resolver stricter
+ * than `scanDeadLinks`, which judges over `knownTargetsLower`: a model writing
+ * "mediterrane Ernährung" for the page "Mediterrane-Ernährung" would miss the
+ * index here and be stamped into a dead link that the scanner would have
+ * accepted unchanged.
+ *
+ * Shared by the link corrector (where the index was born, #482 stage 2) and
+ * the candidate gate, which asks the same question — "does the vault have a
+ * page for this name?" — before pruning a dropped name from related lists.
+ */
+export function buildVaultResolver(
   vaultIndex?: { wikiFolder: string; pages: ExistingPageRef[] },
-): string {
-  // Full-vault name → path index. Titles outrank aliases: a title is the page's
-  // own claim to a name, an alias is someone's cross-reference to it.
-  //
-  // The index is keyed case-folded — `slugify(x, false)` — on both sides, per the
-  // contract stated at slug.ts: comparison callers must not pass `preserveCase`,
-  // so slugs stay comparable whatever the user's `slugCase` setting is. Under
-  // `slugCase: 'preserve'` a case-sensitive key would make this resolver stricter
-  // than `scanDeadLinks`, which judges over `knownTargetsLower`: a model writing
-  // "mediterrane Ernährung" for the page "Mediterrane-Ernährung" would miss the
-  // index here and be stamped into a dead link that the scanner would have
-  // accepted unchanged. The typed-list map (`folderBySlug` below) keys the same
-  // way: it used to take `preserveCase` from the caller, which kept both of its
-  // sides consistent with each other but let the lookup miss whenever the typed
-  // list and the link differed only in spelling — "Mediterrane Ernährung" in
-  // the list, `[[mediterrane ernährung]]` in the body — so the section won over
-  // the known type. No caller passes `preserveCase` any more.
+): (name: string) => string | undefined {
   const pathByTitle = new Map<string, string>();
   const pathByAlias = new Map<string, string>();
   const ambiguousTitles = new Set<string>();
@@ -98,7 +96,7 @@ export function correctRelatedLinkPrefixes(
       }
     }
   }
-  const resolveInVault = (name: string): string | undefined => {
+  return (name: string): string | undefined => {
     const s = slugify(name, false);
     if (!s) return undefined;
     if (!ambiguousTitles.has(s)) {
@@ -108,6 +106,23 @@ export function correctRelatedLinkPrefixes(
     if (!ambiguousAliases.has(s)) return pathByAlias.get(s);
     return undefined;
   };
+}
+
+export function correctRelatedLinkPrefixes(
+  content: string,
+  relatedEntities: string[] | undefined,
+  relatedConcepts: string[] | undefined,
+  relatedEntitiesLabel: string,
+  relatedConceptsLabel: string,
+  vaultIndex?: { wikiFolder: string; pages: ExistingPageRef[] },
+): string {
+  // The typed-list map (`folderBySlug` below) keys the same way as the vault
+  // resolver: it used to take `preserveCase` from the caller, which kept both
+  // of its sides consistent with each other but let the lookup miss whenever
+  // the typed list and the link differed only in spelling — "Mediterrane
+  // Ernährung" in the list, `[[mediterrane ernährung]]` in the body — so the
+  // section won over the known type. No caller passes `preserveCase` any more.
+  const resolveInVault = buildVaultResolver(vaultIndex);
 
   // Name→type map from the typed related lists. Catches links mis-sectioned by
   // the LLM (e.g. an entity listed under Related Concepts): the known type wins

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -35,6 +35,7 @@ import type { SourceRejection } from '../core/source-requirements';
 import { formatRateLimitNotice } from '../core/rate-limit';
 import { extractSourceTags } from '../core/arrays';
 import { gateCandidates } from '../core/candidate-gate';
+import { buildVaultResolver } from '../core/related-link-corrector';
 import { getSourceLanguage, isCrossLanguage } from '../core/source-language';
 import { cleanMarkdownResponse } from '../core/markdown';
 import { injectMentionsSection } from '../core/mentions-injector';
@@ -1042,14 +1043,26 @@ export class WikiEngine {
         const sourceLang = getSourceLanguage(file, this.app);
         const translated = sourceLang !== null && isCrossLanguage(sourceLang, wikiLang);
         if (!translated) {
-          const gated = gateCandidates(analysis, extractBody(opts?.contentOverride ?? await this.app.vault.read(file)), wikiLang);
+          // A dropped name the vault already has a page for keeps its edge:
+          // the gate judges whether this note earns the page, not whether a
+          // page another note earned may be linked. Same resolver as the
+          // related-link corrector, so "known" means the same thing at both
+          // ends of the pipeline.
+          const resolve = buildVaultResolver({ wikiFolder: this.settings.wikiFolder, pages: await this.getExistingWikiPages() });
+          const gated = gateCandidates(
+            analysis,
+            extractBody(opts?.contentOverride ?? await this.app.vault.read(file)),
+            wikiLang,
+            name => resolve(name) !== undefined,
+          );
           if (!gated.applied) {
             console.debug(`[candidate-gate] ${file.path}: no language profile for "${wikiLang}" — gate not applied`);
             this.onProgress?.(`Candidate gate: no language profile for "${wikiLang}" — not applied`);
           } else if (gated.dropped.length > 0) {
             const list = gated.dropped.map(d => `${d.name} (${d.kind}, ${d.verdict})`).join('; ');
-            console.warn(`[candidate-gate] ${file.path}: dropped ${gated.dropped.length} of ${analysis.entities.length + analysis.concepts.length} candidates — ${list}`);
-            this.onProgress?.(`Candidate gate: ${gated.dropped.length} dropped — ${list}`);
+            const kept = gated.linkedAnyway.length > 0 ? ` — linked anyway (existing page): ${gated.linkedAnyway.join('; ')}` : '';
+            console.warn(`[candidate-gate] ${file.path}: dropped ${gated.dropped.length} of ${analysis.entities.length + analysis.concepts.length} candidates — ${list}${kept}`);
+            this.onProgress?.(`Candidate gate: ${gated.dropped.length} dropped — ${list}${kept}`);
             analysis.entities = gated.entities;
             analysis.concepts = gated.concepts;
           }


### PR DESCRIPTION
Closes #620.

**What changes**
- `gateCandidates(analysis, text, language, isKnownPage?)`: a dropped name for which `isKnownPage` is true is not pruned from the survivors' `related_*` lists and is returned in `GateResult.linkedAnyway`. Without the predicate the behaviour is unchanged (all existing tests pass untouched).
- `buildVaultResolver(vaultIndex)` extracted from `correctRelatedLinkPrefixes` (code moved, not changed): title outranks alias, an ambiguous name resolves to neither, `entities/` and `concepts/` only. The corrector calls it; the engine passes `name => resolve(name) !== undefined` to the gate. "Known" means the same thing at both ends of the pipeline.
- Engine log line and progress notice list the names linked anyway.

**Test:** new case — a candidate absent from the note but present in the vault stays in the related lists and appears in `linkedAnyway`; a candidate the vault does not know is pruned as before.

**Known limit, left as is:** the engine uses its 5-second page-index cache. In a back-to-back batch, a page created by the previous note can be missing from a cache that is a few seconds old, and its name is then pruned exactly as before this fix. A fresh index per gate call would close that at one vault read per ingest; I did not want to add that cost without your view.

Gate 1 green locally (3793 tests).
