### PR TITLE
fix(query): stop-word substrings and the lex/PPR merge hid the page the user named

### DIFF
--- a/src/__tests__/core/lex-noise.test.ts
+++ b/src/__tests__/core/lex-noise.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Query lex noise — measured on a 3,025-page German vault (2026-09-03).
+ *
+ * "Kann man bei eingeschränkter Nierenfunktion Creatin nehmen?" loaded
+ * Kahneman, Karpman, Salbei, Pekannüsse and six more pages the query
+ * never named, while the page titled "Creatin" was not among them.
+ * Three mechanisms, each pinned below:
+ *
+ *   1. tokenizeQuery split "über" into "über" + "ber" (ASCII-only run
+ *      class), double-counting every title "über" already hit, and
+ *      kept "Creatin." with its full stop as a needle.
+ *   2. Tokens matched as substrings: "man" → Kahneman, "creatin" →
+ *      Phosphocreatin (a different substance).
+ *   3. mergeWithPPR took max(lexRankHint ∈ (0,1], pprMass ≈ 0.05), so
+ *      any keyword hit outranked every PPR seed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  tokenizeQuery,
+  needleHits,
+  lexMatchByTitleAndAliases,
+  pprCascade,
+  type PageRef,
+  type Graph,
+} from '../../core/ppr-cascade';
+import { makeRng } from '../__support__/rng';
+
+function page(path: string, title: string, aliases: string[] = []): PageRef {
+  return { path, title, aliases };
+}
+
+describe('tokenizeQuery — Latin diacritics and edge punctuation', () => {
+  it('keeps umlaut words whole and emits no ASCII fragments', () => {
+    const tokens = tokenizeQuery('Gib mir Informationen über Creatin.');
+    expect(tokens).toContain('über');
+    expect(tokens).toContain('creatin');
+    expect(tokens).not.toContain('ber');
+    expect(tokens).not.toContain('creatin.');
+  });
+
+  it('does not split a word at a diacritic', () => {
+    const tokens = tokenizeQuery('eingeschränkter Nierenfunktion');
+    expect(tokens).toEqual(expect.arrayContaining(['eingeschränkter', 'nierenfunktion']));
+    expect(tokens).not.toContain('eingeschr');
+    expect(tokens).not.toContain('nkter');
+  });
+
+  it('a punctuation-only token collapses to nothing', () => {
+    expect(tokenizeQuery('???!!')).toEqual([]);
+  });
+
+  it('keeps words of other space-delimited scripts whole, punctuation stripped', () => {
+    // RU is one of the shipped wiki languages; a Latin-only word class
+    // stripped every Cyrillic token to nothing.
+    expect(tokenizeQuery('Что такое креатин?')).toEqual(expect.arrayContaining(['что', 'такое', 'креатин']));
+    expect(tokenizeQuery('Что такое креатин?')).not.toContain('креатин?');
+    expect(tokenizeQuery('Τι είναι η κρεατίνη;')).toContain('κρεατίνη');
+  });
+
+  it('does not split a word at a combining mark (NFD text)', () => {
+    const nfd = 'über Creatin'.normalize('NFD');
+    const tokens = tokenizeQuery(nfd);
+    expect(tokens).toContain('über'.normalize('NFD'));
+    expect(tokens).not.toContain('ber');
+  });
+
+  it('still extracts CJK runs and mixed tokens', () => {
+    expect(tokenizeQuery('什么是Obsidian？')).toEqual(expect.arrayContaining(['obsidian', '什么是']));
+  });
+});
+
+describe('needleHits — Latin needles must start a word', () => {
+  it('rejects a function word buried inside a name', () => {
+    expect(needleHits('daniel kahneman', 'man')).toBe(false);
+    expect(needleHits('salbei', 'bei')).toBe(false);
+    expect(needleHits('pekannüsse', 'kann')).toBe(false);
+  });
+
+  it('accepts a needle at a word start, including after a hyphen or space', () => {
+    expect(needleHits('manuka-honig', 'man')).toBe(true);
+    expect(needleHits('vitamin-d3', 'd3')).toBe(true);
+    expect(needleHits('deepseek dsa hca', 'dsa')).toBe(true);
+    expect(needleHits('überregulation', 'über')).toBe(true);
+    expect(needleHits('creatin-kinase', 'kinase')).toBe(true);
+  });
+
+  it('prefix compounds match, a shared tail does not', () => {
+    expect(needleHits('nierenfunktionsstörung', 'nierenfunktion')).toBe(true);
+    expect(needleHits('phosphocreatin', 'creatin')).toBe(false);
+  });
+
+  it('applies the word start to Cyrillic needles too', () => {
+    expect(needleHits('креатинкиназа', 'киназа')).toBe(false);
+    expect(needleHits('креатин-киназа', 'киназа')).toBe(true);
+  });
+
+  it('a combining mark belongs to its word (NFD)', () => {
+    expect(needleHits('kübel'.normalize('NFD'), 'bel')).toBe(false);
+    expect(needleHits('kübel'.normalize('NFC'), 'bel')).toBe(false);
+  });
+
+  it('keeps substring semantics for CJK needles (no word boundaries)', () => {
+    expect(needleHits('深度学习', '学习')).toBe(true);
+  });
+
+  it('lexMatchByTitleAndAliases: the named page outscores the noise', () => {
+    const pages = [
+      page('e/Kahneman', 'Daniel Kahneman'),
+      page('e/Salbei', 'Salbei'),
+      page('e/Pekan', 'Pekannüsse'),
+      page('e/Creatin', 'Creatin', ['CrM']),
+    ];
+    const hits = lexMatchByTitleAndAliases('Kann man bei Nierenfunktion Creatin nehmen?', pages);
+    expect(hits.map(h => h.page.path)).toEqual(['e/Creatin']);
+  });
+});
+
+describe('mergeWithPPR — PPR mass ranks, the lex hint only orders the rest', () => {
+  // Mature graph: a 40-node ring (seed component, > 50 % of nodes) plus
+  // 12 pages whose titles contain the query word but which PPR from the
+  // seed never reaches. Before the fix the twelve "alphafold-*" pages
+  // filled the top ten by lex rank alone.
+  function fixture() {
+    const pages: PageRef[] = [];
+    const edges: Array<[string, string[]]> = [];
+    for (let i = 0; i < 40; i++) {
+      pages.push(page(`R${i}`, `Ring ${i}`));
+      edges.push([`R${i}`, [`R${(i + 1) % 40}`, `R${(i + 2) % 40}`]]);
+    }
+    for (let i = 0; i < 12; i++) {
+      pages.push(page(`N${i}`, `Alphafold ${i}`));
+      edges.push([`N${i}`, [`N${(i + 1) % 12}`]]);
+    }
+    const g: Graph = {
+      nodes: pages.map(p => p.path),
+      edges: new Map(edges),
+    };
+    return { pages, g };
+  }
+
+  it('explicit seeds and their neighbourhood come before unreached lex hits', () => {
+    const { pages, g } = fixture();
+    const result = pprCascade('alphafold', pages, {
+      graph: g, seeds: ['R0'], rng: makeRng(1),
+    });
+    expect(result[0].page.path).toBe('R0');
+    expect(result[0].arm).toBe('graph-first-ppr');
+    // The seed's out-neighbours carry PPR mass; the lex-only pages do not.
+    const ringFirst = result.findIndex(m => m.page.path.startsWith('N'));
+    const lastRing = result.map(m => m.page.path.startsWith('R')).lastIndexOf(true);
+    expect(ringFirst === -1 || ringFirst > lastRing).toBe(true);
+  });
+
+  it('pages PPR never reached are still ordered by lex rank, below all reached pages', () => {
+    const { pages, g } = fixture();
+    const result = pprCascade('alphafold', pages, {
+      graph: g, seeds: ['R0'], topN: 60, rng: makeRng(1),
+    });
+    const scores = result.map(m => m.score);
+    for (let i = 1; i < scores.length; i++) expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]);
+    const nPaths = result.filter(m => m.page.path.startsWith('N')).map(m => m.page.path);
+    expect(nPaths.length).toBe(12);
+    expect(nPaths[0]).toBe('N0');
+  });
+});

--- a/src/__tests__/core/ppr-cascade.test.ts
+++ b/src/__tests__/core/ppr-cascade.test.ts
@@ -157,9 +157,12 @@ describe('pprCascade — sparse-but-not-empty (lex-seeded PPR arm)', () => {
     const result = pprCascade('page 0', pages, {
       graph: g, minPages: 30, minEdges: 30, rng: makeRng(1),
     });
-    // First hit: P0 (lex match). Arm: lex-seeded-ppr (graph too sparse
-    // for graph-first, but seed has degree ≥ 1).
-    expect(result[0].page.path).toBe('P0');
+    // "page" matches all 50 titles ("0" is a single char and dropped),
+    // so the three lex seeds P0/P1/P2 carry equal PPR mass and the top
+    // hit is whichever of them the walk favoured. The old assertion
+    // `toBe('P0')` held only because max(lexRankHint, ppr) let index
+    // order override PPR — the defect mergeWithPPR no longer has.
+    expect(['P0', 'P1', 'P2']).toContain(result[0].page.path);
     expect(result[0].arm).toBe('lex-seeded-ppr');
   });
 });

--- a/src/core/ppr-cascade.ts
+++ b/src/core/ppr-cascade.ts
@@ -64,6 +64,60 @@ export function formatPageRefSummary(p: PageRef): string {
  * count of needles matched (`tokensFound`) so callers can apply a
  * multi-needle bonus. Pure function — no IO.
  */
+/**
+ * What a "word" is made of: letters, digits and combining marks (so a
+ * decomposed umlaut — NFD, as macOS and iCloud hand files over — stays
+ * inside its word). Shared by the tokenizer and the needle matcher so
+ * both agree. Built with the RegExp constructor because a `\p{…}`
+ * literal is what the ES6 tsconfig target rejects, not the runtime —
+ * the same form candidate-gate.ts uses.
+ */
+const WORD_CHAR_CLASS = '\\p{L}\\p{N}\\p{M}';
+/**
+ * Scripts written without word spaces. A needle in one of them cannot
+ * be asked to start a word — there is no boundary to find — so it keeps
+ * substring semantics; a run of them is not a "word run" either, the
+ * CJK block below cuts those. Matches the tokenizer's CJK/kana/Hangul
+ * handling, plus Thai for the same reason.
+ */
+const NO_BOUNDARY_SCRIPT = '\\p{sc=Han}\\p{sc=Hiragana}\\p{sc=Katakana}\\p{sc=Hangul}\\p{sc=Thai}';
+const BOUNDED_WORD_CHAR = `(?:(?![${NO_BOUNDARY_SCRIPT}])[${WORD_CHAR_CLASS}])`;
+const WORD_CHAR = new RegExp(`[${WORD_CHAR_CLASS}]`, 'u');
+const WORD_RUN = new RegExp(`${BOUNDED_WORD_CHAR}{2,}`, 'gu');
+const BOUNDED_WORD_ONLY = new RegExp(`^${BOUNDED_WORD_CHAR}+$`, 'u');
+/**
+ * Leading/trailing characters that are not part of any word — punctuation
+ * for our purposes. Two alternatives so a token that is nothing but
+ * punctuation collapses to the empty string.
+ */
+const EDGE_PUNCTUATION = new RegExp(`^[^${WORD_CHAR_CLASS}]+|[^${WORD_CHAR_CLASS}]+$`, 'gu');
+
+/**
+ * Does `kw` occur in `textLower`? A needle from a space-delimited script
+ * must start a word; a needle from a script without word spaces (CJK,
+ * Thai …) matches as a substring.
+ *
+ * Substring matching was dominated by accidents of spelling: in a
+ * 3,000-page German vault "man" hit Kahneman and Karpman, "bei" hit
+ * Salbei, "kann" hit Pekannüsse, and "creatin" hit Phosphocreatin — a
+ * different substance that shares seven letters. A word start keeps
+ * prefix compounds ("nierenfunktion" → Nierenfunktionsstörung) and
+ * hyphenated ones ("kinase" → Creatin-Kinase); a tail compound
+ * ("insuffizienz" in Niereninsuffizienz) is left to aliases, the LLM
+ * keyword stage and the graph walk. Pure function.
+ */
+export function needleHits(textLower: string, kw: string): boolean {
+  if (!BOUNDED_WORD_ONLY.test(kw)) {
+    return textLower.includes(kw);
+  }
+  let i = textLower.indexOf(kw);
+  while (i !== -1) {
+    if (i === 0 || !WORD_CHAR.test(textLower[i - 1])) return true;
+    i = textLower.indexOf(kw, i + 1);
+  }
+  return false;
+}
+
 export function scorePagesByNeedles(
   pages: PageRef[],
   needles: string[],
@@ -77,10 +131,10 @@ export function scorePagesByNeedles(
     let tokensFound = 0;
     for (const kw of needles) {
       if (kw.length === 0) continue;
-      if (titleLower.includes(kw)) {
+      if (needleHits(titleLower, kw)) {
         score += 3;
         tokensFound++;
-      } else if (aliasLowers.some(a => a.includes(kw))) {
+      } else if (aliasLowers.some(a => needleHits(a, kw))) {
         score += 2;
         tokensFound++;
       }
@@ -161,6 +215,8 @@ const DEFAULT_MIN_EDGES = 30;
 const DEFAULT_MIN_EDGE_DENSITY = 1.0;
 const DEFAULT_SEED_MIN_DEGREE = 1;
 const DEFAULT_TOP_N = 10;
+/** Share of the top PPR mass the lex rank hint may add — see mergeWithPPR. */
+const LEX_HINT_WEIGHT = 0.1;
 
 /**
  * Tokenize a query into individual searchable terms. Language-aware:
@@ -181,13 +237,20 @@ export function tokenizeQuery(query: string): string[] {
   const tokens = new Set<string>();
   const queryLower = query.toLowerCase();
 
-  // ASCII runs of length ≥ 2.
-  const asciiRuns = queryLower.match(/[a-z0-9]{2,}/g);
-  if (asciiRuns) for (const r of asciiRuns) tokens.add(r);
+  // Word runs of length ≥ 2 in any space-delimited script, diacritics
+  // included. An ASCII-only class split "über" into "ber" and
+  // "eingeschränkter" into "eingeschr" + "nkter": fragments that matched
+  // titles the query never named, and "ber" double-counted every title
+  // "über" already hit. Cyrillic, Greek, Arabic … get the same treatment.
+  const wordRuns = queryLower.match(WORD_RUN);
+  if (wordRuns) for (const r of wordRuns) tokens.add(r);
 
   // Whitespace-split tokens of length ≥ 2 (catches words with CJK
   // mixed in: "InterVL和Janus" → "intervl和janus", "和" rejected by length).
-  for (const t of queryLower.split(/\s+/)) {
+  // Edge punctuation is stripped so "Creatin." and "nehmen?" do not
+  // survive as needles that can never match a title.
+  for (const raw of queryLower.split(/\s+/)) {
+    const t = raw.replace(EDGE_PUNCTUATION, '');
     if (t.length >= 2) tokens.add(t);
   }
 
@@ -275,9 +338,9 @@ function lexMatch(query: string, pages: PageRef[]): PageRef[] {
     let score = 0;
     let tokensFound = 0;
     for (const kw of tokens) {
-      if (titleLower.includes(kw)) { score += 3; tokensFound++; }
-      else if (aliasLowers.some(a => a.includes(kw))) { score += 2; tokensFound++; }
-      else if (summaryLower.includes(kw)) { score += 1; tokensFound++; }
+      if (needleHits(titleLower, kw)) { score += 3; tokensFound++; }
+      else if (aliasLowers.some(a => needleHits(a, kw))) { score += 2; tokensFound++; }
+      else if (needleHits(summaryLower, kw)) { score += 1; tokensFound++; }
     }
     if (tokensFound === tokens.length && tokens.length > 1) score += 2;
     if (score > 0) scored.push({ page, score });
@@ -475,13 +538,36 @@ function mergeWithPPR(
   const byPath = new Map<string, PageRef>();
   for (const p of pages) byPath.set(p.path, p);
 
-  // Merge: each page gets a composite score = max(lexScore, pprScore).
-  // PPR is the dominant signal (ranker); lex is the fallback hint.
+  // Merge: PPR mass is the ranker; the lex rank hint breaks ties among
+  // reached pages and orders the pages PPR never reached. The two live
+  // on different scales — lexScoreOf is a rank placeholder in (0, 1],
+  // PPR mass on a 3,000-node graph is ~0.05 for a seed — so the old
+  // `max(lex, ppr)` let any keyword hit outrank every PPR seed: with 76
+  // lex hits the top ten were all lex, and the seeds the LLM stage had
+  // just paid for were gone.
+  //
+  // Reached pages: ppr + hint × LEX_HINT_WEIGHT × maxPpr — the hint can
+  // reorder pages within a tenth of the top mass (e.g. several seeds of
+  // equal mass), nothing further apart. Unreached pages: hint scaled
+  // strictly below the smallest mass, so one monotone key sorts both.
+  let minPpr = Infinity;
+  let maxPpr = 0;
+  for (const v of pprScores.values()) {
+    if (v <= 0) continue;
+    if (v < minPpr) minPpr = v;
+    if (v > maxPpr) maxPpr = v;
+  }
+  const reachedHintScale = maxPpr * LEX_HINT_WEIGHT;
+  const unreachedHintScale = Number.isFinite(minPpr) ? minPpr / 2 : 1;
+
   const merged = new Map<string, { page: PageRef; score: number; arm: PageMatch['arm'] }>();
 
   for (const page of lex) {
     const ppr = pprScores.get(page.path) ?? 0;
-    const score = Math.max(lexScoreOf(page, lex), ppr);
+    const hint = lexScoreOf(page, lex);
+    const score = ppr > 0
+      ? ppr + hint * reachedHintScale
+      : hint * unreachedHintScale;
     merged.set(page.path, { page, score, arm });
   }
   for (const [path, ppr] of pprScores) {


### PR DESCRIPTION
Closes #623.

**What changes** (`src/core/ppr-cascade.ts`)
- `tokenizeQuery`: word runs are `\p{L}\p{N}\p{M}` (RegExp constructor, the form `candidate-gate.ts` already uses under the ES6 target), so "über" stays whole, Cyrillic/Greek/Arabic queries keep their words, and NFD text keeps its umlauts inside the word. Edge punctuation is stripped from whitespace tokens.
- `needleHits(textLower, kw)`: a needle from a space-delimited script must start a word (`nierenfunktion` → Nierenfunktionsstörung, `kinase` → Creatin-Kinase; `creatin` → Phosphocreatin no longer). Han, kana, Hangul and Thai needles keep substring semantics — there is no boundary to find. Used by `scorePagesByNeedles` and `lexMatch`.
- `mergeWithPPR`: reached pages score `ppr + hint × 0.1 × maxPpr`; unreached pages `hint × minPpr / 2`. One monotone key, PPR ranks, the lex hint orders within a tenth of the top mass and the tail.

**Tests:** `lex-noise.test.ts` pins the three mechanisms (tokenizer, needle boundary incl. Cyrillic and NFD, merge order on a 40-node ring plus 12 lex-only pages). One existing assertion changed: `ppr-cascade.test.ts` expected `P0` first in the sparse arm; "page" matches all 50 titles, so P0/P1/P2 carry equal PPR mass and the old `toBe('P0')` held only through the `max()` defect. Now `toContain` over the three.

**Downstream:** `PageMatch.score` is read only in a debug line (`QueryView-class.ts`); the seed-selector gate reads `scorePagesByNeedles`, whose scale is unchanged.

**Left as is, on purpose:** a tail compound ("insuffizienz" in Niereninsuffizienz) is left to aliases, the keyword stage and the graph walk — the measured false positives all came from tails. Rank fusion instead of the two weights would remove the constants; not done here, the two constants are the smallest change that keeps PPR the ranker.

Gate 1 green locally (3945 tests).
