### PR TITLE
fix(links): re-point folder-wrong links everywhere on the page, on the source page, and once more when the run is over

### DIFF
--- a/src/__tests__/core/related-link-corrector.test.ts
+++ b/src/__tests__/core/related-link-corrector.test.ts
@@ -307,3 +307,56 @@ describe('correctRelatedLinkPrefixes — full-vault resolution (#482)', () => {
     expect(r).toBe(c);
   });
 });
+
+describe('correctRelatedLinkPrefixes — folder-typed links outside the Related sections', () => {
+  // Measured 2026-09-03 on a 3,025-page vault: 314 links pointed at
+  // `concepts/X` or `entities/X` while the page lived in the other folder;
+  // 279 of them stood outside the two Related sections and were never seen.
+  const ENT = 'Related Entities';
+  const CON = 'Related Concepts';
+  const vault = (pages: Array<{ path: string; title: string; aliases?: string[] }>) =>
+    ({ wikiFolder: 'wiki', pages });
+  const creatinVault = vault([
+    { path: 'wiki/entities/Phosphocreatin.md', title: 'Phosphocreatin' },
+    { path: 'wiki/entities/Skelettmuskeln.md', title: 'Skelettmuskeln', aliases: ['Skelettmuskulatur'] },
+    { path: 'wiki/concepts/ATP.md', title: 'ATP' },
+  ]);
+
+  it('re-points a folder-wrong link in prose to the page the vault holds', () => {
+    const c = '## Description\nRegeneration von [[concepts/ATP|ATP]] über [[concepts/Phosphocreatin|Phosphocreatin]].';
+    const r = correctRelatedLinkPrefixes(c, [], [], ENT, CON, creatinVault);
+    expect(r).toBe('## Description\nRegeneration von [[concepts/ATP|ATP]] über [[entities/Phosphocreatin|Phosphocreatin]].');
+  });
+
+  it('re-points on a source page section the corrector was never scoped to', () => {
+    const c = ['## Core Content', 'Stored in [[concepts/Skelettmuskeln]].'].join('\n');
+    const r = correctRelatedLinkPrefixes(c, [], [], ENT, CON, creatinVault);
+    expect(r).toContain('[[entities/Skelettmuskeln|Skelettmuskeln]]');
+  });
+
+  it('follows an alias in prose too', () => {
+    const c = '## Description\nSee [[concepts/Skelettmuskulatur|Muskeln]].';
+    const r = correctRelatedLinkPrefixes(c, [], [], ENT, CON, creatinVault);
+    expect(r).toContain('[[entities/Skelettmuskeln|Muskeln]]');
+  });
+
+  it('leaves a correct folder-typed prose link byte-identical', () => {
+    const c = '## Description\nSee [[entities/Phosphocreatin|Phosphocreatin]] and [[concepts/ATP]].';
+    expect(correctRelatedLinkPrefixes(c, [], [], ENT, CON, creatinVault)).toBe(c);
+  });
+
+  it('leaves a bare link and a sources/ citation in prose alone', () => {
+    const c = '## Description\n[[Phosphocreatin]] per [[sources/Phosphocreatin|Quelle]].';
+    expect(correctRelatedLinkPrefixes(c, [], [], ENT, CON, creatinVault)).toBe(c);
+  });
+
+  it('leaves a name the vault does not know alone — no section, no typed-list fallback in prose', () => {
+    const c = '## Description\nAbout [[concepts/Unbekannt|Unbekannt]].';
+    expect(correctRelatedLinkPrefixes(c, ['Unbekannt'], [], ENT, CON, creatinVault)).toBe(c);
+  });
+
+  it('does nothing in prose without a vault index', () => {
+    const c = '## Description\nAbout [[concepts/Phosphocreatin|Phosphocreatin]].';
+    expect(correctRelatedLinkPrefixes(c, ['Phosphocreatin'], [], ENT, CON)).toBe(c);
+  });
+});

--- a/src/__tests__/wiki/wiki-engine-link-repoint.test.ts
+++ b/src/__tests__/wiki/wiki-engine-link-repoint.test.ts
@@ -1,0 +1,113 @@
+// End-of-run link pass (Stage 4.5).
+//
+// A page written early in an ingest links to a sibling that does not exist
+// yet. The write-time corrector can only trust the extraction's folder for
+// it, and the sibling may land in the other folder once dedup decides.
+// Measured 2026-09-03 on a 3,025-page vault: 35 folder-wrong links sat in
+// Related sections of pages whose target was born in the same run —
+// `entities/Creatin` → `[[concepts/Phosphocreatin]]` among them, while
+// Phosphocreatin lives under entities/. Only at the end of the run does the
+// vault know; this pass asks it then.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+
+const NOTE = 'Notizen/Creatin.md';
+
+const ANALYSIS = JSON.stringify({
+  source_title: 'Creatin',
+  summary: 'Creatin und Phosphocreatin.',
+  entities: [
+    // The extraction calls Phosphocreatin a concept on Creatin's page …
+    { name: 'Creatin', type: 'person', summary: 'x', mentions_in_source: [], related_concepts: ['Phosphocreatin'] },
+    // … and extracts it as an entity of its own, written after Creatin.
+    { name: 'Phosphocreatin', type: 'person', summary: 'y', mentions_in_source: [] },
+  ],
+  concepts: [],
+  contradictions: [],
+  related_pages: [],
+  key_points: [],
+});
+
+const SUMMARY = [
+  '---', 'type: source', '---', '# Creatin - Summary', '',
+  '## Key Concepts', '- [[concepts/Phosphocreatin|Phosphocreatin]]', '',
+].join('\n');
+
+const CREATIN_PAGE = [
+  '---', 'type: entity', '---', '# Creatin', '',
+  '## Description', 'Regeneration über [[concepts/Phosphocreatin|Phosphocreatin]].', '',
+  '## Related Concepts', '- [[concepts/Phosphocreatin|Phosphocreatin]]', '',
+].join('\n');
+
+const PHOSPHO_PAGE = ['---', 'type: entity', '---', '# Phosphocreatin', '', '## Description', 'Energiespeicher.', ''].join('\n');
+
+function note(): TFile {
+  return Object.assign(new TFile(), { path: NOTE, name: 'Creatin.md', basename: 'Creatin', extension: 'md' });
+}
+
+async function run() {
+  const h = createWikiEngineHarness({
+    files: { [NOTE]: '# Creatin\n\nCreatin und Phosphocreatin.' },
+    // Call order observed on the harness: extract, extract, source-page,
+    // page-generate (Creatin), dedup (Phosphocreatin vs. Creatin — an empty
+    // object is no decision, the page is created), page-generate.
+    llmResponses: [ANALYSIS, ANALYSIS, SUMMARY, CREATIN_PAGE, '{}', PHOSPHO_PAGE],
+  });
+  await h.engine.ingestSource(note());
+  return h;
+}
+
+describe('WikiEngine.ingestSource — end-of-run link re-point', () => {
+  it('a link written before its target existed points where the target landed', async () => {
+    const h = await run();
+    expect(h.reports[0]?.success).toBe(true);
+    expect(h.files.has('wiki/entities/phosphocreatin.md')).toBe(true);
+
+    const creatin = h.files.get('wiki/entities/creatin.md') ?? '';
+    expect(creatin).not.toContain('concepts/Phosphocreatin');
+    // Both the prose link and the Related-section link — the section said
+    // "concept", the vault says entity.
+    expect(creatin.match(/\[\[entities\/phosphocreatin\|Phosphocreatin\]\]/g)).toHaveLength(2);
+  });
+
+  it('the source page gets the same pass', async () => {
+    const h = await run();
+    const source = [...h.files.entries()].find(([p]) => p.startsWith('wiki/sources/'))?.[1] ?? '';
+    expect(source).not.toContain('concepts/Phosphocreatin');
+    // Folder is what counts; a link that differs from the file name only in
+    // case already resolves and is left as written.
+    expect(source.toLowerCase()).toContain('[[entities/phosphocreatin|phosphocreatin]]');
+  });
+
+  it('a page with nothing to move is not rewritten', async () => {
+    const h = await run();
+    expect(h.writtenPaths.filter(p => p === 'wiki/entities/phosphocreatin.md')).toHaveLength(1);
+    expect(h.writtenPaths.filter(p => p === 'wiki/entities/creatin.md')).toHaveLength(2);
+  });
+});
+
+describe('WikiEngine.ingestSource — the pass reads only the pages of this run', () => {
+  it('never scans the vault for its index', async () => {
+    const h = createWikiEngineHarness({
+      files: { [NOTE]: '# Creatin\n\nCreatin und Phosphocreatin.' },
+      llmResponses: [ANALYSIS, ANALYSIS, SUMMARY, CREATIN_PAGE, '{}', PHOSPHO_PAGE],
+    });
+    const before = h.stats.vaultMarkdownScans;
+    // Count scans between the last page write of Stage 3/4 and the end of the
+    // run: the pass itself must add none. The write-time corrector and the
+    // index generation scan on their own; the pass is measured by difference
+    // against a run whose pass has nothing to do.
+    await h.engine.ingestSource(note());
+    const withPass = h.stats.vaultMarkdownScans - before;
+
+    const h2 = createWikiEngineHarness({
+      files: { [NOTE]: '# Creatin\n\nCreatin und Phosphocreatin.' },
+      llmResponses: [ANALYSIS, ANALYSIS, SUMMARY, CREATIN_PAGE.replace(/concepts\/Phosphocreatin/g, 'entities/phosphocreatin'), '{}', PHOSPHO_PAGE],
+    });
+    await h2.engine.ingestSource(note());
+    const withoutPass = h2.stats.vaultMarkdownScans;
+    expect(withPass).toBe(withoutPass);
+  });
+});

--- a/src/core/related-link-corrector.ts
+++ b/src/core/related-link-corrector.ts
@@ -118,13 +118,59 @@ export function buildVaultResolver(
   };
 }
 
+export interface VaultIndex { wikiFolder: string; pages: ExistingPageRef[] }
+
+/** Folder-typed entity/concept link, singular prefixes included; never `sources/`. */
+const FOLDER_TYPED_LINK_RE = /\[\[(entities|entity|concepts|concept)\/([^\]|]+)(\|[^\]]*)?\]\]/g;
+
+/**
+ * Re-point every folder-typed link on one line to the page the vault holds
+ * under that name (title first, then curated alias). A link whose target is
+ * already the vault's path, a name the vault does not know, a bare `[[X]]`
+ * and any `sources/` link are left byte-identical. Returns the line and how
+ * many links moved.
+ */
+function repointLine(line: string, resolve: (name: string) => string | undefined): { line: string; moved: number } {
+  let moved = 0;
+  const out = line.replace(FOLDER_TYPED_LINK_RE, (full, folder: string, target: string, display?: string) => {
+    const inVault = resolve(target);
+    // Obsidian resolves links case-insensitively: a link that differs from
+    // the vault path only in case already points at the page, and rewriting
+    // it would cost a write and count as a move that never happened.
+    if (!inVault || inVault.toLowerCase() === `${folder}/${target}`.toLowerCase()) return full;
+    moved++;
+    return `[[${inVault}|${display ? display.slice(1) : target}]]`;
+  });
+  return { line: out, moved };
+}
+
+/**
+ * End-of-run pass over a page (see WikiEngine.repointLinksAfterRun): the
+ * same vault resolution as the prose pass in correctRelatedLinkPrefixes,
+ * applied to every line, Related sections included. No typed lists, no
+ * section fallback — only what the vault can answer for. Pure function.
+ */
+export function repointFolderTypedLinks(
+  content: string,
+  vaultIndex: VaultIndex,
+): { content: string; moved: number } {
+  const resolve = buildVaultResolver(vaultIndex);
+  let moved = 0;
+  const out = content.split('\n').map(line => {
+    const r = repointLine(line, resolve);
+    moved += r.moved;
+    return r.line;
+  }).join('\n');
+  return { content: out, moved };
+}
+
 export function correctRelatedLinkPrefixes(
   content: string,
   relatedEntities: string[] | undefined,
   relatedConcepts: string[] | undefined,
   relatedEntitiesLabel: string,
   relatedConceptsLabel: string,
-  vaultIndex?: { wikiFolder: string; pages: ExistingPageRef[] },
+  vaultIndex?: VaultIndex,
 ): string {
   // The typed-list map (`folderBySlug` below) keys the same way as the vault
   // resolver: it used to take `preserveCase` from the caller, which kept both
@@ -177,15 +223,8 @@ export function correctRelatedLinkPrefixes(
   const bareLinkRe = /\[\[(?!entities\/|entity\/|concepts\/|concept\/|sources\/)([^\]|/]+)(\|[^\]]*)?\]\]/g;
   // Prose pass: only folder-typed entity/concept links, only re-pointed to a
   // page the vault actually holds. Everything else on the line is left as is.
-  const proseLinkRe = /\[\[(entities|entity|concepts|concept)\/([^\]|]+)(\|[^\]]*)?\]\]/g;
-  const repointInProse = (line: string): string => {
-    if (!vaultIndex) return line;
-    return line.replace(proseLinkRe, (full, folder: string, target: string, display?: string) => {
-      const inVault = resolveInVault(target);
-      if (!inVault || inVault === `${folder}/${target}`) return full;
-      return `[[${inVault}|${display ? display.slice(1) : target}]]`;
-    });
-  };
+  const repointInProse = (line: string): string =>
+    vaultIndex ? repointLine(line, resolveInVault).line : line;
 
   let current: 'entities' | 'concepts' | undefined;
   return content.split('\n').map(line => {

--- a/src/core/related-link-corrector.ts
+++ b/src/core/related-link-corrector.ts
@@ -16,6 +16,16 @@
 // `[[sources/<sourceSlug>]]` citations in "Mentions in Source" — whose names often
 // coincide with a related concept (e.g. the source "Gedächtnis" is also a related
 // concept) — are never rewritten. No false-merge risk.
+//
+// Outside those sections a narrower pass runs, with the vault index only: a link
+// the model already typed as `entities/X` or `concepts/X` whose page the vault
+// holds under the other folder is re-pointed there. Measured on a 3,025-page
+// vault, 279 of 314 folder-wrong links stood in prose (Description, Core
+// Content, the source page's Key Entities/Concepts) — the section-scoped pass
+// never saw them, and every one of them was a dead link in the reader and a
+// missing edge in the query graph. Bare `[[X]]` links stay untouched there (no
+// section to type them), `sources/` links are never re-typed, and a name the
+// vault does not know is left alone.
 
 import { slugify } from './slug';
 
@@ -165,6 +175,18 @@ export function correctRelatedLinkPrefixes(
   // the same treatment: resolved against the vault, or folder-stamped from the
   // typed lists so the stub path can pick it up.
   const bareLinkRe = /\[\[(?!entities\/|entity\/|concepts\/|concept\/|sources\/)([^\]|/]+)(\|[^\]]*)?\]\]/g;
+  // Prose pass: only folder-typed entity/concept links, only re-pointed to a
+  // page the vault actually holds. Everything else on the line is left as is.
+  const proseLinkRe = /\[\[(entities|entity|concepts|concept)\/([^\]|]+)(\|[^\]]*)?\]\]/g;
+  const repointInProse = (line: string): string => {
+    if (!vaultIndex) return line;
+    return line.replace(proseLinkRe, (full, folder: string, target: string, display?: string) => {
+      const inVault = resolveInVault(target);
+      if (!inVault || inVault === `${folder}/${target}`) return full;
+      return `[[${inVault}|${display ? display.slice(1) : target}]]`;
+    });
+  };
+
   let current: 'entities' | 'concepts' | undefined;
   return content.split('\n').map(line => {
     const header = /^#{1,6}\s+(.*?)\s*$/.exec(line);
@@ -172,7 +194,7 @@ export function correctRelatedLinkPrefixes(
       current = sectionFolder.get(header[1].trim());
       return line;
     }
-    if (!current) return line;
+    if (!current) return repointInProse(line);
     const rewrite = (target: string, folder: string | undefined, display: string | undefined): string => {
       // The vault's own answer wins: it knows the real path, including the case
       // where `target` is an alias of a page with a different title.

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -48,7 +48,7 @@ import {
   applySectionLabels,
 } from './system-prompts';
 import { getExistingWikiPages } from './lint/get-existing-pages';
-import { correctRelatedLinkPrefixes } from '../core/related-link-corrector';
+import { correctRelatedLinkPrefixes, repointFolderTypedLinks } from '../core/related-link-corrector';
 import { fixDeadLink } from './lint/fix-dead-link';
 import { fillEmptyPage } from './lint/fill-empty-page';
 import { deleteEmptyStubs } from './lint/delete-empty-stubs';
@@ -1412,6 +1412,17 @@ export class WikiEngine {
       }
 
       // Stage 5: Contradiction Recording
+      // Stage 4.5: re-point folder-typed links on every page this run wrote.
+      // A page written early in the run links to a sibling that does not
+      // exist yet; the write-time corrector then trusts the extraction's
+      // folder, and the sibling may land in the other one (the folder is
+      // decided at dedup, #589). Only now does the vault know. Measured:
+      // 35 of 314 folder-wrong links sat in Related sections of pages
+      // whose target was born in the same run.
+      const repointStart = Date.now();
+      await this.repointLinksAfterRun([...analysis.created_pages, ...analysis.updated_pages]);
+      console.debug(`[Time] Link re-point pass: ${Date.now() - repointStart}ms`);
+
       const contradictionStart = Date.now();
       for (const contradiction of analysis.contradictions) {
         try {
@@ -1578,6 +1589,62 @@ export class WikiEngine {
     }
 
     await this.schemaManager.ensureSchemaExists();
+  }
+
+  /**
+   * End-of-run link pass. Deterministic, no model: every folder-typed link on
+   * the pages this run wrote is resolved against the pages this run wrote —
+   * that is the whole class. A target that existed before the run was
+   * resolvable at write time already; only a sibling born later in the same
+   * run was not, so the index is built from the run's own pages (title from
+   * the file name, aliases from the frontmatter), one read per page, and
+   * never from a vault-wide scan. Pages that come out byte-identical are not
+   * rewritten, and a `reviewed: true` page is not touched at all — its body
+   * is locked for every writer (K: reviewed = hands off), this pass included;
+   * it still lends its title and aliases to the index. A failure on one page
+   * is logged and never fails the ingest or the pass for the other pages —
+   * the pages are already on disk.
+   */
+  async repointLinksAfterRun(pagePaths: string[]): Promise<{ pages: number; links: number }> {
+    const paths = [...new Set(pagePaths)].filter(p => p.endsWith('.md'));
+    const result = { pages: 0, links: 0 };
+    if (paths.length === 0) return result;
+    const contents = new Map<string, string>();
+    for (const path of paths) {
+      try {
+        const content = await this.tryReadFile(path);
+        if (content) contents.set(path, content);
+      } catch (error) {
+        console.warn(`[link-repoint] could not read ${path}, left as written:`, error);
+      }
+    }
+    const runIndex = {
+      wikiFolder: this.settings.wikiFolder,
+      pages: [...contents].map(([path, content]) => {
+        const fm = parseFrontmatter(content);
+        return {
+          path,
+          title: (path.split('/').pop() ?? path).replace(/\.md$/, ''),
+          aliases: Array.isArray(fm?.aliases) ? fm.aliases : undefined,
+        };
+      }),
+    };
+    for (const [path, content] of contents) {
+      if (parseFrontmatter(content)?.reviewed === true) continue;
+      const { content: repointed, moved } = repointFolderTypedLinks(content, runIndex);
+      if (moved === 0 || repointed === content) continue;
+      try {
+        await this.createOrUpdateFile(path, repointed);
+        result.pages++;
+        result.links += moved;
+      } catch (error) {
+        console.warn(`[link-repoint] could not write ${path}, left as written:`, error);
+      }
+    }
+    if (result.links > 0) {
+      console.debug(`[link-repoint] ${result.links} link(s) on ${result.pages} page(s) re-pointed to where the target landed`);
+    }
+    return result;
   }
 
   async createSummaryPage(file: TFile, analysis: SourceAnalysis, plannedPaths: string[] = [], sourceSlug?: string, contentOverride?: string): Promise<string> {

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -48,6 +48,7 @@ import {
   applySectionLabels,
 } from './system-prompts';
 import { getExistingWikiPages } from './lint/get-existing-pages';
+import { correctRelatedLinkPrefixes } from '../core/related-link-corrector';
 import { fixDeadLink } from './lint/fix-dead-link';
 import { fillEmptyPage } from './lint/fill-empty-page';
 import { deleteEmptyStubs } from './lint/delete-empty-stubs';
@@ -1692,6 +1693,24 @@ export class WikiEngine {
     // a `domains:` field — one field, and the note itself carries the tags
     // one click away; the mirror only duplicated every tag-pane hit.
     // `tags:` stays the plugin's format axis (#90/#114).
+
+    // The source page was the one writer without the link corrector: 212 of
+    // 314 folder-wrong links measured on a 3,025-page vault stood in its Key
+    // Entities / Key Concepts / Core Content sections. Same pass as the
+    // entity and concept pages — the typed lists come from the analysis, the
+    // two Key sections play the role of the Related sections, and every
+    // folder-typed link elsewhere on the page is checked against the vault.
+    {
+      const labels = getSectionLabels(this.settings);
+      finalContent = correctRelatedLinkPrefixes(
+        finalContent,
+        analysis.entities.map(e => e.name),
+        analysis.concepts.map(c => c.name),
+        labels.key_entities,
+        labels.key_concepts,
+        { wikiFolder: this.settings.wikiFolder, pages: await this.getExistingWikiPages() },
+      );
+    }
 
     await this.createOrUpdateFile(path, finalContent);
     return path;


### PR DESCRIPTION
Closes #624.

Two commits.

**1. `correctRelatedLinkPrefixes` outside the Related sections, and on the source page**
- New prose pass: a link already typed `entities/X` or `concepts/X` is re-pointed when the vault holds X (title, then curated alias) under another path. Bare `[[X]]` stays (no section to type it), `sources/` is never re-typed, an unknown name is left alone — no typed-list fallback in prose. Case-only differences are not a move: Obsidian resolves them, and rewriting would cost a write.
- `createSummaryPage` calls the corrector before writing, with the analysis lists as the typed lists and Key Entities / Key Concepts as the section labels. Uses the engine's cached page index.

**2. Stage 4.5 `repointLinksAfterRun`** — after the related-page updates, before contradictions and index: every page this run created or updated is read once, each folder-typed link is resolved against the pages of this run (title from the file name, aliases from the frontmatter), and pages that moved a link are written through the single write gate. No model, no typed lists. A `reviewed: true` page is not touched (it still lends its title and aliases to the index). Pages that come out byte-identical are not written; a failure on one page is logged and does not stop the others or fail the ingest. `repointFolderTypedLinks` is the pure function behind it; `buildVaultResolver` from #621 is shared.

**Tests:** corrector — prose re-point, source-page section, alias in prose, correct link byte-identical, bare/`sources/` untouched, unknown name untouched, no index no-op. Engine harness — Creatin links `[[concepts/Phosphocreatin]]` in prose and in Related Concepts, Phosphocreatin is created as an entity afterwards, both links and the source page read `entities/…` at the end of the run; a page with nothing to move is not rewritten; the pass adds no vault scan (measured by difference against a run whose pass has nothing to do).

**Left as is, on purpose:** the write-time pass could be dropped in favour of one deferred correction over the whole run — fewer writes, but it moves the corrector out of three page-factory writers; too large for this fix. `[[concepts/X#heading]]` is not resolved (the anchor is part of the name to the resolver); no template emits such links today. The 314 links already on disk are not touched by the plugin — a one-off repair on the vault side.

Gate 1 green locally (3941 tests).
