### PR TITLE
fix(llm): apply the per-step thinking policy on the stream path too

### DIFF
--- a/src/__tests__/core/llm-client-wrapper.test.ts
+++ b/src/__tests__/core/llm-client-wrapper.test.ts
@@ -150,6 +150,36 @@ describe('wrapWithAdvancedSettings — per-step accounting', () => {
       expect(new Map(taskUsageSince(before)).get('untagged')?.calls).toBe(1);
     });
 
+    it('applies the thinking policy on the stream path — the answer the user waits for', async () => {
+      // Measured 2026-09-04: with `*=default:off` the keyword call sent
+      // reasoning_effort none and the streamed answer sent nothing, so the
+      // model thought for 43 of its 55 seconds.
+      const { client, calls } = streamClientSpy();
+      await wrapWithAdvancedSettings(client, {
+        maxTokensPerCall: 0,
+        taskPolicies: { '*': { outputMode: 'default', thinking: 'off' } },
+      }).createMessageStream!({ ...CALL, task: 'query-wiki', onChunk: () => {} });
+      expect(calls[0]?.enableThinking).toBe(false);
+      expect(calls[0]).not.toHaveProperty('outputModeOverride');
+      expect(calls[0]).not.toHaveProperty('reasoningEffort');
+    });
+
+    it('the policy overrides disableThinking from the call site on the stream too', async () => {
+      const { client, calls } = streamClientSpy();
+      await wrapWithAdvancedSettings(client, {
+        maxTokensPerCall: 0,
+        taskPolicies: { 'query-wiki': { outputMode: 'default', thinking: 'on' } },
+      }).createMessageStream!({ ...CALL, task: 'query-wiki', enableThinking: false, onChunk: () => {} });
+      expect(calls[0]?.enableThinking).toBe(true);
+    });
+
+    it('leaves the stream untouched when no policy names its step', async () => {
+      const { client, calls } = streamClientSpy();
+      await wrapWithAdvancedSettings(client, streamSettings)
+        .createMessageStream!({ ...CALL, task: 'query-wiki', onChunk: () => {} });
+      expect(calls[0]).not.toHaveProperty('enableThinking');
+    });
+
     it('forwards a caller-provided temperature with no silent drop on the stream path', async () => {
       // QueryView passes chatTemperature itself; the wrapper must not
       // overwrite it (mirrors the createMessage caller-wins contract).

--- a/src/llm-client-wrapper.ts
+++ b/src/llm-client-wrapper.ts
@@ -113,13 +113,16 @@ export function wrapWithAdvancedSettings(
   // Object.create, silently dropping advanced settings on the stream path.
   // Issue #469: the interface now carries a task label, so the stream path
   // accounts under the step like every other caller — Query Wiki streams
-  // under 'query-wiki' instead of a merged 'untagged' row.
+  // under 'query-wiki' instead of a merged 'untagged' row — and the same
+  // label keys the per-step thinking policy (see applyTaskPolicy).
   if (client.createMessageStream) {
     wrapper.createMessageStream = (params) => withTaskAccounting(params.task, async () => {
       logLlmCall(params.task, params.model, params.max_tokens, 'stream');
+      const { enableThinking } = applyTaskPolicy(params.task, settings);
       return client.createMessageStream!({
         ...params,
         ...injectAdvancedSettings(params, settings, capTokens),
+        ...(enableThinking !== undefined ? { enableThinking } : {}),
       });
     });
   }
@@ -159,8 +162,13 @@ function injectAdvancedSettings(
  * spreads `{}` and changes nothing, which is what keeps the default path
  * byte-identical to pre-#481.
  *
- * Not applied on the stream path — it carries no `task` label (#469), so
- * there is nothing to key a per-step decision on.
+ * The stream path takes only the thinking half: it has no output mode (a
+ * stream is text by construction) and its interface carries no effort
+ * level, so a named level rides as `enableThinking: true` and the budget
+ * is left to the client's default. Until now the stream path was skipped
+ * altogether — the note here said it carried no `task` label, which #469
+ * ended: Query Wiki streams under 'query-wiki', and a policy of
+ * `*=default:off` reached every step except the one the user waits for.
  */
 function applyTaskPolicy(
   task: string | undefined,


### PR DESCRIPTION
Closes #627.

**What changes** (`src/llm-client-wrapper.ts`): `createMessageStream` now spreads `enableThinking` from `applyTaskPolicy(params.task, settings)` after the advanced-settings overlay — the same precedence as the other two paths, so a step-named policy overrides the call site's `disableThinking`. Nothing else on the stream is touched; without a policy the request is byte-identical.

**Tests** (`llm-client-wrapper.test.ts`, stream block): `*=default:off` reaches the stream as `enableThinking: false`; `query-wiki=default:on` overrides a call-site `false`; no policy adds no field.

**Not in this PR:** `reasoningEffort` on the stream (its interface does not carry the field) and the summary-instead-of-full-content question for the answer prompt (12 s of the 55 s were prompt processing of ~8.7k uncached tokens; a design question, not a fix).

Gate 1 green locally (3933 tests).
