### PR TITLE
fix(query): a concept page reaches the answer prompt as its description, not its one-line definition

### DIFF
--- a/src/__tests__/core/section-extractor.test.ts
+++ b/src/__tests__/core/section-extractor.test.ts
@@ -67,6 +67,29 @@ describe('extractSummaryFromPage — English baseline', () => {
     })).toBe('A formal definition.');
   });
 
+  it('prefers ## Description on a concept page that carries both sections', () => {
+    // The concept template writes a one-sentence Definition above the
+    // Description that holds the page's substance; the query prompt used to
+    // take the sentence and drop the substance (measured 2026-09-04: 183 of
+    // 241 concept pages with both sections).
+    const body = [
+      '## Description',
+      'Osteoporosis is multifactorial: vitamin deficiency, inactivity and dysbiosis. Therapy combines D3 + K2 with resistance training.',
+      '',
+      '## Definition',
+      'A disease of reduced bone density.',
+      '',
+      '## More',
+      'bar',
+    ].join('\n');
+    expect(extractSummaryFromPage(body, {
+      descriptionLabel: EN_DESC,
+      definitionLabel: EN_DEF,
+      pageType: 'concept',
+      maxChars: 1000,
+    })).toBe('Osteoporosis is multifactorial: vitamin deficiency, inactivity and dysbiosis. Therapy combines D3 + K2 with resistance training.');
+  });
+
   it('returns content up to the next ## header', () => {
     const body = [
       '## Description',
@@ -233,12 +256,13 @@ describe('extractSummaryFromPage — user-customized label', () => {
   });
 });
 
-describe('extractSummaryFromPage — pageType determines primary label', () => {
+describe('extractSummaryFromPage — the description is primary for both page types', () => {
   it('entity page with both ## Description and ## Definition uses Description', () => {
-    // Concept pages declare a domain via ## Definition. Entity pages declare
-    // via ## Description. The caller (query-engine) knows the page type
-    // and picks the right label. The extractor trusts the caller's choice
-    // when only one label exists; if both exist, pageType wins.
+    // The generation template gives a concept only a Definition; the merge
+    // template writes a Description ("core definition and significance")
+    // above it on every multi-source page. The description is where the
+    // substance accumulates, so it is primary for both types; the
+    // definition is the fallback for a page that has nothing else.
     const body = [
       '## Description',
       'entity desc',
@@ -256,7 +280,7 @@ describe('extractSummaryFromPage — pageType determines primary label', () => {
     })).toBe('entity desc');
   });
 
-  it('concept page with both ## Description and ## Definition uses Definition', () => {
+  it('concept page with both ## Description and ## Definition uses Description too', () => {
     const body = [
       '## Description',
       'entity desc',
@@ -271,7 +295,7 @@ describe('extractSummaryFromPage — pageType determines primary label', () => {
       definitionLabel: 'Definition',
       pageType: 'concept',
       maxChars: 1000,
-    })).toBe('concept def');
+    })).toBe('entity desc');
   });
 
   it('falls back to other label when pageType label is missing', () => {

--- a/src/core/section-extractor.ts
+++ b/src/core/section-extractor.ts
@@ -22,17 +22,18 @@
 //     options: {
 //       descriptionLabel: string;   // entity section title (i18n-translated or custom)
 //       definitionLabel: string;    // concept section title (i18n-translated or custom)
-//       pageType: 'entity' | 'concept';
+//       pageType: 'entity' | 'concept';  // kept for callers; no longer selects the label
 //       maxChars: number;
 //     }
 //   ): string
 //
 // Behavior:
-// - Pick the primary label based on pageType (entity → descriptionLabel,
-//   concept → definitionLabel).
-// - Match `## <primaryLabel>` first (case-insensitive). If not present,
-//   fall back to the other label (the page may have been ingested before
-//   the user changed wikiLanguage).
+// - Match `## <descriptionLabel>` first (case-insensitive), for both page
+//   types: the merge template writes the Description on every multi-source
+//   page and that is where the substance accumulates. If not present, fall
+//   back to `## <definitionLabel>` (a single-source concept page has only
+//   that; a page may also have been ingested before the user changed
+//   wikiLanguage).
 // - Extract content up to the next ## or ### header.
 // - Strip `[[wikilink]]` and `[[#^block-id]]` constructs.
 // - Strip folder prefix from `[[entities/Cardiology]]` → `Cardiology`.
@@ -44,6 +45,7 @@
 export interface SectionExtractOptions {
   descriptionLabel: string;
   definitionLabel: string;
+  /** Kept for callers; no longer selects the label (see extractSummaryFromPage). */
   pageType: 'entity' | 'concept';
   maxChars: number;
 }
@@ -143,14 +145,21 @@ function truncateAtSentenceBoundary(text: string, maxChars: number): string {
 export function extractSummaryFromPage(body: string, options: SectionExtractOptions): string {
   if (!body) return '';
 
-  const { descriptionLabel, definitionLabel, pageType, maxChars } = options;
+  const { descriptionLabel, definitionLabel, maxChars } = options;
 
   // Step 1: strip frontmatter so it doesn't confuse header search.
   const stripped = stripFrontmatter(body);
 
-  // Step 2: pick primary label by pageType, fall back to the other.
-  const primaryLabel = pageType === 'entity' ? descriptionLabel : definitionLabel;
-  const secondaryLabel = pageType === 'entity' ? definitionLabel : descriptionLabel;
+  // Step 2: the description is the page's substance for both page types;
+  // the definition is the one-sentence gloss the concept template writes
+  // above it. Measured 2026-09-04 on a 3,025-page vault: of 241 concept
+  // pages carrying both sections, 183 had a definition under 400 chars and
+  // a description at least three times as long (median ratio 5.2). With
+  // the definition primary, an osteoporosis question reached the model as
+  // one sentence while the 3,100-char description — therapy, exercise,
+  // dysbiosis — never did. A page that has only a definition still gets it.
+  const primaryLabel = descriptionLabel;
+  const secondaryLabel = definitionLabel;
 
   let header = findSectionHeader(stripped, primaryLabel);
   if (!header) {


### PR DESCRIPTION
Closes #628.

**What changes** (`src/core/section-extractor.ts`): `extractSummaryFromPage` matches `## <descriptionLabel>` first for both page types and falls back to `## <definitionLabel>`. `pageType` stays in the options for the callers and no longer selects the label. Only caller is `load-pages.ts`; no signature change.

**Tests:** the pinned rule "concept page with both sections uses Definition" is inverted to Description, with the reason in the test; a new case carries both sections in the shape the merge template writes (Description above Definition) and expects the Description. A concept page with only a Definition still returns it (existing test, unchanged).

**Not in this PR:** the prompt line "loaded with full content" (your editorial surface); the seed tie-break in the keyword scan, where equal-score pages fall back to index order (separate note).

Gate 1 green locally (3931 tests).
