### PR TITLE
fix(merge): a paragraph another source footnoted may not vanish from a rewrite

### DIFF
--- a/src/__tests__/core/paragraph-provenance.test.ts
+++ b/src/__tests__/core/paragraph-provenance.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PARAGRAPH_KEEP_OVERLAP, guardBodyRewrite, preserveSourcedParagraphs } from '../../core/paragraph-provenance';
+import { preserveExistingSections } from '../../core/section-header-canonicalizer';
+
+const DE = [
+  'Beschreibung', 'Hauptmerkmale', 'Verwandte Konzepte', 'Verwandte Entitäten',
+  'Erwähnungen in der Quelle', 'Neue Informationen',
+];
+const M = 'Erwähnungen in der Quelle';
+
+const P_A = 'Berberin senkt den Nüchternblutzucker über eine Aktivierung der AMPK in Leber und Muskel deutlich. ^[Quelle: [[Berberin]]]';
+const P_B = 'Chrom verbessert die Insulinsensitivität der Zielgewebe nur bei nachgewiesenem Mangel messbar. ^[Quelle: [[Chrom]]]';
+const P_C = 'Pektine verzögern die Magenentleerung und flachen den postprandialen Glukoseanstieg ab. ^[Quelle: [[entities/Pektine|Pektine]]]';
+const PLAIN = 'Insulinresistenz bezeichnet eine verminderte Reaktion des Gewebes auf Insulin.';
+
+const page = (...paras: string[]) =>
+  `# Insulinresistenz\n\n## Beschreibung\n${paras.join('\n\n')}\n\n## Hauptmerkmale\n- Merkmal eins\n- Merkmal zwei\n\n## Verwandte Konzepte\n- [[concepts/Adipositas|Adipositas]]`;
+
+describe('preserveSourcedParagraphs (a paragraph another source footnoted may not vanish)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns the rewrite itself when the existing body carries no footnotes', () => {
+    const rewrite = page(PLAIN);
+    expect(preserveSourcedParagraphs(page(PLAIN, 'Zweiter Absatz ohne Marker.'), rewrite, 'Pektine', DE, M)).toBe(rewrite);
+  });
+
+  it('returns the rewrite itself when every footnoted paragraph survived with its footnote', () => {
+    const rewrite = page(PLAIN, P_A, P_B);
+    expect(preserveSourcedParagraphs(page(PLAIN, P_A, P_B), rewrite, 'Pektine', DE, M)).toBe(rewrite);
+  });
+
+  it('puts a paragraph another source dropped back where it stood — after the nearest surviving predecessor', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const out = preserveSourcedParagraphs(page(PLAIN, P_A, P_B), page(PLAIN, P_A, P_C), 'Pektine', DE, M);
+    expect(out).toBe(page(PLAIN, P_A, P_B, P_C));
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('restored 1 paragraph'));
+  });
+
+  it('anchors on an unfootnoted predecessor too, and on the header when none survived', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // PLAIN survived, the two footnoted paragraphs did not: both come back
+    // after PLAIN in their old order, before the model's new paragraph.
+    expect(preserveSourcedParagraphs(page(PLAIN, P_A, P_B), page(PLAIN, P_C), 'Pektine', DE, M))
+      .toBe(page(PLAIN, P_A, P_B, P_C));
+    // Nothing before it survived: it opens the section.
+    expect(preserveSourcedParagraphs(page(P_B, PLAIN), page(P_C), 'Pektine', DE, M))
+      .toBe(page(P_B, P_C));
+  });
+
+  it('lets the source that stated a paragraph rewrite or drop it', () => {
+    const rewrite = page(PLAIN, P_A);
+    expect(preserveSourcedParagraphs(page(PLAIN, P_A, P_B), rewrite, 'Chrom', DE, M)).toBe(rewrite);
+    // Folder prefix, case and Unicode form in the footnote do not hide the ownership.
+    expect(preserveSourcedParagraphs(page(PLAIN, P_C), page(PLAIN), 'pektine', DE, M)).toBe(page(PLAIN));
+    const nfd = 'Grüner Tee senkt den Nüchternblutzucker bei regelmäßigem Konsum messbar. ^[Quelle: [[Grüner Tee]]]';
+    expect(preserveSourcedParagraphs(page(PLAIN, nfd), page(PLAIN), 'Grüner Tee', DE, M)).toBe(page(PLAIN));
+  });
+
+  it('re-attaches the footnote to a paragraph the rewrite kept but stripped', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const reworded = 'Chrom verbessert die Insulinsensitivität der Zielgewebe messbar, allerdings nur bei nachgewiesenem Mangel.';
+    const out = preserveSourcedParagraphs(page(PLAIN, P_B), page(PLAIN, reworded), 'Pektine', DE, M);
+    expect(out).toBe(page(PLAIN, `${reworded} ^[Quelle: [[Chrom]]]`));
+  });
+
+  it('gives a paragraph fused from two sources both footnotes, once each', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fused = 'Berberin senkt den Nüchternblutzucker über eine Aktivierung der AMPK in Leber und Muskel deutlich, und Chrom verbessert die Insulinsensitivität der Zielgewebe nur bei nachgewiesenem Mangel messbar.';
+    const out = preserveSourcedParagraphs(page(PLAIN, P_A, P_B), page(PLAIN, fused), 'Pektine', DE, M);
+    expect(out).toContain(`${fused} ^[Quelle: [[Berberin]]] ^[Quelle: [[Chrom]]]`);
+    expect(out.match(/\[\[Chrom\]\]/g)).toHaveLength(1);
+  });
+
+  it('matches only within the paragraph\'s own section', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // The rewrite dropped P_B from the description but carries most of its
+    // words as a bullet elsewhere: the bullet is not P_B, and must not
+    // inherit its footnote.
+    const bullet = '- Chrom verbessert die Insulinsensitivität der Zielgewebe bei Mangel';
+    const oldBody = `## Beschreibung\n${PLAIN}\n\n${P_B}\n\n## Hauptmerkmale\n- Merkmal eins`;
+    const newBody = `## Beschreibung\n${PLAIN}\n\n## Hauptmerkmale\n- Merkmal eins\n${bullet}`;
+    const out = preserveSourcedParagraphs(oldBody, newBody, 'Pektine', DE, M);
+    expect(out).toBe(`## Beschreibung\n${PLAIN}\n\n${P_B}\n\n## Hauptmerkmale\n- Merkmal eins\n${bullet}`);
+  });
+
+  it('guards list items one by one and puts a bullet back into its list', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const item = '- Senkt den Nüchternblutzucker über eine Aktivierung der AMPK in Leber und Muskel. ^[Quelle: [[Berberin]]]';
+    const oldBody = `## Beschreibung\n${PLAIN}\n\n## Hauptmerkmale\n- Merkmal eins\n${item}\n- Merkmal zwei`;
+    const newBody = `## Beschreibung\n${PLAIN}\n\n## Hauptmerkmale\n- Merkmal eins\n- Merkmal zwei\n- Merkmal drei`;
+    expect(preserveSourcedParagraphs(oldBody, newBody, 'Pektine', DE, M))
+      .toBe(`## Beschreibung\n${PLAIN}\n\n## Hauptmerkmale\n- Merkmal eins\n${item}\n- Merkmal zwei\n- Merkmal drei`);
+  });
+
+  it('ignores footnotes in the lead and in the Mentions section on either side', () => {
+    const quote = `- "Chrom verbessert die Insulinsensitivität der Zielgewebe nur bei nachgewiesenem Mangel messbar" ^[Quelle: [[Chrom]]]`;
+    const lead = `# Titel\n\nVorspann mit einer Fußnote am Ende des Satzes. ^[Quelle: [[Chrom]]]\n\n## Beschreibung\n${PLAIN}\n\n## ${M}\n${quote}`;
+    // The rewrite still carries the Mentions quote: it is not P_B's survivor and gets no footnote.
+    const rewrite = `# Titel\n\n## Beschreibung\n${PLAIN}\n\n## ${M}\n${quote}`;
+    expect(preserveSourcedParagraphs(lead, rewrite, 'Pektine', DE, M)).toBe(rewrite);
+    const withB = `# Titel\n\n## Beschreibung\n${PLAIN}\n\n${P_B}\n\n## ${M}\n${quote}`;
+    expect(preserveSourcedParagraphs(withB, rewrite, 'Pektine', DE, M)).toBe(withB);
+  });
+
+  it('composes with the section guard: a collapsed section comes back whole, and nothing is duplicated', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const paras = Array.from({ length: 5 }, (_, i) =>
+      `Absatz ${i + 1}: ${'Belegter Inhalt aus einer Quelle. '.repeat(6)}^[Quelle: [[Q${i + 1}]]]`);
+    const oldBody = page(...paras);
+    const collapsed = page(paras[0]);
+    const sectionGuarded = preserveExistingSections(oldBody, collapsed, DE, M);
+    const out = preserveSourcedParagraphs(oldBody, sectionGuarded, 'Q9', DE, M);
+    expect(out).toBe(sectionGuarded);
+    for (const p of paras) expect(out.split(p)).toHaveLength(2);
+  });
+
+  it('guardBodyRewrite composes section guard, paragraph guard and H1 in that order', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // The reply starts at the first `##` (no H1), drops P_B, and keeps everything else.
+    const rewrite = page(PLAIN, P_A, P_C).replace('# Insulinresistenz\n\n', '');
+    expect(guardBodyRewrite(page(PLAIN, P_A, P_B), rewrite, 'Pektine', DE, M)).toBe(page(PLAIN, P_A, P_B, P_C));
+  });
+
+  it('treats the keep threshold as the boundary between reworded and gone', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Ten words, exactly half of them kept — at the floor, counts as survived.
+    const old = 'eins zwei drei vier fünf sechs sieben acht neun zehn ^[Quelle: [[Chrom]]]';
+    const half = 'eins zwei drei vier fünf elf zwölf dreizehn vierzehn fünfzehn';
+    expect(PARAGRAPH_KEEP_OVERLAP).toBe(0.5);
+    const kept = preserveSourcedParagraphs(page(old), page(half), 'Pektine', DE, M);
+    expect(kept).toContain(`${half} ^[Quelle: [[Chrom]]]`);
+    const less = 'eins zwei drei vier elf zwölf dreizehn vierzehn fünfzehn sechzehn';
+    const gone = preserveSourcedParagraphs(page(old), page(less), 'Pektine', DE, M);
+    expect(gone).toContain(old);
+  });
+});

--- a/src/core/paragraph-provenance.ts
+++ b/src/core/paragraph-provenance.ts
@@ -1,0 +1,251 @@
+import { preserveExistingSections, reassertH1, sectionIdentityKey } from './section-header-canonicalizer';
+import { turkishCaseFold } from './slug';
+
+// Paragraph-level provenance guard — a paragraph another source footnoted may
+// not vanish from a rewrite this source runs. Pure, no LLM, O(paragraphs²).
+//
+// Multi-source pages accumulate paragraphs that end in an inline footnote
+// naming the source they came from — `^[Quelle: [[Berberin]]]`, `^[Source:
+// [[Berberin]]]`, any label, the wikilink is what carries the attribution.
+// The merge and related-page paths hand the whole body to the model with
+// "keep existing content" and adopt its rewrite. The section guard
+// (`preserveExistingSections`) catches a section that collapsed by an order
+// of magnitude; one paragraph of five going missing passes under it, and
+// measured on a rebuilt vault that is the shape the loss takes — most often
+// in a rewrite that a DIFFERENT source triggered, and more often still the
+// paragraph survives but its footnote is stripped.
+//
+// Ownership, not size, is the variable: a paragraph footnoted to X may only
+// disappear when X itself is the source being merged (its facts are being
+// rewritten by the note that stated them). Every other footnoted paragraph is
+// matched into the same section of the rewrite by word overlap; one that is
+// not found is put back where it stood — after the nearest preceding
+// paragraph that did survive — and one that is found without its footnote
+// gets the footnote re-attached. Unfootnoted prose stays the model's call;
+// the section-shrink floor remains the only guard for it.
+
+/**
+ * An inline footnote that carries a wikilink: `^[<label>: [[X]]]`, alias and
+ * folder tolerated. Label-agnostic on purpose — the vault's config decides how
+ * the marker is worded, the guard only needs the link.
+ */
+const SOURCE_FOOTNOTE = /\^\[[^[\]\n]*\[\[([^\]|\n]+)(?:\|[^\]\n]*)?\]\][^[\]\n]*\]/g;
+/** A footnoted paragraph is "still there" when this fraction of its words appears in one paragraph of its section in the rewrite. Below it, the paragraph is restored. */
+export const PARAGRAPH_KEEP_OVERLAP = 0.5;
+/** Paragraphs with fewer distinct words than this are never guarded — too short for overlap to mean anything. */
+const MIN_GUARDED_WORDS = 4;
+// ES6 target: `\p{…}` needs the constructor form, the literal is rejected.
+const WORD = new RegExp('[\\p{L}\\p{N}]+', 'gu');
+const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s/;
+const HEADER = /^##\s+(.+?)\s*$/;
+
+interface Unit {
+  /** Canonical section identity (label + suffix) the unit sits in. */
+  section: string;
+  /** Index of the unit's last line in the body's line array. */
+  end: number;
+  text: string;
+  /** Footnote source keys (folded basenames) → the verbatim footnote that carried each. */
+  sources: Map<string, string>;
+  words: Set<string>;
+}
+
+interface Layout {
+  units: Unit[];
+  /** Section identity → index of its header line (first occurrence). */
+  headers: Map<string, number>;
+}
+
+/** `entities/Berberin` / `Berberin.md` / `berberin` all name the same source — the same fold the alias layer uses. */
+function sourceKey(name: string): string {
+  const base = name.trim().split('/').pop() ?? '';
+  return turkishCaseFold(base.replace(/\.md$/i, '').trim().normalize('NFC'));
+}
+
+function footnotesOf(text: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const m of text.matchAll(SOURCE_FOOTNOTE)) {
+    const key = sourceKey(m[1]);
+    if (key && !out.has(key)) out.set(key, m[0]);
+  }
+  return out;
+}
+
+function wordsOf(text: string): Set<string> {
+  const words = new Set<string>();
+  for (const m of text.replace(SOURCE_FOOTNOTE, '').normalize('NFC').matchAll(WORD)) {
+    words.add(m[0].toLowerCase());
+  }
+  return words;
+}
+
+function pushTo<K>(map: Map<K, string[]>, key: K, value: string): void {
+  const list = map.get(key);
+  if (list) list.push(value);
+  else map.set(key, [value]);
+}
+
+/**
+ * Split a body into guardable units: a paragraph is a run of non-blank lines,
+ * except that every list item is a unit of its own (footnotes sit on single
+ * bullets as often as on prose). Only lines inside a canonical `##` section
+ * count — the lead, foreign sections and the Mentions section (quotes carry
+ * their own provenance) are outside this guard's contract.
+ */
+function layoutOf(lines: string[], canonicalLabels: string[], mentionsLabel: string): Layout {
+  const units: Unit[] = [];
+  const headers = new Map<string, number>();
+  let section: string | null = null;
+  let start = -1;
+  const flush = (end: number) => {
+    const from = start;
+    start = -1;
+    if (section === null || from < 0) return;
+    const text = lines.slice(from, end + 1).join('\n').trim();
+    if (text) units.push({ section, end, text, sources: footnotesOf(text), words: wordsOf(text) });
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const header = HEADER.exec(line);
+    if (header) {
+      flush(i - 1);
+      const key = sectionIdentityKey(header[1], canonicalLabels);
+      section = key !== null && key !== mentionsLabel ? key : null;
+      if (section !== null && !headers.has(section)) headers.set(section, i);
+      continue;
+    }
+    if (!line.trim() || line.startsWith('#')) {
+      flush(i - 1);
+      continue;
+    }
+    if (LIST_ITEM.test(line)) {
+      flush(i - 1);
+      start = i;
+      continue;
+    }
+    if (start < 0) start = i;
+  }
+  flush(lines.length - 1);
+  return { units, headers };
+}
+
+/** Fraction of `a` found in `b` — containment, not Jaccard: a paragraph the rewrite grew is still the same paragraph. */
+function overlap(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0) return 0;
+  let shared = 0;
+  for (const w of a) if (b.has(w)) shared++;
+  return shared / a.size;
+}
+
+/**
+ * Re-assert the footnoted paragraphs a body rewrite lost.
+ *
+ * `existingBody` is the page before the rewrite, `rewrite` the model's reply
+ * after `preserveExistingSections` — every section that carried content is
+ * present, which is what lets a lost paragraph always find its section —
+ * and `currentSource` the basename of the note whose merge produced it.
+ * Returns `rewrite` itself when there is nothing to do.
+ */
+export function preserveSourcedParagraphs(
+  existingBody: string,
+  rewrite: string,
+  currentSource: string,
+  canonicalLabels: string[],
+  mentionsLabel: string,
+): string {
+  if (existingBody.search(SOURCE_FOOTNOTE) === -1) return rewrite;
+  const old = layoutOf(existingBody.split('\n'), canonicalLabels, mentionsLabel).units;
+  const guarded = (u: Unit) => u.sources.size > 0 && u.words.size >= MIN_GUARDED_WORDS;
+  if (!old.some(guarded)) return rewrite;
+
+  const lines = rewrite.split('\n');
+  const { units, headers } = layoutOf(lines, canonicalLabels, mentionsLabel);
+  const own = sourceKey(currentSource);
+  // old unit index → the unit of the rewrite it survived as (every old unit is
+  // matched, footnoted or not: the unfootnoted ones anchor where a lost
+  // paragraph is put back)
+  const survived = new Map<number, Unit>();
+  // line index → footnotes to append there
+  const reattach = new Map<number, string[]>();
+  // line index → paragraphs to put back after that line, in old order
+  const insertAfter = new Map<number, string[]>();
+  let reattached = 0;
+  let restored = 0;
+
+  old.forEach((o, i) => {
+    let best: Unit | null = null;
+    let bestScore = 0;
+    for (const u of units) {
+      if (u.section !== o.section) continue;
+      const s = overlap(o.words, u.words);
+      if (s > bestScore) { bestScore = s; best = u; }
+    }
+    const isSurvived = best !== null && bestScore >= PARAGRAPH_KEEP_OVERLAP;
+    if (isSurvived) survived.set(i, best as Unit);
+    if (!guarded(o)) return;
+    if (isSurvived) {
+      // The paragraph survived, possibly reworded — make sure its attribution did too.
+      for (const [key, footnote] of o.sources) {
+        if ((best as Unit).sources.has(key)) continue;
+        (best as Unit).sources.set(key, footnote); // a second old paragraph fused into the same one must not re-add it
+        pushTo(reattach, (best as Unit).end, footnote);
+        reattached++;
+      }
+      return;
+    }
+    // Gone. The note that stated it may rewrite it; anyone else may not.
+    if (Array.from(o.sources.keys()).every(key => key === own)) return;
+    for (let j = i - 1; j >= 0 && old[j].section === o.section; j--) {
+      const anchor = survived.get(j);
+      if (anchor) {
+        pushTo(insertAfter, anchor.end, o.text);
+        restored++;
+        return;
+      }
+    }
+    const header = headers.get(o.section);
+    if (header === undefined) {
+      console.warn(`[preserveSourcedParagraphs] section "${o.section}" is absent from the rewrite — run after preserveExistingSections; paragraph not restored`);
+      return;
+    }
+    pushTo(insertAfter, header, o.text);
+    restored++;
+  });
+
+  if (reattached === 0 && restored === 0) return rewrite;
+
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const footnotes = reattach.get(i);
+    out.push(footnotes ? `${lines[i].replace(/\s+$/, '')} ${footnotes.join(' ')}` : lines[i]);
+    for (const text of insertAfter.get(i) ?? []) {
+      // A bullet rejoins its list; prose gets its own block, opening the
+      // section directly under the header the way the template writes it.
+      if (LIST_ITEM.test(text)) out.push(text);
+      else if (HEADER.test(lines[i])) out.push(text, '');
+      else out.push('', text, '');
+    }
+  }
+  console.warn(
+    `[preserveSourcedParagraphs] rewrite from "${currentSource}": restored ${restored} paragraph(s) footnoted to other sources, re-attached ${reattached} footnote(s)`,
+  );
+  return out.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * The deterministic layers a body rewrite passes through before it is
+ * adopted, in the one order they compose: sections the model dropped or
+ * collapsed come back (#618), then the footnoted paragraphs a kept section
+ * lost, then the page's own H1 (#419). Both rewrite paths call this.
+ */
+export function guardBodyRewrite(
+  existingBody: string,
+  rewrite: string,
+  currentSource: string,
+  canonicalLabels: string[],
+  mentionsLabel: string,
+): string {
+  const sectioned = preserveExistingSections(existingBody, rewrite, canonicalLabels, mentionsLabel);
+  const sourced = preserveSourcedParagraphs(existingBody, sectioned, currentSource, canonicalLabels, mentionsLabel);
+  return reassertH1(existingBody, sourced);
+}

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -121,6 +121,16 @@ export function classifyHeader(
   return { label: base, suffix: m[2].trim() };
 }
 
+/**
+ * The key a section's identity is compared under — label, plus ` (suffix)`
+ * when the header carries one — or null for a header that is not a schema
+ * section. Every guard that decides keep-vs-drop per section keys by this.
+ */
+export function sectionIdentityKey(header: string, canonicalLabels: string[]): string | null {
+  const id = classifyHeader(header, canonicalLabels);
+  return id ? (id.suffix === null ? id.label : `${id.label} (${id.suffix})`) : null;
+}
+
 export function canonicalizeSectionHeaders(content: string, canonicalLabels: string[]): string {
   const snap = (header: string): string | null => snapHeaderToCanonical(header, canonicalLabels);
   return content.split('\n').map(line => {
@@ -156,8 +166,7 @@ function canonicalSectionBlocks(
     const m = /^##\s+(.+?)\s*$/.exec(line);
     if (m) {
       flush();
-      const id = classifyHeader(m[1], canonicalLabels);
-      key = id ? (id.suffix === null ? id.label : `${id.label} (${id.suffix})`) : null;
+      key = sectionIdentityKey(m[1], canonicalLabels);
       lines = key ? [line] : [];
       continue;
     }
@@ -274,8 +283,7 @@ function replaceSectionBlocks(
     const m = /^##\s+(.+?)\s*$/.exec(line);
     if (m) {
       skipping = false;
-      const id = classifyHeader(m[1], canonicalLabels);
-      const key = id ? (id.suffix === null ? id.label : `${id.label} (${id.suffix})`) : null;
+      const key = sectionIdentityKey(m[1], canonicalLabels);
       const replacement = key !== null ? replacements.get(key) : undefined;
       if (replacement) {
         out.push(...replacement.join('\n').replace(/\s+$/, '').split('\n'), '');

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -37,10 +37,9 @@ import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import {
   canonicalizeSectionHeaders,
-  preserveExistingSections,
-  reassertH1,
   stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
+import { guardBodyRewrite } from '../../core/paragraph-provenance';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
 import { mergeFrontmatter, parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { incomingTypeTag } from '../../core/tag-vocab';
@@ -325,20 +324,17 @@ export async function mergePage(
       // link targets are resolved here — against every page, not a window.
       { wikiFolder: ctx.settings.wikiFolder, pages: await getExistingWikiPages(ctx.app as never, ctx.settings.wikiFolder) },
     );
-    // Completeness is the schema's call, not the model's: restore any canonical
-    // section that carried content before the rewrite and is wholly absent from
-    // it. The Mentions section is re-attached by assembleFinalContent below.
-    const guardedBody = preserveExistingSections(
+    // Completeness is the schema's call, not the model's: sections the rewrite
+    // dropped or collapsed come back (#618), footnoted paragraphs another source
+    // owns come back, the H1 comes back (#419). The Mentions section is
+    // re-attached by assembleFinalContent below.
+    const titledBody = guardBodyRewrite(
       existingBody,
       correctedBody,
+      sourceFile.basename,
       Object.values(labels),
       labels.mentions_in_source,
     );
-
-    // #419: the guard above owns `##` blocks only, so the title line falls
-    // between the layers — the model is asked for the whole body and the reply
-    // routinely starts at the first `##`. Restore the page's own H1.
-    const titledBody = reassertH1(existingBody, guardedBody);
     await ctx.createOrUpdateFile(
       path,
       await assembleFinalContent(

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -23,11 +23,10 @@ import { mergeFrontmatter, parseFrontmatter } from '../../core/frontmatter';
 import { incomingTypeTag } from '../../core/tag-vocab';
 import { collectActiveVocabulary } from '../../core/domain-axis';
 import { stripMentionsSection } from '../../core/mentions-parser';
+import { guardBodyRewrite } from '../../core/paragraph-provenance';
 import { renderTemplate } from '../../core/template-renderer';
 import {
   canonicalizeSectionHeaders,
-  preserveExistingSections,
-  reassertH1,
   stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
 import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
@@ -175,20 +174,17 @@ export async function updateRelatedPage(
     { wikiFolder: ctx.settings.wikiFolder, pages: await getExistingWikiPages(ctx.app as never, ctx.settings.wikiFolder) },
   );
 
-  // Completeness is the schema's call, not the model's: restore any canonical
-  // section that carried content before the rewrite and is wholly absent from
-  // it. The Mentions section is re-attached by assembleFinalContent below.
-  const guardedBody = preserveExistingSections(
+  // Completeness is the schema's call, not the model's: sections the rewrite
+  // dropped or collapsed come back (#618), footnoted paragraphs another source
+  // owns come back, the H1 comes back (#419). The Mentions section is
+  // re-attached by assembleFinalContent below.
+  const titledBody = guardBodyRewrite(
     promptBody,
     correctedBody,
+    sourceFile.basename,
     Object.values(labels),
     labels.mentions_in_source,
   );
-
-  // #419: the guard above owns `##` blocks only, so the title line falls
-  // between the layers — the model is asked for the whole body and the reply
-  // routinely starts at the first `##`. Restore the page's own H1.
-  const titledBody = reassertH1(promptBody, guardedBody);
 
   // 2. Assemble: programmatic frontmatter + LLM body + Mentions section.
   // Issue #267 established a non-lossy re-ingest on the merge path, but this


### PR DESCRIPTION
**What changes.** `src/core/paragraph-provenance.ts`: `preserveSourcedParagraphs` runs after `preserveExistingSections`. Every paragraph or list item of the old body that ends in an inline footnote carrying a wikilink (`^[Quelle: [[X]]]`, `^[Source: [[X]]]`, any label) is matched into the same section of the rewrite by word overlap (`PARAGRAPH_KEEP_OVERLAP` 0.5). Found without its footnote: the footnote is re-attached. Not found: the paragraph is put back after the nearest preceding paragraph that survived, unless every footnote on it names the source being merged. `guardBodyRewrite` composes the three deterministic layers (sections, sourced paragraphs, H1); both rewrite paths call it. `sectionIdentityKey` is the identity both guards compare under.

**Why.** On 571 rewrite pairs of one vault (720 footnoted paragraphs), 15 % came back with less than half their words anywhere on the page, 102 of those 111 dropped by a rewrite a different source triggered; of the paragraphs whose text survived, 23 % lost their footnote. The shrink floor (#618) sees a collapsed section, not one paragraph of five. Ownership is the variable, not size.

**Tests.** 13 cases: restore position, own-source exemption (folder, case, NFC), re-attachment, fusion of two sources, section-scoped matching, list items, lead and Mentions excluded, composition with the section guard, threshold boundary, `guardBodyRewrite` order. Replay over the same 571 pairs: 103 rewrites touched, 120 paragraphs restored, 164 footnotes re-attached.

**Not in this PR.** The footnote convention itself: the built-in prompts do not ask for one, so the guard is a no-op on a vault without it. `mergeDuplicatePages` and `resolveContradiction` adopt full-body rewrites without either guard (separate note if wanted). The threshold is a regulator: at 0.5 a reworded definition with 45 % shared words comes back next to its rewrite.

Gate 1 green locally (3942 tests).
