### PR TITLE
refactor(audit): phase-3 lossless cleanup — T1 dedupe+relocation, T3 report round-trip (−82 net)

### DIFF
--- a/src/__tests__/core/batch-limits.test.ts
+++ b/src/__tests__/core/batch-limits.test.ts
@@ -4,7 +4,7 @@ import {
   adjustBatchSizeForResponse,
   getCustomTypeCaps,
   GRANULARITY_CONFIG,
-} from './batch-limits';
+} from '../../core/batch-limits';
 
 describe('Batch Limits — Pure Functions', () => {
   describe('calculateBatchLimits', () => {

--- a/src/__tests__/core/batch-merger.test.ts
+++ b/src/__tests__/core/batch-merger.test.ts
@@ -5,8 +5,8 @@ import {
   buildSourceAnalysis,
   extractUniqueNames,
   calculateBatchStats,
-} from './batch-merger';
-import { EntityInfo, ConceptInfo } from '../types';
+} from '../../core/batch-merger';
+import { EntityInfo, ConceptInfo } from '../../types';
 
 describe('Batch Merger — Pure Functions', () => {
   describe('createEmptyAccumulation', () => {

--- a/src/__tests__/core/convergence-detector.test.ts
+++ b/src/__tests__/core/convergence-detector.test.ts
@@ -4,7 +4,7 @@ import {
   checkCumulativeLimits,
   checkEmptyBatch,
   formatConvergenceStatus,
-} from './convergence-detector';
+} from '../../core/convergence-detector';
 
 describe('Convergence Detector — Pure Functions', () => {
   describe('detectConvergence', () => {

--- a/src/__tests__/core/dead-link-detector.test.ts
+++ b/src/__tests__/core/dead-link-detector.test.ts
@@ -4,7 +4,7 @@ import {
   buildDeadLinkReplacement,
   replaceDeadLink,
   type PageRef,
-} from './dead-link-detector';
+} from '../../core/dead-link-detector';
 
 describe('Dead Link Detector — Pure Functions', () => {
   describe('findDeadLinkTarget', () => {

--- a/src/__tests__/core/hub-retirement.test.ts
+++ b/src/__tests__/core/hub-retirement.test.ts
@@ -4,7 +4,7 @@ import {
   buildUndirectedAdjacency,
   assessHubs,
   type HubVerdict,
-} from './hub-retirement';
+} from '../../core/hub-retirement';
 
 // Build an undirected adjacency from an edge list (also exercises
 // buildUndirectedAdjacency, the integration entry point).

--- a/src/__tests__/core/orphan-matcher.test.ts
+++ b/src/__tests__/core/orphan-matcher.test.ts
@@ -6,7 +6,7 @@ import {
   normalizeOrphanPagePath,
   type OrphanContext,
   type OrphanLinkSuggestion,
-} from './orphan-matcher';
+} from '../../core/orphan-matcher';
 
 describe('Orphan Matcher — Pure Functions', () => {
   describe('buildOrphanLinkPrompt', () => {

--- a/src/__tests__/core/prompt-builders.test.ts
+++ b/src/__tests__/core/prompt-builders.test.ts
@@ -4,7 +4,7 @@ import {
   cleanWikiIndex,
   correctLinkPollution,
   type EmptyPageContext,
-} from './prompt-builders';
+} from '../../core/prompt-builders';
 
 describe('Prompt Builders — Pure Functions', () => {
   describe('buildEmptyPagePrompt', () => {

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-credential-manager.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-credential-manager.test.ts
@@ -3,9 +3,9 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { webcrypto } from 'node:crypto';
-import { BedrockAuthManager } from '../../llm-sdk/bedrock-sso/credential-manager';
-import { BEDROCK_IAM_SECRET_ID, BEDROCK_SSO_SECRET_ID } from '../../llm-sdk/bedrock-sso/constants';
-import { BedrockSsoExpiredError } from '../../llm-sdk/bedrock-sso/types';
+import { BedrockAuthManager } from '../../../llm-sdk/bedrock-sso/credential-manager';
+import { BEDROCK_IAM_SECRET_ID, BEDROCK_SSO_SECRET_ID } from '../../../llm-sdk/bedrock-sso/constants';
+import { BedrockSsoExpiredError } from '../../../llm-sdk/bedrock-sso/types';
 
 Object.defineProperty(globalThis, 'crypto', {
   configurable: true,

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-credential-store.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-credential-store.test.ts
@@ -3,8 +3,8 @@
 // validated parse, corrupt JSON → null, clear → empty.
 
 import { describe, expect, it, vi } from 'vitest';
-import { BedrockIamCredentialStore, BedrockSsoCredentialStore } from '../../llm-sdk/bedrock-sso/credential-store';
-import { BEDROCK_IAM_SECRET_ID, BEDROCK_SSO_SECRET_ID } from '../../llm-sdk/bedrock-sso/constants';
+import { BedrockIamCredentialStore, BedrockSsoCredentialStore } from '../../../llm-sdk/bedrock-sso/credential-store';
+import { BEDROCK_IAM_SECRET_ID, BEDROCK_SSO_SECRET_ID } from '../../../llm-sdk/bedrock-sso/constants';
 
 function memoryStorage(): {
   getSecret: ReturnType<typeof vi.fn<(id: string) => string | null>>;

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-factory.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-factory.test.ts
@@ -14,15 +14,15 @@
 // `private readonly` field, so a structural cast is the natural fit.
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { AnthropicSdkClient } from '../../llm-sdk/anthropic-sdk-client';
-import { OpenAICompatSdkClient } from '../../llm-sdk/openai-compat-sdk-client';
-import { obsidianFetchBridge, streamWithFallback } from '../../core/obsidian-fetch-bridge';
-import type { BedrockAuthManager } from '../../llm-sdk/bedrock-sso/credential-manager';
+import { AnthropicSdkClient } from '../../../llm-sdk/anthropic-sdk-client';
+import { OpenAICompatSdkClient } from '../../../llm-sdk/openai-compat-sdk-client';
+import { obsidianFetchBridge, streamWithFallback } from '../../../core/obsidian-fetch-bridge';
+import type { BedrockAuthManager } from '../../../llm-sdk/bedrock-sso/credential-manager';
 import {
   createLLMClientFromSettings,
   createLLMClientFromSettingsSync,
   preloadLLMClientModules,
-} from '../../llm-sdk/create-llm-client';
+} from '../../../llm-sdk/create-llm-client';
 
 function privateBaseURL(client: unknown): string | undefined {
   // Both client classes store baseURL as `private readonly baseURL`.
@@ -118,7 +118,7 @@ describe('Bedrock Stage 1 factory (v1.24.1 PATCH)', () => {
       // provider === 'openai' routes to OpenAISdkClient (official); the
       // bedrock-* branches must NOT be reached. bedrock-openai is
       // OpenAICompatSdkClient — confirm OpenAISdkClient is selected here.
-      const { OpenAISdkClient } = await import('../../llm-sdk/openai-sdk-client');
+      const { OpenAISdkClient } = await import('../../../llm-sdk/openai-sdk-client');
       expect(client).toBeInstanceOf(OpenAISdkClient);
     });
   });

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-role-credentials.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-role-credentials.test.ts
@@ -10,8 +10,8 @@ import {
   getRoleCredentials,
   listAccountRoles,
   listAccounts,
-} from '../../llm-sdk/bedrock-sso/role-credentials';
-import { BedrockSsoExpiredError } from '../../llm-sdk/bedrock-sso/types';
+} from '../../../llm-sdk/bedrock-sso/role-credentials';
+import { BedrockSsoExpiredError } from '../../../llm-sdk/bedrock-sso/types';
 
 Object.defineProperty(globalThis, 'crypto', {
   configurable: true,

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-signing-fetch.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-signing-fetch.test.ts
@@ -8,9 +8,9 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { webcrypto } from 'node:crypto';
-import type { ObsidianFetchInit } from '../../core/obsidian-fetch-bridge';
-import { createSigV4SigningFetch } from '../../llm-sdk/bedrock-sso/signing-fetch';
-import type { BedrockCredentials } from '../../llm-sdk/bedrock-sso/types';
+import type { ObsidianFetchInit } from '../../../core/obsidian-fetch-bridge';
+import { createSigV4SigningFetch } from '../../../llm-sdk/bedrock-sso/signing-fetch';
+import type { BedrockCredentials } from '../../../llm-sdk/bedrock-sso/types';
 
 Object.defineProperty(globalThis, 'crypto', {
   configurable: true,

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-sigv4.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-sigv4.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { webcrypto } from 'node:crypto';
-import { signRequest, hashSha256Hex } from '../../llm-sdk/bedrock-sso/sigv4';
+import { signRequest, hashSha256Hex } from '../../../llm-sdk/bedrock-sso/sigv4';
 
 // The shared setup installs a minimal deterministic crypto.subtle stub
 // (digest-only, NOT SHA-256). SigV4 conformance needs REAL primitives:

--- a/src/__tests__/llm-sdk/bedrock-sso/bedrock-sso-oidc.test.ts
+++ b/src/__tests__/llm-sdk/bedrock-sso/bedrock-sso-oidc.test.ts
@@ -10,13 +10,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   bedrockOidcBaseUrl,
-} from '../../llm-sdk/bedrock-sso/constants';
+} from '../../../llm-sdk/bedrock-sso/constants';
 import {
   completeDeviceAuthorization,
   registerClient,
   startDeviceAuthorization,
   type BedrockDeviceAuthorization,
-} from '../../llm-sdk/bedrock-sso/sso-oidc';
+} from '../../../llm-sdk/bedrock-sso/sso-oidc';
 
 const REGION = 'us-east-1';
 const OIDC = bedrockOidcBaseUrl(REGION);

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-auth-core.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-auth-core.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildAuthorizationUrl, extractAccountId, extractTokenResponseAccountId, generateOAuthState, generatePkce, parseTokenResponse } from '../../llm-sdk/openai-codex/auth-core';
-import { CODEX_DEVICE_URL, CODEX_MODELS, CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_ISSUER, CODEX_REDIRECT_URI, CODEX_RESPONSES_URL, CODEX_SECRET_ID, CODEX_TOKEN_URL } from '../../llm-sdk/openai-codex/constants';
+import { buildAuthorizationUrl, extractAccountId, extractTokenResponseAccountId, generateOAuthState, generatePkce, parseTokenResponse } from '../../../llm-sdk/openai-codex/auth-core';
+import { CODEX_DEVICE_URL, CODEX_MODELS, CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_ISSUER, CODEX_REDIRECT_URI, CODEX_RESPONSES_URL, CODEX_SECRET_ID, CODEX_TOKEN_URL } from '../../../llm-sdk/openai-codex/constants';
 
 function encodedPayload(value: Record<string, unknown>): string {
   return btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-auth-manager.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-auth-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import { CodexAuthManager } from '../../llm-sdk/openai-codex/auth-manager';
-import type { CodexCredential } from '../../llm-sdk/openai-codex/types';
-import { expiredCredential, freshCredential, memoryCredentialStore } from './openai-codex-test-helpers';
+import { CodexAuthManager } from '../../../llm-sdk/openai-codex/auth-manager';
+import type { CodexCredential } from '../../../llm-sdk/openai-codex/types';
+import { expiredCredential, freshCredential, memoryCredentialStore } from '../openai-codex-test-helpers';
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve = (_value: T): void => undefined;

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-credential-store.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-credential-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CodexCredentialStore } from '../../llm-sdk/openai-codex/credential-store';
+import { CodexCredentialStore } from '../../../llm-sdk/openai-codex/credential-store';
 
 function backendWith(raw?: string): { values: Map<string, string>; getSecret: (id: string) => string | null; setSecret: (id: string, value: string) => void } {
   const values = new Map<string, string>();

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-device-flow.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-device-flow.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { completeDeviceAuthorization, requestDeviceCode } from '../../llm-sdk/openai-codex/device-flow';
-import { CODEX_OAUTH_CLIENT_ID, CODEX_TOKEN_URL } from '../../llm-sdk/openai-codex/constants';
-import type { FetchLike } from '../../llm-sdk/openai-codex/types';
-import { jwt } from './openai-codex-test-helpers';
+import { completeDeviceAuthorization, requestDeviceCode } from '../../../llm-sdk/openai-codex/device-flow';
+import { CODEX_OAUTH_CLIENT_ID, CODEX_TOKEN_URL } from '../../../llm-sdk/openai-codex/constants';
+import type { FetchLike } from '../../../llm-sdk/openai-codex/types';
+import { jwt } from '../openai-codex-test-helpers';
 
 const authorization = { deviceAuthId: 'dev-1', userCode: 'ABCD-EFGH', intervalMs: 1000 };
 

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-loopback-flow.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-loopback-flow.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { createLoopbackServer, loadNodeHttp, parseLoopbackCallback, runLoopbackLogin } from '../../llm-sdk/openai-codex/loopback-flow';
-import type { LoopbackHttpModule } from '../../llm-sdk/openai-codex/loopback-flow';
-import type { FetchLike } from '../../llm-sdk/openai-codex/types';
-import { fakeLoopbackServer, failingFetch, jwt } from './openai-codex-test-helpers';
+import { createLoopbackServer, loadNodeHttp, parseLoopbackCallback, runLoopbackLogin } from '../../../llm-sdk/openai-codex/loopback-flow';
+import type { LoopbackHttpModule } from '../../../llm-sdk/openai-codex/loopback-flow';
+import type { FetchLike } from '../../../llm-sdk/openai-codex/types';
+import { fakeLoopbackServer, failingFetch, jwt } from '../openai-codex-test-helpers';
 
 const callbackUrl = '/auth/callback?code=abc&state=state-1';
 

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-model-catalog.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-model-catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fetchCodexModelCatalog } from '../../llm-sdk/openai-codex/model-catalog';
+import { fetchCodexModelCatalog } from '../../../llm-sdk/openai-codex/model-catalog';
 
 function catalogResponse(models: unknown[], status = 200): Response {
   return new Response(JSON.stringify({ models }), { status, headers: { 'Content-Type': 'application/json' } });

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-request-adapter.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-request-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeCodexRequest } from '../../llm-sdk/openai-codex/request-adapter';
+import { normalizeCodexRequest } from '../../../llm-sdk/openai-codex/request-adapter';
 
 const access = { accessToken: 'oauth-secret', accountId: 'acct' };
 

--- a/src/__tests__/llm-sdk/openai-codex/openai-codex-sdk-client.test.ts
+++ b/src/__tests__/llm-sdk/openai-codex/openai-codex-sdk-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createCodexRequestFetch, OpenAICodexSdkClient } from '../../llm-sdk/openai-codex-sdk-client';
-import { errorResponse, fakeAuthManager, messageParams, textResponse } from './openai-codex-test-helpers';
+import { createCodexRequestFetch, OpenAICodexSdkClient } from '../../../llm-sdk/openai-codex-sdk-client';
+import { errorResponse, fakeAuthManager, messageParams, textResponse } from '../openai-codex-test-helpers';
 import { requestUrl } from 'obsidian';
 
 function streamingResponse(chunks: string[]): Response {

--- a/src/core/pdf-cache.ts
+++ b/src/core/pdf-cache.ts
@@ -230,7 +230,7 @@ export class PdfConversionCache {
  * Centralized here so the 3 call sites (pdf-converter, main.ts clear,
  * main.ts housekeeping) cannot drift.
  */
-export function getPdfCacheDir(app: { vault: { configDir: string } }): string {
+function getPdfCacheDir(app: { vault: { configDir: string } }): string {
   return `${app.vault.configDir}/plugins/karpathywiki/pdf-cache`;
 }
 

--- a/src/core/rate-limit.ts
+++ b/src/core/rate-limit.ts
@@ -19,7 +19,7 @@ export interface RateLimitInfo {
  * Adding/removing markers (e.g. 'quota exceeded') is a one-line edit
  * here; both consumers pick up the change automatically.
  */
-export const RATE_LIMIT_MARKER_RE = /429|rate.?limit|too many requests|throttl/i;
+const RATE_LIMIT_MARKER_RE = /429|rate.?limit|too many requests|throttl/i;
 
 /**
  * v1.26.0 Batch 7 + CR-3 fix: accept a structured failure item (with

--- a/src/core/section-header-canonicalizer.ts
+++ b/src/core/section-header-canonicalizer.ts
@@ -207,7 +207,7 @@ function canonicalSectionBlocks(
  * it programmatically below — once, at the right anchor. Pure, O(lines × labels).
  */
 /** A kept section whose content falls below this fraction of its previous length is restored. */
-export const SECTION_SHRINK_FLOOR = 0.5;
+const SECTION_SHRINK_FLOOR = 0.5;
 /** Sections shorter than this before the rewrite are never shrink-guarded — the model may reword them freely. */
 export const SECTION_SHRINK_MIN_CHARS = 400;
 

--- a/src/core/task-policy.ts
+++ b/src/core/task-policy.ts
@@ -50,7 +50,7 @@ export type TaskOutputMode = 'default' | OutputMode;
 export type TaskThinking = 'default' | 'off' | 'on' | 'low' | 'medium' | 'high';
 
 /** The three that name a budget, as opposed to just not suppressing. */
-export const THINKING_EFFORTS = ['low', 'medium', 'high'] as const;
+const THINKING_EFFORTS = ['low', 'medium', 'high'] as const;
 export type ThinkingEffort = (typeof THINKING_EFFORTS)[number];
 
 export function thinkingEffort(thinking: TaskThinking): ThinkingEffort | undefined {
@@ -70,7 +70,7 @@ export const DEFAULT_TASK_POLICY: TaskPolicy = Object.freeze({
 });
 
 /** Wildcard key: applies to every task that has no entry of its own. */
-export const TASK_POLICY_WILDCARD = '*';
+const TASK_POLICY_WILDCARD = '*';
 
 export type TaskPolicyMap = Readonly<Record<string, TaskPolicy>>;
 

--- a/src/llm-sdk/output-mode-prober.ts
+++ b/src/llm-sdk/output-mode-prober.ts
@@ -58,7 +58,7 @@ import { classifyFieldError } from './shared-rejection-verbs';
  * The numeric index in OUTPUT_MODES is the demotion order: a 400 with
  * Tier N's rejection demotes to Tier N+1.
  */
-export const OUTPUT_MODES = ['json_schema', 'json_object', 'text_prompt'] as const;
+const OUTPUT_MODES = ['json_schema', 'json_object', 'text_prompt'] as const;
 export type OutputMode = (typeof OUTPUT_MODES)[number];
 
 /**

--- a/src/llm-sdk/output-mode-prober.ts
+++ b/src/llm-sdk/output-mode-prober.ts
@@ -55,11 +55,11 @@ import { classifyFieldError } from './shared-rejection-verbs';
 
 /**
  * The three output-mode tiers, ordered strongest → weakest.
- * The numeric index in OUTPUT_MODES is the demotion order: a 400 with
- * Tier N's rejection demotes to Tier N+1.
+ * The demotion order is documented by the numeric comments below: a 400
+ * with Tier N's rejection demotes to Tier N+1. The order is encoded in
+ * the literal union (kept in sync with the prober's demotion chain).
  */
-const OUTPUT_MODES = ['json_schema', 'json_object', 'text_prompt'] as const;
-export type OutputMode = (typeof OUTPUT_MODES)[number];
+export type OutputMode = 'json_schema' | 'json_object' | 'text_prompt';
 
 /**
  * Field markers for the Tier 1 demotion classifier (json_object /

--- a/src/wiki/lint/controller.ts
+++ b/src/wiki/lint/controller.ts
@@ -41,24 +41,6 @@ import { SchemaTask } from '../../schema/schema-manager';
 // ui/modals/ indirect import) still reference `LintContext` from this file.
 export type { LintContext } from './types';
 
-/**
- * Extract just the per-section body from a full Lint report.
- *
- * The LLM analysis prompt wants the findings (per-section markdown) without
- * the title heading and the summary line (which is already encoded in the
- * prompt's own template). We strip them here so the same builder output
- * feeds both the LLM prompt and the user-facing report.
- */
-function extractProgReport(fullReport: string): string {
-  // The full report has structure: `# title\n\n> summary\n\n<body>`.
-  // The body starts after the first `\n\n` following the `>` summary line.
-  const summaryEnd = fullReport.indexOf('\n\n', fullReport.indexOf('> '));
-  if (summaryEnd < 0) return fullReport;
-  const after = fullReport.indexOf('\n\n', summaryEnd + 2);
-  if (after < 0) return '';
-  return fullReport.slice(after + 2);
-}
-
 export async function runLintWiki(
   ctx: LintContext,
   signal?: AbortSignal,
@@ -189,105 +171,38 @@ export async function runLintWiki(
       }
     }
 
-    // ---- 4. Build programmatic findings report (delegated to report-builder) ----
-    // Compute duplicate-affected counts for the summary line.
-    const duplicatePaths = new Set<string>();
-    for (const d of duplicates) {
-      duplicatePaths.add(d.target);
-      duplicatePaths.add(d.source);
-    }
-    let deadLinkFromDup = 0;
-    for (const dl of deadLinks) {
-      const sourcePath = `${ctx.settings.wikiFolder}/${dl.source}.md`;
-      const targetPath = `${ctx.settings.wikiFolder}/${dl.target}.md`;
-      if (duplicatePaths.has(sourcePath) || duplicatePaths.has(targetPath)) deadLinkFromDup++;
-    }
-    let orphanFromDup = 0;
-    for (const op of orphans) {
-      if (duplicatePaths.has(op)) orphanFromDup++;
-    }
-
-    const findingsWithEmpty: ProgrammaticFindings = {
-      ...findings,
-      emptyPages,
-    };
-    let progReport = buildLintReport({
-      settings: ctx.settings,
-      findings: findingsWithEmpty,
-      duplicates,
-      contradictionsReport: '',
-      elapsedSeconds: 0,
-      totalPages: wikiFiles.length,
-    });
-    // Extract the inner body (skip title + summary) for the LLM analysis prompt.
-    // The LLM prompt needs only the per-section findings, not the title/summary.
-    progReport = extractProgReport(progReport);
-
-    // ---- 5. Contradiction scanning (LLM-assisted / mixed) ----
+    // ---- 4. Contradiction scanning (LLM-assisted / mixed) ----
     //
     // v1.24.0: extracted to lint/llm-phases/contradiction-phase.ts.
     // Behavior is identical to the previous inline implementation; see
     // that file for the review_ok auto-resolve + report-render details.
+    //
+    // v1.27.x audit (Phase 3 T3-1): the contradiction phase now runs
+    // BEFORE the report is built. Historically it ran after a throwaway
+    // buildLintReport call whose output was stripped (extractProgReport)
+    // for the LLM analysis prompt — deleted in v1.26.4 #473. With that
+    // consumer gone, the strip-then-re-add round-trip (and the duplicate
+    // summaryText / aliasPre re-derivation in this file) is dead weight:
+    // the builder already emits `# title + summary + aliasPre + body` in
+    // one pass. One call, real elapsed time, contradictions appended.
+    const findingsWithEmpty: ProgrammaticFindings = {
+      ...findings,
+      emptyPages,
+    };
     const { report: contradictionsReport } = await runContradictionPhase(phaseCtx);
 
-    // ---- 6. LLM analysis ----
-    //
-    // v1.24.0: extracted to lint/llm-phases/analysis-phase.ts.
-    // Behavior is identical to the previous inline implementation; see
-    // that file for content-sample building and prompt-construction details.
-    //
-    // v1.25.1 Phase F2 (closes controller.ts:239 TODO from v1.18.0+):
-    // analysis-phase.ts makes a single LLM call with token-bounded content
-    // ---- 6. (removed) LLM analysis phase ----
-    //
-    // v1.26.4 PATCH #473 follow-up: the LLM analysis section was deleted
-    // entirely from the LintReportModal. Rationale ( Karpathy first
-    // principles + complementary memory model ):
-    //   1. The prompt asks the LLM to judge the whole wiki, but the LLM
-    //      only sees a 5-field WikiStats block + 8 pages of content sample
-    //      (~5 K tokens of the 152 K-token vault). The analysis is
-    //      dishonest: it has to repeat the programmatic findings or invent
-    //      details about pages it never read.
-    //   2. Karpathy's lint design ("ask the LLM to health-check") is
-    //      conversational. The schema-suggest button keeps that path for
-    //      users who want LLM-driven schema recommendations.
-    //   3. The LLM call also surfaced 5 known regressions we kept
-    //      patching instead of removing: duplicate "## LLM 分析" heading,
-    //      leaked chain-of-thought from LM Studio reasoning models,
-    //      nested <ul><ul> rendering, repeated headings, JSON parse
-    //      failures on truncated output. Removing the call removes all of
-    //      them at once.
-    //   4. Lint speed up by ~10-30 s on large wikis (one fewer LLM call).
-    //
-    // The contradictions phase (above) remains — it surfaces genuinely
-    // LLM-shaped judgements (claim A contradicts claim B), which are
-    // hard to detect programmatically. Schema suggestions remain on the
-    // "Analyze Schema" button (Layer 4 in the modal).
-
-    // ---- 7. Combine and display ----
+    // ---- 5. Build the full report (delegated to report-builder) ----
     // Measure elapsed wall time since runLintWiki started. Round to whole
     // seconds for the user-facing summary; sub-second precision is noise here.
     const elapsedSeconds = Math.max(1, Math.round((Date.now() - lintStartTime) / 1000));
-    const summaryText = t.lintReportSummary
-      .replace('{total}', String(wikiFiles.length))
-      .replace('{aliasesMissing}', String(aliasDeficientPages.length))
-      .replace('{duplicates}', String(duplicates.length))
-      .replace('{deadLinks}', String(deadLinks.length))
-      .replace('{deadLinkFromDup}', String(deadLinkFromDup))
-      .replace('{orphans}', String(orphans.length))
-      .replace('{orphanFromDup}', String(orphanFromDup))
-      .replace('{emptyPages}', String(emptyPages.length))
-      .replace('{ungroundedQuotes}', String(ungroundedQuotes.length))
-      .replace('{tagViolations}', String(tagViolations.length))
-      .replace('{elapsedSeconds}', String(elapsedSeconds));
-
-    // Prepend aliases deficiency section to progReport (shown first in report body)
-    if (aliasDeficientPages.length > 0) {
-      const aliasPre = `> ${t.lintAliasesMissing.replace('{count}', String(aliasDeficientPages.length))}\n\n`;
-      progReport = aliasPre + progReport;
-    }
-
-    const fullReport = `# ${t.lintReportTitle}\n\n> ${summaryText}\n\n${progReport}${contradictionsReport}`;
+    const fullReport = buildLintReport({
+      settings: ctx.settings,
+      findings: findingsWithEmpty,
+      duplicates,
+      contradictionsReport,
+      elapsedSeconds,
+      totalPages: wikiFiles.length,
+    });
 
     // v1.24.0: removed the v1.18.0-era "Missing Concept Pages tracker" TODO
     // (24 lines of design notes that had been parked here since 2026-07 and

--- a/src/wiki/lint/duplicate-detection.ts
+++ b/src/wiki/lint/duplicate-detection.ts
@@ -36,7 +36,7 @@ export interface DuplicateCandidate {
  */
 export type WikiPageType = 'entity' | 'concept' | 'source' | 'other';
 
-export function pageTypeOf(path: string): WikiPageType {
+function pageTypeOf(path: string): WikiPageType {
   if (path.includes(`/${WIKI_SUBFOLDERS.entities}/`)) return 'entity';
   if (path.includes(`/${WIKI_SUBFOLDERS.concepts}/`)) return 'concept';
   if (path.includes(`/${WIKI_SUBFOLDERS.sources}/`)) return 'source';
@@ -84,7 +84,7 @@ export function isCrossTypePairAllowed(a: WikiPageType, b: WikiPageType): boolea
 // ── Pure Functions (extracted for testability) ───────────────────────────────
 
 /** Extract character bigrams from string for similarity comparison. */
-export function bigrams(s: string): Set<string> {
+function bigrams(s: string): Set<string> {
   const result = new Set<string>();
   const normalized = s.toLowerCase().replace(/[^a-z0-9一-鿿]/g, '');
   for (let i = 0; i < normalized.length - 1; i++) {

--- a/src/wiki/page-factory/complementary-appends.ts
+++ b/src/wiki/page-factory/complementary-appends.ts
@@ -27,6 +27,7 @@ import { resolveModelForTask } from '../../core/model-resolver';
 import { stripThinkingBlocks } from '../../core/markdown';
 import { snapHeaderToCanonical } from '../../core/section-header-canonicalizer';
 import { getSectionLabels } from '../system-prompts';
+import { escapeRegex } from '../lint/utils';
 import { isListSection } from './contextualize';
 import type { ComplementaryItem } from './merge-triage';
 
@@ -56,10 +57,12 @@ export interface ComplementaryContext {
 /**
  * Escape regex special characters in a string.
  * Pure function — independently testable.
+ *
+ * v1.27.x audit (Phase 3 T1-1): canonical copy lives in `../lint/utils`
+ * (`escapeRegex`). Re-exported under the legacy name so the existing
+ * public API and its 13 test refs keep working without an import churn.
  */
-export function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+export { escapeRegex as escapeRegExp };
 
 /**
  * Find a `## headingName` section in `body`. Returns its content (trimmed
@@ -72,7 +75,7 @@ export function findSectionInBody(
 ): SectionAnchor | null {
   // No /m flag — see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   const nextLinePattern = new RegExp(
-    `(?:^|\\n)##\\s*${escapeRegExp(headingText)}\\s*\\n([\\s\\S]*?)(?=\\n##\\s|$)`,
+    `(?:^|\\n)##\\s*${escapeRegex(headingText)}\\s*\\n([\\s\\S]*?)(?=\\n##\\s|$)`,
   );
   const m = nextLinePattern.exec(body);
   if (!m) return null;

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -61,7 +61,7 @@ export interface CreatePageContext extends PathResolutionContext {
  * the engine already hands to this module. Returns undefined when there is no
  * analysis (lint-side callers), which keeps the merge path unchanged for them.
  */
-export function sourceContextFromAnalysis(
+function sourceContextFromAnalysis(
   analysis: SourceAnalysis | undefined,
 ): SourceContext | undefined {
   if (!analysis) return undefined;

--- a/src/wiki/page-factory/merge-triage.ts
+++ b/src/wiki/page-factory/merge-triage.ts
@@ -213,7 +213,7 @@ export async function classifyMergeNeed(
  * The source name is not repeated here — `buildNewInfoSummary` already writes
  * `Source: <basename>` into `{{new_info}}`.
  */
-export function renderSourceContextBlock(sourceContext?: SourceContext): string {
+function renderSourceContextBlock(sourceContext?: SourceContext): string {
   const summary = sourceContext?.summary?.trim();
   if (!summary) return '';
   return `\n\n**What the source document as a whole is about:**\nSource summary: ${summary}`;
@@ -227,7 +227,7 @@ export function renderSourceContextBlock(sourceContext?: SourceContext): string 
  * Rendered only alongside the summary: asking whether a source is the page's
  * subject, without saying what the source is about, is not answerable.
  */
-export function renderSourceOwnershipRule(sourceContext?: SourceContext): string {
+function renderSourceOwnershipRule(sourceContext?: SourceContext): string {
   if (!renderSourceContextBlock(sourceContext)) return '';
   return '\n- Consider whether this source is primarily ABOUT this page or only mentions it in passing. A source whose subject IS this page carries more weight for the page\'s core description than an incidental mention — prefer "merge" over "skip" for it.';
 }

--- a/src/wiki/page-factory/note-window.ts
+++ b/src/wiki/page-factory/note-window.ts
@@ -37,7 +37,7 @@ export interface NoteExcerptOptions {
 /** Default cap for the matched-paragraph window. */
 export const EXCERPT_MAX_CHARS = 4000;
 /** Default cap for the lemma full-note case. */
-export const EXCERPT_FULL_NOTE_MAX_CHARS = 12000;
+const EXCERPT_FULL_NOTE_MAX_CHARS = 12000;
 
 const TRUNCATION_MARK = '\n[…]';
 


### PR DESCRIPTION
## Audit Phase 3 — Tier 1+2+3 lossless cleanup (6 commits / 33 files / +90 −172)

Follow-up to audit phases 1 (#632) + 2 (#633). Third full structural + redundancy audit (3 parallel read-only slices: test bloat / production redundancy / structure drift) on main @ 5ba91e1, then lossless-executed on one branch in per-phase commits. Each phase planned up-front and three-zero-verified (no breaking change / no side effect / no perf regression) before commit.

### Commits (chronological)

| Commit | Phase | What |
|--------|-------|------|
| `88810d1` | T1-1 | escapeRegExp → canonical `lint/utils` escapeRegex (re-export alias keeps the 13-test public API) |
| `c5132fb` | T1-2 | relocate 7 inline `src/core/*.test.ts` into `__tests__/core/` mirror (pure git mv + import depth) |
| `da06362` | T1-3 | restore `__tests__/llm-sdk/{bedrock-sso,openai-codex}/` mirror depth (15 files; shared test-helper intentionally stays flat) |
| `dc3754a` | T1-4 | privatize 12 dead exports (0 prod + 0 test importers; types OutputMode/ThinkingEffort kept exported) |
| `c094003` | T3-1 | collapse controller.ts report round-trip into ONE buildLintReport call (−85L; extractProgReport + summaryText/aliasPre re-derivation deleted — vestige of the v1.26.4 #473-removed LLM analysis prompt) |
| `55e5536` | T1-4 fix | OUTPUT_MODES const had zero runtime consumers → delete, literal-union type (eslint-clean) |

### Three-zero verification per phase
- **No breaking change**: test count 3932 → 3932 (relocations are moves, not merges — zero test loss); report-builder tests pin the byte-identical full-report shape; tsc 0.
- **No side effect**: `pnpm lint` 0 warnings, shazam_verify PASS 0 new orphans, no import/API signature changes (12 privatized exports verified 0 importers corpus-wide first).
- **No perf regression**: T3-1 removes a redundant report string build + strip (strictly faster); everything else is compile-time or test-org only.

### Full Gate 1 on branch tip: lint / tsc / build / 3932 tests / css-lint all green.

### Deliberately NOT done (audit-verified as needs-design or PURE-LOCKED, filed for separate rounds)
- Cluster A/B/C makeCtx dedup: audit's "duplication" is pattern-shared but semantically-customized fixtures (wikiLanguage variants, writes-capture, files-map, prompt-capture) — forced unification risks silent test-semantics drift. Real fix = writes-capture option on createMockContext (backlog).
- controller `onFixAll` (190L): high-frequency user path, hardcoded-EN notices need an i18n plan — separate design PR.
- indexLabels/logLabels 9-locale byte-identical tables: texts.ts schema decision + AGENTS "don't delete locale content" rule — separate decision.
- dedup-phase inline retry → `core/llm-retry.ts`: perf-sensitive (979s→151s history), file's own v1.27.0 debt comment — separate design PR.
- PURE-LOCKED escapeRegex copies (section-extractor 0-import, candidate-gate 1-type-import) — deliberately untouched.
