### PR TITLE
feat(related): siblings link each other, known pages keep their title, and the Related sections are rendered from the lists

### DIFF
--- a/src/__tests__/__support__/wiki-engine-harness.ts
+++ b/src/__tests__/__support__/wiki-engine-harness.ts
@@ -71,6 +71,7 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
 
   const app = {
     vault: {
+      configDir: '.obsidian',
       read: async (f: { path: string }) => files.get(f.path) ?? '',
       create: async (p: string, c: string) => { files.set(p, c); },
       process: async (f: { path: string }, fn: (d: string) => string) => {

--- a/src/__tests__/core/related-sections.test.ts
+++ b/src/__tests__/core/related-sections.test.ts
@@ -1,0 +1,74 @@
+// See core/related-sections.ts.
+import { describe, it, expect } from 'vitest';
+import { renderRelatedSections } from '../../core/related-sections';
+
+const vault = new Map([['metformin', 'entities/Metformin'], ['oxidativer-stress', 'concepts/Oxidativer-Stress']]);
+const opts = { preserveCase: true, resolve: (n: string) => vault.get(n.toLowerCase().replace(/\s+/g, '-')) };
+const E = 'Verwandte Entitäten'; const C = 'Verwandte Konzepte';
+
+const page = [
+  '# Berberin', '', '## Beschreibung', '', 'Text mit [[entities/Metformin|Metformin]].', '',
+  `## ${E}`, '', '- [[entities/Metformin|Metformin]]', '- [[entities/Vitamine/Vitamin C|Vitamin C]]', '',
+  `## ${C}`, '', '- [[concepts/Oxidativer_Stress|Oxidativer Stress]]', '',
+  '## Erwähnungen in der Quelle', '', '- "…"', '',
+].join('\n');
+
+describe('renderRelatedSections', () => {
+  it('writes both sections from the lists: vault path when known, planned path otherwise, name as display', () => {
+    const out = renderRelatedSections(page, ['Metformin', 'Vitamin C'], ['Oxidativer Stress', 'H₂O₂'], E, C, opts);
+    expect(out).toContain(`## ${E}\n\n- [[entities/Metformin|Metformin]]\n- [[entities/Vitamin-C|Vitamin C]]\n\n## ${C}\n\n- [[concepts/Oxidativer-Stress|Oxidativer Stress]]\n- [[concepts/H₂O₂|H₂O₂]]\n\n## Erwähnungen`);
+    expect(out).not.toContain('Vitamine/Vitamin C');
+    expect(out).toContain('Text mit [[entities/Metformin|Metformin]].');
+  });
+
+  it('drops what the model added on its own — the list is the source of truth', () => {
+    const out = renderRelatedSections(page, ['Metformin'], [], E, C, opts);
+    expect(out).toContain(`## ${E}\n\n- [[entities/Metformin|Metformin]]\n\n## ${C}\n\n## Erwähnungen`);
+  });
+
+  it('keeps the entries the page had before a rewrite, in front, re-resolved, without duplicates', () => {
+    const before = `# Berberin\n\n## ${E}\n\n- [[entities/Statine|Statine]]\n- [[entities/metformin|Metformin]]\n\n## ${C}\n`;
+    const out = renderRelatedSections(page, ['Metformin', 'Vitamin C'], [], E, C, { ...opts, keepFrom: before });
+    expect(out).toContain(`## ${E}\n\n- [[entities/Statine|Statine]]\n- [[entities/Metformin|Metformin]]\n- [[entities/Vitamin-C|Vitamin C]]\n`);
+  });
+
+  it('lists one target once across both sections — a kept entry follows its page when the folder changed', () => {
+    // Bar was linked as a concept; the vault now holds it as an entity and the new list names it as one.
+    const resolve = (n: string) => (n === 'Bar' ? 'entities/Bar' : opts.resolve(n));
+    const before = `# X\n\n## ${E}\n\n## ${C}\n\n- [[concepts/Bar|Bar]]\n- [[concepts/Baz|Baz]]\n`;
+    const out = renderRelatedSections(page, ['Bar'], ['Baz'], E, C, { ...opts, resolve, keepFrom: before });
+    expect(out).toContain(`## ${E}\n\n- [[entities/Bar|Bar]]\n\n## ${C}\n\n- [[concepts/Baz|Baz]]\n`);
+    expect(out.match(/\|Bar\]\]/g)).toHaveLength(1);
+  });
+
+  it('compares a kept entry and a new name under one key regardless of Unicode form', () => {
+    const nfd = 'Häm-a₃'.normalize('NFD'); const nfc = 'Häm-a₃'.normalize('NFC');
+    const before = `# X\n\n## ${E}\n\n- [[entities/${nfd}|${nfd}]]\n`;
+    const out = renderRelatedSections(page, [nfc], [], E, C, { ...opts, keepFrom: before });
+    expect((out.match(/^- \[\[/gm) ?? []).length).toBe(1);
+  });
+
+  it('finds a Related heading the canonicalizer would snap — the kept entries survive a lowercase label', () => {
+    const before = `# X\n\n## Related entities\n\n- [[entities/Statine|Statine]]\n`;
+    const out = renderRelatedSections(page, ['Metformin'], [], E, C, { ...opts, keepFrom: before });
+    expect(out).toContain(`## ${E}\n\n- [[entities/Statine|Statine]]\n- [[entities/Metformin|Metformin]]\n`);
+  });
+
+  it('inserts a missing section next to its sibling, or at the end', () => {
+    const noSections = '# Berberin\n\n## Beschreibung\n\nText.\n';
+    const out = renderRelatedSections(noSections, ['Metformin'], ['Oxidativer Stress'], E, C, opts);
+    expect(out).toBe(`# Berberin\n\n## Beschreibung\n\nText.\n\n## ${E}\n\n- [[entities/Metformin|Metformin]]\n\n## ${C}\n\n- [[concepts/Oxidativer-Stress|Oxidativer Stress]]\n`);
+  });
+
+  it('inserts missing sections in the order the page kind lists them — concepts first on a concept page', () => {
+    const noSections = '# X\n\n## Beschreibung\n\nText.\n';
+    const out = renderRelatedSections(noSections, ['Metformin'], ['Oxidativer Stress'], E, C, { ...opts, firstSection: 'concepts' });
+    expect(out).toBe(`# X\n\n## Beschreibung\n\nText.\n\n## ${C}\n\n- [[concepts/Oxidativer-Stress|Oxidativer Stress]]\n\n## ${E}\n\n- [[entities/Metformin|Metformin]]\n`);
+  });
+
+  it('recognises the canonical English headers and rewrites them under the localized label', () => {
+    const en = '# X\n\n## Related Entities\n\n- [[entities/Foo|Foo]]\n\n## Related Concepts\n\n- [[concepts/Bar|Bar]]\n';
+    const out = renderRelatedSections(en, ['Metformin'], [], E, C, opts);
+    expect(out).toBe(`# X\n\n## ${E}\n\n- [[entities/Metformin|Metformin]]\n\n## ${C}\n\n`);
+  });
+});

--- a/src/__tests__/core/related-shaping.test.ts
+++ b/src/__tests__/core/related-shaping.test.ts
@@ -1,0 +1,93 @@
+// See core/related-shaping.ts.
+import { describe, it, expect } from 'vitest';
+import { shapeRelatedLists } from '../../core/related-shaping';
+import type { EntityInfo, ConceptInfo } from '../../types';
+
+const ent = (name: string, rel: Partial<EntityInfo> = {}): EntityInfo =>
+  ({ name, type: 'other', summary: '', mentions_in_source: [], ...rel });
+const con = (name: string, rel: Partial<ConceptInfo> = {}): ConceptInfo =>
+  ({ name, type: 'term', summary: '', mentions_in_source: [], related_concepts: [], ...rel });
+
+const vault = new Map([
+  ['oxidativer-stress', { title: 'Oxidativer-Stress', kind: 'concept' as const }],
+  ['metformin', { title: 'Metformin', kind: 'entity' as const }],
+]);
+const deps = {
+  resolve: (n: string) => vault.get(n.toLowerCase().replace(/\s+/g, '-')),
+  willExist: ['Vitamin K2'],
+};
+
+describe('shapeRelatedLists', () => {
+  it('keeps a related name nothing answers as written and counts it', () => {
+    const r = shapeRelatedLists({ entities: [ent('Berberin', { related_entities: ['Secukinumab'] })], concepts: [] }, deps);
+    expect(r.entities[0].related_entities).toEqual(['Secukinumab']);
+    expect(r.unanswered).toEqual([{ on: 'Berberin', name: 'Secukinumab' }]);
+  });
+
+  it('keeps a vault page under its own title, routed to its own folder kind', () => {
+    const r = shapeRelatedLists({ entities: [ent('Berberin', { related_entities: ['oxidativer stress', 'Metformin'] })], concepts: [] }, deps);
+    expect(r.entities[0].related_entities).toEqual(['Metformin']);
+    expect(r.entities[0].related_concepts).toEqual(['Oxidativer-Stress']);
+    expect(r.unanswered).toEqual([]);
+  });
+
+  it('keeps a note title from the watched folders and a planned stub name as they are', () => {
+    const r = shapeRelatedLists(
+      { entities: [ent('Berberin', { related_entities: ['vitamin k2', 'Dissent-Stub'] })], concepts: [] },
+      { ...deps, willExist: [...deps.willExist, 'Dissent-Stub'] },
+    );
+    expect(r.entities[0].related_entities).toEqual(['vitamin k2', 'Dissent-Stub']);
+  });
+
+  it('links every page born from the note to its siblings, by kind, without self or duplicates', () => {
+    const r = shapeRelatedLists(
+      { entities: [ent('Berberin'), ent('Metformin', { related_entities: ['berberin'] })], concepts: [con('Insulinresistenz')] },
+      deps,
+    );
+    expect(r.entities[0].related_entities).toEqual(['Metformin']);
+    expect(r.entities[0].related_concepts).toEqual(['Insulinresistenz']);
+    expect(r.entities[1].related_entities).toEqual(['Berberin']);
+    expect(r.concepts[0].related_entities).toEqual(['Berberin', 'Metformin']);
+    expect(r.concepts[0].related_concepts).toEqual([]);
+    expect(r.siblings).toBe(5);
+  });
+
+  it('routes a survivor named in the wrong list to the list of its kind', () => {
+    const r = shapeRelatedLists(
+      { entities: [ent('Berberin', { related_entities: ['Insulinresistenz'] })], concepts: [con('Insulinresistenz')] },
+      deps,
+    );
+    expect(r.entities[0].related_entities).toEqual([]);
+    expect(r.entities[0].related_concepts).toEqual(['Insulinresistenz']);
+  });
+
+  it('drops a tag value — prefixed in any spelling, or bare when only the vocabulary knows the word', () => {
+    const d = { ...deps, vocabulary: ['Thema/Therapie', 'Fach/Immunologie', 'Sorte/Erkrankung'], willExist: ['Immunologie'] };
+    const r = shapeRelatedLists(
+      { entities: [ent('Berberin', { related_concepts: ['Thema/Therapie', 'Th.Therapie', 'Therapie', 'Immunologie', 'Erkrankung'] })], concepts: [] },
+      d,
+    );
+    // Immunologie is a note title as well as a tag leaf: the note wins.
+    expect(r.entities[0].related_concepts).toEqual(['Immunologie']);
+    expect(r.tags.map(t => t.name)).toEqual(['Thema/Therapie', 'Th.Therapie', 'Therapie', 'Erkrankung']);
+    expect(r.unanswered).toEqual([]);
+  });
+
+  it('resolves a name with a parenthetical through its parts', () => {
+    const r = shapeRelatedLists(
+      { entities: [ent('Interleukin-6'), ent('hsCRP', { related_entities: ['Interleukin-6 (IL-6)', 'Metformin (Glucophage)'] })], concepts: [] },
+      deps,
+    );
+    expect(r.entities[1].related_entities).toEqual(['Interleukin-6', 'Metformin']);
+    expect(r.unanswered).toEqual([]);
+  });
+
+  it('is idempotent', () => {
+    const once = shapeRelatedLists({ entities: [ent('A', { related_entities: ['Gone', 'Metformin'] }), ent('B')], concepts: [con('C')] }, deps);
+    const twice = shapeRelatedLists(once, deps);
+    expect(twice.entities).toEqual(once.entities);
+    expect(twice.concepts).toEqual(once.concepts);
+    expect(twice.unanswered).toEqual([{ on: 'A', name: 'Gone' }]);
+    expect(twice.siblings).toBe(0);
+  });
+});

--- a/src/__tests__/wiki/wiki-engine-link-repoint.test.ts
+++ b/src/__tests__/wiki/wiki-engine-link-repoint.test.ts
@@ -69,7 +69,10 @@ describe('WikiEngine.ingestSource — end-of-run link re-point', () => {
     expect(creatin).not.toContain('concepts/Phosphocreatin');
     // Both the prose link and the Related-section link — the section said
     // "concept", the vault says entity.
-    expect(creatin.match(/\[\[entities\/phosphocreatin\|Phosphocreatin\]\]/g)).toHaveLength(2);
+    // Shaping routes a related name to its kind before generation, so
+    // the Related-section link is born as `entities/Phosphocreatin` and only
+    // the prose link is re-pointed; the two differ in case, which resolves.
+    expect(creatin.match(/\[\[entities\/phosphocreatin\|Phosphocreatin\]\]/gi)).toHaveLength(2);
   });
 
   it('the source page gets the same pass', async () => {

--- a/src/__tests__/wiki/wiki-engine-related-shaping.test.ts
+++ b/src/__tests__/wiki/wiki-engine-related-shaping.test.ts
@@ -1,0 +1,54 @@
+// The related lists reach page generation shaped — vault pages under their
+// title and kind, siblings linked, unanswered names kept as written.
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+
+const NOTE_PATH = 'Notizen/Berberin.md';
+const NOTE = '---\ntags:\n  - Thema/Therapie\n---\n\n# Berberin\n\nBerberin senkt den Blutzucker wie Metformin und wirkt über AMPK auf die Insulinresistenz.\n';
+const noteFile = () => Object.assign(new TFile(), { path: NOTE_PATH, basename: 'Berberin', extension: 'md' });
+
+const EXTRACTION = JSON.stringify({
+  source_title: 'Berberin', summary: 'Berberin.',
+  entities: [
+    { name: 'Berberin', type: 'other', summary: 's', mentions_in_source: ['Berberin senkt den Blutzucker'], related_entities: ['metformin', 'Secukinumab', 'Vitamin K2'] },
+  ],
+  concepts: [
+    { name: 'Insulinresistenz', type: 'term', summary: 's', mentions_in_source: ['auf die Insulinresistenz'], related_concepts: ['Metabolisches Syndrom', 'Thema/Therapie', 'Therapie'] },
+  ],
+});
+
+describe('WikiEngine.ingestSource — related shaping', () => {
+  it('hands page generation the shaped lists: titles, kinds, siblings, unanswered names kept', async () => {
+    const h = createWikiEngineHarness({
+      files: {
+        [NOTE_PATH]: NOTE,
+        'Notizen/Vitamin K2.md': '# Vitamin K2\n',
+        'wiki/entities/Metformin.md': '---\ntype: entity\n---\n# Metformin\n',
+      },
+      llmResponses: [EXTRACTION],
+      settings: { wikiLanguage: 'de', watchedFolders: ['Notizen'] },
+    });
+    await h.engine.ingestSource(noteFile());
+
+    const lines = h.llmRequests
+      .map(r => JSON.stringify(r.messages))
+      .filter(m => m.includes('Related entities:'))
+      .map(m => `${(m.match(/Related entities:[^\\]*/) ?? [''])[0]} | ${(m.match(/Related concepts:[^\\]*/) ?? [''])[0]}`);
+    expect(lines).toEqual([
+      // Berberin: Metformin under its vault title, Secukinumab kept as written, Vitamin K2 as a note that will be a page, sibling concept added
+      'Related entities: Metformin, Secukinumab, Vitamin K2 | Related concepts: Insulinresistenz',
+      // Insulinresistenz: sibling entity added, the unanswered concept kept
+      'Related entities: Berberin | Related concepts: Metabolisches Syndrom',
+    ]);
+
+    // The written page carries the sections rendered from the
+    // same lists — Metformin on its vault path, the unanswered names on their
+    // planned paths, the sibling concept — whatever the model returned.
+    const berberinPage = h.files.get('wiki/entities/berberin.md') ?? '';
+    expect(berberinPage).toContain('## Verwandte Entitäten\n\n- [[entities/Metformin|Metformin]]\n- [[entities/secukinumab|Secukinumab]]\n- [[entities/vitamin-k2|Vitamin K2]]\n\n## Verwandte Konzepte\n\n- [[concepts/insulinresistenz|Insulinresistenz]]\n');
+
+    const msg = h.progressMessages.find(m => m.startsWith('Related lists:'));
+    expect(msg).toBe('Related lists: 2 sibling edges, 2 unanswered names, 2 tag values dropped');
+  });
+});

--- a/src/core/related-sections.ts
+++ b/src/core/related-sections.ts
@@ -1,0 +1,143 @@
+// The Related sections are written from the shaped lists, not transcribed
+// by the model.
+//
+// After shaping (core/related-shaping.ts) the analysis's related_entities /
+// related_concepts are exact: vault pages under their title, siblings,
+// unanswered names as written. The model was still asked to render them into
+// the two sections and misspelt what it had been handed (`H₂O₂` re-encoded,
+// `Vitamine/Vitamin C` as an invented path, underscores, a parenthetical
+// appended) — every one a dead link the list had answered. So the list
+// writes the section: deterministic link per name (vault path when the vault
+// has the page, planned path otherwise), display text the name itself. On a
+// rewrite the entries the page already had are kept in front — re-resolved
+// against the vault, so a link that has since moved folders follows the page
+// — and one target is listed once across both sections. The two sections
+// belong to the list; everything else on the page is left byte-identical.
+
+import { slugify } from './slug';
+import { snapHeaderToCanonical } from './section-header-canonicalizer';
+import { nameKey } from './related-shaping';
+
+export interface RelatedRenderOpts {
+  /** `slugCase: 'preserve'` — the planned path of a page not yet in the vault. */
+  preserveCase: boolean;
+  /** Vault path (`entities/X`) for a name the vault answers, else undefined. */
+  resolve: (name: string) => string | undefined;
+  /** Body before the rewrite: its list entries are kept in front of the new ones. */
+  keepFrom?: string;
+  /** Which Related section the page's schema puts first — decides where a missing one is inserted. */
+  firstSection?: Folder;
+}
+
+export type Folder = 'entities' | 'concepts';
+
+const HEADING_RE = /^## (.+?)\s*$/;
+const LINK_RE = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|([^\]]*))?\]\]/;
+
+/**
+ * The section under one of `labels`, tolerant of the spelling drift the
+ * header canonicalizer tolerates. `universe` holds every label the page may
+ * carry for either Related section, so a garbled header snaps to the nearer
+ * of the two rather than to whichever section is asked for first.
+ */
+function findSection(lines: string[], labels: string[], universe: string[]): { start: number; end: number } | undefined {
+  const wanted = new Set(labels.map(l => l.trim()));
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEADING_RE.exec(lines[i]);
+    if (!m) continue;
+    const snapped = snapHeaderToCanonical(m[1].trim(), universe);
+    if (snapped === null || !wanted.has(snapped)) continue;
+    let end = i + 1;
+    while (end < lines.length && !HEADING_RE.test(lines[end])) end++;
+    return { start: i, end };
+  }
+  return undefined;
+}
+
+interface Entry { rel: string; name: string }
+
+/** The list links of one Related section, re-resolved: the page's current path when the vault knows the name. */
+function keptEntries(lines: string[], labels: string[], universe: string[], resolve: RelatedRenderOpts['resolve']): Entry[] {
+  const sec = findSection(lines, labels, universe);
+  if (!sec) return [];
+  const out: Entry[] = [];
+  for (const line of lines.slice(sec.start + 1, sec.end)) {
+    if (!/^\s*[-*]\s+\[\[/.test(line)) continue;
+    const m = LINK_RE.exec(line);
+    if (!m) continue;
+    const target = m[1].trim();
+    const name = (m[2] ?? target.slice(target.lastIndexOf('/') + 1)).trim();
+    out.push({ rel: resolve(name) ?? target, name });
+  }
+  return out;
+}
+
+function folderOf(rel: string, fallback: Folder): Folder {
+  return rel.startsWith('concepts/') ? 'concepts' : rel.startsWith('entities/') ? 'entities' : fallback;
+}
+
+/**
+ * Replace (or insert) the two Related sections with lists rendered from the
+ * typed related names. Everything outside the two sections is left byte-identical.
+ */
+export function renderRelatedSections(
+  content: string,
+  relatedEntities: string[] | undefined,
+  relatedConcepts: string[] | undefined,
+  relatedEntitiesLabel: string,
+  relatedConceptsLabel: string,
+  opts: RelatedRenderOpts,
+): string {
+  const labelsOf: Record<Folder, string[]> = {
+    entities: [relatedEntitiesLabel, 'Related Entities'],
+    concepts: [relatedConceptsLabel, 'Related Concepts'],
+  };
+  const headingOf: Record<Folder, string> = { entities: relatedEntitiesLabel.trim(), concepts: relatedConceptsLabel.trim() };
+  const universe = [...labelsOf.entities, ...labelsOf.concepts];
+
+  // Kept entries first, in the section their page lives in today; then the
+  // list. One target once, whichever section names it first.
+  const lists: Record<Folder, string[]> = { entities: [], concepts: [] };
+  const seen = new Set<string>();
+  const add = (rel: string, name: string, into: Folder) => {
+    const k = nameKey(rel.slice(rel.lastIndexOf('/') + 1));
+    if (!k || seen.has(k)) return;
+    seen.add(k);
+    lists[into].push(`- [[${rel}|${name}]]`);
+  };
+  const keptLines = opts.keepFrom ? opts.keepFrom.split('\n') : [];
+  for (const folder of ['entities', 'concepts'] as const) {
+    for (const e of keptEntries(keptLines, labelsOf[folder], universe, opts.resolve)) add(e.rel, e.name, folderOf(e.rel, folder));
+  }
+  for (const [names, folder] of [[relatedEntities, 'entities'], [relatedConcepts, 'concepts']] as const) {
+    for (const raw of names ?? []) {
+      const name = raw.trim();
+      if (!name) continue;
+      const rel = opts.resolve(name) ?? `${folder}/${slugify(name, opts.preserveCase)}`;
+      add(rel, name, folderOf(rel, folder));
+    }
+  }
+
+  // Sections in the order the page's schema lists them: a missing second
+  // section goes right after the first, a missing first one at the end.
+  const first: Folder = opts.firstSection ?? 'entities';
+  const second: Folder = first === 'entities' ? 'concepts' : 'entities';
+  let lines = content.split('\n');
+  const put = (folder: Folder, after?: Folder) => {
+    const block = [`## ${headingOf[folder]}`, '', ...lists[folder], ''];
+    const sec = findSection(lines, labelsOf[folder], universe);
+    if (sec) {
+      lines = [...lines.slice(0, sec.start), ...block, ...lines.slice(sec.end)];
+      return;
+    }
+    const anchor = after ? findSection(lines, labelsOf[after], universe) : undefined;
+    const at = anchor ? anchor.end : lines.length;
+    const tail = lines.slice(at);
+    const head = lines.slice(0, at);
+    while (head.length && head[head.length - 1].trim() === '') head.pop();
+    lines = [...head, '', ...block, ...tail];
+  };
+  put(first);
+  put(second, first);
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+}

--- a/src/core/related-shaping.ts
+++ b/src/core/related-shaping.ts
@@ -1,0 +1,133 @@
+// Related lists: siblings link each other, and a related name the vault
+// already answers is written under that page's own title and folder.
+//
+// The extraction may name anything from the note in `related_entities` /
+// `related_concepts`; nothing downstream checks whether a page exists or
+// will. Measured on a rebuild of a 413-note vault after 136 notes: 676 dead
+// related entries on 870 pages, 93 % of them naming neither a page nor a
+// note. In the same vault 101 of 103 pages without a single live outgoing
+// link had at least one sibling page born from the same note — an edge the
+// engine knew and never wrote. A further 265 dead links were spelling
+// variants of pages the vault had (`Interleukin 6` for `Interleukin-6`).
+//
+// Both are deterministic shaping of the analysis after the candidate gate,
+// before any page is planned: no model call, no new setting. A name nothing
+// answers is left exactly as it is today — it is counted in the log so the
+// gap stays visible, but not removed.
+
+import { slugKeys } from './slug';
+import type { EntityInfo, ConceptInfo, SourceAnalysis } from '../types';
+
+export type RelatedKind = 'entity' | 'concept';
+
+export interface RelatedShapingDeps {
+  /** A page the vault holds under this name (title or alias): its title and folder kind. */
+  resolve: (name: string) => { title: string; kind: RelatedKind } | undefined;
+  /** Names that will have a page without being survivors: notes in the watched folders, stubs this run plans. */
+  willExist: readonly string[];
+  /** The active tag vocabulary (`Group/Value` or bare values): a tag is not a page. */
+  vocabulary?: readonly string[];
+}
+
+export interface RelatedShapingResult {
+  entities: EntityInfo[];
+  concepts: ConceptInfo[];
+  /** Related names nothing answers yet — kept as written, counted. */
+  unanswered: Array<{ on: string; name: string }>;
+  /** Sibling edges added (one per list entry). */
+  siblings: number;
+  /** Related names that were tag values, not pages — removed. */
+  tags: Array<{ on: string; name: string }>;
+}
+
+/** The comparison key two names meet under — `slugKeys`' contract (NFC, never `preserveCase`). */
+export function nameKey(name: string): string {
+  for (const k of slugKeys(name)) return k;
+  return '';
+}
+
+/** The folder kind a vault-relative page path denotes. */
+export function kindOf(rel: string): RelatedKind {
+  return rel.startsWith('concepts/') ? 'concept' : 'entity';
+}
+
+/** `Thema/Therapie`, `Th.Therapie`, `Thema: Therapie` → `Therapie`; a bare name stays. */
+function tagLeaf(name: string): { leaf: string; prefixed: boolean } {
+  const m = /^\s*([\p{L}]+)\s*[/.:]\s*(.+)$/u.exec(name);
+  return m ? { leaf: m[2].trim(), prefixed: true } : { leaf: name.trim(), prefixed: false };
+}
+
+/** `Interleukin-6 (IL-6)` → also try `Interleukin-6` and `IL-6`. */
+function nameVariants(name: string): string[] {
+  const m = /^(.*?)\s*\(([^()]+)\)\s*$/.exec(name);
+  return m ? [name, m[1].trim(), m[2].trim()].filter(Boolean) : [name];
+}
+
+export function shapeRelatedLists(
+  analysis: Pick<SourceAnalysis, 'entities' | 'concepts'>,
+  deps: RelatedShapingDeps,
+): RelatedShapingResult {
+  const survivors = new Map<string, { name: string; kind: RelatedKind }>();
+  for (const e of analysis.entities) survivors.set(nameKey(e.name), { name: e.name, kind: 'entity' });
+  for (const c of analysis.concepts) survivors.set(nameKey(c.name), { name: c.name, kind: 'concept' });
+  const willExist = new Set(deps.willExist.map(nameKey));
+  const tagLeaves = new Set((deps.vocabulary ?? []).map(v => nameKey(tagLeaf(v).leaf)).filter(Boolean));
+  const unanswered: RelatedShapingResult['unanswered'] = [];
+  const tags: RelatedShapingResult['tags'] = [];
+  let siblings = 0;
+
+  const shape = (self: string, ents: string[] | undefined, cons: string[] | undefined) => {
+    const outE: string[] = []; const outC: string[] = []; const seen = new Set<string>([nameKey(self)]);
+    const put = (name: string, kind: RelatedKind | undefined, into: RelatedKind) => {
+      const k = nameKey(name);
+      if (!k || seen.has(k)) return;
+      seen.add(k);
+      ((kind ?? into) === 'concept' ? outC : outE).push(name);
+    };
+    for (const [list, into] of [[ents, 'entity'], [cons, 'concept']] as const) {
+      for (const raw of list ?? []) {
+        const name = raw.trim();
+        if (!name) continue;
+        // A tag value is not a page: `Thema/Therapie`, `Th.Therapie` (the
+        // model abbreviates the group) or the bare generic `Therapie` when
+        // nothing but the vocabulary knows the word.
+        const { leaf, prefixed } = tagLeaf(name);
+        const k = nameKey(name);
+        if (prefixed && tagLeaves.has(nameKey(leaf))) { tags.push({ on: self, name }); continue; }
+        let placed = false;
+        for (const v of nameVariants(name)) {
+          const vk = nameKey(v);
+          const s = survivors.get(vk);
+          if (s) { put(s.name, s.kind, into); placed = true; break; }
+          const r = deps.resolve(v);
+          if (r) { put(r.title, r.kind, into); placed = true; break; }
+        }
+        if (placed) continue;
+        if (willExist.has(k)) { put(name, undefined, into); continue; }
+        if (!prefixed && tagLeaves.has(k)) { tags.push({ on: self, name }); continue; }
+        if (!seen.has(k)) unanswered.push({ on: self, name });
+        put(name, undefined, into);
+      }
+    }
+    for (const s of survivors.values()) {
+      if (seen.has(nameKey(s.name))) continue;
+      put(s.name, s.kind, s.kind); siblings++;
+    }
+    return { outE, outC };
+  };
+
+  const entities = analysis.entities.map(e => {
+    const { outE, outC } = shape(e.name, e.related_entities, e.related_concepts);
+    const next: EntityInfo = { ...e };
+    if (outE.length || e.related_entities) next.related_entities = outE;
+    if (outC.length || e.related_concepts) next.related_concepts = outC;
+    return next;
+  });
+  const concepts = analysis.concepts.map(c => {
+    const { outE, outC } = shape(c.name, c.related_entities, c.related_concepts);
+    const next: ConceptInfo = { ...c, related_concepts: outC };
+    if (outE.length || c.related_entities) next.related_entities = outE;
+    return next;
+  });
+  return { entities, concepts, unanswered, siblings, tags };
+}

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -32,14 +32,13 @@ import { TOKENS_PAGE_GENERATION } from '../../constants';
 import { resolveModelForTask } from '../../core/model-resolver';
 import { cleanMarkdownResponse } from '../../core/markdown';
 import { canonicalizeSectionHeaders, stripUnknownSections } from '../../core/section-header-canonicalizer';
-import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
+import { applyRelatedLinks } from './related-links';
 import { parseFrontmatter, enforceFrontmatterConstraints, mergeFrontmatterArrayField } from '../../core/frontmatter';
 import { collectActiveVocabulary } from '../../core/domain-axis'; // local patch (Tag-Achse S138)
 import { injectMentionsSection } from '../../core/mentions-injector';
 import { renderTemplate } from '../../core/template-renderer';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { resolvePagePath, type PathResolutionContext } from './path-resolution';
-import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { mergePage } from './merge-page';
 import { appendToReviewedPage } from './merge-page';
 import { isConversationSource, contextualizeError } from './contextualize';
@@ -239,16 +238,9 @@ export async function createNewPage(
     // Drop prompt-scaffolding sections the model copied into the body (e.g.
     // `## Active Tag Vocabulary`) — the schema decides which sections exist.
     const prunedContent = stripUnknownSections(canonicalizedContent, Object.values(labels));
-    const correctedContent = correctRelatedLinkPrefixes(
-      prunedContent,
-      info.related_entities,
-      info.related_concepts,
-      labels.related_entities,
-      labels.related_concepts,
-      // #482 stage 2: the prompt no longer carries a page list, so the link
-      // targets are resolved here — against every page, not a window.
-      { wikiFolder: ctx.settings.wikiFolder, pages: await getExistingWikiPages(ctx.app as never, ctx.settings.wikiFolder) },
-    );
+    // Related links resolved against every page, sections written from the
+    // lists — see page-factory/related-links.ts.
+    const correctedContent = await applyRelatedLinks(ctx, prunedContent, info, labels, { pageType });
     // Issue #244: programmatically inject the Mentions section.
     const isConv = isConversationSource(sourceFile, ctx.settings.wikiFolder);
     const mentionsForInject = isConv

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -40,7 +40,7 @@ import {
   stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
 import { guardBodyRewrite } from '../../core/paragraph-provenance';
-import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
+import { applyRelatedLinks } from './related-links';
 import { mergeFrontmatter, parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { incomingTypeTag } from '../../core/tag-vocab';
 import { collectActiveVocabulary } from '../../core/domain-axis';
@@ -52,7 +52,6 @@ import { injectMentionsSection } from '../../core/mentions-injector';
 import { renderTemplate } from '../../core/template-renderer';
 import { applySectionLabels, getSectionLabels } from '../system-prompts';
 import { UNIVERSAL_LINK_CONSTRAINTS } from '../prompts/constraints';
-import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { classifyMergeNeed, isSourceOwnPageLemma, type ComplementaryItem } from './merge-triage';
 import { assembleFinalContent } from './mentions-integration';
 import { applyComplementaryAppends } from './complementary-appends';
@@ -314,16 +313,9 @@ export async function mergePage(
     const labels = getSectionLabels(ctx.settings);
     const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
     const prunedBody = stripUnknownSections(canonicalizedBody, Object.values(labels));
-    const correctedBody = correctRelatedLinkPrefixes(
-      prunedBody,
-      info.related_entities,
-      info.related_concepts,
-      labels.related_entities,
-      labels.related_concepts,
-      // #482 stage 2: the merge prompt no longer carries a page list, so the
-      // link targets are resolved here — against every page, not a window.
-      { wikiFolder: ctx.settings.wikiFolder, pages: await getExistingWikiPages(ctx.app as never, ctx.settings.wikiFolder) },
-    );
+    // Related links resolved against every page, sections written from the
+    // lists with the page's earlier entries in front — see page-factory/related-links.ts.
+    const correctedBody = await applyRelatedLinks(ctx, prunedBody, info, labels, { pageType, keepFrom: existingBody });
     // Completeness is the schema's call, not the model's: sections the rewrite
     // dropped or collapsed come back (#618), footnoted paragraphs another source
     // owns come back, the H1 comes back (#419). The Mentions section is

--- a/src/wiki/page-factory/related-links.ts
+++ b/src/wiki/page-factory/related-links.ts
@@ -1,0 +1,50 @@
+// One pass, shared by the three page factories: resolve the Related links
+// against every page in the vault (#482 stage 2 — the prompt carries no page
+// list any more), then write the two Related sections from the typed lists
+// (core/related-sections.ts). A rewrite hands the body it replaces in
+// `keepFrom`, so the relations the page already had stay in front.
+
+import { correctRelatedLinkPrefixes, buildVaultResolver } from '../../core/related-link-corrector';
+import { renderRelatedSections } from '../../core/related-sections';
+import type { Folder } from '../../core/related-sections';
+import { getExistingWikiPages } from '../lint/get-existing-pages';
+
+interface RelatedLinkCtx {
+  app: unknown;
+  settings: { wikiFolder: string; slugCase?: string };
+}
+
+interface RelatedLists {
+  related_entities?: string[];
+  related_concepts?: string[];
+}
+
+/** `getSectionLabels(settings)` — the two Related labels are read by key. */
+type RelatedLabels = Record<string, string>;
+
+export async function applyRelatedLinks(
+  ctx: RelatedLinkCtx,
+  content: string,
+  lists: RelatedLists,
+  labels: RelatedLabels,
+  opts: { pageType: 'entity' | 'concept'; keepFrom?: string },
+): Promise<string> {
+  const firstSection: Folder = opts.pageType === 'concept' ? 'concepts' : 'entities';
+  const vaultIndex = { wikiFolder: ctx.settings.wikiFolder, pages: await getExistingWikiPages(ctx.app as never, ctx.settings.wikiFolder) };
+  const prefixed = correctRelatedLinkPrefixes(
+    content,
+    lists.related_entities,
+    lists.related_concepts,
+    labels.related_entities,
+    labels.related_concepts,
+    vaultIndex,
+  );
+  return renderRelatedSections(
+    prefixed,
+    lists.related_entities,
+    lists.related_concepts,
+    labels.related_entities,
+    labels.related_concepts,
+    { preserveCase: ctx.settings.slugCase === 'preserve', resolve: buildVaultResolver(vaultIndex), keepFrom: opts.keepFrom, firstSection },
+  );
+}

--- a/src/wiki/page-factory/related-page.ts
+++ b/src/wiki/page-factory/related-page.ts
@@ -29,7 +29,7 @@ import {
   canonicalizeSectionHeaders,
   stripUnknownSections,
 } from '../../core/section-header-canonicalizer';
-import { correctRelatedLinkPrefixes } from '../../core/related-link-corrector';
+import { applyRelatedLinks } from './related-links';
 import { getSectionLabels } from '../system-prompts';
 import { getExistingWikiPages } from '../lint/get-existing-pages';
 import { UNIVERSAL_LINK_CONSTRAINTS } from '../prompts/constraints';
@@ -162,17 +162,9 @@ export async function updateRelatedPage(
   // `sources/`-mis-prefixed link in a Related section was never re-typed.
   const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
   const prunedBody = stripUnknownSections(canonicalizedBody, Object.values(labels));
-  const correctedBody = correctRelatedLinkPrefixes(
-    prunedBody,
-    newInfo.related_entities,
-    newInfo.related_concepts,
-    labels.related_entities,
-    labels.related_concepts,
-    // #482 stage 2: resolve the link targets against every page. This path
-    // never had a candidate list in its prompt, so until now a related name
-    // whose page carries a different title could only become a dead link.
-    { wikiFolder: ctx.settings.wikiFolder, pages: await getExistingWikiPages(ctx.app as never, ctx.settings.wikiFolder) },
-  );
+  // Related links resolved against every page, sections written from the
+  // lists with the page's earlier entries in front — see page-factory/related-links.ts.
+  const correctedBody = await applyRelatedLinks(ctx, prunedBody, newInfo, labels, { pageType: asEntity ? 'entity' : 'concept', keepFrom: existingBody });
 
   // Completeness is the schema's call, not the model's: sections the rewrite
   // dropped or collapsed come back (#618), footnoted paragraphs another source

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -23,6 +23,8 @@ import { formatTaskUsage, snapshotTaskUsage, taskUsageSince } from '../core/llm-
 import { TEXTS } from '../texts';
 import { renderTemplate } from '../core/template-renderer';
 import { slugify } from '../core/slug';
+import { shapeRelatedLists, kindOf } from '../core/related-shaping';
+import { isIngestableSource } from '../core/folder-scope';
 import { resolveSourceSlug } from '../core/source-slug';
 import { parseFrontmatter, upsertFrontmatterField, mergeFrontmatterArrayField, extractBody } from '../core/frontmatter';
 import { setGenerationComplete } from '../core/incomplete-page-cleaner';
@@ -1142,6 +1144,7 @@ export class WikiEngine {
       // has already been folded into the routing, so only the domain
       // validation runs — over the survivors AND the planned stubs, whose
       // frontmatter carries the same validated subset.
+      let domainVocabulary: string[] = [];
       {
         if (!tableApplied) {
           // #620 parity: a dropped name the vault already has a page for keeps
@@ -1166,7 +1169,7 @@ export class WikiEngine {
         // Stage 5 (#568): validation accepts exactly what the declared source
         // folders and the wiki's own pages carry — new values are born by
         // tagging a note or a page, not by editing a settings list.
-        const domainVocabulary = collectActiveVocabulary(this.app, this.settings);
+        domainVocabulary = collectActiveVocabulary(this.app, this.settings);
         for (const item of [...analysis.entities, ...analysis.concepts, ...stubPlan.map(s => s.item)]) {
           const selection = selectDomains(item.domains, domainVocabulary);
           if (selection.rejected.length > 0) {
@@ -1174,6 +1177,39 @@ export class WikiEngine {
           }
           if (selection.kept.length > 0) item.domains = selection.kept;
           else delete item.domains;
+        }
+      }
+
+      // Every page born from this note links its siblings, a related name
+      // the vault answers is written under the page's own title and kind,
+      // and a name nothing answers stays as written and is counted.
+      // Deterministic, no model call; see core/related-shaping.ts.
+      {
+        const pages = await this.getExistingWikiPages();
+        const resolvePath = buildVaultResolver({ wikiFolder: this.settings.wikiFolder, pages });
+        const prefix = this.settings.wikiFolder + '/';
+        const titleByRel = new Map(pages.map(p => [p.path.slice(prefix.length).replace(/\.md$/, ''), p.title]));
+        const folders = (this.settings.watchedFolders ?? []).map(w => w.trim()).filter(Boolean);
+        const configDir = this.app.vault.configDir;
+        const noteTitles = folders.length === 0 ? [] : this.app.vault.getMarkdownFiles()
+          .filter(f => folders.some(w => isIngestableSource(f.path, w, false, this.settings.wikiFolder, configDir)))
+          .map(f => f.basename);
+        const shaped = shapeRelatedLists(analysis, {
+          resolve: name => {
+            const rel = resolvePath(name);
+            if (!rel) return undefined;
+            return { title: titleByRel.get(rel) ?? name, kind: kindOf(rel) };
+          },
+          willExist: [...noteTitles, ...stubPlan.map(s => s.item.name)],
+          vocabulary: domainVocabulary,
+        });
+        analysis.entities = shaped.entities;
+        analysis.concepts = shaped.concepts;
+        if (shaped.unanswered.length > 0 || shaped.siblings > 0 || shaped.tags.length > 0) {
+          const list = shaped.unanswered.map(d => `${d.name} (on ${d.on})`).join('; ');
+          const tagList = shaped.tags.map(d => `${d.name} (on ${d.on})`).join('; ');
+          console.debug(`[related-shape] ${file.path}: ${shaped.siblings} sibling edge(s) added; ${shaped.unanswered.length} related name(s) nothing answers yet${list ? ` — ${list}` : ''}; ${shaped.tags.length} tag value(s) dropped${tagList ? ` — ${tagList}` : ''}`);
+          this.onProgress?.(`Related lists: ${shaped.siblings} sibling edges, ${shaped.unanswered.length} unanswered names, ${shaped.tags.length} tag values dropped`);
         }
       }
 


### PR DESCRIPTION
Closes #635.

**What changes**
- `core/related-shaping.ts` — `shapeRelatedLists(analysis, deps)`: after the gate, before planning. Siblings by kind; a name the vault answers (title or alias, a parenthetical tried through its parts) under the page's own title and kind; a tag value (`Thema/Therapie`, or the bare leaf when only the vocabulary knows the word) dropped; a name nothing answers kept as written and counted. Pure over the analysis and a resolver; no I/O.
- `core/related-sections.ts` — `renderRelatedSections`: the two Related sections are written from the typed lists; vault path when known, planned path otherwise, the name as display text. Entries from the body before a rewrite stay in front, re-resolved against the vault, one target once across both sections; a missing section is inserted in the order the page kind's template lists them. Headings are matched with the same tolerance `section-header-canonicalizer` gives them. Everything outside the two sections is byte-identical.
- `page-factory/related-links.ts` — one helper for create/merge/related-page: prefix correction (#482 stage 2) then rendering. The three call sites collapse to one line each.
- Engine: one block in `ingestSource` builds the resolver from the page index (title outranks alias, ambiguous resolves to neither — `buildVaultResolver` from #621), lists watched-folder notes through `isIngestableSource`, and logs `[related-shape]` with the counts.

**Measured** (413-note vault, rebuild): pages without a live outgoing link 103 → 0 of 870; sibling lists complete 246/246; related entries dead 24 % → 1 %; the misspelt-name class gone because the model no longer writes those lines.

**Default behaviour changes, deliberately without a switch.** The two Related sections are now owned by the list on every write. I did not add a setting because the previous behaviour was not a choice anyone made — the model transcribed a list it had been handed and got it wrong one time in four — and because a switch would keep two rendering paths alive for one section. If you would rather have it opt-in for one release, the helper has a single entry point and that is a five-line change.

**Left as follow-ups, not in this PR:** the generation/merge prompts still ask for the two sections that are now overwritten (drop them from the templates, saves output tokens); `buildVaultResolver` could return `{path, title, kind}` so the engine block stops wrapping it; the parenthetical resolution could move into the resolver so the corrector and the repoint pass see it too; the section-scoped half of `correctRelatedLinkPrefixes` is now redundant. Each is a small separate change on top of this one.

Tests: 4 new files / cases (shaping, rendering incl. NFC and cross-section dedup, engine hookup, link-repoint expectation), full suite 3993 green, typecheck clean.
