### PR TITLE
fix(deps): close 8 fast-uri Dependabot alerts at the root — ^3.1.7, drop redundant override, CI audit gate + Dependabot auto-PR config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot version updates (security updates are always-on and need no config).
+#
+# Why this exists: the fast-uri 3.1.5 -> 3.1.6 -> 3.1.7 chain (2026-09, four
+# GHSA advisories) showed the failure mode this prevents — a vulnerable
+# transitive devDep sat pinned by a manual `overrides` entry until a human
+# noticed the Dependabot alert and hand-bumped it. The overrides that forced a
+# single instance (fast-uri) are gone; the one that genuinely needs pinning
+# (brace-expansion 5.0.9, because old minimatch@8/9/3 peers declare ^2/^1 and
+# would otherwise pull vulnerable legacy instances) stays. With this file,
+# Dependabot opens a PR the day a transitive dep drifts out of range; the
+# `pnpm audit --audit-level high` step in pr-ci.yml blocks merges in the
+# meantime. Human action reduces to review + merge, not hand-editing four files.
+#
+# `package-ecosystem: npm` covers pnpm-lock.yaml (GitHub native support) and
+# package-lock.json alike. `open-pull-requests-limit` kept low to avoid a
+# burst of dependency churn PRs competing with the release queue.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 3
+    versioning-strategy: increase-if-necessary
+    # No `labels:` — the repo has no `dependencies` label and Dependabot would
+    # create one implicitly; the maintainer's triage labels (bug/enhancement)
+    # don't fit dependency PRs. Default no-label is fine: the audit gate + CI
+    # are the real signal.
+    ignore:
+      # eslint stays at the Bot-aligned major (10.x per eslint-plugin-obsidianmd
+      # review pipeline); never auto-bump across major.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      # brace-expansion is force-pinned by overrides (legacy minimatch peers
+      # would pull ^2/^1); a Dependabot PR for it can never merge as-is.
+      - dependency-name: "brace-expansion"
+
+  # GitHub Actions themselves (checkout/setup-node/attest-build-provenance)
+  # are supply-chain surface too — a vulnerable action version is as bad as a
+  # vulnerable npm dep. Weekly, low limit; same review path as npm PRs.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 2

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -46,6 +46,16 @@ jobs:
       - name: Install (lockfile-pinned)
         run: pnpm install --frozen-lockfile
 
+      - name: Audit (dev + prod, high+)
+        # Dependency security gate: fail the PR the day a vulnerable transitive
+        # dep lands, not when a human notices the Dependabot alert. `--audit-level
+        # high` so low/moderate advisories (noisy, often unfixable) don't block;
+        # `--ignore-registry-errors` so a transient registry reset (ECONNRESET
+        # seen in the wild) fails the *audit step's exit-code intent* instead of
+        # hard-failing the PR on a network blip. Dependabot auto-PRs (separate
+        # config) are the fix path; this gate only catches drift before merge.
+        run: pnpm audit --audit-level high --ignore-registry-errors
+
       - name: Five-Gate (lint + typecheck + build + test + css-lint)
         # Order is non-negotiable: `build` MUST run before `test`. The test
         # suite contains build-artifact verifications (e.g.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "esbuild": "0.28.1",
         "eslint": "10.2.1",
         "eslint-plugin-obsidianmd": "^0.4.2",
-        "fast-uri": "3.1.5",
+        "fast-uri": "^3.1.7",
         "jsdom": "^30.0.1",
         "obsidian": "1.12.3",
         "tslib": "2.4.0",
@@ -3360,9 +3360,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "esbuild": "0.28.1",
     "eslint": "10.2.1",
     "eslint-plugin-obsidianmd": "^0.4.2",
-    "fast-uri": "3.1.5",
+    "fast-uri": "^3.1.7",
     "jsdom": "^30.0.1",
     "obsidian": "1.12.3",
     "tslib": "2.4.0",
@@ -51,7 +51,6 @@
     "yaml": "^2.4.2"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
     "brace-expansion": "5.0.9"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: 3.1.5
   brace-expansion: 5.0.9
 
 importers:
@@ -53,8 +52,8 @@ importers:
         specifier: ^0.4.2
         version: 0.4.2(@eslint/js@9.39.4)(@eslint/json@0.14.0)(@typescript-eslint/parser@8.59.1(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(obsidian@1.12.3(@codemirror/state@6.5.0)(@codemirror/view@6.38.6))(typescript-eslint@8.59.1(eslint@10.2.1)(typescript@5.9.3))
       fast-uri:
-        specifier: 3.1.5
-        version: 3.1.5
+        specifier: ^3.1.7
+        version: 3.1.7
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -404,8 +403,8 @@ packages:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
 
-  '@humanwhocodes/momoa@3.3.10':
-    resolution: {integrity: sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==}
+  '@humanwhocodes/momoa@3.3.13':
+    resolution: {integrity: sha512-AbKq3EW41+HY6pNMJgAOrz68iyiTTf0Nr1JRHHfuG5zwniJ9Dw8J3U7oa1I2ptpqYwmEf1sXKOGK6lbdZ9eqmg==}
     engines: {node: '>=18'}
 
   '@humanwhocodes/retry@0.4.3':
@@ -415,8 +414,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@marijn/find-cluster-break@1.0.2':
-    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+  '@marijn/find-cluster-break@1.0.4':
+    resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
 
   '@microsoft/eslint-plugin-sdl@1.1.0':
     resolution: {integrity: sha512-dxdNHOemLnBhfY3eByrujX9KyLigcNtW8sU+axzWv5nLGcsSBeKW2YYyTpfPo1hV8YPOmIGnfA4fZHyKVtWqBQ==}
@@ -749,8 +748,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  crelt@1.0.6:
-    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1030,8 +1029,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2047,12 +2046,12 @@ snapshots:
 
   '@codemirror/state@6.5.0':
     dependencies:
-      '@marijn/find-cluster-break': 1.0.2
+      '@marijn/find-cluster-break': 1.0.4
 
   '@codemirror/view@6.38.6':
     dependencies:
       '@codemirror/state': 6.5.0
-      crelt: 1.0.6
+      crelt: 1.0.7
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
@@ -2201,7 +2200,7 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       '@eslint/plugin-kit': 0.4.1
-      '@humanwhocodes/momoa': 3.3.10
+      '@humanwhocodes/momoa': 3.3.13
       natural-compare: 1.4.0
 
   '@eslint/object-schema@3.0.5': {}
@@ -2232,13 +2231,13 @@ snapshots:
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
-  '@humanwhocodes/momoa@3.3.10': {}
+  '@humanwhocodes/momoa@3.3.13': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@marijn/find-cluster-break@1.0.2': {}
+  '@marijn/find-cluster-break@1.0.4': {}
 
   '@microsoft/eslint-plugin-sdl@1.1.0(eslint@10.2.1)':
     dependencies:
@@ -2532,7 +2531,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2642,7 +2641,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  crelt@1.0.6: {}
+  crelt@1.0.7: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3099,7 +3098,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 onlyBuiltDependencies:
   - esbuild
 overrides:
-  fast-uri: 3.1.5
   brace-expansion: 5.0.9


### PR DESCRIPTION
## Root-cause fix for the recurring vulnerable-transitive-dep cycle (fast-uri 3.1.5 → 3.1.7)

Closes 8 open Dependabot alerts (4 × GHSA × 2 manifests, all `fast-uri < 3.1.6`).

### What changed

1. **fast-uri `3.1.5` → `^3.1.7`** (3.x latest). Four GHSA advisories (2026-09-03: SSRF / host confusion via skipped IDN canonicalization `GHSA-5jgf-p345-68v8`, malformed IPv6 normalization `GHSA-f65p-4m7j-42xc`, percent-encoded scheme normalization `GHSA-jqff-g426-hqxp`, repeated hostname percent-decoding `GHSA-fph4-wmhf-6fwf`) — all patched at 3.1.6+. DevDep widened from exact pin to `^3.1.7` so future 3.x patches resolve without editing package.json; `pnpm update fast-uri` refreshes the lock.

2. **Drop the fast-uri `overrides` entry** (package.json + pnpm-workspace.yaml). Verified redundant: every consumer (ajv@8.20.0, eslint-plugin-json-schema-validator, json-schema-migrate) declares `fast-uri@^3.0.1`, which natively permits 3.1.7 — the override forced a single instance the semver ranges already agree on. **brace-expansion override KEPT**: it genuinely pins 5.0.9 against legacy minimatch@8/9/3 peers declaring `^2/^1`; removing it would resurrect vulnerable multi-instance legacy brace-expansion.

3. **CI audit gate** (.github/workflows/pr-ci.yml): `pnpm audit --audit-level high --ignore-registry-errors` step after Install. Fails the PR the day a vulnerable dep lands, not when a human notices the alert. `--audit-level high` filters noisy low/moderate; `--ignore-registry-errors` prevents a transient registry ECONNRESET from false-failing.

4. **Dependabot auto-PR config** (.github/dependabot.yml, new): npm weekly (monday 09:00 Asia/Shanghai, limit 3, increase-if-necessary; eslint major ignored for Bot alignment, brace-expansion ignored as override-pinned) + github-actions weekly (checkout/setup-node/attest-build-provenance are supply-chain surface too). Security updates need no config — always on.

### Verification (three-zero)

| Check | Result |
|-------|--------|
| `pnpm install --frozen-lockfile` | clean |
| lockfile resolution | fast-uri 3.1.7 single instance + brace-expansion 5.0.9 single instance (both manifests) |
| `pnpm audit` + `npm audit` | both **0 vulnerabilities** |
| Gate 1 (lint / tsc / build / test / css-lint) | 0 / 0 / 0 / **3993 tests** / 0 |
| prod code | untouched — devDependency-only change |

### Not in this PR (deliberately)

- The **double-lockfile** question (pnpm dev + npm release) — larger process decision, separate PR.
- CI 跑 audit 的实际效果会在本 PR 的 Gate 1 run 里直接可见（Audit step 应 pass）。
