### PR TITLE
fix(related): siblings only rescue an orphan, capped at three

### DIFF
--- a/src/__tests__/core/related-shaping.test.ts
+++ b/src/__tests__/core/related-shaping.test.ts
@@ -1,6 +1,6 @@
 // See core/related-shaping.ts.
 import { describe, it, expect } from 'vitest';
-import { shapeRelatedLists } from '../../core/related-shaping';
+import { SIBLING_CAP, shapeRelatedLists } from '../../core/related-shaping';
 import type { EntityInfo, ConceptInfo } from '../../types';
 
 const ent = (name: string, rel: Partial<EntityInfo> = {}): EntityInfo =>
@@ -39,17 +39,33 @@ describe('shapeRelatedLists', () => {
     expect(r.entities[0].related_entities).toEqual(['vitamin k2', 'Dissent-Stub']);
   });
 
-  it('links every page born from the note to its siblings, by kind, without self or duplicates', () => {
+  it('gives an orphan its siblings, by kind, without self or duplicates — a page with a live entry gets none', () => {
     const r = shapeRelatedLists(
       { entities: [ent('Berberin'), ent('Metformin', { related_entities: ['berberin'] })], concepts: [con('Insulinresistenz')] },
       deps,
     );
-    expect(r.entities[0].related_entities).toEqual(['Metformin']);
+    expect(r.entities[0].related_entities).toEqual(['Metformin']); // orphan: siblings
     expect(r.entities[0].related_concepts).toEqual(['Insulinresistenz']);
-    expect(r.entities[1].related_entities).toEqual(['Berberin']);
+    expect(r.entities[1].related_entities).toEqual(['Berberin']); // live entry of its own: no sibling added
+    expect(r.entities[1].related_concepts).toBeUndefined();
     expect(r.concepts[0].related_entities).toEqual(['Berberin', 'Metformin']);
     expect(r.concepts[0].related_concepts).toEqual([]);
-    expect(r.siblings).toBe(5);
+    expect(r.siblings).toBe(4);
+  });
+
+  it('a page whose only related name is itself is an orphan (review fix)', () => {
+    const r = shapeRelatedLists({ entities: [ent('Berberin', { related_entities: ['berberin'] }), ent('Metformin')], concepts: [] }, deps);
+    expect(r.entities[0].related_entities).toEqual(['Metformin']);
+  });
+
+  it('caps an orphan at SIBLING_CAP siblings and counts an unanswered name as no way out', () => {
+    const r = shapeRelatedLists(
+      { entities: [ent('A1', { related_entities: ['Niemand'] }), ent('A2'), ent('A3'), ent('A4'), ent('A5')], concepts: [] },
+      deps,
+    );
+    expect(r.entities[0].related_entities).toEqual(['Niemand', 'A2', 'A3', 'A4']); // frontier name kept, then 3 siblings
+    expect(r.entities[1].related_entities).toHaveLength(SIBLING_CAP);
+    expect(r.siblings).toBe(5 * SIBLING_CAP);
   });
 
   it('routes a survivor named in the wrong list to the list of its kind', () => {

--- a/src/__tests__/wiki/wiki-engine-related-shaping.test.ts
+++ b/src/__tests__/wiki/wiki-engine-related-shaping.test.ts
@@ -36,19 +36,21 @@ describe('WikiEngine.ingestSource — related shaping', () => {
       .filter(m => m.includes('Related entities:'))
       .map(m => `${(m.match(/Related entities:[^\\]*/) ?? [''])[0]} | ${(m.match(/Related concepts:[^\\]*/) ?? [''])[0]}`);
     expect(lines).toEqual([
-      // Berberin: Metformin under its vault title, Secukinumab kept as written, Vitamin K2 as a note that will be a page, sibling concept added
-      'Related entities: Metformin, Secukinumab, Vitamin K2 | Related concepts: Insulinresistenz',
-      // Insulinresistenz: sibling entity added, the unanswered concept kept
+      // Berberin: Metformin under its vault title, Secukinumab kept as written, Vitamin K2 as a note that will be a page — live entries, so no sibling
+      'Related entities: Metformin, Secukinumab, Vitamin K2 | Related concepts: No related concepts',
+      // Insulinresistenz: its only name is unanswered, so the sibling entity rescues it; the unanswered concept kept
       'Related entities: Berberin | Related concepts: Metabolisches Syndrom',
     ]);
 
     // The written page carries the sections rendered from the
     // same lists — Metformin on its vault path, the unanswered names on their
-    // planned paths, the sibling concept — whatever the model returned.
+    // planned paths — whatever the model returned; no sibling concept, the
+    // page has live entries of its own.
     const berberinPage = h.files.get('wiki/entities/berberin.md') ?? '';
-    expect(berberinPage).toContain('## Verwandte Entitäten\n\n- [[entities/Metformin|Metformin]]\n- [[entities/secukinumab|Secukinumab]]\n- [[entities/vitamin-k2|Vitamin K2]]\n\n## Verwandte Konzepte\n\n- [[concepts/insulinresistenz|Insulinresistenz]]\n');
+    expect(berberinPage).toContain('## Verwandte Entitäten\n\n- [[entities/Metformin|Metformin]]\n- [[entities/secukinumab|Secukinumab]]\n- [[entities/vitamin-k2|Vitamin K2]]\n');
+    expect(berberinPage).not.toContain('concepts/insulinresistenz');
 
     const msg = h.progressMessages.find(m => m.startsWith('Related lists:'));
-    expect(msg).toBe('Related lists: 2 sibling edges, 2 unanswered names, 2 tag values dropped');
+    expect(msg).toBe('Related lists: 1 sibling edges, 2 unanswered names, 2 tag values dropped');
   });
 });

--- a/src/core/related-shaping.ts
+++ b/src/core/related-shaping.ts
@@ -1,4 +1,4 @@
-// Related lists: siblings link each other, and a related name the vault
+// Related lists: an orphan gets siblings, and a related name the vault
 // already answers is written under that page's own title and folder.
 //
 // The extraction may name anything from the note in `related_entities` /
@@ -63,6 +63,9 @@ function nameVariants(name: string): string[] {
   return m ? [name, m[1].trim(), m[2].trim()].filter(Boolean) : [name];
 }
 
+/** Siblings an orphan gets — enough for a way out, not a clique. */
+export const SIBLING_CAP = 3;
+
 export function shapeRelatedLists(
   analysis: Pick<SourceAnalysis, 'entities' | 'concepts'>,
   deps: RelatedShapingDeps,
@@ -78,11 +81,13 @@ export function shapeRelatedLists(
 
   const shape = (self: string, ents: string[] | undefined, cons: string[] | undefined) => {
     const outE: string[] = []; const outC: string[] = []; const seen = new Set<string>([nameKey(self)]);
-    const put = (name: string, kind: RelatedKind | undefined, into: RelatedKind) => {
+    let hasLive = false;
+    const put = (name: string, kind: RelatedKind | undefined, into: RelatedKind): boolean => {
       const k = nameKey(name);
-      if (!k || seen.has(k)) return;
+      if (!k || seen.has(k)) return false;
       seen.add(k);
       ((kind ?? into) === 'concept' ? outC : outE).push(name);
+      return true;
     };
     for (const [list, into] of [[ents, 'entity'], [cons, 'concept']] as const) {
       for (const raw of list ?? []) {
@@ -98,20 +103,29 @@ export function shapeRelatedLists(
         for (const v of nameVariants(name)) {
           const vk = nameKey(v);
           const s = survivors.get(vk);
-          if (s) { put(s.name, s.kind, into); placed = true; break; }
+          if (s) { hasLive = put(s.name, s.kind, into) || hasLive; placed = true; break; }
           const r = deps.resolve(v);
-          if (r) { put(r.title, r.kind, into); placed = true; break; }
+          if (r) { hasLive = put(r.title, r.kind, into) || hasLive; placed = true; break; }
         }
         if (placed) continue;
-        if (willExist.has(k)) { put(name, undefined, into); continue; }
+        if (willExist.has(k)) { hasLive = put(name, undefined, into) || hasLive; continue; }
         if (!prefixed && tagLeaves.has(k)) { tags.push({ on: self, name }); continue; }
         if (!seen.has(k)) unanswered.push({ on: self, name });
         put(name, undefined, into);
       }
     }
-    for (const s of survivors.values()) {
-      if (seen.has(nameKey(s.name))) continue;
-      put(s.name, s.kind, s.kind); siblings++;
+    // Siblings only rescue an orphan. Written for every page they were 99 %
+    // of the live edges on a 537-page rebuild (8562 of 8673), cliques of up
+    // to 20 pages per note, 462 pages with no other live edge — a graph of
+    // co-birth, not content, and redundant with the source page both
+    // siblings already link. A page whose own related names reach nothing
+    // alive (a self-link is nothing) gets up to SIBLING_CAP siblings.
+    if (!hasLive) {
+      const before = siblings;
+      for (const s of survivors.values()) {
+        if (siblings - before >= SIBLING_CAP) break;
+        if (put(s.name, s.kind, s.kind)) siblings++;
+      }
     }
     return { outE, outC };
   };


### PR DESCRIPTION
Closes #644.

`shapeRelatedLists` adds siblings only when a page's own related names reach
nothing alive — no page of this run, no vault page, no note that will become
one — and then at most `SIBLING_CAP = 3`. A self-link counts as nothing
(review finding: the placed-but-deduplicated case). Every other page keeps
what the model named; the log line keeps counting sibling edges added.

Measured on a 537-page rebuild: 8562 of 8673 live edges were sibling edges,
cliques of up to 20 pages per note, 462 pages with no other live edge.
Numbers and reasoning in #644.

Ready: the rebuild ran with this rule (413 notes, 2 095 pages) — orphans 9 = 0.4 %, the rule's footprint a spike at exactly three entries on single-source pages. The sibling-edge share promised above turned out to be the wrong measure; the correction and numbers are in #644. Gate 1 green (3995 tests).
