### PR TITLE
fix(ingest): a cancel reaches the running model call and stops at the next page write

### DIFF
--- a/src/__tests__/core/llm-abort.test.ts
+++ b/src/__tests__/core/llm-abort.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { withAbortSignal } from '../../core/llm-abort';
+
+describe('withAbortSignal (#646)', () => {
+  const make = () => {
+    const calls: unknown[] = [];
+    class Client {
+      private secret = 'kept';
+      async createMessage(p: Record<string, unknown>) { calls.push(p); return 'text'; }
+      async createMessageWithOutput(p: Record<string, unknown>) { calls.push(p); return { text: this.secret }; }
+      async createMessageStream(p: Record<string, unknown>) { calls.push(p); return 'stream'; }
+      other() { return this.secret; }
+    }
+    return { client: new Client(), calls };
+  };
+
+  it('adds the current signal to all three call shapes and leaves other members working', async () => {
+    const { client, calls } = make();
+    const ctl = new AbortController();
+    const w = withAbortSignal(client, () => ctl.signal);
+    await w.createMessage({ model: 'm' });
+    expect(await w.createMessageWithOutput({ model: 'm' })).toEqual({ text: 'kept' });
+    await w.createMessageStream({ model: 'm' });
+    expect(calls.map(c => (c as { abortSignal?: AbortSignal }).abortSignal)).toEqual([ctl.signal, ctl.signal, ctl.signal]);
+    expect(w.other()).toBe('kept');
+  });
+
+  it('reads the signal at call time, keeps a caller-set signal, and passes through when there is none', async () => {
+    const { client, calls } = make();
+    let current: AbortSignal | undefined;
+    const w = withAbortSignal(client, () => current);
+    await w.createMessage({ model: 'm' });
+    const own = new AbortController().signal;
+    current = new AbortController().signal;
+    await w.createMessage({ model: 'm', abortSignal: own });
+    await w.createMessage({ model: 'm' });
+    expect(calls.map(c => (c as { abortSignal?: AbortSignal }).abortSignal)).toEqual([undefined, own, current]);
+  });
+});

--- a/src/__tests__/llm-sdk/openai-compat-sdk-client.test.ts
+++ b/src/__tests__/llm-sdk/openai-compat-sdk-client.test.ts
@@ -131,6 +131,14 @@ describe('OpenAICompatSdkClient', () => {
       expect(callOpts.apiKey).toBe('test-key');
     });
 
+    it('hands the abort signal to the AI SDK (#646)', async () => {
+      const client = new OpenAICompatSdkClient({ apiKey: 'test-key', baseURL: preset.baseURL, provider: preset.id });
+      const signal = new AbortController().signal;
+      await client.createMessage({ model: preset.model, max_tokens: 100, messages: [{ role: 'user', content: 'hi' }], abortSignal: signal });
+      const call = mockGenerateText.mock.calls.at(-1)![0] as Record<string, unknown>;
+      expect(call.abortSignal).toBe(signal);
+    });
+
     it('creates the model with the given id', async () => {
       const client = new OpenAICompatSdkClient({
         apiKey: 'test-key',

--- a/src/__tests__/llm-sdk/sampling-args.test.ts
+++ b/src/__tests__/llm-sdk/sampling-args.test.ts
@@ -48,3 +48,11 @@ describe('buildSamplingArgs', () => {
     expect(Object.keys(result)).toEqual(['temperature']);
   });
 });
+
+describe('abortSignal (#646)', () => {
+  it('is emitted when given and absent otherwise', () => {
+    const signal = new AbortController().signal;
+    expect(buildSamplingArgs({ temperature: 0.1, abortSignal: signal })).toEqual({ temperature: 0.1, abortSignal: signal });
+    expect(buildSamplingArgs({ temperature: 0.1 })).toEqual({ temperature: 0.1 });
+  });
+});

--- a/src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts
+++ b/src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts
@@ -91,3 +91,25 @@ describe('WikiEngine.ingestSource — cancellation removes the completion marker
     expect(h.reports[0]?.cancelled).toBe(true);
   });
 });
+
+describe('WikiEngine — a cancel is honoured at the next page write', () => {
+  it('writes no content page after the cancel, even when the model call it was waiting on returns', async () => {
+    // The abort signal does not reach the model call; the call returns its
+    // page body after the user pressed stop. The write gate refuses it, the
+    // AbortError branch trashes the summary page, and nothing half-written
+    // stays behind for a later trigger to skip.
+    let h: ReturnType<typeof createWikiEngineHarness> | null = null;
+    h = createWikiEngineHarness({
+      files: { [SOURCE_NOTE_PATH]: '# ACT\n\nBody text.' },
+      llmResponses: [ANALYSIS_RESPONSE, SUMMARY_RESPONSE, '# Steven Hayes\n\nFounder of ACT.', '# Psychological Flexibility\n\nCore construct.'],
+      beforeLLMCall: () => {
+        if (h && summaryPageWritten(h.files)) h.engine.cancelIngestion();
+      },
+    });
+    await h.engine.ingestSource(sourceFile());
+
+    expect([...h.files.keys()].filter(p => /\/(entities|concepts)\//.test(p))).toEqual([]);
+    expect(summaryPageWritten(h.files)).toBeUndefined();
+    expect(h.reports[0]?.cancelled).toBe(true);
+  });
+});

--- a/src/core/llm-abort.ts
+++ b/src/core/llm-abort.ts
@@ -1,0 +1,30 @@
+// #646: the engine's cancel reaches the model call. `cancelIngestion()`
+// aborts the engine's controller, but until now that signal reached only the
+// PDF conversion call; extraction, merge and every other call ran to their
+// end and the cancel was noticed at three checkpoints per ingest — minutes
+// later on a local model, and never if Obsidian closed in between. The
+// engine hands out its client through one getter; this wraps it so every
+// `createMessage` / `createMessageWithOutput` / `createMessageStream` call
+// carries the current signal.
+// A call site that sets its own signal keeps it.
+
+type Signalled = { abortSignal?: AbortSignal };
+
+export function withAbortSignal<C extends object>(client: C, signal: () => AbortSignal | undefined): C {
+  const inject = <P extends Signalled>(params: P): P => {
+    if (params.abortSignal) return params;
+    const s = signal();
+    return s ? { ...params, abortSignal: s } : params;
+  };
+  return new Proxy(client, {
+    get(target, key, receiver) {
+      if (key === 'createMessage' || key === 'createMessageWithOutput' || key === 'createMessageStream') {
+        const fn = Reflect.get(target, key, target) as ((p: Signalled) => unknown) | undefined;
+        if (typeof fn !== 'function') return fn;
+        return (params: Signalled) => fn.call(target, inject(params));
+      }
+      const v = Reflect.get(target, key, receiver);
+      return typeof v === 'function' ? (v as (...a: unknown[]) => unknown).bind(target) : v;
+    },
+  });
+}

--- a/src/llm-sdk/anthropic-sdk-client.ts
+++ b/src/llm-sdk/anthropic-sdk-client.ts
@@ -176,7 +176,7 @@ export class AnthropicSdkClient implements LLMClient {
   }
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
-    const { model, max_tokens, system, messages, temperature, top_p, repetition_penalty, enableThinking, cacheBreakpoint, onFinish } = params;
+    const { model, max_tokens, system, messages, temperature, top_p, repetition_penalty, enableThinking, cacheBreakpoint, onFinish, abortSignal } = params;
 
     // Issue #449 v1.26.4 PATCH follow-up: when cacheBreakpoint is defined,
     // split the FIRST user message's text content at the offset and attach
@@ -201,7 +201,7 @@ export class AnthropicSdkClient implements LLMClient {
           enableThinking,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-        ...buildSamplingArgs({ temperature, top_p }, { withSeed: false }),
+        ...buildSamplingArgs({ temperature, top_p, abortSignal }, { withSeed: false }),
       });
       reportFinish(onFinish, result.finishReason);
       return result.text;
@@ -230,7 +230,7 @@ export class AnthropicSdkClient implements LLMClient {
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p }, { withSeed: false }),
+          ...buildSamplingArgs({ temperature, top_p, abortSignal }, { withSeed: false }),
         });
         reportFinish(onFinish, result.finishReason);
         return result.text;
@@ -274,6 +274,7 @@ export class AnthropicSdkClient implements LLMClient {
   async createMessageStream(params: {
     model: string;
     max_tokens: number;
+    abortSignal?: AbortSignal;
     system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     onChunk: (chunk: string) => void;
@@ -287,7 +288,7 @@ export class AnthropicSdkClient implements LLMClient {
     /** Step label for per-task accounting (Issue #469). Not consumed here — forwarded for interface conformance. */
     task?: string;
   }): Promise<string> {
-    const { model, max_tokens, system, messages, onChunk, temperature, top_p, repetition_penalty, enableThinking } = params;
+    const { model, max_tokens, system, messages, onChunk, temperature, top_p, repetition_penalty, enableThinking, abortSignal } = params;
 
     // v1.23.0 P1.5: same URL fallback as createMessage, so streaming
     // (Query Wiki) is consistent with non-streaming (Ingest / Lint /
@@ -306,7 +307,7 @@ export class AnthropicSdkClient implements LLMClient {
           enableThinking,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-        ...buildSamplingArgs({ temperature, top_p }, { withSeed: false }),
+        ...buildSamplingArgs({ temperature, top_p, abortSignal }, { withSeed: false }),
       });
 
       let fullText = '';
@@ -355,7 +356,7 @@ export class AnthropicSdkClient implements LLMClient {
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p }, { withSeed: false }),
+          ...buildSamplingArgs({ temperature, top_p, abortSignal }, { withSeed: false }),
         });
 
         let fullText = '';

--- a/src/llm-sdk/openai-codex-sdk-client.ts
+++ b/src/llm-sdk/openai-codex-sdk-client.ts
@@ -133,7 +133,7 @@ export class OpenAICodexSdkClient implements LLMClient {
     const system = forcedTextPromptSystem(params.system, params.response_format, params.outputModeOverride);
     try {
       let streamError: unknown;
-      const result = streamText({ model, ...(system ? { system } : {}), messages: params.messages.map((message) => ({ role: message.role, content: message.content })), maxOutputTokens: params.max_tokens, ...(params.temperature !== undefined ? { temperature: params.temperature } : {}), ...(params.top_p !== undefined ? { topP: params.top_p } : {}), ...(!forcedText && params.response_format?.type === 'json_object' ? { output: Output.json() } : {}), providerOptions: this.providerOptions(params.enableThinking), maxRetries: 0, onError: ({ error }) => { streamError = error; } });
+      const result = streamText({ model, ...(system ? { system } : {}), messages: params.messages.map((message) => ({ role: message.role, content: message.content })), maxOutputTokens: params.max_tokens, ...(params.temperature !== undefined ? { temperature: params.temperature } : {}), ...(params.top_p !== undefined ? { topP: params.top_p } : {}), ...(!forcedText && params.response_format?.type === 'json_object' ? { output: Output.json() } : {}), ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}), providerOptions: this.providerOptions(params.enableThinking), maxRetries: 0, onError: ({ error }) => { streamError = error; } });
       let text = '';
       for await (const chunk of result.textStream) text += chunk;
       if (streamError !== undefined) throw streamError instanceof Error ? streamError : new Error(typeof streamError === 'string' ? streamError : 'Codex stream failed');
@@ -145,7 +145,7 @@ export class OpenAICodexSdkClient implements LLMClient {
   async createMessageStream(params: Parameters<NonNullable<LLMClient['createMessageStream']>>[0]): Promise<string> {
     const model = this.getModel(params.model, this.streamFetchImpl);
     try {
-      const result = streamText({ model, ...(params.system ? { system: params.system } : {}), messages: params.messages.map((message) => ({ role: message.role, content: message.content })), maxOutputTokens: params.max_tokens, ...(params.temperature !== undefined ? { temperature: params.temperature } : {}), ...(params.top_p !== undefined ? { topP: params.top_p } : {}), providerOptions: this.providerOptions(params.enableThinking), maxRetries: 0 });
+      const result = streamText({ model, ...(params.system ? { system: params.system } : {}), messages: params.messages.map((message) => ({ role: message.role, content: message.content })), maxOutputTokens: params.max_tokens, ...(params.temperature !== undefined ? { temperature: params.temperature } : {}), ...(params.top_p !== undefined ? { topP: params.top_p } : {}), ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}), providerOptions: this.providerOptions(params.enableThinking), maxRetries: 0 });
       let text = '';
       for await (const chunk of result.textStream) {
         text += chunk;

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -276,7 +276,7 @@ export class OpenAICompatSdkClient implements LLMClient {
   }
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
-    const { model, max_tokens, messages, temperature, top_p, repetition_penalty, seed, enableThinking, reasoningEffort, response_format, outputModeOverride, onFinish } = params;
+    const { model, max_tokens, messages, temperature, top_p, repetition_penalty, seed, enableThinking, reasoningEffort, response_format, outputModeOverride, onFinish, abortSignal } = params;
     // Issue #481: a pinned mode skips the prober for this call. `text_prompt`
     // puts no `response_format` on the wire, so the JSON shape has to come from
     // the prompt — the same prefix the 400-driven demotion adds at retry time,
@@ -345,7 +345,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           reasoningEffort,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-        ...buildSamplingArgs({ temperature, top_p, seed }),
+        ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
       });
       reportFinish(onFinish, result.finishReason, result.usage);
       // Issue #443 follow-up (v1.26.x PATCH) — mirror createMessageWithOutput:
@@ -520,7 +520,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
@@ -604,7 +604,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         // Retry succeeded — commit the cache decision now. If the
         // retry above throws, this line never runs and the cache is
@@ -740,7 +740,7 @@ export class OpenAICompatSdkClient implements LLMClient {
               reasoningEffort,
               repetitionPenalty: repetition_penalty,
             }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-            ...buildSamplingArgs({ temperature, top_p, seed }),
+            ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
           });
           console.debug(`[OUTPUT-MODE-DEMOTE-DEBUG] baseURL=${this.baseURL} retry succeeded. Cache committed: mode=${demotedMode}.`);
           reportFinish(onFinish, result.finishReason, result.usage);
@@ -803,7 +803,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
@@ -847,6 +847,7 @@ export class OpenAICompatSdkClient implements LLMClient {
   async createMessageWithOutput<T = unknown>(params: {
     model: string;
     max_tokens: number;
+    abortSignal?: AbortSignal;
     system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string | MessageContentPart[] }>;
     response_format?: { type: 'json_object'; schema?: Record<string, unknown> | z.ZodType };
@@ -866,7 +867,7 @@ export class OpenAICompatSdkClient implements LLMClient {
     finishReason: LLMFinishReason;
     usage?: LLMUsage;
   }> {
-    const { model, max_tokens, messages, response_format, outputModeOverride, enableThinking, reasoningEffort, repetition_penalty, temperature, top_p, seed, onFinish } = params;
+    const { model, max_tokens, messages, response_format, outputModeOverride, enableThinking, reasoningEffort, repetition_penalty, temperature, top_p, seed, onFinish, abortSignal } = params;
     // See createMessage — a pinned `text_prompt` needs the prompt-side
     // enforcement up front, because no demotion retry will add it.
     const system = forcedTextPromptSystem(params.system, response_format, outputModeOverride);
@@ -921,7 +922,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           reasoningEffort,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-        ...buildSamplingArgs({ temperature, top_p, seed }),
+        ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
       });
       reportFinish(onFinish, result.finishReason, result.usage);
       // Issue #443 follow-up (v1.26.x PATCH) — LMStudio + Qwen3.5 routes the
@@ -1044,7 +1045,7 @@ export class OpenAICompatSdkClient implements LLMClient {
                   reasoningEffort,
                   repetitionPenalty: repetition_penalty,
                 }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-                ...buildSamplingArgs({ temperature, top_p, seed }),
+                ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
               });
               reportFinish(onFinish, retryResult.finishReason, retryResult.usage);
               // Cache committed per-model ONLY on retry success (mirror the
@@ -1145,7 +1146,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         reportFinish(onFinish, result.finishReason, result.usage);
         return {
@@ -1206,7 +1207,7 @@ export class OpenAICompatSdkClient implements LLMClient {
                 reasoningEffort,
                 repetitionPenalty: repetition_penalty,
               }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-              ...buildSamplingArgs({ temperature, top_p, seed }),
+              ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
             });
             reportFinish(onFinish, result.finishReason, result.usage);
             return {
@@ -1246,7 +1247,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             reasoningEffort,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         reportFinish(onFinish, result.finishReason, result.usage);
         return {
@@ -1421,6 +1422,7 @@ export class OpenAICompatSdkClient implements LLMClient {
   async createMessageStream(params: {
     model: string;
     max_tokens: number;
+    abortSignal?: AbortSignal;
     system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     onChunk: (chunk: string) => void;
@@ -1433,7 +1435,7 @@ export class OpenAICompatSdkClient implements LLMClient {
     task?: string;
     onFinish?: (meta: { finishReason: LLMFinishReason }) => void;
   }): Promise<string> {
-    const { model, max_tokens, system, messages, onChunk, temperature, top_p, repetition_penalty, seed, enableThinking, onFinish } = params;
+    const { model, max_tokens, system, messages, onChunk, temperature, top_p, repetition_penalty, seed, enableThinking, onFinish, abortSignal } = params;
 
     // v1.23.0 P1-7 follow-up: stream path uses streamWithFallback
     // (real streaming via window.fetch with CORS fallback to
@@ -1469,7 +1471,7 @@ export class OpenAICompatSdkClient implements LLMClient {
           enableThinking,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-        ...buildSamplingArgs({ temperature, top_p, seed }),
+        ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
       });
 
       let fullText = '';
@@ -1545,7 +1547,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
 
         let fullText = '';
@@ -1597,7 +1599,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         let fullText = '';
         for await (const chunk of result.textStream) {
@@ -1636,7 +1638,7 @@ export class OpenAICompatSdkClient implements LLMClient {
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         let fullText = '';
         for await (const chunk of result.textStream) {

--- a/src/llm-sdk/openai-sdk-client.ts
+++ b/src/llm-sdk/openai-sdk-client.ts
@@ -138,7 +138,7 @@ export class OpenAISdkClient implements LLMClient {
 
   async createMessage(params: LLMClient['createMessage'] extends (p: infer P) => unknown ? P : never): Promise<string> {
     // Type-safe params destructure (LLMClient.createMessage signature).
-    const { model, max_tokens, system, messages, temperature, top_p, repetition_penalty, seed, enableThinking, response_format, onFinish } = params;
+    const { model, max_tokens, system, messages, temperature, top_p, repetition_penalty, seed, enableThinking, response_format, onFinish, abortSignal } = params;
 
     try {
       const languageModel = this.getProvider(model, this.fetchImpl);
@@ -170,7 +170,7 @@ export class OpenAISdkClient implements LLMClient {
         // `seed` is forwarded but the Responses model discards it; see comment in
         // src/llm-sdk/sampling-args.ts. Top-level repetition_penalty is
         // non-standard for OpenAI; pass via providerOptions.
-        ...buildSamplingArgs({ temperature, top_p, seed }),
+        ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         // Top-level repetition_penalty is non-standard for OpenAI; pass via providerOptions.
       });
       reportFinish(onFinish, result.finishReason, result.usage);
@@ -200,7 +200,7 @@ export class OpenAISdkClient implements LLMClient {
             repetitionPenalty: repetition_penalty,
             responseFormat: response_format,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         reportFinish(onFinish, result.finishReason, result.usage);
         return result.text;
@@ -238,7 +238,7 @@ export class OpenAISdkClient implements LLMClient {
             repetitionPenalty: repetition_penalty,
             responseFormat: response_format,
           }) as unknown as Parameters<typeof generateText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         // Retry succeeded — commit the cache decision now. If the
         // retry above throws, this line never runs and the cache is
@@ -370,6 +370,7 @@ export class OpenAISdkClient implements LLMClient {
   async createMessageStream(params: {
     model: string;
     max_tokens: number;
+    abortSignal?: AbortSignal;
     system?: string;
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     onChunk: (chunk: string) => void;
@@ -381,7 +382,7 @@ export class OpenAISdkClient implements LLMClient {
     /** Step label for per-task accounting (Issue #469). Not consumed here — interface conformance. */
     task?: string;
   }): Promise<string> {
-    const { model, max_tokens, system, messages, onChunk, temperature, top_p, repetition_penalty, seed, enableThinking } = params;
+    const { model, max_tokens, system, messages, onChunk, temperature, top_p, repetition_penalty, seed, enableThinking, abortSignal } = params;
 
     // v1.23.0 P1.5: same URL fallback as createMessage, so streaming
     // (Query Wiki) is consistent with non-streaming (Ingest / Lint).
@@ -404,7 +405,7 @@ export class OpenAISdkClient implements LLMClient {
           enableThinking,
           repetitionPenalty: repetition_penalty,
         }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-        ...buildSamplingArgs({ temperature, top_p, seed }),
+        ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
       });
 
       // Accumulate text deltas (sent to onChunk) and reasoning (prepended).
@@ -468,7 +469,7 @@ export class OpenAISdkClient implements LLMClient {
             enableThinking,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
 
         let fullText = '';
@@ -519,7 +520,7 @@ export class OpenAISdkClient implements LLMClient {
             enableThinking: true,
             repetitionPenalty: repetition_penalty,
           }) as unknown as Parameters<typeof streamText>[0]['providerOptions'],
-          ...buildSamplingArgs({ temperature, top_p, seed }),
+          ...buildSamplingArgs({ temperature, top_p, seed, abortSignal }),
         });
         let fullText = '';
         for await (const chunk of result.textStream) {

--- a/src/llm-sdk/sampling-args.ts
+++ b/src/llm-sdk/sampling-args.ts
@@ -28,6 +28,8 @@ export interface SamplingArgs {
   temperature?: number;
   top_p?: number;
   seed?: number;
+  /** #646: rides along here because every real model call spreads this helper. */
+  abortSignal?: AbortSignal;
 }
 
 /**
@@ -46,11 +48,13 @@ export function buildSamplingArgs(
   temperature?: number;
   topP?: number;
   seed?: number;
+  abortSignal?: AbortSignal;
 } {
   const withSeed = options.withSeed ?? true;
-  const out: { temperature?: number; topP?: number; seed?: number } = {};
+  const out: { temperature?: number; topP?: number; seed?: number; abortSignal?: AbortSignal } = {};
   if (args.temperature !== undefined) out.temperature = args.temperature;
   if (args.top_p !== undefined) out.topP = args.top_p;
   if (withSeed && args.seed !== undefined) out.seed = args.seed;
+  if (args.abortSignal !== undefined) out.abortSignal = args.abortSignal;
   return out;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -895,6 +895,12 @@ export interface LLMClient {
     // schema is the single source of truth for both the Tier 0 wire
     // shape and the Tier 1/2 fallback parseJsonResponse validation).
     response_format?: { type: 'json_object'; schema?: Record<string, unknown> | z.ZodType };
+    /**
+     * Aborts the request (#646). The engine's cancel flips it; the SDK
+     * clients hand it to the AI SDK, which aborts the HTTP request. Without
+     * it a cancel waits for the running call to finish.
+     */
+    abortSignal?: AbortSignal;
     task?: string;
     /** See `createMessage`. Set by the wrapper from the per-task policy. */
     outputModeOverride?: OutputMode;
@@ -926,6 +932,8 @@ export interface LLMClient {
     seed?: number;
     repetition_penalty?: number;
     /** Step label for per-task LLM accounting (Issue #469) — same contract as createMessage. */
+    /** Aborts the request (#646) — see `createMessage`. */
+    abortSignal?: AbortSignal;
     task?: string;
     /** Issue: streamed answers were truncated silently — surface finish_reason. */
     onFinish?: (meta: LLMFinishMeta) => void;

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -24,6 +24,7 @@ import { TEXTS } from '../texts';
 import { renderTemplate } from '../core/template-renderer';
 import { slugify } from '../core/slug';
 import { shapeRelatedLists, kindOf } from '../core/related-shaping';
+import { withAbortSignal } from '../core/llm-abort';
 import { isIngestableSource } from '../core/folder-scope';
 import { resolveSourceSlug } from '../core/source-slug';
 import { parseFrontmatter, upsertFrontmatterField, mergeFrontmatterArrayField, extractBody } from '../core/frontmatter';
@@ -214,7 +215,11 @@ export class WikiEngine {
     const ctx: EngineContext = {
       app: this.app,
       settings: this.settings,
-      getClient: () => this.getLLMClient(),
+      // #646: the engine's cancel rides on every model call.
+      getClient: () => {
+        const client = this.getLLMClient();
+        return client ? withAbortSignal(client, () => this.abortController?.signal) : client;
+      },
       createOrUpdateFile: (p, c) => this.createOrUpdateFile(p, c),
       deleteFile: p => this.deleteFile(p),
       tryReadFile: p => this.tryReadFile(p),
@@ -1820,6 +1825,14 @@ export class WikiEngine {
   }
 
   async createOrUpdateFile(path: string, content: string): Promise<void> {
+    // #646: a cancelled ingest stops at the next page write. The abort signal
+    // reaches the model call only since the same fix; before, every call ran
+    // to its end and the cancel was honoured at three checkpoints per ingest.
+    // A stop pressed during a merge went unnoticed for minutes, and closing
+    // Obsidian inside that window skipped #583's cleanup — the summary page
+    // stayed, stamped complete, and every later trigger skipped the source.
+    // Outside an ingest there is no controller and this is a no-op.
+    this.checkCancelled();
     console.debug('createOrUpdateFile:', path);
 
     // Central pollution detection: strip folder-prefix duplication from wiki-links


### PR DESCRIPTION
Closes #646.

Two halves:

**The signal reaches the call.** `LLMClient.createMessage` /
`createMessageWithOutput` / `createMessageStream` take an optional
`abortSignal`; the four SDK clients hand it to `generateText`/`streamText`
through `buildSamplingArgs`, which every real call already spreads (the
Codex client inline). The engine hands its client out through one getter
and wraps it there (`core/llm-abort.ts`): a Proxy that adds the engine's
current signal to the three call shapes and leaves every other member
bound to the client. A caller-set signal wins; outside an ingest there is
no controller and nothing is added.

On the default fetch path (native fetch, `streamWithFallback`) the HTTP
request is aborted. On the `requestUrl` fallback Obsidian cannot abort a
request in flight; the bridge throws the AbortError as soon as the
response arrives, which is still before any page is written.

**The write gate checks first.** `createOrUpdateFile` calls
`checkCancelled()` before writing, so a cancel lands before the next page
write even when a call was already returning; the AbortError branch then
trashes the summary page as #583 intended.

5 tests: wrapper (three shapes, caller-set signal, live read), sampling
args, compat client forwards the signal, and a harness test — cancel
during a content call, the page body arrives, nothing may be written —
that is red without the change.

Running the rebuild with it now.