### PR TITLE
fix(frontmatter): skip empty sources: entries when merging

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -529,6 +529,16 @@ describe('mergeFrontmatter', () => {
     expect(result.wasMerged).toBe(true);
   });
 
+  it('does not emit a stray empty wikilink when an existing bare sources field is empty', () => {
+    // The create-path stamp calls mergeFrontmatter on enforce output, where a
+    // model-written block sources field has been reduced to a bare `sources:`
+    // line → parseFrontmatter yields ['']. The empty entry must be dropped.
+    const input = '---\ntype: entity\nsources:\ntags:\n---\n\nBody';
+    const result = mergeFrontmatter(input, 'sources/Neurologie');
+    expect(result.frontmatter).toContain('[[sources/Neurologie]]');
+    expect(result.frontmatter).not.toContain('[[]]');
+  });
+
   it('preserves created date', () => {
     const input = '---\ntype: entity\ncreated: 2026-01-01\nupdated: 2026-01-01\n---\n\nBody';
     const result = mergeFrontmatter(input, 'sources/test.md');

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -534,9 +534,15 @@ export function mergeFrontmatter(
   const existingSources = Array.isArray(fm.sources) ? fm.sources : [];
   const sourceSet = new Set<string>();
   for (const s of existingSources) {
-    sourceSet.add(normalizeSourcePath(String(s)));
+    // Skip empty entries: a bare `sources:` line parses to [''], which would
+    // otherwise emit a stray `[[]]` link that the #125 normalizer has to clean
+    // up downstream. (Originally found on the create path; since v1.26.0 that
+    // path uses upstream's `appendSourceSlugToFrontmatter`, so merge-page.ts is
+    // the remaining caller that can see a model-written bare `sources:`.)
+    const n = normalizeSourcePath(String(s));
+    if (n) sourceSet.add(n);
   }
-  sourceSet.add(newSourcePath);
+  if (newSourcePath) sourceSet.add(newSourcePath);
   const mergedSources = Array.from(sourceSet).map(s => `[[${s}]]`);
 
   const created = fm.created || localDateStamp();


### PR DESCRIPTION
A bare `sources:` line in model-written frontmatter parses to `['']`, which mergeFrontmatter turned into a stray `[[]]` link that the #125 normalizer had to clean up downstream. Skip empty entries on both the existing list and the new source path. The create path has used appendSourceSlugToFrontmatter since v1.26.0, so merge-page.ts is the remaining caller that can see such a line.

Closes #648

Gate: 282 test files, 3994 tests (base 3993), eslint 0, tsc clean.