### PR TITLE
fix(create): drop model-written sources before stamping the true one

### DIFF
--- a/src/__tests__/wiki/page-factory/append-source-slug.test.ts
+++ b/src/__tests__/wiki/page-factory/append-source-slug.test.ts
@@ -308,3 +308,42 @@ describe('appendSourceSlugToFrontmatter (#399)', () => {
     });
   });
 });
+
+// local patch (S142): the create path drops model-written `sources:` before
+// stamping the true source — fabricated provenance is worse than none.
+import { dropSourcesField } from '../../../wiki/page-factory/create-page';
+
+describe('dropSourcesField (S142 create-path provenance guard)', () => {
+  it('removes a block-style sources list, keeping every other field', () => {
+    const input = '---\ntype: concept\nsources:\n  - "[[sources/Metabolismus_Übersicht]]"\n  - "[[sources/Acetylsalicylsäure]]"\ntags:\n  - "Thema/Diagnostik"\n---\n\n# Titel\n';
+    const out = dropSourcesField(input);
+    expect(out).not.toContain('sources:');
+    expect(out).toContain('type: concept');
+    expect(out).toContain('tags:');
+    expect(out).toContain('# Titel');
+  });
+
+  it('removes a block-style list whose items sit at column 0', () => {
+    const input = '---\ntype: entity\nsources:\n- "[[sources/A]]"\n- "[[sources/B]]"\ntags: [x]\n---\n\nBody\n';
+    expect(dropSourcesField(input)).toBe('---\ntype: entity\ntags: [x]\n---\n\nBody\n');
+  });
+
+  it('removes a flow-style sources line', () => {
+    const input = '---\ntype: entity\nsources: ["[[sources/X]]"]\n---\n\nBody\n';
+    expect(dropSourcesField(input)).toBe('---\ntype: entity\n---\n\nBody\n');
+  });
+
+  it('leaves content without sources or frontmatter unchanged (same reference)', () => {
+    const noFm = '# Nur Body\n';
+    expect(dropSourcesField(noFm)).toBe(noFm);
+    const noSources = '---\ntype: entity\n---\n\nBody\n';
+    expect(dropSourcesField(noSources)).toBe(noSources);
+  });
+
+  it('drop + append leaves exactly the one true source', () => {
+    const input = '---\ntype: concept\nsources:\n  - "[[sources/Erfunden]]"\n---\n\nBody\n';
+    const out = appendSourceSlugToFrontmatter(dropSourcesField(input), 'Acetylsalicylsäure');
+    expect(out).toContain('[[sources/Acetylsalicylsäure]]');
+    expect(out).not.toContain('Erfunden');
+  });
+});

--- a/src/wiki/page-factory/create-page.ts
+++ b/src/wiki/page-factory/create-page.ts
@@ -295,8 +295,15 @@ export async function createNewPage(
     // `mergeFrontmatter` helper still owns the merge-page.ts path
     // (which has different requirements: emit a fresh `updated:`
     // stamp and full re-serialization).
+    // On the create path the machine knows the page's complete provenance:
+    // exactly the one source of this run. The model
+    // sometimes invents additional `sources:` entries (observed: 5 of 8
+    // "multi-source" pages were born with a second source whose note does
+    // not exist), and the #523 passthrough carries them past the
+    // constraints pass. Drop whatever the model wrote before stamping the
+    // true source: fabricated provenance is worse than none.
     const sourcedContent = sourceSlug
-      ? appendSourceSlugToFrontmatter(mentionsInjectedContent, sourceSlug)
+      ? appendSourceSlugToFrontmatter(dropSourcesField(mentionsInjectedContent), sourceSlug)
       : mentionsInjectedContent;
     // Stage 4 (#568): one field — the extraction's validated belonging
     // subset joins the identity value in `tags:` instead of feeding a
@@ -425,4 +432,20 @@ export function appendSourceSlugToFrontmatter(content: string, sourceSlug: strin
     lines.splice(sourcesIdx + 1, contEnd - (sourcesIdx + 1), ...newContinuation);
   }
   return `---\n${lines.join('\n')}\n---\n${body}`;
+}
+
+/**
+ * Remove any `sources:` field (block or flow style) from the frontmatter.
+ * Used by the create path only, right before the true source is stamped —
+ * see the call site in `createNewPage`. List items may sit at column 0 or
+ * indented; the run ends at the first line that is not a `- ` item. Content
+ * without frontmatter is returned unchanged.
+ */
+export function dropSourcesField(content: string): string {
+  if (!content.startsWith('---')) return content;
+  const fmEnd = content.indexOf('\n---\n', 3);
+  if (fmEnd === -1) return content;
+  const fm = content.substring(0, fmEnd + 1);
+  const cleaned = fm.replace(/^sources:[^\n]*\n(?:[ \t]*-[^\n]*\n)*/m, '');
+  return cleaned === fm ? content : cleaned + content.substring(fmEnd + 1);
 }


### PR DESCRIPTION
On the create path the page's provenance is fully known: exactly the one source of this run. The model sometimes invents additional `sources:` entries (5 of 8 "multi-source" pages in a rebuild sample were born with a second source whose note does not exist), and since #523 the constraints pass carries unknown block-form fields through, so the invented entries survived to disk. Remove whatever the model wrote under `sources:` before appendSourceSlugToFrontmatter stamps the real one. Flow and block style are both handled; list items may be indented or at column 0.

replaceFrontmatterArrayField was considered and not used: it re-serialises the whole block with block-style tags while the create path writes inline tags.

Closes #650

Gate: 282 test files, 3998 tests (base 3993), eslint 0, tsc clean.