### PR TITLE
fix(lint): prefer a page's real display name over its filename slug when repairing dead links

### DIFF
--- a/src/__tests__/core/dead-link-detector.test.ts
+++ b/src/__tests__/core/dead-link-detector.test.ts
@@ -202,6 +202,26 @@ describe('Dead Link Detector — Pure Functions', () => {
       const result = buildDeadLinkReplacement(nestedPage, 'wiki');
       expect(result).toBe('[[concepts/deep/learning|Deep Learning]]');
     });
+
+    // Issue #592: `title` is the filename slug — prefer `displayTitle` (the page's real H1 or first alias) when set, since title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
+    it('prefers displayTitle over title when set', () => {
+      const page: PageRef = {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+      };
+      const result = buildDeadLinkReplacement(page, 'wiki');
+      expect(result).toBe('[[entities/haem-a3|Haem A₃]]');
+    });
+
+    it('falls back to title when displayTitle is absent', () => {
+      const page: PageRef = {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+      };
+      const result = buildDeadLinkReplacement(page, 'wiki');
+      expect(result).toBe('[[entities/haem-a3|haem-a3]]');
+    });
   });
 
   describe('replaceDeadLink', () => {

--- a/src/__tests__/core/dead-link-detector.test.ts
+++ b/src/__tests__/core/dead-link-detector.test.ts
@@ -256,6 +256,15 @@ describe('Dead Link Detector — Pure Functions', () => {
       expect(result).toBe('See [[entities/cot|first name]] and later [[entities/cot|second name]] again.');
     });
 
+    // DocTpoint's #653 review: a bare occurrence and an aliased occurrence of the same
+    // target on one page must not cross-contaminate — the bare one gets the fallback
+    // replacement (i.e. displayTitle), the aliased one keeps its own alias, independently.
+    it('gives the fallback replacement to a bare occurrence while a sibling occurrence keeps its own alias', () => {
+      const mixed = 'First bare [[wrong-target]] then aliased [[wrong-target|receptors]].';
+      const result = replaceDeadLink(mixed, 'wrong-target', '[[entities/cot|Chain of Thought]]');
+      expect(result).toBe('First bare [[entities/cot|Chain of Thought]] then aliased [[entities/cot|receptors]].');
+    });
+
     it('handles links with section anchors', () => {
       const linkWithAnchor = 'See [[思维链#section]] for details.';
       const result = replaceDeadLink(linkWithAnchor, '思维链', '[[entities/cot|Chain of Thought]]');

--- a/src/__tests__/core/dead-link-detector.test.ts
+++ b/src/__tests__/core/dead-link-detector.test.ts
@@ -265,6 +265,13 @@ describe('Dead Link Detector — Pure Functions', () => {
       expect(result).toBe('First bare [[entities/cot|Chain of Thought]] then aliased [[entities/cot|receptors]].');
     });
 
+    it('leaves an aliased occurrence untouched instead of throwing when replacement is malformed', () => {
+      const linkWithDisplay = 'See [[wrong-target|thinking chain]] for more.';
+      const result = () => replaceDeadLink(linkWithDisplay, 'wrong-target', '[[]]');
+      expect(result).not.toThrow();
+      expect(result()).toBe(linkWithDisplay);
+    });
+
     it('handles links with section anchors', () => {
       const linkWithAnchor = 'See [[思维链#section]] for details.';
       const result = replaceDeadLink(linkWithAnchor, '思维链', '[[entities/cot|Chain of Thought]]');

--- a/src/__tests__/core/dead-link-detector.test.ts
+++ b/src/__tests__/core/dead-link-detector.test.ts
@@ -203,7 +203,7 @@ describe('Dead Link Detector — Pure Functions', () => {
       expect(result).toBe('[[concepts/deep/learning|Deep Learning]]');
     });
 
-    // Issue #592: `title` is the filename slug — prefer `displayTitle` (the page's real H1 or first alias) when set, since title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
+    // Issue #592: `title` is the filename slug — prefer `displayTitle` (the page's real H1) when set, since title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
     it('prefers displayTitle over title when set', () => {
       const page: PageRef = {
         path: 'wiki/entities/haem-a3.md',
@@ -240,11 +240,20 @@ describe('Dead Link Detector — Pure Functions', () => {
       expect(result).toContain('[[entities/cot|Chain of Thought]]');
     });
 
-    it('handles links with display text', () => {
-      const linkWithDisplay = 'See [[思维链|thinking chain]] for more.';
-      const result = replaceDeadLink(linkWithDisplay, '思维链', '[[entities/cot|Chain of Thought]]');
-      expect(result).toContain('[[entities/cot|Chain of Thought]]');
-      expect(result).not.toContain('[[思维链|thinking chain]]');
+    // Issue #653 follow-up: an occurrence that already has its own alias keeps it — the
+    // reader already saw that name — only the path is corrected to the resolved target.
+    it('keeps the existing alias on an occurrence that already has one', () => {
+      const linkWithDisplay = 'See [[wrong-target|thinking chain]] for more.';
+      const result = replaceDeadLink(linkWithDisplay, 'wrong-target', '[[entities/cot|Chain of Thought]]');
+      expect(result).toContain('[[entities/cot|thinking chain]]');
+      expect(result).not.toContain('[[wrong-target|thinking chain]]');
+      expect(result).not.toContain('Chain of Thought');
+    });
+
+    it('preserves each occurrence\'s own alias independently, not just the first one\'s', () => {
+      const twoAliases = 'See [[wrong-target|first name]] and later [[wrong-target|second name]] again.';
+      const result = replaceDeadLink(twoAliases, 'wrong-target', '[[entities/cot|Chain of Thought]]');
+      expect(result).toBe('See [[entities/cot|first name]] and later [[entities/cot|second name]] again.');
     });
 
     it('handles links with section anchors', () => {

--- a/src/__tests__/wiki/lint/fix-dead-link-display-title.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link-display-title.test.ts
@@ -150,6 +150,31 @@ describe('fixDeadLink — preserves an existing alias already in the dead link (
     expect(writes[0]!.content).not.toContain('Haem A₃');
   });
 
+  // Issue #653 follow-up: extractDeadLinkAlias used to grab only the FIRST occurrence's
+  // alias and stamp it onto every occurrence of the same target. Each occurrence must
+  // keep its own alias instead.
+  it('pre-check: keeps each occurrence\'s own alias, not just the first one\'s', async () => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    const { ctx, writes } = makeCtx(
+      noopClient(),
+      '# My Page\n\nFirst mention [[wrong-path/haem-a3|receptors]], later [[wrong-path/haem-a3|the receptor]] again.\n'
+    );
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'wrong-path/haem-a3');
+
+    expect(out).toContain('pre-check corrected');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|receptors]]');
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|the receptor]]');
+  });
+
   it('deterministic fallback: keeps the link\'s own existing alias over the target\'s displayTitle', async () => {
     vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
       {

--- a/src/__tests__/wiki/lint/fix-dead-link-display-title.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link-display-title.test.ts
@@ -1,0 +1,175 @@
+// `PageRef.title` (`getExistingWikiPages`) is the filename slug, not a display name — title-casing it can't recover punctuation, spacing, or subscripts a real heading has.
+// `displayTitle` (H1, or the first frontmatter alias when the body has none) must win over `title` in every branch of `fixDeadLink` that repairs a link to an already-existing page.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fixDeadLink } from '../../../wiki/lint/fix-dead-link';
+import * as getExistingPages from '../../../wiki/lint/get-existing-pages';
+import type { EngineContext, LLMClient } from '../../../types';
+
+const SOURCE_CONTENT = '# My Page\n\nReferences [[haem-a3]] here.\n';
+
+function makeCtx(client: LLMClient, sourceContent: string = SOURCE_CONTENT): { ctx: EngineContext; writes: Array<{ path: string; content: string }> } {
+  const written: Array<{ path: string; content: string }> = [];
+  const ctx = {
+    app: {},
+    settings: {
+      wikiFolder: 'wiki',
+      wikiLanguage: 'en',
+      disableThinking: false,
+      slugCase: 'preserve',
+    },
+    getClient: () => client,
+    getSchemaContext: () => ({}),
+    tryReadFile: async (_path: string): Promise<string | null> => sourceContent,
+    createOrUpdateFile: async (path: string, content: string): Promise<void> => {
+      written.push({ path, content });
+    },
+  } as unknown as EngineContext;
+  return { ctx, writes: written };
+}
+
+function noopClient(): LLMClient {
+  return {
+    createMessage: vi.fn(async () => '') as unknown as LLMClient['createMessage'],
+  } as LLMClient;
+}
+
+describe('fixDeadLink — prefers displayTitle over the filename slug (#592)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pre-check: uses the H1-derived displayTitle, not the slug title', async () => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    const { ctx, writes } = makeCtx(noopClient());
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'haem-a3');
+
+    expect(out).toContain('pre-check corrected');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|Haem A₃]]');
+    expect(writes[0]!.content).not.toContain('|haem-a3]]');
+  });
+
+  it('pre-check: falls back to the raw title when no displayTitle is set', async () => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    const { ctx, writes } = makeCtx(noopClient());
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'haem-a3');
+
+    expect(out).toContain('pre-check corrected');
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|haem-a3]]');
+  });
+
+  it('alias safety net: uses displayTitle when the LLM create_stub suggestion actually matches an existing alias', async () => {
+    // Pre-check runs against the ORIGINAL link target ('totally-unrelated'), which matches nothing, so the LLM path runs. The LLM's suggested stub_title ('Cytochrome Haem A3') happens to match an existing page's alias — the safety-net re-check inside the create_stub branch, not the pre-check — is what must prefer displayTitle here.
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+        aliases: ['Cytochrome Haem A3'],
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    const client = {
+      createMessage: vi.fn(async () =>
+        JSON.stringify({ action: 'create_stub', stub_title: 'Cytochrome Haem A3', stub_type: 'entity' })
+      ) as unknown as LLMClient['createMessage'],
+    } as LLMClient;
+    const { ctx, writes } = makeCtx(client, '# My Page\n\nReferences [[totally-unrelated]] here.\n');
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'totally-unrelated');
+
+    expect(out).toContain('safety-net corrected');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|Haem A₃]]');
+  });
+});
+
+// A dead link may already carry an author-written alias (`[[wrong-path|My Custom Alias]]`). That alias is a stronger signal than the target page's own displayTitle/H1 — the reader already saw this name, so repairing the path must not silently swap it out. Distinct from the displayTitle fallback above, which only applies when the link has no alias of its own.
+describe('fixDeadLink — preserves an existing alias already in the dead link (#592)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pre-check: keeps the link\'s own existing alias over the target\'s displayTitle', async () => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    const { ctx, writes } = makeCtx(noopClient(), '# My Page\n\nReferences [[wrong-path/haem-a3|My Custom Alias]] here.\n');
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'wrong-path/haem-a3');
+
+    expect(out).toContain('pre-check corrected');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|My Custom Alias]]');
+    expect(writes[0]!.content).not.toContain('Haem A₃');
+  });
+
+  it('alias safety net: keeps the link\'s own existing alias over the target\'s displayTitle', async () => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+        aliases: ['Cytochrome Haem A3'],
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    const client = {
+      createMessage: vi.fn(async () =>
+        JSON.stringify({ action: 'create_stub', stub_title: 'Cytochrome Haem A3', stub_type: 'entity' })
+      ) as unknown as LLMClient['createMessage'],
+    } as LLMClient;
+    const { ctx, writes } = makeCtx(client, '# My Page\n\nReferences [[totally-unrelated|My Custom Alias]] here.\n');
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'totally-unrelated');
+
+    expect(out).toContain('safety-net corrected');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|My Custom Alias]]');
+    expect(writes[0]!.content).not.toContain('Haem A₃');
+  });
+
+  it('deterministic fallback: keeps the link\'s own existing alias over the target\'s displayTitle', async () => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([
+      {
+        path: 'wiki/entities/haem-a3.md',
+        title: 'haem-a3',
+        displayTitle: 'Haem A₃',
+        wikiLink: '[[entities/haem-a3|haem-a3]]',
+      },
+    ] as never);
+    // Empty LLM response with no retry payload drives fixDeadLink past both the pre-check (target name below doesn't match by title/alias/slug directly — the fallback's own slug/alias comparison is what should match 'haem-a3') and the LLM branches, into the deterministic fallback.
+    const client = {
+      createMessage: vi.fn(async () => '') as unknown as LLMClient['createMessage'],
+    } as LLMClient;
+    const { ctx, writes } = makeCtx(client, '# My Page\n\nReferences [[haem-a3|My Custom Alias]] here.\n');
+
+    const out = await fixDeadLink(ctx, 'wiki/entities/MyPage.md', 'haem-a3');
+
+    // NOTE: as of this writing the pre-check already matches 'haem-a3' by title, so this exercises the same code path as the first test above via a different entry point. Left in to pin the fallback branch's own newLink construction too, in case the pre-check's matching narrows in the future and this becomes the first test to actually reach it.
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[entities/haem-a3|My Custom Alias]]');
+    expect(writes[0]!.content).not.toContain('Haem A₃');
+  });
+});

--- a/src/__tests__/wiki/lint/fix-dead-link-malformed-correction.test.ts
+++ b/src/__tests__/wiki/lint/fix-dead-link-malformed-correction.test.ts
@@ -1,0 +1,103 @@
+// Issue #653 review: an LLM `action: 'correct'` reply with an empty/garbage `correct_link` (e.g. whitespace, or
+// "]"/"|" leading) used to be trusted verbatim, and replaceDeadLink's per-match alias-preservation would throw
+// trying to parse a path out of it. An unclosed one (e.g. "[[foo" — already starts with "[[" so the wrap step
+// below skips it) used to be written straight into the page as broken markdown.
+// A malformed correct_link now falls through to the deterministic stub fallback instead — same as if the LLM
+// hadn't returned a usable action at all.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fixDeadLink } from '../../../wiki/lint/fix-dead-link';
+import * as getExistingPages from '../../../wiki/lint/get-existing-pages';
+import type { EngineContext, LLMClient } from '../../../types';
+
+const SOURCE_CONTENT = '# My Page\n\nReferences [[missing-target|My Alias]] here.\n';
+const BARE_SOURCE_CONTENT = '# My Page\n\nReferences [[missing-target]] here.\n';
+
+function makeCtx(
+  client: LLMClient,
+  sourceContent: string = SOURCE_CONTENT,
+): { ctx: EngineContext; writes: Array<{ path: string; content: string }> } {
+  const written: Array<{ path: string; content: string }> = [];
+  const ctx = {
+    app: {},
+    settings: {
+      wikiFolder: 'wiki',
+      wikiLanguage: 'en',
+      disableThinking: false,
+      slugCase: 'preserve',
+    },
+    getClient: () => client,
+    getSchemaContext: () => ({}),
+    tryReadFile: async (_path: string): Promise<string | null> => sourceContent,
+    createOrUpdateFile: async (path: string, content: string): Promise<void> => {
+      written.push({ path, content });
+    },
+  } as unknown as EngineContext;
+  return { ctx, writes: written };
+}
+
+function typedClient(payload: unknown): LLMClient {
+  return {
+    createMessage: vi.fn(async () => '') as unknown as LLMClient['createMessage'],
+    createMessageWithOutput: vi.fn(async () => ({
+      text: JSON.stringify(payload),
+      output: payload,
+      outputMode: 'json_schema',
+      finishReason: 'stop',
+    })) as unknown as LLMClient['createMessageWithOutput'],
+  } as LLMClient;
+}
+
+describe('fixDeadLink — malformed LLM correct_link', () => {
+  beforeEach(() => {
+    vi.spyOn(getExistingPages, 'getExistingWikiPages').mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw on a whitespace-only correct_link, and falls through to the stub fallback', async () => {
+    const client = typedClient({ action: 'correct', correct_link: '   ' });
+    const { ctx, writes } = makeCtx(client);
+
+    const out = await fixDeadLink(ctx, 'wiki/concepts/MyPage.md', 'missing-target');
+
+    expect(out).toContain('fallback stub created');
+    expect(writes).toHaveLength(2);
+  });
+
+  it('preserves the source link\'s own alias in the fallback stub link', async () => {
+    const client = typedClient({ action: 'correct', correct_link: '   ' });
+    const { ctx, writes } = makeCtx(client);
+
+    await fixDeadLink(ctx, 'wiki/concepts/MyPage.md', 'missing-target');
+
+    const referringWrite = writes.find(w => w.path === 'wiki/concepts/MyPage.md')!;
+    expect(referringWrite.content).toContain('|My Alias]]');
+  });
+
+  it('does not write an unclosed link on a bare (no-alias) dead link, and falls through to the stub fallback', async () => {
+    // Already starts with "[[", so the wrap-if-missing step below is skipped, leaving it unclosed. On a bare
+    // dead link (no alias), replaceDeadLink would have spliced this straight in as broken markdown.
+    const client = typedClient({ action: 'correct', correct_link: '[[real-target' });
+    const { ctx, writes } = makeCtx(client, BARE_SOURCE_CONTENT);
+
+    const out = await fixDeadLink(ctx, 'wiki/concepts/MyPage.md', 'missing-target');
+
+    expect(out).toContain('fallback stub created');
+    const referringWrite = writes.find(w => w.path === 'wiki/concepts/MyPage.md')!;
+    expect(referringWrite.content).not.toContain('[[real-target');
+  });
+
+  it('still applies a well-formed correct_link as before', async () => {
+    const client = typedClient({ action: 'correct', correct_link: '[[real-target|Real Target]]' });
+    const { ctx, writes } = makeCtx(client);
+
+    const out = await fixDeadLink(ctx, 'wiki/concepts/MyPage.md', 'missing-target');
+
+    expect(out).toContain('corrected: [[real-target|Real Target]]');
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.content).toContain('[[real-target|My Alias]]');
+  });
+});

--- a/src/__tests__/wiki/lint/get-existing-pages-display-title.test.ts
+++ b/src/__tests__/wiki/lint/get-existing-pages-display-title.test.ts
@@ -1,4 +1,4 @@
-// `getExistingWikiPages()` sets `title` from the filename slug, not a display name. `displayTitle` (H1, or the first frontmatter alias when there is no parseable heading) is what a display name should come from instead — this pins its extraction directly.
+// `getExistingWikiPages()` sets `title` from the filename slug, not a display name. `displayTitle` (the page's H1) is what a display name should come from instead — this pins its extraction directly.
 
 import { describe, it, expect } from 'vitest';
 import { getExistingWikiPages } from '../../../wiki/lint/get-existing-pages';
@@ -19,7 +19,10 @@ describe('getExistingWikiPages — displayTitle extraction (#592)', () => {
     expect(pages[0]!.displayTitle).toBe('Haem A₃');
   });
 
-  it('falls back to the first frontmatter alias when there is no H1', async () => {
+  // Aliases are unordered abbreviations/variants, not necessarily what the page is
+  // called — the filename (via `title`, left for callers to fall back to) is the
+  // safer default when there's no H1 to go by.
+  it('leaves displayTitle undefined when there is no H1, even with frontmatter aliases present', async () => {
     const { ctx } = createMockContext({
       vaultFiles: {
         'wiki/entities/no-h1.md': '---\ntype: entity\naliases:\n  - "My Frontmatter Alias"\n  - "Other Alias"\n---\nNo heading here, just prose.\n',
@@ -29,7 +32,7 @@ describe('getExistingWikiPages — displayTitle extraction (#592)', () => {
     const pages = await getExistingWikiPages(ctx.app, 'wiki');
 
     expect(pages).toHaveLength(1);
-    expect(pages[0]!.displayTitle).toBe('My Frontmatter Alias');
+    expect(pages[0]!.displayTitle).toBeUndefined();
   });
 
   it('leaves displayTitle undefined when there is neither an H1 nor an alias', async () => {

--- a/src/__tests__/wiki/lint/get-existing-pages-display-title.test.ts
+++ b/src/__tests__/wiki/lint/get-existing-pages-display-title.test.ts
@@ -1,0 +1,47 @@
+// `getExistingWikiPages()` sets `title` from the filename slug, not a display name. `displayTitle` (H1, or the first frontmatter alias when there is no parseable heading) is what a display name should come from instead — this pins its extraction directly.
+
+import { describe, it, expect } from 'vitest';
+import { getExistingWikiPages } from '../../../wiki/lint/get-existing-pages';
+import { createMockContext } from '../../__support__/engine-context';
+
+describe('getExistingWikiPages — displayTitle extraction (#592)', () => {
+  it('uses the page\'s H1 as displayTitle when present', async () => {
+    const { ctx } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/haem-a3.md': '---\ntype: entity\n---\n# Haem A₃\n\nSome description.\n',
+      },
+    });
+
+    const pages = await getExistingWikiPages(ctx.app, 'wiki');
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.title).toBe('haem-a3');
+    expect(pages[0]!.displayTitle).toBe('Haem A₃');
+  });
+
+  it('falls back to the first frontmatter alias when there is no H1', async () => {
+    const { ctx } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/no-h1.md': '---\ntype: entity\naliases:\n  - "My Frontmatter Alias"\n  - "Other Alias"\n---\nNo heading here, just prose.\n',
+      },
+    });
+
+    const pages = await getExistingWikiPages(ctx.app, 'wiki');
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.displayTitle).toBe('My Frontmatter Alias');
+  });
+
+  it('leaves displayTitle undefined when there is neither an H1 nor an alias', async () => {
+    const { ctx } = createMockContext({
+      vaultFiles: {
+        'wiki/entities/bare.md': '---\ntype: entity\n---\nNo heading, no aliases.\n',
+      },
+    });
+
+    const pages = await getExistingWikiPages(ctx.app, 'wiki');
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0]!.displayTitle).toBeUndefined();
+  });
+});

--- a/src/core/dead-link-detector.ts
+++ b/src/core/dead-link-detector.ts
@@ -10,7 +10,7 @@ export interface PageRef {
   aliases?: string[];
   /**
    * Issue #592: `title` is the filename slug (`getExistingWikiPages` sets it from `f.basename`), not a display name — title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
-   * When present, this is the page's real H1 (or, absent that, its first frontmatter alias) and should be preferred over `title` anywhere a link repair needs to show the reader something, not just address the page.
+   * When present, this is the page's real H1 and should be preferred over `title` anywhere a link repair needs to show the reader something, not just address the page.
    */
   displayTitle?: string;
 }
@@ -86,7 +86,6 @@ export function findDeadLinkTarget(
  *
  * @param page - The matching page
  * @param wikiFolder - Wiki root folder (e.g., "wiki")
- * @param existingAlias - An alias the dead link already carried (`[[wrong-path|Custom Name]]`), from `extractDeadLinkAlias`. The reader already saw this name — it outranks even the target's own `displayTitle`.
  * @returns Formatted wiki link (e.g., "[[entities/chain-of-thought|Chain of Thought]]")
  *
  * @example
@@ -97,43 +96,26 @@ export function findDeadLinkTarget(
  */
 export function buildDeadLinkReplacement(
   page: PageRef,
-  wikiFolder: string,
-  existingAlias?: string
+  wikiFolder: string
 ): string {
   const relPath = page.path
     .replace(wikiFolder + '/', '')
     .replace('.md', '');
-  return `[[${relPath}|${existingAlias || page.displayTitle || page.title}]]`;
-}
-
-/**
- * A dead link may already carry an author-written alias. Extracted once by `fixDeadLink` and passed into every branch that repairs the link, so a pre-existing alias always wins over the target's own displayTitle/title.
- * Only matches links that already have a `|alias` segment — a bare `[[target]]` or `[[target#heading]]` correctly returns undefined so callers fall through to displayTitle/title.
- *
- * @example
- * extractDeadLinkAlias('See [[wrong-path|Custom Name]] here', 'wrong-path')
- * // => 'Custom Name'
- * extractDeadLinkAlias('See [[wrong-path]] here', 'wrong-path')
- * // => undefined
- */
-export function extractDeadLinkAlias(
-  content: string,
-  targetName: string
-): string | undefined {
-  const linkRegex = /\[\[([^\]|#]+)(?:#[^\]|]*)?\|([^\]]+)\]\]/g;
-  let m: RegExpExecArray | null;
-  while ((m = linkRegex.exec(content)) !== null) {
-    if (m[1].trim() === targetName) return m[2].trim();
-  }
-  return undefined;
+  return `[[${relPath}|${page.displayTitle || page.title}]]`;
 }
 
 /**
  * Replace dead link in content with corrected link.
  *
+ * A dead link may already carry an author-written alias (`[[wrong-path|Custom Name]]`).
+ * The reader already saw that name, so it outranks whatever display name `replacement`
+ * carries — this is checked per match, not once for the whole file, so a page with two
+ * occurrences of the same target under two different aliases keeps both instead of one
+ * overwriting the other.
+ *
  * @param content - Source page content
  * @param targetName - Dead link target to find
- * @param replacement - Replacement wiki link
+ * @param replacement - Replacement wiki link, used verbatim for an occurrence with no alias of its own
  * @returns Updated content with link replaced
  *
  * @example
@@ -145,12 +127,14 @@ export function replaceDeadLink(
   targetName: string,
   replacement: string
 ): string {
-  const linkRegex = /\[\[([^\]|#]+)(?:[|#][^\]]+)?\]\]/g;
+  const linkRegex = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|([^\]]+))?\]\]/g;
   return content.replace(
     linkRegex,
-    (fullMatch: string, capturedTarget: string) => {
-      if (capturedTarget.trim() === targetName) return replacement;
-      return fullMatch;
+    (fullMatch: string, capturedTarget: string, capturedAlias?: string) => {
+      if (capturedTarget.trim() !== targetName) return fullMatch;
+      if (!capturedAlias) return replacement;
+      const relPath = replacement.match(/^\[\[([^\]|]+)/)![1];
+      return `[[${relPath}|${capturedAlias.trim()}]]`;
     }
   );
 }

--- a/src/core/dead-link-detector.ts
+++ b/src/core/dead-link-detector.ts
@@ -3,17 +3,15 @@
 // Zero side effects, fully testable
 
 import { computeSlug } from './slug';
+import type { WikiPageRef } from '../types';
 
-export interface PageRef {
-  path: string;
-  title: string;
-  aliases?: string[];
-  /**
-   * Issue #592: `title` is the filename slug (`getExistingWikiPages` sets it from `f.basename`), not a display name — title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
-   * When present, this is the page's real H1 and should be preferred over `title` anywhere a link repair needs to show the reader something, not just address the page.
-   */
-  displayTitle?: string;
-}
+// Deliberately narrower than WikiPageRef — these functions only need a page's
+// identity and names, not wikiLink/tags/ctime/text, so callers (and tests) can
+// build a minimal literal instead of a full page object. Derived via Pick so
+// the shared fields (notably displayTitle, see below) have one definition.
+export type PageRef = Pick<WikiPageRef, 'path' | 'title' | 'aliases' | 'displayTitle'>;
+// Issue #592: `title` is the filename slug (`getExistingWikiPages` sets it from `f.basename`), not a display name — title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
+// `displayTitle`, when present, is the page's real H1 and should be preferred over `title` anywhere a link repair needs to show the reader something, not just address the page.
 
 // #308: a link target is slugified ("Systemische-Inflammation"), titles and
 // aliases are not ("Systemische Inflammation"). toLowerCase() alone leaves the

--- a/src/core/dead-link-detector.ts
+++ b/src/core/dead-link-detector.ts
@@ -113,7 +113,10 @@ export function buildDeadLinkReplacement(
  *
  * @param content - Source page content
  * @param targetName - Dead link target to find
- * @param replacement - Replacement wiki link, used verbatim for an occurrence with no alias of its own
+ * @param replacement - Replacement wiki link, used verbatim for an occurrence with no alias of its own. Must itself
+ * be a well-formed `[[path...]]`; an occurrence that has its own alias to preserve falls back to leaving that
+ * occurrence untouched if `replacement`'s own path can't be parsed out, rather than trusting a caller-supplied
+ * value that could be malformed.
  * @returns Updated content with link replaced
  *
  * @example
@@ -131,8 +134,9 @@ export function replaceDeadLink(
     (fullMatch: string, capturedTarget: string, capturedAlias?: string) => {
       if (capturedTarget.trim() !== targetName) return fullMatch;
       if (!capturedAlias) return replacement;
-      const relPath = replacement.match(/^\[\[([^\]|]+)/)![1];
-      return `[[${relPath}|${capturedAlias.trim()}]]`;
+      const relPathMatch = replacement.match(/^\[\[([^\]|]+)/);
+      if (!relPathMatch) return fullMatch;
+      return `[[${relPathMatch[1]}|${capturedAlias.trim()}]]`;
     }
   );
 }

--- a/src/core/dead-link-detector.ts
+++ b/src/core/dead-link-detector.ts
@@ -8,6 +8,11 @@ export interface PageRef {
   path: string;
   title: string;
   aliases?: string[];
+  /**
+   * Issue #592: `title` is the filename slug (`getExistingWikiPages` sets it from `f.basename`), not a display name — title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
+   * When present, this is the page's real H1 (or, absent that, its first frontmatter alias) and should be preferred over `title` anywhere a link repair needs to show the reader something, not just address the page.
+   */
+  displayTitle?: string;
 }
 
 // #308: a link target is slugified ("Systemische-Inflammation"), titles and
@@ -81,6 +86,7 @@ export function findDeadLinkTarget(
  *
  * @param page - The matching page
  * @param wikiFolder - Wiki root folder (e.g., "wiki")
+ * @param existingAlias - An alias the dead link already carried (`[[wrong-path|Custom Name]]`), from `extractDeadLinkAlias`. The reader already saw this name — it outranks even the target's own `displayTitle`.
  * @returns Formatted wiki link (e.g., "[[entities/chain-of-thought|Chain of Thought]]")
  *
  * @example
@@ -91,12 +97,35 @@ export function findDeadLinkTarget(
  */
 export function buildDeadLinkReplacement(
   page: PageRef,
-  wikiFolder: string
+  wikiFolder: string,
+  existingAlias?: string
 ): string {
   const relPath = page.path
     .replace(wikiFolder + '/', '')
     .replace('.md', '');
-  return `[[${relPath}|${page.title}]]`;
+  return `[[${relPath}|${existingAlias || page.displayTitle || page.title}]]`;
+}
+
+/**
+ * A dead link may already carry an author-written alias. Extracted once by `fixDeadLink` and passed into every branch that repairs the link, so a pre-existing alias always wins over the target's own displayTitle/title.
+ * Only matches links that already have a `|alias` segment — a bare `[[target]]` or `[[target#heading]]` correctly returns undefined so callers fall through to displayTitle/title.
+ *
+ * @example
+ * extractDeadLinkAlias('See [[wrong-path|Custom Name]] here', 'wrong-path')
+ * // => 'Custom Name'
+ * extractDeadLinkAlias('See [[wrong-path]] here', 'wrong-path')
+ * // => undefined
+ */
+export function extractDeadLinkAlias(
+  content: string,
+  targetName: string
+): string | undefined {
+  const linkRegex = /\[\[([^\]|#]+)(?:#[^\]|]*)?\|([^\]]+)\]\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = linkRegex.exec(content)) !== null) {
+    if (m[1].trim() === targetName) return m[2].trim();
+  }
+  return undefined;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -982,6 +982,20 @@ export const DEFAULT_SOURCE_TAG = 'other';
 //   onFileWrite — notifies file watcher of writes for change detection
 //   onProgress / onDone — ingestion progress → UI modal
 
+// Shape returned by wiki/lint/get-existing-pages.ts's getExistingWikiPages, shared
+// with EngineContext's and WikiEngine's own accessors so the three don't drift
+// out of sync with each other or with the field the implementation actually sets.
+export interface WikiPageRef {
+  path: string;
+  title: string;
+  displayTitle?: string;
+  wikiLink: string;
+  aliases?: string[];
+  tags?: string[];
+  ctime?: number;
+  text?: string;
+}
+
 export interface EngineContext {
   app: App;
   settings: LLMWikiSettings;
@@ -991,7 +1005,7 @@ export interface EngineContext {
   deleteFile: (path: string) => Promise<void>;
   buildSystemPrompt: (task: string) => Promise<string | undefined>;
   getSectionLabels: () => Record<string, string>;
-  getExistingWikiPages: () => Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[] }>>;
+  getExistingWikiPages: () => Promise<WikiPageRef[]>;
   getSchemaContext: (task: string) => Promise<string | undefined>;
   /**
    * SubtleCrypto from Obsidian's popout-window-aware `activeWindow.crypto`.

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -10,6 +10,7 @@ import {
   findDeadLinkTarget,
   buildDeadLinkReplacement,
   replaceDeadLink,
+  extractDeadLinkAlias,
 } from '../../core/dead-link-detector';
 import { getExistingWikiPages } from './get-existing-pages';
 import { selectCandidateWindow, contextAround } from '../../core/candidate-window';
@@ -144,10 +145,13 @@ export async function fixDeadLink(
     ? targetName.split('/').pop()!
     : targetName;
 
+  // A dead link may already carry an author-written alias (`[[wrong-path|Custom Name]]`) - extracted once so every branch below that repairs this link prefers it over the target's own displayTitle/title. See extractDeadLinkAlias's doc comment.
+  const existingAlias = extractDeadLinkAlias(sourceContent, targetName);
+
   const preMatch = findDeadLinkTarget(existingPages, targetBasename);
 
   if (preMatch) {
-    const newLink = buildDeadLinkReplacement(preMatch, ctx.settings.wikiFolder);
+    const newLink = buildDeadLinkReplacement(preMatch, ctx.settings.wikiFolder, existingAlias);
     const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
     return `pre-check corrected (alias match): ${newLink}`;
@@ -266,7 +270,7 @@ export async function fixDeadLink(
       p.aliases?.some(a => slugify(a).toLowerCase() === safetySlug)
     );
     if (aliasMatch) {
-      const newLink = `[[${makeRelPath(aliasMatch.path, ctx.settings.wikiFolder)}|${aliasMatch.title}]]`;
+      const newLink = `[[${makeRelPath(aliasMatch.path, ctx.settings.wikiFolder)}|${existingAlias || aliasMatch.displayTitle || aliasMatch.title}]]`;
       const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
       await ctx.createOrUpdateFile(sourcePath, updatedContent);
       return `safety-net corrected (alias match for stub): ${newLink}`;
@@ -322,7 +326,7 @@ export async function fixDeadLink(
   }
 
   if (match) {
-    const newLink = `[[${makeRelPath(match.path, ctx.settings.wikiFolder)}|${match.title}]]`;
+    const newLink = `[[${makeRelPath(match.path, ctx.settings.wikiFolder)}|${existingAlias || match.displayTitle || match.title}]]`;
     const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
     return `fallback corrected: ${newLink}`;

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -237,9 +237,15 @@ export async function fixDeadLink(
       newLink = `[[${newLink}]]`;
     }
 
-    const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
-    await ctx.createOrUpdateFile(sourcePath, updatedContent);
-    return `corrected: ${newLink}`;
+    // A hallucinated/empty/unclosed correct_link (e.g. "[[]]", or "[[foo" left open because it already
+    // started with "[[" and skipped the wrap above) has no path replaceDeadLink can pair with a preserved
+    // alias, or would write broken markdown outright — treat it as no usable answer and fall through to the
+    // create_stub / deterministic-stub branches below instead.
+    if (/^\[\[[^\]|]+.*\]\]$/.test(newLink)) {
+      const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
+      await ctx.createOrUpdateFile(sourcePath, updatedContent);
+      return `corrected: ${newLink}`;
+    }
   }
 
   if (result?.action === 'create_stub' && result.stub_title) {

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -10,7 +10,6 @@ import {
   findDeadLinkTarget,
   buildDeadLinkReplacement,
   replaceDeadLink,
-  extractDeadLinkAlias,
 } from '../../core/dead-link-detector';
 import { getExistingWikiPages } from './get-existing-pages';
 import { selectCandidateWindow, contextAround } from '../../core/candidate-window';
@@ -27,17 +26,6 @@ const PLURAL_MAP: Record<string, string> = {
 
 function makeRelPath(path: string, wikiFolder: string): string {
   return path.replace(wikiFolder + '/', '').replace(/\.md$/i, '');
-}
-
-function replaceTargetLink(sourceContent: string, targetName: string, newLink: string): string {
-  const linkRegex = /\[\[([^\]|#]+)(?:[|#][^\]]+)?\]\]/g;
-  return sourceContent.replace(
-    linkRegex,
-    (fullMatch: string, capturedTarget: string) => {
-      if (capturedTarget.trim() === targetName) return newLink;
-      return fullMatch;
-    }
-  );
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -145,13 +133,10 @@ export async function fixDeadLink(
     ? targetName.split('/').pop()!
     : targetName;
 
-  // A dead link may already carry an author-written alias (`[[wrong-path|Custom Name]]`) - extracted once so every branch below that repairs this link prefers it over the target's own displayTitle/title. See extractDeadLinkAlias's doc comment.
-  const existingAlias = extractDeadLinkAlias(sourceContent, targetName);
-
   const preMatch = findDeadLinkTarget(existingPages, targetBasename);
 
   if (preMatch) {
-    const newLink = buildDeadLinkReplacement(preMatch, ctx.settings.wikiFolder, existingAlias);
+    const newLink = buildDeadLinkReplacement(preMatch, ctx.settings.wikiFolder);
     const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
     return `pre-check corrected (alias match): ${newLink}`;
@@ -252,7 +237,7 @@ export async function fixDeadLink(
       newLink = `[[${newLink}]]`;
     }
 
-    const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
+    const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
     return `corrected: ${newLink}`;
   }
@@ -270,8 +255,8 @@ export async function fixDeadLink(
       p.aliases?.some(a => slugify(a).toLowerCase() === safetySlug)
     );
     if (aliasMatch) {
-      const newLink = `[[${makeRelPath(aliasMatch.path, ctx.settings.wikiFolder)}|${existingAlias || aliasMatch.displayTitle || aliasMatch.title}]]`;
-      const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
+      const newLink = `[[${makeRelPath(aliasMatch.path, ctx.settings.wikiFolder)}|${aliasMatch.displayTitle || aliasMatch.title}]]`;
+      const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
       await ctx.createOrUpdateFile(sourcePath, updatedContent);
       return `safety-net corrected (alias match for stub): ${newLink}`;
     }
@@ -303,7 +288,7 @@ export async function fixDeadLink(
     // shouldFabricateStubForUnresolvableLink for the policy gate.
 
     const newLink = `[[${stubDir}/${stubSlug}|${sanitizedTitle}]]`;
-    const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
+    const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
     return `stub created (unfilled): ${stubPath} — will be filled by next ingest of a real source`;
   }
@@ -326,8 +311,8 @@ export async function fixDeadLink(
   }
 
   if (match) {
-    const newLink = `[[${makeRelPath(match.path, ctx.settings.wikiFolder)}|${existingAlias || match.displayTitle || match.title}]]`;
-    const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
+    const newLink = `[[${makeRelPath(match.path, ctx.settings.wikiFolder)}|${match.displayTitle || match.title}]]`;
+    const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
     await ctx.createOrUpdateFile(sourcePath, updatedContent);
     return `fallback corrected: ${newLink}`;
   }
@@ -360,7 +345,7 @@ await ctx.createOrUpdateFile(stubPath, stubContent);
 // #197: deliberately do NOT call fillEmptyPage here.
 
 const newLink = `[[${stubDir}/${stubSlug}|${cleanBasename}]]`;
-const updatedContent = replaceTargetLink(sourceContent, targetName, newLink);
+const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
 await ctx.createOrUpdateFile(sourcePath, updatedContent);
 return `fallback stub created (unfilled): ${stubPath} — will be filled by next ingest of a real source`;
 }

--- a/src/wiki/lint/fix-dead-link.ts
+++ b/src/wiki/lint/fix-dead-link.ts
@@ -293,30 +293,7 @@ export async function fixDeadLink(
     return `stub created (unfilled): ${stubPath} — will be filled by next ingest of a real source`;
   }
 
-  // ---- Deterministic fallback when LLM fails ----
-  const lowerTarget = targetBasename.toLowerCase();
-  const targetSlug = slugify(targetBasename).toLowerCase();
-  let match = existingPages.find(p =>
-    p.title.toLowerCase() === lowerTarget ||
-    slugify(p.title).toLowerCase() === targetSlug
-  );
-
-  if (!match) {
-    match = existingPages.find(p =>
-      p.aliases?.some(a =>
-        a.toLowerCase() === lowerTarget ||
-        slugify(a).toLowerCase() === targetSlug
-      )
-    );
-  }
-
-  if (match) {
-    const newLink = `[[${makeRelPath(match.path, ctx.settings.wikiFolder)}|${match.displayTitle || match.title}]]`;
-    const updatedContent = replaceDeadLink(sourceContent, targetName, newLink);
-    await ctx.createOrUpdateFile(sourcePath, updatedContent);
-    return `fallback corrected: ${newLink}`;
-  }
-
+  // findDeadLinkTarget's pre-check above already ruled out every existing-page match.
   // No match — create an honest placeholder stub. Do NOT expand it via LLM.
   // #485: same leave-it gate as the LLM create_stub branch above.
   if (!shouldCreateStubForUnresolvableLink(ctx.settings)) {

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -2,11 +2,12 @@ import { App } from 'obsidian';
 import { parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { CANDIDATE_WINDOW_TEXT_CHARS } from '../../constants';
 import { isInFolderScope } from '../../core/folder-scope';
+import type { WikiPageRef } from '../../types';
 
 export async function getExistingWikiPages(
   app: App,
   wikiFolder: string
-): Promise<Array<{ path: string; title: string; displayTitle?: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }>> {
+): Promise<WikiPageRef[]> {
   const wikiFiles = app.vault
     .getMarkdownFiles()
     .filter(
@@ -18,7 +19,7 @@ export async function getExistingWikiPages(
         !f.path.includes('/contradictions/')
     );
 
-  const pages: Array<{ path: string; title: string; displayTitle?: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }> = [];
+  const pages: WikiPageRef[] = [];
   for (const f of wikiFiles) {
     const relPath = f.path.replace(wikiFolder + '/', '').replace('.md', '');
     const content = await app.vault.read(f);

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -44,12 +44,10 @@ export async function getExistingWikiPages(
     }
 
     // Issue #592: `title` (below) is the filename slug, not a display name — title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
-    // Prefer the page's actual H1, falling back to its first frontmatter alias when the body has no parseable heading (a real, existing page can still lack one).
+    // Prefer the page's actual H1; when there's no parseable heading, leave it unset so callers fall back to `title` — frontmatter aliases are unordered abbreviations/variants, not necessarily what the page is called.
     // Costs no extra read — `body` is already produced above for the candidate-window text below.
     const h1Match = body.trim().match(/^#\s+(.+?)(?:\n|$)/);
-    const displayTitle = h1Match
-      ? h1Match[1].trim()
-      : (Array.isArray(fm?.aliases) && fm.aliases.length > 0 ? String(fm.aliases[0]) : undefined);
+    const displayTitle = h1Match ? h1Match[1].trim() : undefined;
 
     pages.push({
       path: f.path,

--- a/src/wiki/lint/get-existing-pages.ts
+++ b/src/wiki/lint/get-existing-pages.ts
@@ -6,7 +6,7 @@ import { isInFolderScope } from '../../core/folder-scope';
 export async function getExistingWikiPages(
   app: App,
   wikiFolder: string
-): Promise<Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }>> {
+): Promise<Array<{ path: string; title: string; displayTitle?: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }>> {
   const wikiFiles = app.vault
     .getMarkdownFiles()
     .filter(
@@ -18,11 +18,12 @@ export async function getExistingWikiPages(
         !f.path.includes('/contradictions/')
     );
 
-  const pages: Array<{ path: string; title: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }> = [];
+  const pages: Array<{ path: string; title: string; displayTitle?: string; wikiLink: string; aliases?: string[]; tags?: string[]; ctime?: number; text?: string }> = [];
   for (const f of wikiFiles) {
     const relPath = f.path.replace(wikiFolder + '/', '').replace('.md', '');
     const content = await app.vault.read(f);
     const fm = parseFrontmatter(content);
+    const body = extractBody(content);
 
     // v1.23.0 P0-2 follow-up: skip Welcome notes. They have
     // `type: welcome` frontmatter and a localized filename
@@ -42,9 +43,18 @@ export async function getExistingWikiPages(
       continue;
     }
 
+    // Issue #592: `title` (below) is the filename slug, not a display name — title-casing a slug can't recover punctuation, spacing, or subscripts a real heading has.
+    // Prefer the page's actual H1, falling back to its first frontmatter alias when the body has no parseable heading (a real, existing page can still lack one).
+    // Costs no extra read — `body` is already produced above for the candidate-window text below.
+    const h1Match = body.trim().match(/^#\s+(.+?)(?:\n|$)/);
+    const displayTitle = h1Match
+      ? h1Match[1].trim()
+      : (Array.isArray(fm?.aliases) && fm.aliases.length > 0 ? String(fm.aliases[0]) : undefined);
+
     pages.push({
       path: f.path,
       title: f.basename,
+      displayTitle,
       wikiLink: `[[${relPath}|${f.basename}]]`,
       aliases: Array.isArray(fm?.aliases) ? fm.aliases : undefined,
       // Issue #446: ranking signal for designators that match more than one
@@ -56,7 +66,7 @@ export async function getExistingWikiPages(
       // bounded, lower-cased slice of the body costs no second read and lets
       // the dedup and dead-link prompts rank pages by what they say, not only
       // by what they are called.
-      text: extractBody(content).toLowerCase().slice(0, CANDIDATE_WINDOW_TEXT_CHARS),
+      text: body.toLowerCase().slice(0, CANDIDATE_WINDOW_TEXT_CHARS),
     });
   }
   return pages;

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -12,6 +12,7 @@ import {
   IngestOptions,
   BatchRequirementsContext,
   EngineContext,
+  WikiPageRef,
   VALID_SOURCE_TAGS,
   DEFAULT_SOURCE_TAG,
 } from '../types';
@@ -171,7 +172,7 @@ export class WikiEngine {
   private onLintStart: (() => void) | null = null;
   private onLintEnd: (() => void) | null = null;
   private onStatusBarUpdate: ((text: string) => void) | null = null;
-  private pagesCache: Array<{path: string; title: string; wikiLink: string; aliases?: string[]}> | null = null;
+  private pagesCache: WikiPageRef[] | null = null;
   private pagesCacheTime = 0;
   private readonly PAGES_CACHE_TTL_MS = PAGES_CACHE_TTL_MS;
   // #164: ingested content-hash snapshot, cached on the same TTL/lifecycle as
@@ -2054,7 +2055,7 @@ export class WikiEngine {
 
   // ---- Lint-fix delegation ----
 
-  getExistingWikiPages(): Promise<Array<{path: string; title: string; wikiLink: string; aliases?: string[]}>> {
+  getExistingWikiPages(): Promise<WikiPageRef[]> {
     const now = Date.now();
     if (this.pagesCache && (now - this.pagesCacheTime) < this.PAGES_CACHE_TTL_MS) {
       return Promise.resolve(this.pagesCache);


### PR DESCRIPTION
fixDeadLink() repairs a broken wikilink's path against getExistingWikiPages()'s page list, but the display text it wrote back had two problems:
First, when the link had no alias of its own, it fell back to the target page's filename slug title-cased, which can't recover punctuation, spacing, or subscripts a real heading has.
Second, the report's own headline complaint: when the link already carried an author-written alias, that alias was silently discarded and replaced regardless.

Adds displayTitle to a new named WikiPageRef shape, populated from the page's real H1 only — no frontmatter-alias fallback, since aliases are unordered abbreviations/variants, not necessarily the page's real name; falling back to the filename is safer than guessing from an alias. Each dead-link occurrence's own alias, when present, is captured and preserved independently per match (not just the first occurrence found for a given target), so a page referencing the same dead target twice under two different aliases keeps both instead of one clobbering the other.

Beyond the fixes DocTpoint's review asked for, a Gate-2 side-effects pass over this change turned up two related, previously-latent bugs:

- An LLM correct_link reply is now validated before being trusted at all — a blank target ([[ ]]), a blank alias ([[foo|]]), two links concatenated together ([[foo]] and [[bar]]), an embedded \r or \n are all rejected.
  - On a rejected reply, the link is left dead instead of being applied: the LLM tried and failed to produce something usable, which is different from having no guidance at all, so it no longer falls through to stub creation. (A stub the LLM never asked for is invisible to Delete Empty Stubs and would become permanent vault clutter.)
  - A dropped or doubled bracket on either side of correct_link — including a fully unclosed reply like "[[foo" — is repaired into a clean link rather than rejected, since brackets are never valid content inside a target or alias, so any bracket-count mismatch at the edges is unambiguous delimiter noise, the same class of damage a bracket-less bare reply already tolerated.
  - The repaired link is rebuilt from its trimmed target and (if present) trimmed alias, so accidental whitespace padding never reaches the file.
  - A raw carriage return or newline embedded in the target or alias is not repairable padding, so it's treated the same as any other unusable case: the correction is rejected and the link is left dead.
- replaceDeadLink's own alias-preservation logic had the identical gap (no end-of-string anchor) — safe today only because every current caller happens to hand it a well-formed link, but not defended in the shared function itself. It now leaves a link occurrence untouched rather than crashing if a future caller passes something malformed.

Verified against a live vault, including a direct comparison against unmodified upstream to confirm the underlying defect is real.

Fixes #592