### PR TITLE
fix(ui): stop the schema diff modal crashing on first render

### DIFF
--- a/src/__tests__/ui/schema-diff-modal.test.ts
+++ b/src/__tests__/ui/schema-diff-modal.test.ts
@@ -12,7 +12,7 @@ vi.mock('obsidian', () => ({
 }));
 
 import { lineDiff } from '../../core/diff';
-import { applyDiffModalClasses, removeDiffModalClasses } from '../../ui/schema-diff-modal-classes';
+import { applyDiffModalClasses, removeDiffModalClasses, buildDiffCell } from '../../ui/schema-diff-modal-classes';
 
 // v1.22.0 #97: when the LLM reports changes_needed=false, the
 // SchemaDiffModal should show the *current* schema in BOTH panes
@@ -144,5 +144,34 @@ describe('SchemaDiffModal modalEl class lifecycle (v1.22.1)', () => {
       modalEl as unknown as { addClass: (c: string) => void; removeClass: (c: string) => void; empty: () => void },
     );
     expect(classes.has('llm-wiki-schema-diff-modal')).toBe(false);
+  });
+});
+
+// `buildDiffCell` must never construct elements directly on a Document — a Document can only ever hold one child element, so appending a second one throws `HierarchyRequestError`. Building on the given `parent` Element instead (which can hold any number of children) is what makes rendering more than one cell possible at all; see `buildDiffCell`'s own doc comment.
+describe('buildDiffCell (#593)', () => {
+  it('does not throw, and appends the cell as a child of the given parent', () => {
+    const parent = document.createElement('div');
+    let cell: HTMLElement | undefined;
+    expect(() => {
+      cell = buildDiffCell(parent, 1, 'some line', false, 'left');
+    }).not.toThrow();
+    expect(parent.contains(cell!)).toBe(true);
+  });
+
+  it('builds a cell with the gutter line number and content text', () => {
+    const parent = document.createElement('div');
+    const cell = buildDiffCell(parent, 3, 'hello world', true, 'left');
+    expect(cell.className).toContain('llm-wiki-schema-diff-row');
+    expect(cell.className).toContain('llm-wiki-schema-diff-row-del');
+    expect(cell.querySelector('.llm-wiki-schema-diff-gutter')?.textContent).toBe('3');
+    expect(cell.querySelector('.llm-wiki-schema-diff-content')?.textContent).toBe('hello world');
+    expect(cell.querySelector('.llm-wiki-schema-diff-content')?.className).toContain('llm-wiki-schema-diff-content-highlight');
+  });
+
+  it('right-side highlight uses the add row class, not del', () => {
+    const parent = document.createElement('div');
+    const cell = buildDiffCell(parent, null, '', true, 'right');
+    expect(cell.className).toContain('llm-wiki-schema-diff-row-add');
+    expect(cell.querySelector('.llm-wiki-schema-diff-gutter')?.textContent).toBe('');
   });
 });

--- a/src/ui/schema-diff-modal-classes.ts
+++ b/src/ui/schema-diff-modal-classes.ts
@@ -49,3 +49,32 @@ export function normalizeEmptyMode(opts: {
 }): string {
   return opts.isEmpty ? opts.currentBody : opts.newBody;
 }
+
+/**
+ * Builds one diff-pane cell (gutter + content) as a child of `parent`. Lives here rather than on SchemaDiffModal, same as its siblings above — testable without triggering Vite's import-analysis failure on the real Modal class.
+ *
+ * Builds directly on `parent` rather than on `activeDocument`: Obsidian's `Node.createEl`/`createDiv`/`createSpan` create AND append the new element to `this` (per obsidian.d.ts: "Create an element and append it to this node"). A Document can only ever have one child element, so calling these on `activeDocument` throws `HierarchyRequestError` on the second cell — an ordinary Element can hold any number of children, so building on `parent` avoids that entirely, matching the file's own existing idiom elsewhere (`contentEl.createDiv(...)`, `diffContainer.createDiv(...)` above).
+ *
+ * Each cell uses the row-highlight color matching its side: left pane highlights (deletions) get a red tint, right pane highlights (additions) get a green tint, so a row that's red on the left is green on the right, and rows that only change on one side get a blank placeholder on the other.
+ */
+export function buildDiffCell(
+  parent: HTMLElement,
+  lineNo: number | null,
+  text: string,
+  highlighted: boolean,
+  side: 'left' | 'right',
+): HTMLElement {
+  const sideClass = side === 'left' ? ' llm-wiki-schema-diff-row-del' : ' llm-wiki-schema-diff-row-add';
+  const rowClass = 'llm-wiki-schema-diff-row' + (highlighted ? sideClass : '');
+  const contentClass = 'llm-wiki-schema-diff-content' + (highlighted ? ' llm-wiki-schema-diff-content-highlight' : '');
+
+  const cell = parent.createDiv({ cls: rowClass });
+
+  const gutter = cell.createSpan({ cls: 'llm-wiki-schema-diff-gutter' });
+  gutter.textContent = lineNo == null ? '' : String(lineNo);
+
+  const content = cell.createSpan({ cls: contentClass });
+  content.textContent = text;
+
+  return cell;
+}

--- a/src/ui/schema-diff-modal.ts
+++ b/src/ui/schema-diff-modal.ts
@@ -31,6 +31,7 @@ import { lineDiff } from '../core/diff';
 import { TEXTS } from '../texts';
 import {
   applyDiffModalClasses,
+  buildDiffCell,
   normalizeEmptyMode,
   removeDiffModalClasses,
 } from './schema-diff-modal-classes';
@@ -307,36 +308,9 @@ export class SchemaDiffModal extends Modal {
     leftPane.empty();
     rightPane.empty();
     for (const row of this.rows) {
-      leftPane.appendChild(this.renderCell(row.leftLineNo, row.leftText, row.op === 'del', 'left'));
-      rightPane.appendChild(this.renderCell(row.rightLineNo, row.rightText, row.op === 'add', 'right'));
+      buildDiffCell(leftPane, row.leftLineNo, row.leftText, row.op === 'del', 'left');
+      buildDiffCell(rightPane, row.rightLineNo, row.rightText, row.op === 'add', 'right');
     }
-  }
-
-  private renderCell(lineNo: number | null, text: string, highlighted: boolean, side: 'left' | 'right'): HTMLElement {
-    // Each cell uses the row-highlight color matching its side: left
-    // pane highlights (deletions) get a red tint, right pane highlights
-    // (additions) get a green tint. This way the two sides are visually
-    // distinct — a row that's red on the left is green on the right, and
-    // rows that only change on one side have a blank placeholder on the
-    // other side.
-    const sideClass = side === 'left' ? ' llm-wiki-schema-diff-row-del' : ' llm-wiki-schema-diff-row-add';
-    const rowClass = 'llm-wiki-schema-diff-row' + (highlighted ? sideClass : '');
-    const contentClass = 'llm-wiki-schema-diff-content' + (highlighted ? ' llm-wiki-schema-diff-content-highlight' : '');
-
-    const cell = activeDocument.createDiv();
-    cell.className = rowClass;
-
-    const gutter = activeDocument.createSpan();
-    gutter.className = 'llm-wiki-schema-diff-gutter';
-    gutter.textContent = lineNo == null ? '' : String(lineNo);
-    cell.appendChild(gutter);
-
-    const content = activeDocument.createSpan();
-    content.className = contentClass;
-    content.textContent = text;
-    cell.appendChild(content);
-
-    return cell;
   }
 
   private refresh() {


### PR DESCRIPTION
SchemaDiffModal.renderCell built its cell elements by calling activeDocument.createDiv()/.createSpan() directly on the Document object. Obsidian's createDiv/createSpan/createEl helpers create and append the new element to `this`; a Document can only ever have one child element, so appending a second one throws HierarchyRequestError regardless of which window's document it is.

Extracts the cell-building logic into buildDiffCell() (in the already-obsidian-dependency-free schema-diff-modal-classes.ts, alongside its siblings, for the same testability reason) and has it build directly on the intended parent pane element instead of on Document — an ordinary Element can hold any number of children, and this also matches the file's own existing idiom elsewhere (contentEl.createDiv(...)). No lint suppressions needed.


Fixes #593