### PR TITLE
fix(prompts): make schema-suggestion wording read as a proposal, not something already applied

### DIFF
--- a/src/__tests__/wiki/prompts/suggest-schema-update-voice.test.ts
+++ b/src/__tests__/wiki/prompts/suggest-schema-update-voice.test.ts
@@ -1,0 +1,27 @@
+// Both `new_schema_body`'s description and the `suggestions` field must consistently read as a proposal that hasn't been applied yet — nothing is applied until the user clicks Apply.
+
+import { describe, it, expect } from 'vitest';
+import { GENERATION_PROMPTS } from '../../../wiki/prompts/generation';
+
+describe('suggestSchemaUpdate prompt — proposal voice (#594)', () => {
+  const tpl = GENERATION_PROMPTS.suggestSchemaUpdate;
+
+  it('does not phrase new_schema_body or the CRITICAL restatement as already-applied', () => {
+    expect(tpl).not.toContain('after the update');
+    expect(tpl).not.toContain('schema after your changes');
+  });
+
+  it('new_schema_body description signals a not-yet-applied proposal', () => {
+    expect(tpl).toContain('as it would read IF this proposal were accepted');
+    expect(tpl).toContain('Nothing has been applied yet');
+  });
+
+  it('the CRITICAL restatement uses the same not-yet-applied framing as the field description', () => {
+    expect(tpl).toContain('as it would read IF this proposal were accepted — not a diff, not a patch, and not yet applied');
+  });
+
+  it('suggestions field carries an explicit proposal-voice instruction', () => {
+    expect(tpl).toContain('Phrase this as a proposal that has not been applied yet');
+    expect(tpl).toContain('never past tense');
+  });
+});

--- a/src/wiki/prompts/generation.ts
+++ b/src/wiki/prompts/generation.ts
@@ -278,8 +278,8 @@ Consider:
 Output JSON format:
 {
   "changes_needed": true,
-  "new_schema_body": "The COMPLETE updated schema body in markdown, starting with the H1 title. Include all sections that should exist after the update (you may keep unchanged sections exactly as-is).",
-  "suggestions": "Markdown description of suggested schema changes with reasoning (1-3 sentences)"
+  "new_schema_body": "The COMPLETE schema body, in markdown, as it would read IF this proposal were accepted — starting with the H1 title, including every section that would exist after accepting (unchanged sections may be kept exactly as-is). Nothing has been applied yet.",
+  "suggestions": "Markdown description of the PROPOSED schema changes with reasoning (1-3 sentences). Phrase this as a proposal that has not been applied yet ('would add...', 'proposes to...') — never past tense ('added...', 'changed...'), since Apply has not been clicked."
 }
 
 If no changes are needed:
@@ -290,7 +290,7 @@ If no changes are needed:
 
 CRITICAL:
 - The "suggestions" field must be written in the user's UI language below (after this CRITICAL block). Do NOT default to English unless the user's UI language is English.
-- new_schema_body is the COMPLETE schema after your changes — not a diff, not a patch. The apply path replaces the current body with new_schema_body verbatim.
+- new_schema_body is the COMPLETE schema as it would read IF this proposal were accepted — not a diff, not a patch, and not yet applied. The apply path replaces the current body with new_schema_body verbatim only if and when the user clicks Apply.
 - DO NOT include YAML frontmatter (--- ... ---) in new_schema_body. Start directly with the H1 title (e.g. "# Wiki Schema Configuration").
 - DO NOT wrap new_schema_body in markdown code fences (\`\`\`). The parser strips them, but cleaner output reduces parse risk on small models.
 - Preserve all existing sections that are still relevant. Only change what the analysis actually warrants.


### PR DESCRIPTION
The schema-suggestion generation prompt described the proposed new schema body and its rationale in language that read as already-applied ("after your changes", restated in a CRITICAL block) with no instruction steering the model toward proposal voice. Rewords both to explicitly frame the body as what the schema would read like if the proposal were accepted, and adds a voice instruction so suggestion text is written as a proposal ("would add...") rather than past tense. Verified against the vault's own suggestions.md log: entries generated before this fix read as already-applied; entries generated after read as proposals.

Fixes #594