### PR TITLE
fix(merge): render the Related sections after a complementary append

### DIFF
--- a/src/__tests__/wiki/page-factory/merge-page.test.ts
+++ b/src/__tests__/wiki/page-factory/merge-page.test.ts
@@ -507,3 +507,66 @@ describe('mergePage — the triage lane reports what it records (onContradiction
     expect(seen).toEqual([]);
   });
 });
+
+// The complementary path writes into whatever section the triage names, and a
+// Related section is a legal target — its per-section call produces prose
+// bullets with a provenance marker, which the two Related sections are not
+// supposed to carry: every other write path renders them from the typed lists.
+describe('mergePage — a complementary append into a Related section is rendered, not pasted', () => {
+  const WITH_RELATED = [
+    '---', 'title: Caching', '---', '',
+    '## Description', 'Old text.', '',
+    '## Related Concepts', '', '- [[concepts/Alpha|Alpha]]', '- [[concepts/Beta|Beta]]', '',
+  ].join('\n');
+
+  function run(appended: string) {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({
+        strategy: 'complementary',
+        reason: 'expand',
+        items: [{ kind: 'complementary', content: 'more', target_section: 'Related Concepts' }],
+      }),
+      appended,
+    ]));
+    return mergePage(
+      ctx, createMockEntity({ name: 'Caching' }), 'entity',
+      { path: 'note.md', basename: 'note.md' }, WITH_RELATED, [], 'wiki/entities/caching.md',
+    ).then(() => ctx.written.get('wiki/entities/caching.md')!);
+  }
+
+  function relatedBullets(page: string): string[] {
+    const sec = /^## Related Concepts\n([\s\S]*?)(?=^## |\Z)/m.exec(page);
+    return (sec?.[1] ?? '').split('\n').filter(l => l.startsWith('- [['));
+  }
+
+  it('keeps the link the append named and drops the prose around it', async () => {
+    const page = await run('- [[concepts/SCFAs|SCFAs]] strengthen the barrier. ^[Source: [[Leaky Gut]]]');
+    const bullets = relatedBullets(page);
+    expect(bullets).toContain('- [[concepts/SCFAs|SCFAs]]');
+    expect(bullets.every(l => /^- \[\[[^\]]+\]\]$/.test(l))).toBe(true);
+  });
+
+  it('lists a target once when the append repeats one the page already has', async () => {
+    const page = await run([
+      '- [[concepts/Alpha|Alpha]] again, with prose. ^[Source: [[X]]]',
+      '- [[concepts/SCFAs|SCFAs]] (protective)',
+    ].join('\n'));
+    expect(relatedBullets(page).filter(l => l.includes('concepts/Alpha'))).toHaveLength(1);
+  });
+
+  it('leaves the list untouched when the append lands in another section', async () => {
+    const ctx = makeCtx(makeClient([
+      JSON.stringify({
+        strategy: 'complementary', reason: 'expand',
+        items: [{ kind: 'complementary', content: 'more', target_section: 'Description' }],
+      }),
+      'One more sentence.',
+    ]));
+    await mergePage(
+      ctx, createMockEntity({ name: 'Caching' }), 'entity',
+      { path: 'note.md', basename: 'note.md' }, WITH_RELATED, [], 'wiki/entities/caching.md',
+    );
+    expect(relatedBullets(ctx.written.get('wiki/entities/caching.md')!))
+      .toEqual(['- [[concepts/Alpha|Alpha]]', '- [[concepts/Beta|Beta]]']);
+  });
+});

--- a/src/core/related-sections.ts
+++ b/src/core/related-sections.ts
@@ -72,6 +72,22 @@ function keptEntries(lines: string[], labels: string[], universe: string[], reso
   return out;
 }
 
+/**
+ * The bullet lines of both Related sections, verbatim — a cheap "did this
+ * write touch the list" check for callers that only sometimes have to run the
+ * rendering pass, which reads every page in the vault.
+ */
+export function relatedListLines(content: string, entitiesLabel: string, conceptsLabel: string): string {
+  const lines = content.split('\n');
+  const universe = [entitiesLabel, 'Related Entities', conceptsLabel, 'Related Concepts'];
+  const out: string[] = [];
+  for (const labels of [[entitiesLabel, 'Related Entities'], [conceptsLabel, 'Related Concepts']]) {
+    const sec = findSection(lines, labels, universe);
+    if (sec) out.push(...lines.slice(sec.start + 1, sec.end).filter(l => /^\s*[-*]\s+\[\[/.test(l)));
+  }
+  return out.join('\n');
+}
+
 function folderOf(rel: string, fallback: Folder): Folder {
   return rel.startsWith('concepts/') ? 'concepts' : rel.startsWith('entities/') ? 'entities' : fallback;
 }

--- a/src/wiki/page-factory/merge-page.ts
+++ b/src/wiki/page-factory/merge-page.ts
@@ -41,6 +41,7 @@ import {
 } from '../../core/section-header-canonicalizer';
 import { guardBodyRewrite } from '../../core/paragraph-provenance';
 import { applyRelatedLinks } from './related-links';
+import { relatedListLines } from '../../core/related-sections';
 import { mergeFrontmatter, parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { incomingTypeTag } from '../../core/tag-vocab';
 import { collectActiveVocabulary } from '../../core/domain-axis';
@@ -148,6 +149,8 @@ export async function mergePage(
     // the #312 override below: only `skip` is rerouted. A write that adds
     // content promotes the page: the marker is stripped below.
     const existingIsStub = isStubPage(existingFm);
+
+    const labels = getSectionLabels(ctx.settings);
 
     // 1. v1.24.0 #216 — classify-then-route triage.
     let shouldSkip = false;
@@ -257,7 +260,30 @@ export async function mergePage(
     }
 
     if (shouldSkip) {
-      const bodyToWrite = complementaryBody ?? existingBody;
+      let bodyToWrite = complementaryBody ?? existingBody;
+      // The complementary append writes into whatever section the triage named,
+      // and a Related section is a legal target. What the per-section call
+      // writes there is prose with a provenance marker rather than a list
+      // entry, so it never passes the pass that renders these two sections
+      // from the typed lists — the one the create, related and rewrite paths
+      // all go through. The result is a Related list holding model prose and
+      // the same target twice. Run the same pass here, but only when the
+      // append actually changed a Related section: it reads every page in the
+      // vault, and most appends land elsewhere.
+      if (
+        complementaryBody !== null &&
+        relatedListLines(existingBody, labels.related_entities, labels.related_concepts) !==
+          relatedListLines(complementaryBody, labels.related_entities, labels.related_concepts)
+      ) {
+        // Two deliberate narrowings. `keepFrom` is the appended body, not the
+        // one before it: the append named a relation, and that stays an entry
+        // — what goes is the prose around the link, which the list does not
+        // carry. And the typed lists are left out: this path is here to render
+        // what the append wrote, not to add the new source's related names.
+        // Passing them would make every complementary merge grow the list,
+        // which is a different change with a different argument.
+        bodyToWrite = await applyRelatedLinks(ctx, bodyToWrite, {}, labels, { pageType, keepFrom: bodyToWrite });
+      }
       // Item-level contradictions reach this path (complementary write):
       // stamp the same frontmatter marker the rewrite path stamps below.
       let fmToWrite = contradictedSourcePath
@@ -310,7 +336,6 @@ export async function mergePage(
     }
 
     // 3. Assemble final content (re-assert related-link types deterministically).
-    const labels = getSectionLabels(ctx.settings);
     const canonicalizedBody = canonicalizeSectionHeaders(cleanedBody, Object.values(labels));
     const prunedBody = stripUnknownSections(canonicalizedBody, Object.values(labels));
     // Related links resolved against every page, sections written from the


### PR DESCRIPTION
Closes #659.

Runs the same pass the other three write paths use on the complementary body, so the two Related sections come out as a rendered list instead of whatever the per-section call pasted into them.

Two narrowings, both deliberate:

- **Only when the append actually changed a Related section.** The pass reads every page in the vault, and most appends land elsewhere; the new `relatedListLines` helper is a cheap string comparison that decides it.
- **The typed lists are not passed.** This is here to render what the append wrote, not to add the new source's related names to the page — passing them would make every complementary merge grow the list, which is a different change with a different argument.

`keepFrom` is the appended body rather than the one before it, so the relation the append named survives as an entry and only the prose around the link is dropped.

Three tests on the complementary path: the prose bullet becomes a plain entry, a repeated target is listed once, and an append into another section leaves the list untouched. All three fail without the change.

⚠️ `openai-codex-loopback-flow.test.ts` fails on this branch and on `main` alike — inherited, not from this change.
