### PR TITLE
fix(dedup): a name too short to infer identity from is created, not asked about

### DIFF
--- a/src/__tests__/wiki/page-factory/path-resolution.test.ts
+++ b/src/__tests__/wiki/page-factory/path-resolution.test.ts
@@ -503,3 +503,60 @@ describe('resolvePagePath — a cross-folder match re-decides the classification
     expect(ctx.written.get('wiki/concepts/Stress.md')).toContain('type_conflict: entity');
   });
 });
+
+describe('resolvePagePath — a name too short to infer identity from (#661)', () => {
+  // `Cr` reached the semantic call on a vault where no page carried it and was
+  // merged into `Kreatinin` by two different window builders. Two code points
+  // carry nothing a summary could confirm, so when no page claims the name,
+  // the model is not asked.
+  const vaultOf = (files: Record<string, string>) => ({
+    files,
+    mockVault: {
+      getMarkdownFiles: () =>
+        Object.keys(files).map(p => ({ path: p, basename: p.split('/').pop()!.replace(/\.md$/, '') })),
+    },
+  });
+  const stranger = vaultOf({ 'wiki/entities/Kreatinin.md': '---\ntitle: Kreatinin\n---\n\n# page' });
+  const carrier = vaultOf({ 'wiki/entities/Kreatinin.md': '---\naliases:\n  - Cr\n---\n\n# page' });
+  const twoCarriers = vaultOf({
+    'wiki/entities/Chrom.md': '---\naliases:\n  - Cr\n---\nbody',
+    'wiki/entities/Kalorienrestriktion.md': '---\naliases:\n  - Cr\n---\nbody',
+  });
+  const answering = (reply: object) => ({ createMessage: vi.fn(async () => JSON.stringify(reply)) });
+
+  it('creates a two-character name without asking the model when no page carries it', async () => {
+    const client = answering({ match: true, path: 'wiki/entities/Kreatinin.md' });
+    const result = await resolvePagePath(makeCtx({ ...stranger, client }), 'Cr', 'entity', 'Kreatinin-Kurzform im Laborbefund');
+    expect(client.createMessage).not.toHaveBeenCalled();
+    expect(result.path).toBe('wiki/entities/Cr.md');
+  });
+
+  it('still asks the model for a three-character name', async () => {
+    const client = answering({ match: false });
+    await resolvePagePath(makeCtx({ ...stranger, client }), 'CRP', 'entity', 'desc');
+    expect(client.createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('still asks the model for a two-character name in a script whose characters are words', async () => {
+    // 肝脏 (liver) is a complete Chinese name at two code points.
+    const client = answering({ match: false });
+    await resolvePagePath(makeCtx({ ...stranger, client }), '肝脏', 'entity', 'desc');
+    expect(client.createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('still resolves a two-character alias deterministically', async () => {
+    const client = answering({ match: false });
+    const result = await resolvePagePath(makeCtx({ ...carrier, client }), 'Cr', 'entity', 'desc');
+    expect(result.path).toBe('wiki/entities/Kreatinin.md');
+    expect(client.createMessage).not.toHaveBeenCalled();
+  });
+
+  it('still routes a two-character ambiguous designator through the ranked candidates', async () => {
+    // #446's path: the pages carrying the name are shown, the model only
+    // chooses among them. The guard is about names nobody claims.
+    const client = answering({ match: true, path: 'wiki/entities/Chrom.md' });
+    const result = await resolvePagePath(makeCtx({ ...twoCarriers, client }), 'Cr', 'entity', 'desc');
+    expect(client.createMessage).toHaveBeenCalledTimes(1);
+    expect(result.path).toBe('wiki/entities/Chrom.md');
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -838,3 +838,12 @@ export const BATCH_CHARS_PER_ITEM = 600;
 export const MIN_ALIAS_LENGTH = 2;
 export const MIN_ALIAS_LENGTH_MIN = 2;
 export const MIN_ALIAS_LENGTH_MAX = 6;
+
+// #661: the shortest extracted name the semantic dedup may be asked about when
+// no page carries it. Two code points carry nothing a summary could confirm —
+// `Cr` was merged into `Kreatinin` by two different window builders — so below
+// this the resolver creates instead of inferring. Deliberately not
+// `MIN_ALIAS_LENGTH`: what a vault accepts as an alias is the user's setting;
+// this is about what the resolver may infer, and a short alias a user did set
+// still resolves deterministically.
+export const MIN_DEDUP_NAME_LENGTH = 3;

--- a/src/wiki/page-factory/path-resolution.ts
+++ b/src/wiki/page-factory/path-resolution.ts
@@ -21,7 +21,7 @@
 //     fires; optionally appends includePaths that aren't already in the
 //     list.
 
-import { WIKI_SUBFOLDERS, TOKENS_DEDUP_RESOLUTION, DEDUP_CANDIDATE_TOP_K } from '../../constants';
+import { MIN_DEDUP_NAME_LENGTH, WIKI_SUBFOLDERS, TOKENS_DEDUP_RESOLUTION, DEDUP_CANDIDATE_TOP_K } from '../../constants';
 import { slugify } from '../../core/slug';
 import { ConflictResolver } from '../../core/conflict-resolver';
 import { selectCandidateWindow } from '../../core/candidate-window';
@@ -104,6 +104,11 @@ export interface PathResolutionContext extends AliasesContext {
  * match, re-decides the entity/concept classification against the vault's
  * Classification Rules (see `applyClassificationDecision`).
  */
+// #661: the length floor applies to names written in scripts whose letters are
+// not words on their own. A two-character Han, Kana or Hangul name is a complete
+// word and keeps its model call; a name mixing in anything else is left alone too.
+const ALPHABETIC_NAME = /^[\p{Script=Latin}\p{Script=Greek}\p{Script=Cyrillic}\p{N}\p{M}\p{P}\s]+$/u;
+
 export async function resolvePagePath(
   ctx: PathResolutionContext,
   name: string,
@@ -212,6 +217,17 @@ export async function resolvePagePath(
       ...ambiguous,
       ...crossCandidates,
     ].filter((p, i, arr) => arr.findIndex(q => q.path === p.path) === i);
+
+    // #661: no page carries this name and it is too short to infer identity
+    // from (see `MIN_DEDUP_NAME_LENGTH`). The deterministic answers are all in
+    // `seeded` by now; what would follow is a lexical window and a model call,
+    // so the create fallback is taken before either is built.
+    if (seeded.length === 0 && ALPHABETIC_NAME.test(name.trim()) && [...name.trim()].length < MIN_DEDUP_NAME_LENGTH) {
+      console.debug(
+        `Entity resolution: "${name}" is shorter than ${MIN_DEDUP_NAME_LENGTH} code points and no page carries it — creating, not asking the model`,
+      );
+      return { path: fallbackPath };
+    }
 
     // Both wiki folders feed the window (#472 both ways): the folder is the
     // extraction's guess, not a property of the referent, so a near-name twin


### PR DESCRIPTION
Closes #661.

When no page carries an extracted name, `resolvePagePath` builds a lexical window of pages that merely resemble it and asks the model whether one of them is the same thing. For a two-code-point name that question has no evidence behind it: `Cr` was merged into `Kreatinin` by two different window builders on the same vault.

Below `MIN_DEDUP_NAME_LENGTH` (3) the resolver takes the create fallback before the window is built — but only when nothing claims the name. The deterministic answers are unchanged: one title/alias hit resolves; several go through #446's tag-ranked candidates, where the model chooses among pages that actually carry the name.

The floor applies to names in Latin, Greek or Cyrillic script, where a letter is not a word. A two-character Han, Kana or Hangul name is a complete word and keeps its model call (test included — this came out of the code-review pass).

Deliberately a separate constant from `MIN_ALIAS_LENGTH`: what a vault accepts as an alias is the user's setting and stays untouched; this is about what the resolver may infer. A short alias a user did set still resolves deterministically.

Tests: 5 new (1 red on the parent commit), 3993 → 3998. typecheck/lint clean. `/simplify` moved the guard ahead of the window filter; `/code-review` surfaced the script question.
