### PR TITLE
fix(sources): apply the alias floor the create path already applies

### DIFF
--- a/src/__tests__/core/frontmatter.test.ts
+++ b/src/__tests__/core/frontmatter.test.ts
@@ -989,6 +989,42 @@ source_url: https://example.com/spec
     expect(result).toContain('z');
   });
 
+  // The seam between the rebuilt block and the body: `serializeFrontmatter`
+  // ends on `---` without a trailing newline and the retained slice starts
+  // with whatever followed the old closing delimiter, so joining them with a
+  // `\n` used to add one blank line per call. Two consecutive calls made it
+  // two. Both directions are pinned here.
+  it('replaceFrontmatterArrayField keeps exactly one blank line between frontmatter and body', () => {
+    const content = `---
+type: entity
+tags: [x]
+---
+
+# Body
+
+Text.
+`;
+    const once = replaceFrontmatterArrayField(content, 'tags', ['y']);
+    expect(once).toContain('---\n\n# Body');
+    expect(once).not.toContain('---\n\n\n');
+
+    const twice = replaceFrontmatterArrayField(once, 'tags', ['z']);
+    expect(twice).toContain('---\n\n# Body');
+    expect(twice).not.toContain('---\n\n\n');
+    // The seam is the only thing under test here, so compare the bodies.
+    expect(twice.slice(twice.indexOf('\n---\n') + 5)).toBe(once.slice(once.indexOf('\n---\n') + 5));
+  });
+
+  it('replaceFrontmatterArrayField inserts the blank line when the body followed on the next line', () => {
+    const content = `---
+type: entity
+tags: [x]
+---
+# Body`;
+    const result = replaceFrontmatterArrayField(content, 'tags', ['y']);
+    expect(result).toContain('---\n\n# Body');
+  });
+
   it('mergeFrontmatterArrayField on a page with only canonical fields is byte-identical to v1.25.9', () => {
     // Backward-compat: when no unknown fields exist, the writer must not
     // invent a `---\n---` line just to "have a passthrough section".

--- a/src/__tests__/wiki/wiki-engine-summary-aliases.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-aliases.test.ts
@@ -76,12 +76,17 @@ function harnessFor(extraFiles: Record<string, string> = {}) {
 
 describe('WikiEngine.createSummaryPage — Issue #185 aliases propagation', () => {
   it('appends source-note aliases to the generated sources/<slug> page frontmatter', async () => {
+    // 'exekutive Funktionen' is deliberately absent from the expectation:
+    // it differs from 'Exekutive Funktionen' by case only, and both readers
+    // of this pool compare case-folded (fix-dead-link.ts:264
+    // `a.toLowerCase()` / `slugify(a).toLowerCase()`, scanners.ts:146
+    // `knownTargetsLower`). Carrying both retargets nothing extra and only
+    // widens the alias line in the fix-dead-link prompt. Pinned below.
     const curatedAliases = [
       'Exekutive Funktionen',
       'Executive Function',
       'Exekutiv Funktionen',
       'Exekutiven Funktionen',
-      'exekutive Funktionen',
     ];
     const h = harnessFor();
 
@@ -104,6 +109,19 @@ describe('WikiEngine.createSummaryPage — Issue #185 aliases propagation', () =
     for (const a of curatedAliases) {
       expect((fm.aliases as string[])).toContain(a);
     }
+  });
+
+  it('keeps one of two aliases that differ by case only', async () => {
+    const h = harnessFor();
+    const writtenPath: string = await h.engine.createSummaryPage(
+      sourceFile(),
+      makeAnalysis(['Exekutive Funktionen', 'exekutive Funktionen']),
+      [],
+    );
+    const fm = parseFrontmatter(h.files.get(writtenPath)!) ?? {};
+    const aliases = (fm.aliases ?? []) as string[];
+    expect(aliases).toContain('Exekutive Funktionen');
+    expect(aliases).not.toContain('exekutive Funktionen');
   });
 
   it('skips injection when the source note has no frontmatter aliases (no regression)', async () => {
@@ -161,5 +179,102 @@ Existing summary.
     ]);
     // No duplicates
     expect(new Set(aliases).size).toBe(aliases.length);
+  });
+});
+
+// The floor the other two writers of `aliases:` already apply.
+//
+// `resolveMinAliasLength`'s own doc comment names two writers — the append
+// path in page-factory/aliases.ts and `enforceFrontmatterConstraints` on the
+// create path — and exists so both resolve the same floor from the same
+// place. `createSummaryPage` is a third writer of the same field and applies
+// no floor at all: the model's `aliases:` reach disk verbatim and the curated
+// note aliases are merged on top of them unfiltered.
+//
+// Measured on a 131-page sources/ folder (288 aliases): 2 below a configured
+// floor of 3 ("MD", "IR"), 1 that only differs from the page name by case
+// ("ARNi" on ARNI.md). The same vault's 757 entity/concept pages (965
+// aliases) carry none of either — that is the difference this fix removes.
+describe('WikiEngine.createSummaryPage — the alias floor the create path applies', () => {
+  // createSummaryPage issues exactly one model call, so this is the response
+  // it consumes. The summary path expects markdown, not JSON.
+  const SUMMARY_PAGE = `---
+type: source
+source_file: "[[${SOURCE_NOTE_PATH}]]"
+tags:
+  - "other"
+generation_complete: true
+aliases:
+  - "Executive Function"
+  - "EF"
+  - "Exekutive-Funktionen"
+---
+
+# Exekutive Funktionen - Summary
+
+## Zusammenfassung
+
+Kognitive Kontrolle.
+`;
+
+  function harnessWithModelAliases() {
+    return createWikiEngineHarness({
+      files: { [SOURCE_NOTE_PATH]: SAMPLE_BODY },
+      llmResponses: [SUMMARY_PAGE],
+      settings: { minAliasLength: 3 },
+    });
+  }
+
+  async function aliasesOnDisk(noteAliases: string[]) {
+    const h = harnessWithModelAliases();
+    const writtenPath: string = await h.engine.createSummaryPage(sourceFile(), makeAnalysis(noteAliases), []);
+    const fm = parseFrontmatter(h.files.get(writtenPath)!) ?? {};
+    return (fm.aliases ?? []) as string[];
+  }
+
+  it('drops a model-written alias shorter than the configured floor', async () => {
+    const aliases = await aliasesOnDisk([]);
+    expect(aliases).toContain('Executive Function');
+    expect(aliases).not.toContain('EF');
+  });
+
+  it('drops a model-written alias that only differs from the page name by case', async () => {
+    const aliases = await aliasesOnDisk([]);
+    expect(aliases).not.toContain('Exekutive-Funktionen');
+  });
+
+  it('applies the floor to curated note aliases merged on top, not only to the model list', async () => {
+    const aliases = await aliasesOnDisk(['Kognitive Kontrolle', 'KK']);
+    expect(aliases).toContain('Kognitive Kontrolle');
+    expect(aliases).not.toContain('KK');
+  });
+
+  // The rewrite goes through replaceFrontmatterArrayField, which rebuilds the
+  // whole block. A source page carries three keys that are not in
+  // FrontmatterData — they survive as passthrough lines, and this pins that.
+  it('preserves the source page\'s non-canonical frontmatter across the rewrite', async () => {
+    const h = harnessWithModelAliases();
+    const writtenPath: string = await h.engine.createSummaryPage(sourceFile(), makeAnalysis([]), []);
+    const written = h.files.get(writtenPath)!;
+
+    expect(written).toContain('source_file:');
+    expect(written).toContain('generation_complete: true');
+    expect(written).toContain('contentHash:');
+    expect(parseFrontmatter(written)?.type).toBe('source');
+    expect(parseFrontmatter(written)?.tags).toEqual(['other']);
+  });
+
+  // The narrowing that keeps this off the 128 of 131 pages whose aliases
+  // already pass: nothing is dropped, so nothing is rewritten.
+  it('leaves the frontmatter byte-identical when every alias already passes', async () => {
+    const clean = createWikiEngineHarness({
+      files: { [SOURCE_NOTE_PATH]: SAMPLE_BODY },
+      llmResponses: [SUMMARY_PAGE.replace('  - "EF"\n', '').replace('  - "Exekutive-Funktionen"\n', '')],
+      settings: { minAliasLength: 3 },
+    });
+    const writtenPath: string = await clean.engine.createSummaryPage(sourceFile(), makeAnalysis([]), []);
+    const written = clean.files.get(writtenPath)!;
+
+    expect(written).toContain('aliases:\n  - "Executive Function"');
   });
 });

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -430,8 +430,14 @@ export function replaceFrontmatterArrayField(
   if (content.startsWith('---')) {
     const endIdx = content.indexOf('\n---', 3);
     if (endIdx !== -1) {
-      const body = content.substring(endIdx + 4);
-      return `${fmBlock}\n${body}`;
+      // Normalize the seam instead of carrying it over. `fmBlock` ends on
+      // `---` with no trailing newline and the slice begins with whatever
+      // followed the old closing delimiter, so pasting the two together with
+      // a `\n` grew the gap by one blank line on every call. One blank line
+      // is the shape `enforceFrontmatterConstraints` and the branch below
+      // already produce, which also makes this idempotent.
+      const body = content.substring(endIdx + 4).replace(/^\n+/, '');
+      return `${fmBlock}\n\n${body}`;
     }
   }
   return `${fmBlock}\n\n${content}`;

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -22,12 +22,12 @@ import { buildRepetitionPenaltyHint } from '../core/repetition-penalty-hint';
 import { formatTaskUsage, snapshotTaskUsage, taskUsageSince } from '../core/llm-task-usage';
 import { TEXTS } from '../texts';
 import { renderTemplate } from '../core/template-renderer';
-import { slugify } from '../core/slug';
+import { slugify, filterRedundantAliases, resolveMinAliasLength } from '../core/slug';
 import { shapeRelatedLists, kindOf } from '../core/related-shaping';
 import { withAbortSignal } from '../core/llm-abort';
 import { isIngestableSource } from '../core/folder-scope';
 import { resolveSourceSlug } from '../core/source-slug';
-import { parseFrontmatter, upsertFrontmatterField, mergeFrontmatterArrayField, extractBody } from '../core/frontmatter';
+import { parseFrontmatter, upsertFrontmatterField, mergeFrontmatterArrayField, replaceFrontmatterArrayField, extractBody } from '../core/frontmatter';
 import { setGenerationComplete } from '../core/incomplete-page-cleaner';
 import { convertPdfToMarkdown, UnsupportedProviderError, EncryptedPdfError } from '../core/pdf-converter';
 import { MineruPdfError, MINERU_PHASE_KEY } from '../core/mineru-converter';
@@ -1775,6 +1775,32 @@ export class WikiEngine {
           `[Issue #185] Propagated ${analysis.source_note_aliases.length} alias(es) to ${path}`
         );
         finalContent = withAliases;
+      }
+    }
+
+    // The alias floor the other two writers of this field already apply.
+    // `resolveMinAliasLength` exists so both of them resolve the same floor
+    // from the same place; this is a third writer that resolved none. The
+    // model's `aliases:` arrive verbatim inside `cleanedContent` and the
+    // curated note aliases merge on top of them, so the filter belongs here,
+    // after both, on the finished list — filtering either input alone leaves
+    // the other unchecked.
+    //
+    // Rewrites the block only when something is actually dropped: a page
+    // whose aliases already pass keeps the bytes the model wrote.
+    const writtenAliases = parseFrontmatter(finalContent)?.aliases;
+    if (Array.isArray(writtenAliases)) {
+      const kept = filterRedundantAliases(
+        path,
+        writtenAliases,
+        undefined,
+        resolveMinAliasLength(this.settings),
+      );
+      if (kept.length !== writtenAliases.length) {
+        console.debug(
+          `[aliases] dropped ${writtenAliases.length - kept.length} alias(es) below the floor or redundant with the page name on ${path}`
+        );
+        finalContent = replaceFrontmatterArrayField(finalContent, 'aliases', kept);
       }
     }
 


### PR DESCRIPTION
Fixes #670.

Two commits. The second is the fix; the first is the prerequisite it exposed.

## 1. `fix(frontmatter): stop replaceFrontmatterArrayField growing the seam`

`serializeFrontmatter` returns a block ending on `---` with no trailing newline. The retained body slice starts at the character after the old closing delimiter, so it already begins with the blank line that separated frontmatter from body. Joining the two with another `\n` added one blank line per call:

```
in:  ---\ntype: source\naliases:\n  - "A"\n  - "B"\n---\n\n# Titel
out: ---\ntype: source\naliases:\n  - "A"\n---\n\n\n# Titel
```

Invisible until now: the helper had one production caller (`fix-runners.ts`) on a path nobody diffed byte-for-byte. The alias floor sends `sources/` pages through it, so the gap would have appeared on every page that drops an alias.

Normalises instead of preserving — strip the leading newlines and re-emit exactly one blank line, the shape `enforceFrontmatterConstraints` and this function's own no-frontmatter branch already produce. That also fixes the opposite direction (a body that followed immediately on the next line now gets the blank line) and makes the helper idempotent.

## 2. `fix(sources): apply the alias floor the create path already applies`

Calls `filterRedundantAliases` with `resolveMinAliasLength(this.settings)` on the finished list, after both inputs are merged. Filtering either input alone leaves the other unchecked: the model's aliases arrive inside `cleanedContent`, the curated note aliases merge on top.

Two narrowings worth reading:

- **The block is rewritten only when something is actually dropped.** On the measured vault that is 3 pages of 131; the other 128 keep the bytes the model wrote. No reformat, no reordering, no diff.
- **`existingAliasesAcrossPages` is passed `undefined`**, exactly as the create path does. This PR applies the floor and the self-pointing rule. Cross-page alias uniqueness is a separate decision and is not made here.

## Gate 1

lint 0 · tsc 0 · build · **4036/4036** (284 files) · css-lint 0.

Baseline on `upstream/main` is 4028, and both commits are green in isolation: 4028 → 4030 → 4036, so the branch is bisect-safe.

All counts were taken with a build in place — `openai-codex-loopback-flow.test.ts` asserts against the bundle and fails in a worktree that has never run esbuild. Worth knowing before someone reads a red suite as inherited breakage.

8 new tests: the floor on the model list, the floor on the merged note list, the self-pointing page name, the case collapse, passthrough survival of `source_file` / `generation_complete` / `contentHash` across the rewrite, the no-op path when nothing is dropped, and both seam directions. 4 of them are red on the parent commit.

## One existing expectation changes

The `#185` test listed both `"Exekutive Funktionen"` and `"exekutive Funktionen"` among the curated aliases. The shared filter keeps one. Both readers of this pool already compare case-folded — `fix-dead-link.ts:264` (`a.toLowerCase()` and `slugify(a).toLowerCase()`) and `scanners.ts:146` (`knownTargetsLower`) — so the second variant retargets nothing the first does not, and only widens the alias line in the fix-dead-link prompt. The test now pins the collapse instead of the duplicate.

## The deeper seam, and why it is not in this PR

The honest reading of this fix is that it makes three writers apply the same rule instead of two, which is better than two but is still three. `createOrUpdateFile` is the obvious candidate for one owner: it already normalises content from every path that reaches it — polluted links, `sources:`, heading spacing — and `appendAliases`, `create-page.ts` and `merge-duplicates.ts` all write through it.

Two things stop that being a free move, both checked against `main` rather than assumed:

- **`createOrUpdateFile` has no `reviewed: true` guard.** `enforceFrontmatterConstraints` returns early on a reviewed page and touches only the dates. Putting the alias floor in the gate would rewrite aliases on frozen pages, which is the one thing the review lock exists to prevent.
- **The gate is not the only door.** Six writers still reach the vault through `vault.process` / `vault.modify` directly — `link-retarget.ts`, `lint/phases/preparation.ts`, `engine-internals/log-writer.ts`, `schema/schema-manager.ts`, `schema/apply-suggestion.ts`, `core/sources-normalizer.ts`. That is #603. Until it is settled, "one owner" in the gate would be a claim rather than a fact.

So this PR closes the measured gap at the call site that has it, and leaves the consolidation to #603, where the argument for it already lives.

## Collision

Touches `src/wiki/wiki-engine.ts`, as does #653 — at `getExistingWikiPages` (line 2054), forty lines past this hunk. Different functions, no overlap.
