### PR TITLE
fix(aliases): fold case when checking the page's own aliases too

### DIFF
--- a/src/__tests__/wiki/page-factory/aliases.test.ts
+++ b/src/__tests__/wiki/page-factory/aliases.test.ts
@@ -181,6 +181,48 @@ describe('appendAliases — cross-page uniqueness gate', () => {
   });
 });
 
+// The page's own aliases are the one list compared byte-exactly.
+//
+// `filterRedundantAliases` folds case for all three of its rules, and the
+// cross-page gate above is pinned as case-insensitive. The dedup against the
+// aliases already on THIS page is a plain `Array.includes`, so a candidate
+// that differs from an existing entry only in case passes both stages and
+// lands on the page next to it.
+//
+// Measured over 802 entity/concept pages: 3 carry such a pair — "NAC"/"NAc",
+// "obstruktive Schlafapnoe"/"Obstruktive Schlafapnoe", "sustained
+// attention"/"Sustained Attention".
+describe('appendAliases — dedup against the page\'s own aliases', () => {
+  it('does not add an alias that differs from an existing one only in case', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['NAC']) });
+    await appendAliases(ctx, PAGE, ['NAc']);
+    expect(ctx.written.get(PAGE)!).toBe(makePage(['NAC']));
+  });
+
+  it('matches the own-page list with the same fold the cross-page gate uses', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['sustained attention']) });
+    await appendAliases(ctx, PAGE, ['Sustained Attention', 'Wachheit']);
+    const written = ctx.written.get(PAGE)!;
+    expect(written).toContain('  - "Wachheit"');
+    expect(written).not.toContain('  - "Sustained Attention"');
+  });
+
+  it('keeps the spelling already on the page, not the incoming one', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['Obstruktive Schlafapnoe']) });
+    await appendAliases(ctx, PAGE, ['obstruktive Schlafapnoe']);
+    expect(ctx.written.get(PAGE)!).toContain('  - "Obstruktive Schlafapnoe"');
+    expect(ctx.written.get(PAGE)!).not.toContain('  - "obstruktive Schlafapnoe"');
+  });
+
+  it('still drops a batch-internal case variant (unchanged behaviour)', async () => {
+    const ctx = makeContext({ [PAGE]: makePage(['existing']) });
+    await appendAliases(ctx, PAGE, ['Wachheit', 'wachheit']);
+    const written = ctx.written.get(PAGE)!;
+    expect(written).toContain('  - "Wachheit"');
+    expect(written).not.toContain('  - "wachheit"');
+  });
+});
+
 describe('aliasClaimsFromPages', () => {
   const pages = [
     { path: 'wiki/entities/a.md', title: 'Alpha', aliases: ['A-Zeichen', ''] },

--- a/src/core/slug.ts
+++ b/src/core/slug.ts
@@ -132,7 +132,12 @@ export function slugKeys(
 // a composed alias from the model must meet, and `İstanbul`/`istanbul` must
 // be one alias, not two — `toLowerCase()` turns `İ` into `i` + COMBINING DOT
 // ABOVE, so without the fold the uniqueness gate never fires on that pair.
-function aliasKey(raw: string): string {
+//
+// Exported because the comparison must be the same wherever two aliases are
+// asked whether they are one alias. `filterRedundantAliases` folds; the
+// append path used to compare the page's OWN existing aliases with a plain
+// `Array.includes`, which let "NAC" and "NAc" stand side by side on a page.
+export function aliasKey(raw: string): string {
   return turkishCaseFold(raw.trim().normalize('NFC'));
 }
 

--- a/src/wiki/page-factory/aliases.ts
+++ b/src/wiki/page-factory/aliases.ts
@@ -12,7 +12,7 @@
 //   - Replaces the existing `aliases:` block if present, otherwise injects a
 //     fresh block before the closing `---`.
 
-import { filterRedundantAliases, resolveMinAliasLength } from '../../core/slug';
+import { aliasKey, filterRedundantAliases, resolveMinAliasLength } from '../../core/slug';
 import { parseFrontmatter } from '../../core/frontmatter';
 
 // Moved to core/slug.ts so the create path (enforceFrontmatterConstraints)
@@ -60,7 +60,12 @@ export async function appendAliases(
 
   const fm = parseFrontmatter(content);
   const existingAliases = Array.isArray(fm?.aliases) ? fm.aliases : [];
-  const toAdd = candidates.filter(a => !existingAliases.includes(a));
+  // Fold before comparing, the same way `filterRedundantAliases` just folded
+  // the batch and the cross-page claims. A plain `includes` here made this the
+  // one list compared byte-exactly, so an incoming "NAc" did not recognise the
+  // "NAC" already on the page. The spelling already on disk wins.
+  const existingKeys = new Set(existingAliases.map(aliasKey));
+  const toAdd = candidates.filter(a => !existingKeys.has(aliasKey(a)));
   if (toAdd.length === 0) return;
 
   const merged = [...existingAliases, ...toAdd];


### PR DESCRIPTION
## Summary

Fixes #674.

`appendAliases` folds case everywhere except the one place it matters most.
`filterRedundantAliases` normalises NFC and case-folds for all three of its
rules, and the cross-page uniqueness gate is pinned as case-insensitive by its
own test ("matches claims case-insensitively"). The dedup against the aliases
already on the target page is a plain `Array.includes`, which is byte-exact.

So a page carrying `"NAC"` accepts an incoming `"NAc"`: the floor passes it,
the filename does not match it, the batch has not seen it, no other page
claims it, and `includes` does not recognise it. Both spellings end up on the
page, one under the other.

Measured over 802 entity and concept pages in one vault: three carry such a
pair — `"NAC"`/`"NAc"`, `"obstruktive Schlafapnoe"`/`"Obstruktive
Schlafapnoe"`, `"sustained attention"`/`"Sustained Attention"`. Both readers
of the alias pool compare case-folded (fix-dead-link.ts:264 and :266,
scanners.ts:146), so the second entry of each pair resolves nothing the first
does not; it only widens the alias line in the fix-dead-link prompt and makes
the page look as if it claims two names.

Exports `aliasKey` from core/slug.ts rather than repeating the fold, so the
question "are these one alias" has one answer in one place. The spelling
already on disk wins; rewriting the existing entry to the incoming casing
would be churn without a reader that can tell the difference.

Tests: 4 new (3 red on the parent commit), 4028 -> 4032. The fourth pins the
direction that already worked — a case variant inside a single incoming batch
is still dropped by `filterRedundantAliases`.



Gate 1: lint 0/0 · tsc 0 · build · 4032/4032 · css-lint 0.
