### PR TITLE
fix(sources, mentions): take the note path from the code, not the model's copy

### DIFF
--- a/src/__tests__/core/mentions.test.ts
+++ b/src/__tests__/core/mentions.test.ts
@@ -343,7 +343,7 @@ describe('normalizeBatchResponse — fillMentionsWithProvenance (#244)', () => {
       }],
       concepts: [],
     };
-    const { data } = normalizeBatchResponse(raw);
+    const { data } = normalizeBatchResponse(raw, 'note.md');
     expect(data.entities[0].mentions_with_provenance).toHaveLength(1);
     expect(data.entities[0].mentions_with_provenance![0].quote).toBe('structured quote');
     // Manual-test fix: when both fields are present, legacy is cleared to avoid
@@ -361,7 +361,7 @@ describe('normalizeBatchResponse — fillMentionsWithProvenance (#244)', () => {
       }],
       concepts: [],
     };
-    const { data } = normalizeBatchResponse(raw);
+    const { data } = normalizeBatchResponse(raw, 'note.md');
     expect(data.entities[0].mentions_with_provenance).toHaveLength(2);
     expect(data.entities[0].mentions_with_provenance![0].quote).toBe('quote A');
     expect(data.entities[0].mentions_with_provenance![1].quote).toBe('quote B');
@@ -374,7 +374,7 @@ describe('normalizeBatchResponse — fillMentionsWithProvenance (#244)', () => {
       entities: [{ name: 'Entity X', type: 'person' as const, summary: '', mentions_in_source: [] }],
       concepts: [],
     };
-    const { data } = normalizeBatchResponse(raw);
+    const { data } = normalizeBatchResponse(raw, 'note.md');
     expect(data.entities[0].mentions_with_provenance).toBeUndefined();
   });
 
@@ -389,9 +389,44 @@ describe('normalizeBatchResponse — fillMentionsWithProvenance (#244)', () => {
         related_concepts: [],
       }],
     };
-    const { data } = normalizeBatchResponse(raw);
+    const { data } = normalizeBatchResponse(raw, 'note.md');
     expect(data.concepts[0].mentions_with_provenance).toHaveLength(1);
     expect(data.concepts[0].mentions_with_provenance![0].quote).toBe('concept quote');
+  });
+
+  // Issue #679: the prompt asks the model to copy the note path into every
+  // quote, and downstream `m.source_path || defaultSourcePath` let the copy
+  // win. Measured copies: a typo (`Zytokines`), a control character for `α`,
+  // a translation (`Omega-3-Fatty-Acids`). Every quote of a batch comes from
+  // the note being ingested, and the code knows its path.
+  it('replaces a model-copied source_path with the note path the code passes', () => {
+    const raw = {
+      entities: [],
+      concepts: [{
+        name: 'JAK-STAT',
+        type: 'phenomenon' as const,
+        summary: 'Test',
+        mentions_in_source: [],
+        mentions_with_provenance: [
+          { quote: 'fördert Th17-Differenzierung', source_path: 'Notizen/Zytokines.md', source_slug: 'zytokines', extracted_at: '2026-09-11T00:00:00Z' },
+          { quote: 'Akute-Phase-Proteine', source_path: '', source_slug: '', extracted_at: '2026-09-11T00:00:00Z' },
+        ],
+        related_concepts: [],
+      }],
+    };
+    const { data } = normalizeBatchResponse(raw, 'Notizen/Zytokine.md');
+    const paths = data.concepts[0].mentions_with_provenance!.map(m => m.source_path);
+    expect(paths).toEqual(['Notizen/Zytokine.md', 'Notizen/Zytokine.md']);
+    expect(data.concepts[0].mentions_with_provenance![0].quote).toBe('fördert Th17-Differenzierung');
+  });
+
+  it('gives synthesized provenance the note path as well', () => {
+    const raw = {
+      entities: [{ name: 'TNF-α', type: 'other' as const, summary: 'Test', mentions_in_source: ['TNF-α treibt die Entzündung'] }],
+      concepts: [],
+    };
+    const { data } = normalizeBatchResponse(raw, 'Notizen/TNF-α.md');
+    expect(data.entities[0].mentions_with_provenance![0].source_path).toBe('Notizen/TNF-α.md');
   });
 });
 

--- a/src/__tests__/wiki/wiki-engine-summary-source-file.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-source-file.test.ts
@@ -1,0 +1,66 @@
+// Issue #679: `source_file:` on a sources/ page is the canonical owner
+// (`originNoteRefs` → `pageBelongsToNote` → `isAlreadyIngested`, and
+// `scanSourceDrift`). The template hands the model `file.path` and the model
+// writes the whole page, frontmatter included — so the field was whatever the
+// model copied. Measured on a rebuilt vault: `Notizen/Zytokine.md` came back
+// as `Notizen/Zytokines.md`, and the note then read as "not ingested".
+// The code knows the path exactly; it sets the field, like `contentHash`.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+import type { SourceAnalysis } from '../../types';
+
+const SOURCE_NOTE_PATH = 'Notizen/Zytokine.md';
+
+function sourceFile(): TFile {
+  return Object.assign(new TFile(), {
+    path: SOURCE_NOTE_PATH,
+    basename: 'Zytokine',
+    extension: 'md',
+  });
+}
+
+function makeAnalysis(): SourceAnalysis {
+  return {
+    source_file: SOURCE_NOTE_PATH,
+    source_title: 'Zytokine',
+    summary: 'Signal proteins.',
+    entities: [],
+    concepts: [],
+    contradictions: [],
+    related_pages: [],
+    key_points: [],
+    created_pages: [],
+    updated_pages: [],
+  };
+}
+
+function harnessFor(summaryPage: string) {
+  return createWikiEngineHarness({
+    files: { [SOURCE_NOTE_PATH]: '# Zytokine\n\nSignalproteine des Immunsystems.\n' },
+    llmResponses: [summaryPage],
+  });
+}
+
+describe('WikiEngine.createSummaryPage — source_file comes from the code, not the model (#679)', () => {
+  it('overwrites a source_file the model miscopied', async () => {
+    const h = harnessFor(
+      '---\ntype: source\nsource_file: "[[Notizen/Zytokines.md]]"\ntags: [other]\n---\n\n# Zytokine - Summary\n\nSignal proteins.\n',
+    );
+    const writtenPath = await h.engine.createSummaryPage(sourceFile(), makeAnalysis(), []);
+
+    const written = h.files.get(writtenPath)!;
+    expect(written).toContain('source_file: "[[Notizen/Zytokine.md]]"');
+    expect(written).not.toContain('Zytokines');
+  });
+
+  it('adds source_file when the model left it out', async () => {
+    const h = harnessFor('---\ntype: source\ntags: [other]\n---\n\n# Zytokine - Summary\n\nSignal proteins.\n');
+    const writtenPath = await h.engine.createSummaryPage(sourceFile(), makeAnalysis(), []);
+
+    const written = h.files.get(writtenPath)!;
+    expect(written).toContain('source_file: "[[Notizen/Zytokine.md]]"');
+    expect(written.match(/^source_file:/gm)).toHaveLength(1);
+  });
+});

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -115,9 +115,9 @@ export function parseFrontmatter(content: string): FrontmatterData | null {
  * paths.
  *
  * Two fields can name them and they are not interchangeable. The scalar
- * `source_file:` is the canonical owner, written by the generation
- * template. The `sources:` list records the multi-source merge: the other
- * ingests that later extended this page. It holds `[[sources/X]]`
+ * `source_file:` is the canonical owner, stamped from the note path by
+ * `createSummaryPage` (#679). The `sources:` list records the multi-source
+ * merge: the other ingests that later extended this page. It holds `[[sources/X]]`
  * wikilinks by contract — the Issue #81 normalizer removes or remaps any
  * external `[[Notizen/X.md]]` entry that lands there — so a note path
  * found in it is the exception, not the rule. Read the scalar first and

--- a/src/core/mentions-parser.ts
+++ b/src/core/mentions-parser.ts
@@ -29,8 +29,9 @@ import { dedupMentionsByProvenanceKey } from './batch-merger';
  * `preserveRaw` non-null so the caller preserves it verbatim rather than
  * risk dropping curated quotes.
  *
- * `defaultSourcePath` fills any blank `source_path` (structured LLM output
- * leaves them blank) and any `.md` suffix is stripped so legacy paths match
+ * `defaultSourcePath` fills any blank `source_path` (new mentions carry the
+ * note path from `normalizeBatchResponse`, #679; the fallback serves mentions
+ * handed in without one) and any `.md` suffix is stripped so legacy paths match
  * the rendered on-page form — callers can hand raw mentions.
  */
 export interface ReingestMentionsResult {

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -53,15 +53,22 @@ export type BatchValidity = 'valid' | 'empty' | 'unusable';
  * legacy `mentions_in_source` field so the LLM doesn't see both arrays in
  * the analysis log (and so downstream code that prefers the structured form
  * never accidentally falls back to a stale legacy array).
+ *
+ * Issue #679: every quote of a batch comes from the note being ingested, so
+ * `source_path` is that note's path — set here, not copied by the model.
+ * Downstream `m.source_path || defaultSourcePath` let a model copy win, and
+ * measured copies were a typo, a control character for `α`, and a
+ * translation of the file name.
  */
-function fillMentionsWithProvenance<T extends EntityInfo | ConceptInfo>(item: T): T {
-  // If the LLM already returned structured provenance, keep it as-is
+function fillMentionsWithProvenance<T extends EntityInfo | ConceptInfo>(item: T, sourcePath: string): T {
+  // If the LLM already returned structured provenance, keep its quotes
   // but clear the legacy field when both are present (avoids duplicate output).
   if (item.mentions_with_provenance?.length) {
-    if (item.mentions_in_source?.length) {
-      return { ...item, mentions_in_source: undefined };
-    }
-    return item;
+    return {
+      ...item,
+      mentions_with_provenance: item.mentions_with_provenance.map(m => ({ ...m, source_path: sourcePath })),
+      ...(item.mentions_in_source?.length ? { mentions_in_source: undefined } : {}),
+    };
   }
   // Otherwise, synthesize provenance from the legacy string[].
   const quotes = item.mentions_in_source?.filter(q => q?.trim()) ?? [];
@@ -69,7 +76,7 @@ function fillMentionsWithProvenance<T extends EntityInfo | ConceptInfo>(item: T)
   const now = new Date().toISOString();
   const provenance: MentionWithProvenance[] = quotes.map(quote => ({
     quote,
-    source_path: '',      // filled by page-factory at write time
+    source_path: sourcePath,
     source_slug: '',      // filled by page-factory at write time
     extracted_at: now,
   }));
@@ -92,7 +99,8 @@ export interface NormalizedBatch {
 //   'empty'    — both arrays present but zero items ⟹ signal to stop iteration
 //   'valid'    — at least one extractable item found ⟹ continue processing
 export function normalizeBatchResponse(
-  raw: Partial<SourceAnalysis> | null
+  raw: Partial<SourceAnalysis> | null,
+  sourcePath: string,
 ): { validity: BatchValidity; data: NormalizedBatch } {
   if (!raw) {
     return { validity: 'unusable', data: emptyBatch() };
@@ -100,10 +108,10 @@ export function normalizeBatchResponse(
 
   const entities = coerceToArray<EntityInfo>(raw.entities)
     .filter(e => e?.name?.trim())
-    .map(e => fillMentionsWithProvenance(e));
+    .map(e => fillMentionsWithProvenance(e, sourcePath));
   const concepts = coerceToArray<ConceptInfo>(raw.concepts)
     .filter(c => c?.name?.trim())
-    .map(c => fillMentionsWithProvenance(c));
+    .map(c => fillMentionsWithProvenance(c, sourcePath));
 
   // Strip wiki-link formatting if LLM outputs [[path|name]] instead of plain name
   const relatedPages = coerceToArray<string>(raw.related_pages).map(p => {
@@ -595,7 +603,7 @@ export class SourceAnalyzer {
         retryingBatch = false;
         escalateMaxTokens = false;
 
-        const { validity, data: norm } = normalizeBatchResponse(analysisData);
+        const { validity, data: norm } = normalizeBatchResponse(analysisData, file.path);
 
         if (isFirstBatch) {
           if (validity === 'unusable') {

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -1755,6 +1755,10 @@ export class WikiEngine {
     // #164: stamp a content fingerprint so future ingests can detect duplicates.
     // Injected programmatically — the LLM can't be trusted to emit it.
     let finalContent = upsertFrontmatterField(cleanedContent, 'contentHash', hashBody(extractBody(content)));
+    // #679: `source_file` is the canonical owner (`originNoteRefs`), read by the
+    // ingest skip and the drift scan — the same kind of field as `contentHash`.
+    // The model copied it from the template; a copy came back misspelled.
+    finalContent = upsertFrontmatterField(finalContent, 'source_file', `"[[${file.path}]]"`);
 
     // Issue #185: append the source note's curated frontmatter `aliases:`
     // to the generated `sources/<slug>` page. Merged inline (BEFORE the


### PR DESCRIPTION
Closes #679.

The note path reached two load-bearing fields by being copied through the model, and in both the model's copy won. The code knows the path exactly, so it now sets both.

**1. `source_file` on the sources/ page** (`2ba57cc`)

`createSummaryPage` upserts `source_file: "[[<file.path>]]"` next to `contentHash`, which is stamped for the same reason. `source_file` is the canonical owner for `originNoteRefs`, and so for `pageBelongsToNote` → `isAlreadyIngested`, the file picker and `scanSourceDrift`. The case from the issue: `Notizen/Zytokines.md` for `Notizen/Zytokine.md` made the note read as "not ingested", and its drift was never scanned.

**2. `source_path` on every mention** (`54ae286`)

`normalizeBatchResponse(raw, sourcePath)` sets the note path on each mention, both structured and synthesized from `mentions_in_source`. That is the point where model output first enters the code, so the create, merge and reviewed-merge paths all receive it without changes of their own. `computeReingestMentions` keeps `m.source_path || defaultSourcePath` for mentions parsed from an existing page. Side effect: a quote that came in two batches with two different copies of the path now deduplicates on `(quote, source_path)`.

**Tests.** Four new tests, red without the change: a miscopied and a missing `source_file` on the written page, and a model-copied and a synthesized `source_path` after normalization. The four existing `normalizeBatchResponse` calls pass a path now, with no other change.

**Checks.** Gate 1 is green locally (lint, typecheck, build, 4,032 tests, css-lint). `/simplify` folded the structured branch of `fillMentionsWithProvenance` into one return and corrected two comments that the change made wrong (`frontmatter.ts`, `mentions-parser.ts`). `/code-review` found nothing.

**Not in this PR**

- The prompts still ask the model for both values: `source_file:` in the summary template, and "Use this EXACT path" plus `source_path` in the extraction example. Both are now overwritten, so the extraction copy costs roughly 10–15 output tokens per quote for nothing. Removing them changes what the model sees, so I would do it separately. It also touches `generation.ts` and `ingestion.ts`, which #673 changes.
- The body line "Original file: [[…]]" is still model output (83 of 103 pages carry it, none wrong in the measured vault).
- Existing pages with a wrong `source_file` or wrong mention paths are not repaired. The origin can be recovered exactly from `contentHash`.
- `conversation-ingest.ts` writes its own sources/ page with `source_file: Conversation: <title>`. That is a label, not a note path, and no reader resolves it.

**Overlap:** #671 and #673 (both mine) also touch `createSummaryPage`. Whichever merges second needs a small rebase.
