### PR TITLE
fix(sources): the source page head comes from the code — title, note path, date

### DIFF
--- a/src/__tests__/core/source-page-head.test.ts
+++ b/src/__tests__/core/source-page-head.test.ts
@@ -1,0 +1,75 @@
+// The head of a sources/ page — H1 and Source section — carries what the code
+// knows (title, note path, ingest date). The model copied all three from the
+// template, and a copy could come back wrong.
+
+import { describe, it, expect } from 'vitest';
+import { stampSourcePageHead } from '../../core/source-page-head';
+import { SECTION_LABELS, SOURCE_PAGE_HEAD_LABELS, getSourcePageHeadLabels } from '../../wiki/system-prompts';
+import type { LLMWikiSettings } from '../../types';
+
+const labels = (wikiLanguage: string) => getSourcePageHeadLabels({ wikiLanguage } as LLMWikiSettings);
+
+const HEAD = { title: 'Zytokine', sourcePath: 'Notizen/Zytokine.md', date: '2026-09-11' };
+
+const MODEL_PAGE = `---
+type: source
+source_file: "[[Notizen/Zytokine.md]]"
+---
+
+# Zytokines - Summary
+
+## Quelle
+
+- Originaldatei: [[Notizen/Zytokines.md]]
+- Datum der Erfassung: 2026-09-10
+
+## Kerninhalt
+
+Signalproteine des Immunsystems.
+`;
+
+describe('stampSourcePageHead', () => {
+  it('replaces the model-written H1 and Source section with the code-known values', () => {
+    const out = stampSourcePageHead(MODEL_PAGE, HEAD, labels('de'));
+    expect(out).toContain('# Zytokine - Zusammenfassung\n');
+    expect(out).toContain('## Quelle\n\n- Originaldatei: [[Notizen/Zytokine.md]]\n- Importiert: 2026-09-11');
+    expect(out).not.toContain('Zytokines');
+    expect(out).not.toContain('Datum der Erfassung');
+    expect(out.match(/^## Quelle/gm)).toHaveLength(1);
+  });
+
+  it('keeps the frontmatter and every other section as written', () => {
+    const out = stampSourcePageHead(MODEL_PAGE, HEAD, labels('de'));
+    expect(out.startsWith('---\ntype: source\nsource_file: "[[Notizen/Zytokine.md]]"\n---\n\n# Zytokine')).toBe(true);
+    expect(out).toContain('## Kerninhalt\n\nSignalproteine des Immunsystems.');
+  });
+
+  it('adds the head when the model wrote neither H1 nor Source section', () => {
+    const out = stampSourcePageHead('---\ntype: source\n---\n\n## Core Content\n\nText.\n', HEAD, labels('en'));
+    expect(out).toBe(
+      '---\ntype: source\n---\n\n# Zytokine - Summary\n\n## Source\n\n- Original file: [[Notizen/Zytokine.md]]\n- Ingested: 2026-09-11\n\n## Core Content\n\nText.\n',
+    );
+  });
+
+  it('removes a Source section that is the last section of the page', () => {
+    const page = '---\ntype: source\n---\n\n# X - Summary\n\n## Core Content\n\nText.\n\n## Source\n\n- Original file: [[wrong.md]]\n';
+    const out = stampSourcePageHead(page, HEAD, labels('en'));
+    expect(out).not.toContain('wrong.md');
+    expect(out.match(/^## Source/gm)).toHaveLength(1);
+    expect(out).toContain('## Core Content\n\nText.');
+  });
+
+  it('leaves an H1 alone that does not open the body', () => {
+    const page = '---\ntype: source\n---\n\n## Core Content\n\n# Not the title\n';
+    const out = stampSourcePageHead(page, HEAD, labels('en'));
+    expect(out).toContain('# Not the title');
+  });
+
+  it('has head labels for every wiki language, kept out of the section headings', () => {
+    for (const lang of Object.keys(SECTION_LABELS)) {
+      expect(Object.values(SOURCE_PAGE_HEAD_LABELS[lang] ?? {}).filter(v => v.trim())).toHaveLength(3);
+      const headings = Object.values(SECTION_LABELS[lang]);
+      for (const label of Object.values(SOURCE_PAGE_HEAD_LABELS[lang])) expect(headings).not.toContain(label);
+    }
+  });
+});

--- a/src/__tests__/wiki/source-analyzer-note-title.test.ts
+++ b/src/__tests__/wiki/source-analyzer-note-title.test.ts
@@ -1,0 +1,53 @@
+// A note's title is its own: its H1 or its file name. The extraction prompt
+// shows the model the note path, and for 21 of 105 notes without an H1 the
+// model returned that path as the title (`Notizen/Carrageenan.md`). Only a PDF
+// keeps the title the model read off the document.
+
+import { describe, it, expect } from 'vitest';
+import { createMockContext } from '../__support__/engine-context';
+import { SourceAnalyzer } from '../../wiki/source-analyzer';
+import { TFile } from 'obsidian';
+
+const EMPTY_BATCH = JSON.stringify({ entities: [], concepts: [] });
+
+function extraction(sourceTitle: string): string {
+  return JSON.stringify({
+    source_title: sourceTitle,
+    summary: 'Ein Verdickungsmittel.',
+    entities: [{ name: 'Carrageenan', type: 'other', summary: 'Polysaccharid.', mentions_in_source: ['a'] }],
+    concepts: [],
+  });
+}
+
+async function titleFor(path: string, extension: string, body: string, modelTitle: string, contentOverride?: string) {
+  const { ctx } = createMockContext({
+    vaultFiles: { [path]: body },
+    llmResponses: [extraction(modelTitle), EMPTY_BATCH],
+  });
+  const file = Object.assign(new TFile(), { path, basename: 'Carrageenan', extension });
+  const analysis = await new SourceAnalyzer(ctx).analyzeSource(file, contentOverride ? { contentOverride } : undefined);
+  return analysis?.source_title;
+}
+
+describe('SourceAnalyzer — the source title of a note comes from the note', () => {
+  it('uses the file name when the note has no H1, not the path the model copied', async () => {
+    const title = await titleFor('Notizen/Carrageenan.md', 'md', 'Carrageenan ist ein Verdickungsmittel aus Rotalgen.\n', 'Notizen/Carrageenan.md');
+    expect(title).toBe('Carrageenan');
+  });
+
+  it('uses the H1 on the first body line', async () => {
+    const title = await titleFor(
+      'Notizen/Carrageenan.md', 'md',
+      '---\ntags: [x]\n---\n# Carrageenan — Übersicht\n\nEin Verdickungsmittel aus Rotalgen.\n',
+      'Carrageenan in Lebensmitteln',
+    );
+    expect(title).toBe('Carrageenan — Übersicht');
+  });
+
+  it('keeps the model title for a PDF, whatever the case of its extension', async () => {
+    for (const ext of ['pdf', 'PDF']) {
+      const title = await titleFor(`Docs/scan.${ext}`, ext, '', 'Carrageenan in Lebensmitteln', 'Carrageenan ist ein Verdickungsmittel.');
+      expect(title).toBe('Carrageenan in Lebensmitteln');
+    }
+  });
+});

--- a/src/__tests__/wiki/source-analyzer.test.ts
+++ b/src/__tests__/wiki/source-analyzer.test.ts
@@ -112,7 +112,7 @@ describe('SourceAnalyzer', () => {
     expect(result!.entities).toHaveLength(0);
   });
 
-  it('extracts source_title and summary from first batch', async () => {
+  it('takes source_title from the note H1 and summary from the first batch', async () => {
     const a = mockAnalyze(
       { [DOC_PATH]: '# Doc\nBody.' },
       [JSON.stringify({
@@ -124,7 +124,9 @@ describe('SourceAnalyzer', () => {
     );
     const result = await run(a, DOC_PATH);
     expect(result).not.toBeNull();
-    expect(result!.source_title).toBe('My Document');
+    // A note's title is its own H1; the model title only stands for a PDF.
+    expect(result!.source_title).toBe('Doc');
+    expect(result!.summary).toBe('This document covers important topics.');
   });
 
   it('handles LLM returning empty arrays for both categories', async () => {

--- a/src/__tests__/wiki/wiki-engine-summary-head.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-head.test.ts
@@ -1,0 +1,62 @@
+// createSummaryPage writes the head of the sources/ page — H1 and Source
+// section — from the analysis title, the note path and the ingest date, over
+// whatever the model copied there. Measured: `[[Notizen/Zytokines.md]]` in the
+// Source section of `sources/Zytokine`, file paths as H1 titles, and the
+// English "Summary" suffix on German pages.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+import type { SourceAnalysis } from '../../types';
+
+const NOTE = 'Notizen/Zytokine.md';
+
+const MODEL_PAGE = `---
+type: source
+tags: [other]
+---
+
+# Notizen/Zytokines.md - Summary
+
+## Quelle
+
+- Originaldatei: [[Notizen/Zytokines.md]]
+- Datum der Erfassung: 2026-01-01
+
+## Kerninhalt
+
+Signalproteine des Immunsystems.
+`;
+
+function analysis(): SourceAnalysis {
+  return {
+    source_file: NOTE,
+    source_title: 'Zytokine',
+    summary: 'Signalproteine.',
+    entities: [],
+    concepts: [],
+    contradictions: [],
+    related_pages: [],
+    key_points: [],
+    created_pages: [],
+    updated_pages: [],
+  };
+}
+
+describe('WikiEngine.createSummaryPage — the page head comes from the code', () => {
+  it('renders H1 and Source section from title, path and date, in the wiki language', async () => {
+    const h = createWikiEngineHarness({
+      files: { [NOTE]: 'Signalproteine des Immunsystems.\n' },
+      llmResponses: [MODEL_PAGE],
+      settings: { wikiLanguage: 'de' },
+    });
+    const file = Object.assign(new TFile(), { path: NOTE, basename: 'Zytokine', extension: 'md' });
+    const written = h.files.get(await h.engine.createSummaryPage(file, analysis(), []))!;
+
+    expect(written).toContain('# Zytokine - Zusammenfassung\n');
+    expect(written).toMatch(/## Quelle\n\n- Originaldatei: \[\[Notizen\/Zytokine\.md\]\]\n- Importiert: \d{4}-\d{2}-\d{2}\n/);
+    expect(written).not.toContain('Zytokines');
+    expect(written).not.toContain('2026-01-01');
+    expect(written).toContain('## Kerninhalt');
+  });
+});

--- a/src/core/source-page-head.ts
+++ b/src/core/source-page-head.ts
@@ -1,0 +1,37 @@
+// The head of a sources/ page — its H1 and its Source section — holds only
+// what the code knows: the source's title, the note's path and the ingest
+// date. The model used to copy all three from the template, and a copy could
+// come back wrong: `[[Notizen/Zytokines.md]]` for `Notizen/Zytokine.md`, a
+// file path as the title, the English "Summary" suffix on a German page.
+// Same route as the Mentions section (#244): what the model wrote there is
+// replaced, not trusted.
+
+import { stripMentionsSection } from './mentions-parser';
+import type { SourcePageHeadLabels } from '../wiki/system-prompts';
+
+export interface SourcePageHead {
+  title: string;
+  sourcePath: string;
+  date: string;
+}
+
+/**
+ * Replace the H1 (when it opens the body) and the `## <labels.source>` section
+ * (wherever it sits) with the code-rendered head, placed right after the
+ * frontmatter. Every other section is left as written.
+ */
+export function stampSourcePageHead(
+  content: string,
+  head: SourcePageHead,
+  labels: SourcePageHeadLabels & { source: string },
+): string {
+  const fmEnd = content.startsWith('---') ? content.indexOf('\n---', 3) : -1;
+  const frontmatter = fmEnd === -1 ? '' : content.slice(0, fmEnd + 4);
+  const body = (fmEnd === -1 ? content : content.slice(fmEnd + 4)).replace(/^\s*# [^\n]*\n?/, '');
+  // The section stripper is label-generic despite its name.
+  const rest = stripMentionsSection(body, labels.source).trimStart();
+
+  const stamped = `# ${head.title} - ${labels.summary}\n\n## ${labels.source}\n\n`
+    + `- ${labels.original_file}: [[${head.sourcePath}]]\n- ${labels.ingested}: ${head.date}\n`;
+  return `${frontmatter ? `${frontmatter}\n\n` : ''}${stamped}${rest ? `\n${rest}` : ''}`;
+}

--- a/src/wiki/source-analyzer.ts
+++ b/src/wiki/source-analyzer.ts
@@ -19,7 +19,7 @@ import { renderTemplate } from '../core/template-renderer';
 import { matchExtractedToExisting } from '../core/index-search';
 import { coerceToArray } from '../core/arrays';
 import { buildDomainContext, collectActiveVocabulary } from '../core/domain-axis'; // domain axis stages 3-5 (#568)
-import { isBlankSource } from '../core/frontmatter';
+import { isBlankSource, extractBody } from '../core/frontmatter';
 import { MAX_TOKENS_BATCH, TOKENS_PER_ITEM_BUDGET, TOKENS_LEMMA_CLASSIFY, TOKENS_TYPE_REPAIR, SOURCE_ANALYZER_RETRY_MULTIPLIER } from '../constants';
 import { getExistingWikiPages } from './lint/get-existing-pages';
 import { getGranularityInstruction } from './system-prompts';
@@ -761,13 +761,22 @@ export class SourceAnalyzer {
       if (accumulation.concepts.length > cCap) accumulation.concepts = accumulation.concepts.slice(0, cCap);
     }
 
+    // A note's title is its own: its H1 on the first body line (the #592 rule
+    // `getExistingWikiPages` uses) or its file name. The prompt shows the
+    // model the note path, and for notes without an H1 it returned that path
+    // as the title (21 of 105 measured, `Notizen/Carrageenan.md`). Only a PDF
+    // keeps the title the model read off the document.
+    const noteTitle = file.extension?.toLowerCase() === 'pdf'
+      ? null
+      : extractBody(content).match(/^#\s+(.+?)(?:\n|$)/)?.[1].trim() || file.basename;
+
     // Build final SourceAnalysis using pure function (Phase 3)
     const analysis = buildSourceAnalysis(
       file.path,
       file.basename,
       accumulation,
       firstBatchData ? {
-        sourceTitle: firstBatchData.sourceTitle,
+        sourceTitle: noteTitle ?? firstBatchData.sourceTitle,
         summary: firstBatchData.summary
       } : undefined,
       // Issue #185: forward curated source-note aliases so the

--- a/src/wiki/system-prompts.ts
+++ b/src/wiki/system-prompts.ts
@@ -152,6 +152,36 @@ export function getSectionLabels(settings: LLMWikiSettings): Record<string, stri
   return SECTION_LABELS[lang] || SECTION_LABELS.en;
 }
 
+export interface SourcePageHeadLabels {
+  /** H1 suffix: `# <title> - <summary>`. */
+  summary: string;
+  original_file: string;
+  /** Same word as the file picker's `multiFileRowIngested`. */
+  ingested: string;
+}
+
+// Kept out of SECTION_LABELS on purpose: its values are the list of known
+// section headings (canonicalizeSectionHeaders / stripUnknownSections, the
+// merge-triage prompt), and none of these is a section.
+export const SOURCE_PAGE_HEAD_LABELS: Record<string, SourcePageHeadLabels> = {
+  en: { summary: 'Summary', original_file: 'Original file', ingested: 'Ingested' },
+  zh: { summary: '摘要', original_file: '原始文件', ingested: '已摄入' },
+  'zh-Hant': { summary: '摘要', original_file: '原始檔案', ingested: '已攝入' },
+  ja: { summary: '要約', original_file: '元ファイル', ingested: '取り込み済み' },
+  ko: { summary: '요약', original_file: '원본 파일', ingested: '수집됨' },
+  de: { summary: 'Zusammenfassung', original_file: 'Originaldatei', ingested: 'Importiert' },
+  fr: { summary: 'Résumé', original_file: 'Fichier original', ingested: 'Importé' },
+  es: { summary: 'Resumen', original_file: 'Archivo original', ingested: 'Ingerido' },
+  pt: { summary: 'Resumo', original_file: 'Arquivo original', ingested: 'Ingerido' },
+  it: { summary: 'Riepilogo', original_file: 'File originale', ingested: 'Acquisito' },
+  ru: { summary: 'Сводка', original_file: 'Исходный файл', ingested: 'Импортировано' },
+};
+
+export function getSourcePageHeadLabels(settings: LLMWikiSettings): SourcePageHeadLabels & { source: string } {
+  const lang = settings.wikiLanguage || 'en';
+  return { source: getSectionLabels(settings).source, ...(SOURCE_PAGE_HEAD_LABELS[lang] || SOURCE_PAGE_HEAD_LABELS.en) };
+}
+
 // Granularity instruction text for extraction prompts.
 // custom is generated dynamically (injects concrete entity/concept limit numbers from settings).
 const GRANULARITY_INSTRUCTIONS: Record<ExtractionGranularity, string> = {

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -43,11 +43,13 @@ import { buildStubIdentityResolver, createDissentStubs, stubPath } from './page-
 import { selectDomains, collectActiveVocabulary } from '../core/domain-axis'; // domain axis stages 3-5 (#568)
 import { getSourceLanguage, isCrossLanguage } from '../core/source-language';
 import { cleanMarkdownResponse } from '../core/markdown';
+import { stampSourcePageHead } from '../core/source-page-head';
 import { injectMentionsSection } from '../core/mentions-injector';
 import { SchemaManager, SchemaTask } from '../schema/schema-manager';
 import {
   buildSystemPrompt,
   getSectionLabels,
+  getSourcePageHeadLabels,
   applySectionLabels,
 } from './system-prompts';
 import { getExistingWikiPages } from './lint/get-existing-pages';
@@ -1729,13 +1731,14 @@ export class WikiEngine {
         '\n' +
         analysis.concepts.map(c => `- [[concepts/${slugify(c.name, preserveCase)}|${c.name}]]`).join('\n');
 
+    const ingestDate = localDateStamp();
     const prompt = renderTemplate(PROMPTS.generateSummaryPage, {
       source_title: analysis.source_title,
       content: content.substring(0, 500),
       analysis: JSON.stringify(analysis),
       created_pages_list: createdPagesList || '(none)',
       source_file: file.path,
-      date: localDateStamp(),
+      date: ingestDate,
       tags: tagsValue,
       constraints: UNIVERSAL_LINK_CONSTRAINTS,
     });
@@ -1755,6 +1758,13 @@ export class WikiEngine {
     // #164: stamp a content fingerprint so future ingests can detect duplicates.
     // Injected programmatically — the LLM can't be trusted to emit it.
     let finalContent = upsertFrontmatterField(cleanedContent, 'contentHash', hashBody(extractBody(content)));
+    // The page head — H1 and Source section — from the title, the note path
+    // and the date the code knows; the model's copies of them came back wrong.
+    finalContent = stampSourcePageHead(
+      finalContent,
+      { title: analysis.source_title, sourcePath: file.path, date: ingestDate },
+      getSourcePageHeadLabels(this.settings),
+    );
 
     // Issue #185: append the source note's curated frontmatter `aliases:`
     // to the generated `sources/<slug>` page. Merged inline (BEFORE the


### PR DESCRIPTION
Follow-up to #679 / #680, as announced there: the rest of what the model copied onto a sources/ page.

**1. A note's source title is its own** (`3ec62eb`)

For anything but a PDF, `source_title` is now the note's H1 on the first body line (the #592 rule `getExistingWikiPages` uses) or its file name. A PDF keeps the title the model read off the document. The PDF check ignores the extension's case, like the engine's own.

Measured over 105 source pages of a rebuilt vault (84 of the notes have no H1):

| Model title | Pages |
|---|---|
| = file name | 46 |
| path or file name copied back (`Notizen/Carrageenan.md`, `Vitamin D.md`) | 21 |
| formulated by the model (`Kardiales Remodeling` for `Remodeling.md`) | 21 |
| = the note's H1 | 17 |

One more came back with a control character in place of `α`. All 21 copies are on notes without an H1, and the prompt shows the model the note path. The cost of the rule: the 21 formulated titles become the file name or H1. They are not reliably better (`Das Gedächtnis` for `Gedächtnis.md`), and the note's author chose its name. The lemma guarantee is unaffected, because it already uses the file name.

**2. The page head is rendered in code** (`358fb4d`)

`stampSourcePageHead` replaces the body-opening H1 and the Source section with `# <title> - <summary>` and `- <original file>: [[<path>]]` / `- <ingested>: <date>`. It takes the same route as the Mentions section (#244), and every other section stays as written. The line labels have their own table, `SOURCE_PAGE_HEAD_LABELS`, for all 11 languages, and `ingested` reuses the file picker's word. They are deliberately not in `SECTION_LABELS`: its values are the known section headings for `canonicalizeSectionHeaders`, `stripUnknownSections` and the merge-triage prompt, so a `## Zusammenfassung` on a concept page would stop being stripped. A test pins that separation.

Probe over the 105 source pages: exactly one Source section per page after stamping, no other section lost.

**Tests.** New tests for the head function, the title rule (no H1, H1, PDF in either case) and `createSummaryPage` in German, all red without the change. One existing test changed its expectation: `source-analyzer.test.ts` pinned the model title over the note's H1 (`My Document` over `# Doc`), which is exactly what this reverses.

**Checks.** Gate 1 is green locally (4,038 tests). `/simplify` swapped a hand-written section regex for `stripMentionsSection`, which is label-generic. `/code-review` found two things, both fixed before the push: the labels first sat in `SECTION_LABELS` (see above), and the PDF check was case-sensitive.

**Not in this PR**

- The prompts still ask the model for all of this: H1 and Source section in the summary template (roughly 30–45 output tokens per ingest, now discarded), and a `source_title` plus the note path in the extraction prompt. Removing them changes what the model sees and touches the files #673 changes, so it gets its own PR after #673, together with the `source_path` cleanup from #680.
- `conversation-ingest.ts` writes its own sources/ page. It has no note path, and there the model title is the point.
- The first-line H1 regex now exists three times (`get-existing-pages.ts`, a local closure in `merge-duplicates.ts`, here). A shared helper would touch #653's file, so later.
- Existing pages are not rewritten. A re-ingest renders the new head.

**Overlap:** #680, #671 and #673 also touch `createSummaryPage`.
