### PR TITLE
fix(json): repair one-token defects before spending a model call on them

### DIFF
--- a/src/__tests__/core/json-known-defects.test.ts
+++ b/src/__tests__/core/json-known-defects.test.ts
@@ -1,0 +1,166 @@
+// One-token defects a small model leaves in otherwise sound pretty-printed
+// JSON, fixed before the parser spends a model call on them. Each case is the
+// shape measured in real extraction responses (gemma-4-26b on LM Studio); the
+// model repair regenerated the whole response for each of them, and one call
+// in five ran to the token cap.
+
+import { describe, it, expect, vi } from 'vitest';
+import { parseJsonResult } from '../../core/json';
+
+/** Parse with a repair callback that records whether it was reached. */
+async function parse(text: string) {
+  const repair = vi.fn(async () => { throw new Error('model repair reached'); });
+  const result = await parseJsonResult(text, repair);
+  return { result, repaired: repair.mock.calls.length > 0 };
+}
+
+const item = (lines: string) => `{
+  "entities": [
+    {
+      "name": "Bradykinin",
+      "summary": "Ein Peptid."
+    },
+    {
+${lines}
+    }
+  ],
+  "concepts": []
+}`;
+
+describe('parseJsonResult — known one-token defects, no model call', () => {
+  it('a key that lost its closing quote: "name: "X"', async () => {
+    const { result, repaired } = await parse(item(`      "name: "Ramipril",
+      "summary": "Ein ACE-Hemmer."`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { name: 'Ramipril' }] } });
+  });
+
+  it('a key and a one-word value merged into one string: "coverage: named"', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Ramipril",
+      "coverage: named",
+      "summary": "Ein ACE-Hemmer."`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { coverage: 'named' }] } });
+  });
+
+  it('a key that lost its opening quote, bare or behind a stray = or |', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Ramipril",
+      summary: "Ein ACE-Hemmer.",
+      ="aliases": [],
+|      "coverage": "named"`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({
+      ok: true,
+      value: { entities: [{}, { summary: 'Ein ACE-Hemmer.', aliases: [], coverage: 'named' }] },
+    });
+  });
+
+  it('a value that lost its opening quote', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Ramipril",
+      "summary": Ein ACE-Hemmer gegen Bluthochdruck.",
+      "coverage": "named"`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { summary: 'Ein ACE-Hemmer gegen Bluthochdruck.' }] } });
+  });
+
+  it('a string that lost its closing quote at the end of its line', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Leitlinien",
+      "mentions_in_source": [
+        "Viele Autoren haben Pharma-Kontakte (Honorare, Beratung),
+        "Der Nutzen überwiegt meist."
+      ]`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({
+      ok: true,
+      value: { entities: [{}, { mentions_in_source: ['Viele Autoren haben Pharma-Kontakte (Honorare, Beratung)', 'Der Nutzen überwiegt meist.'] }] },
+    });
+  });
+
+  it('a backslash JSON cannot escape: $\\alpha$ and a table pipe', async () => {
+    const { result, repaired } = await parse(item(String.raw`      "name": "$\alpha$-Synuclein",
+      "summary": "Siehe [[Vitamin K2\|K2]]."`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { name: String.raw`$\alpha$-Synuclein`, summary: String.raw`Siehe [[Vitamin K2\|K2]].` }] } });
+  });
+
+  it('an array closed with } instead of ]', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Pektin",
+      "domains": [
+        "Thema/Metabolismus"
+      }`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { domains: ['Thema/Metabolismus'] }] } });
+  });
+
+  it('a stray full stop after a closing quote', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Darmbarriere",
+      "mentions_in_source": [
+        "Die Schleimhautbarriere wird durchlässig (Leaky Gut)".
+      ]`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { mentions_in_source: ['Die Schleimhautbarriere wird durchlässig (Leaky Gut)'] }] } });
+  });
+
+  // On its own `escapeContentQuotes` already copes; next to a second defect
+  // (as measured) it did not, and the model repair was called.
+  it('a German quote closed with the ASCII quote, next to a second defect', async () => {
+    const { result, repaired } = await parse(item(`      "name: "Cast-Nephropathie",
+      "summary": "Die „Myelomniere" ist das häufigste Muster."`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { summary: 'Die „Myelomniere“ ist das häufigste Muster.' }] } });
+  });
+
+  // `fixCommonJsonIssues` ran `escapeContentQuotes` before its comma rule,
+  // which escaped the very quote the rule needs.
+  it('two properties on consecutive lines without the comma', async () => {
+    const { result, repaired } = await parse(item(`      "name": "Eisenmangel",
+      "summary": "Ein Zeichen für chronischen Eisenmangel."
+      "mentions_in_source": ["Koilonychie."]`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { mentions_in_source: ['Koilonychie.'] }] } });
+  });
+});
+
+describe('parseJsonResult — what the known-defect pass leaves alone', () => {
+  it('reads $\\beta$ in valid JSON as a LaTeX command, not backspace + "eta"', async () => {
+    // `\\alpha` and `\\kappa` are escaped correctly; `\beta` and `\rightarrow` are not.
+    const { result } = await parse(String.raw`{"summary": "IKK$\\alpha/\beta$ und $\rightarrow$ NF-$\\kappa$B"}`);
+    expect(result).toMatchObject({ ok: true, value: { summary: String.raw`IKK$\alpha/\beta$ und $\rightarrow$ NF-$\kappa$B` } });
+  });
+
+  it('keeps a real escape outside a $…$ span', async () => {
+    const { result } = await parse('{"summary": "Zeile eins\\nbeta ist hier kein Befehl"}');
+    expect(result).toMatchObject({ ok: true, value: { summary: 'Zeile eins\nbeta ist hier kein Befehl' } });
+  });
+
+  it('does not split a quote that begins with "Label: text" into a key and a value', async () => {
+    const { result, repaired } = await parse(item(`      "name: "Psoriasis",
+      "mentions_in_source": [
+        "Therapie: Anti-TNF (Infliximab, Adalimumab)."
+      ]`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { mentions_in_source: ['Therapie: Anti-TNF (Infliximab, Adalimumab).'] }] } });
+  });
+
+  it('does not read a quote that begins with "word: [[Link]]" as a key', async () => {
+    const { result, repaired } = await parse(item(`      "name: "Vitamin D",
+      "mentions_in_source": [
+        "siehe: [[Vitamin D]] senkt das Risiko."
+      ]`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { mentions_in_source: ['siehe: [[Vitamin D]] senkt das Risiko.'] }] } });
+  });
+
+  it('keeps an already escaped quote after „', async () => {
+    const { result, repaired } = await parse(item(`      "name: "Alzheimer",
+      "summary": "Oft als „Typ-3-Diabetes\\" bezeichnet."`));
+    expect(repaired).toBe(false);
+    expect(result).toMatchObject({ ok: true, value: { entities: [{}, { summary: 'Oft als „Typ-3-Diabetes" bezeichnet.' }] } });
+  });
+
+  it('still hands a truncated response to the model repair', async () => {
+    const { result, repaired } = await parse('{\n  "entities": [\n    {\n      "name": "Bradykinin"\n    },\n    {\n      "name": "Ramipril",\n      "summary": "Ein ACE');
+    expect(repaired).toBe(true);
+    expect(result).toMatchObject({ ok: false });
+  });
+});

--- a/src/core/json.ts
+++ b/src/core/json.ts
@@ -265,6 +265,11 @@ export async function parseJsonResult(
     normalized = normalized.replace(/\n?```$/, '');
     normalized = normalized.trim();
 
+    // Step 1.1b: LaTeX commands the model left with one backslash. `\beta`,
+    // `\rightarrow`, `\text` start with a valid JSON escape, so the response
+    // parses — to a backspace plus "eta". Nothing downstream can tell.
+    normalized = escapeLatexInMath(normalized);
+
     // Step 1.2: Prefill artifact correction
     if (normalized.startsWith('{{')) {
       normalized = normalized.substring(1);
@@ -308,6 +313,17 @@ export async function parseJsonResult(
 
     // ===== Layer 2: JSON Extraction =====
     const firstBrace = normalized.indexOf('{');
+
+    // Step 2.1b: one-token defects a small model leaves in otherwise sound
+    // JSON — a key missing a quote, `\alpha` with one backslash, an array
+    // closed with `}`. Used only where the parser would otherwise call the
+    // model repair or give up, so every response the steps above and below
+    // already recover comes out exactly as before. Measured on 3,893
+    // extraction responses: 198 reached the model repair, which regenerates
+    // the whole response to fix one character and ran to the token cap on
+    // one call in five; these rules parse 176 of them.
+    const known = firstBrace === -1 ? null : repairKnownDefects(normalized.substring(firstBrace));
+
     if (firstBrace !== -1) {
       const balanced = extractBalancedJson(normalized, firstBrace);
       if (balanced) {
@@ -319,6 +335,7 @@ export async function parseJsonResult(
         }
 
         if (repairFn) {
+          if (known) return gatePlaceholder({ ok: true, value: known });
           try {
             const repaired = await repairFn(balanced);
             const cleanedLlm = repaired.trim()
@@ -346,6 +363,7 @@ export async function parseJsonResult(
       }
 
       if (repairFn) {
+        if (known) return gatePlaceholder({ ok: true, value: known });
         try {
           const repaired = await repairFn(candidate);
           const cleanedLlm = repaired.trim()
@@ -419,6 +437,9 @@ export async function parseJsonResult(
 
     // Non-empty + unparseable. `normalized` travels with the failure so the
     // caller can reproduce the legacy 3-line operator signal verbatim.
+    // A caller without a repair callback gets the known-defect pass as its
+    // last attempt, after every step it had before.
+    if (known) return gatePlaceholder({ ok: true, value: known });
     return { ok: false, reason: 'malformed', rawLength: response.length, normalized };
 
   } catch (error) {
@@ -614,8 +635,11 @@ function tryParseFromThinkingBlocks(
 
 function fixCommonJsonIssues(json: string): string {
   let fixed = json.replace(/,\s*\}/g, '}').replace(/,\s*\]/g, ']');
-  fixed = escapeContentQuotes(fixed);
+  // The missing comma first: `escapeContentQuotes` reads a quote followed by
+  // another quote as text and escapes it, and the comma rule then no longer
+  // finds the pair it needs.
   fixed = fixed.replace(/"\s*\n\s*"/g, '",\n"');
+  fixed = escapeContentQuotes(fixed);
   fixed = fixed.replace(/,\s*\}/g, '}').replace(/,\s*\]/g, ']');
   return fixed;
 }
@@ -670,4 +694,125 @@ function escapeContentQuotes(json: string): string {
 
 function isJsonWhitespace(ch: string): boolean {
   return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+}
+
+// ─── Known one-token defects ─────────────────────────────────────────────
+//
+// A small model writes pretty-printed JSON that is sound except for one
+// character. Each rule below targets one defect class measured on 781
+// extraction responses (gemma-4-26b, 10–11 Sep 2026) and matches only a shape
+// that valid JSON cannot contain, so a response that parses is never touched
+// by `repairKnownDefects` (it runs after every other deterministic step has
+// failed). The model repair stays the last resort, for truncation and for
+// whatever these rules do not know.
+
+// A single backslash (an odd run) before anything JSON cannot escape:
+// `$\alpha$`, `[[Page\|alias]]`, `\u` without four hex digits.
+const INVALID_ESCAPE = /(?<!\\)((?:\\\\)*)\\(?!["\\/bfnrt]|u[0-9a-fA-F]{4})/g;
+
+// LaTeX commands whose first letter makes `\<letter>` a valid JSON escape —
+// `\beta` parses to backspace + "eta", `\rightarrow` to carriage return +
+// "ightarrow". Rewritten only inside a `$…$` span and only as a whole command
+// name, where a real control character has no business.
+const LATEX_ESCAPE_IN_MATH = /(?<!\\)((?:\\\\)*)\\(?=(?:beta|bar|bullet|frac|forall|nabla|neq|ne|not|nu|rho|rightarrow|theta|tau|times|textbf|textit|text|tilde|top|to|triangle)(?![A-Za-z]))/g;
+
+function escapeLatexInMath(text: string): string {
+  if (!text.includes('$')) return text;
+  return text.replace(/\$[^$\n]{1,200}\$/g, span => span.replace(LATEX_ESCAPE_IN_MATH, '$1\\\\'));
+}
+
+/**
+ * Try to parse `text` after fixing the one-token defects a small model leaves
+ * in pretty-printed JSON. Returns the parsed object, or null when the text
+ * still does not parse — the caller then falls through to the model repair.
+ */
+function repairKnownDefects(text: string): Record<string, unknown> | null {
+  const t = closeMismatchedBrackets(closeUnterminatedLines(
+    text
+      .replace(INVALID_ESCAPE, '$1\\\\')
+      // `"name: "Psoriasis",` — the key lost its closing quote (25 of 50).
+      // Before a bracket only when it ends the line: `"siehe: [[Vitamin D]] …"`
+      // is a valid quote, not a key.
+      .replace(/^(\s*)"([a-z_][a-z0-9_]*): (?="|[[{]\s*$)/gm, '$1"$2": ')
+      // `"coverage: named",` — key and one-word value merged into one string.
+      // Narrow on purpose: `"Therapie: Anti-TNF (…)."` is a valid quote in an
+      // array, and a broader pattern splits it into a key and a value.
+      .replace(/^(\s*)"([a-z_][a-z0-9_]*): ([a-z_]+)"(\s*,?)$/gm, '$1"$2": "$3"$4')
+      // `summary: "…"`, `="mentions_in_source": [` — the key lost its opening quote.
+      .replace(/^(\s*)(?![\s"])=?"?([A-Za-z_]\w*)"?:(?=\s)/gm, '$1"$2":')
+      // `"summary": Ein Medikament …",` — the value lost its opening quote.
+      .replace(/^(\s*"[A-Za-z_]\w*":\s*)(?!(?:true|false|null)\b)([^\s"[{\d-][^\n]*"\s*,?)$/gm, '$1"$2')
+      // `|      "mentions_in_source": [` — a stray pipe opening the line.
+      .replace(/^\|(?=\s*")/gm, '')
+      // `(„Myelomniere")` — a German quote closed with the ASCII quote, which
+      // ends the JSON string early. Only when that quote is not followed by
+      // what would legitimately come after a string's end, and not when it is
+      // already escaped (`„X\"`).
+      .replace(/„([^"“”\n]{0,119}[^"“”\n\\])"(?!\s*[,:\]}])/g, '„$1“')
+      // `"… (Leaky Gut)".` before a closing bracket — a stray full stop.
+      .replace(/"\.(?=\s*\n\s*[\]},])/g, '"'),
+  ));
+  const candidate = extractBalancedJson(t, 0) ?? t;
+  for (const attempt of [candidate, fixCommonJsonIssues(candidate)]) {
+    try {
+      const parsed: unknown = JSON.parse(attempt);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        console.debug('known one-token JSON defects repaired without a model call');
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // next attempt
+    }
+  }
+  return null;
+}
+
+/**
+ * `"Studien zeigen: … (Honorare, Beratung),` — a string that lost its closing
+ * quote at the end of its line. Only a line with an odd number of unescaped
+ * quotes that ends in a comma after text, followed by a line that opens the
+ * next value or closes the container, gets the quote back.
+ */
+function closeUnterminatedLines(text: string): string {
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length - 1; i++) {
+    const line = lines[i];
+    if (!/[^"\]}\d\s],\s*$/.test(line)) continue;
+    if (countUnescapedQuotes(line) % 2 === 0) continue;
+    if (!/^\s*["\]}]/.test(lines[i + 1])) continue;
+    lines[i] = line.replace(/,\s*$/, '",');
+  }
+  return lines.join('\n');
+}
+
+function countUnescapedQuotes(line: string): number {
+  let n = 0;
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === '\\') { i++; continue; }
+    if (line[i] === '"') n++;
+  }
+  return n;
+}
+
+/** `"domains": [ … }` — a container closed with the other bracket. */
+function closeMismatchedBrackets(text: string): string {
+  const out = text.split('');
+  const stack: string[] = [];
+  let inString = false;
+  for (let i = 0; i < out.length; i++) {
+    const ch = out[i];
+    if (inString) {
+      if (ch === '\\') i++;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{' || ch === '[') stack.push(ch);
+    else if (ch === '}' || ch === ']') {
+      const open = stack.pop();
+      if (open === '[' && ch === '}') out[i] = ']';
+      else if (open === '{' && ch === ']') out[i] = '}';
+    }
+  }
+  return out.join('');
 }


### PR DESCRIPTION
Closes #682.

**What changes**

- **`repairKnownDefects`** in `src/core/json.ts` has one rule for each defect class in the issue. Each rule matches only a shape that valid JSON cannot contain. After the rules, `extractBalancedJson` and `JSON.parse` run, and once more through `fixCommonJsonIssues` if needed.
- **The pass is used in three places only:** before each of the two `repairFn` calls, and before the final `malformed` return. Every step that recovers a response today runs first and is unchanged.
- **`fixCommonJsonIssues`** now runs its missing-comma rule before `escapeContentQuotes`. This reaches every caller of the function. On the replay below it changed no response that parsed before.
- **Step 1.1b, `escapeLatexInMath`:** inside a `$…$` span, whole LaTeX command names that start with b/f/n/r/t keep their backslash. This is the one change that reaches responses which parse today.

**Evidence.** I replayed the same 3,893 extraction responses through the old and the new `parseJsonResult`:

| | responses |
|---|---|
| identical object | 3,671 |
| only the LaTeX strings differ | 21 |
| any other difference | 0 |
| newly failing | 0 |
| repair cases now parsed without a model call | 176 of 198 |

The remaining 22 need the model: 9 truncations, repetition loops, and misplaced structure such as a key inside an array.

**Two rules were narrowed during review:**
- The missing-quote key rule would split a valid quote like `"siehe: [[Vitamin D]] …"` if it also fired before `[`.
- The German-quote rule must skip a quote that is already escaped (`„X\"`).

Both have tests.

**Tests.** The new file `src/__tests__/core/json-known-defects.test.ts` has 16 cases: one per defect class, plus the things the pass must leave alone. Those are a real escape outside `$…$`, a `"Label: text"` quote, an escaped quote, and a truncated response that still reaches the repair. 12 of the 16 fail on `main`.

**Checks.** Gate 1 is green locally: lint, typecheck, build, 4,044 tests, css-lint. `/code-review` found the two rules above. `/simplify` replaced a memoized helper with one computed value, and moved the comma fix into `fixCommonJsonIssues` itself instead of repeating the rule in the new pass. Regex lookbehind is already used in `candidate-gate.ts`, so this adds no new platform requirement for mobile.

**Not in this PR**
- Truncation keeps its halving and repair path.
- The repair call itself is unchanged. It is the call that ran to the token cap, and that is a separate question.
