### PR TITLE
fix(log): one label table for the ingest log, read by writer and parser alike (#667)

### DIFF
--- a/src/__tests__/core/log-labels.test.ts
+++ b/src/__tests__/core/log-labels.test.ts
@@ -1,0 +1,77 @@
+// One table for the ingest log's section labels, read by the writer and the
+// parser alike (#667). Before: the writer read an eight-language table out
+// of `TEXTS.en`, so it/ru/zh-Hant vaults got English headings; the parser
+// carried its own hand-typed alternation, which had lost Spanish.
+
+import { describe, it, expect, vi } from 'vitest';
+import { LOG_LABELS, getLogLabels, logLabelLineRe } from '../../core/log-labels';
+import { WIKI_LANGUAGES } from '../../types';
+import { LogWriter } from '../../wiki/engine-internals/log-writer';
+import { parseLogEntries } from '../../core/log-parser';
+import type { SourceAnalysis } from '../../types';
+
+describe('LOG_LABELS', () => {
+  it('covers every selectable wiki language with three non-empty labels', () => {
+    for (const lang of Object.keys(WIKI_LANGUAGES)) {
+      const labels = LOG_LABELS[lang];
+      expect(labels, lang).toBeDefined();
+      for (const value of Object.values(labels)) {
+        expect(value.trim().length, lang).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('falls back to English for an unknown or missing language', () => {
+    expect(getLogLabels('xx')).toBe(LOG_LABELS.en);
+    expect(getLogLabels(undefined)).toBe(LOG_LABELS.en);
+    expect(getLogLabels('constructor')).toBe(LOG_LABELS.en);
+    expect(getLogLabels('ru')).toBe(LOG_LABELS.ru);
+  });
+
+  it('logLabelLineRe matches every language and captures the rest of the line', () => {
+    const re = logLabelLineRe('createdPages');
+    for (const [lang, labels] of Object.entries(LOG_LABELS)) {
+      const m = re.exec(`**${labels.createdPages}**：[[entities/A]]`);
+      expect(m, lang).not.toBeNull();
+      expect(m![1]).toBe('[[entities/A]]');
+    }
+    expect(re.test('**Updated pages**: [[entities/A]]')).toBe(false);
+  });
+});
+
+describe('writer and parser share the table', () => {
+  const analysis: SourceAnalysis = {
+    source_file: 'sources/t.md',
+    source_title: 'T',
+    summary: '',
+    entities: [],
+    concepts: [],
+    contradictions: [],
+    related_pages: [],
+    key_points: [],
+    created_pages: ['wiki/entities/Foo'],
+    updated_pages: ['entities/Bar'],
+    source_note_aliases: [],
+  };
+
+  // es was unparseable before (the parser knew `Páginas criadas` twice and
+  // `Páginas creadas` not at all); it, ru and zh-Hant were written in English.
+  it.each(['es', 'it', 'ru', 'zh-Hant'])('%s: what the writer writes, the parser reads', async (lang) => {
+    let written = '';
+    const writer = new LogWriter({
+      wikiFolder: 'wiki',
+      wikiLanguage: lang,
+      readFile: vi.fn().mockResolvedValue(''),
+      writeFile: vi.fn(async (_p: string, c: string) => { written = c; }),
+    });
+    await writer.appendIngest('ingest', analysis);
+
+    expect(written).toContain(`**${LOG_LABELS[lang].createdPages}**`);
+    expect(written).not.toContain('**Created pages**');
+
+    const entries = parseLogEntries(written);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].createdPages).toEqual(['entities/Foo']);
+    expect(entries[0].updatedPages).toEqual(['entities/Bar']);
+  });
+});

--- a/src/core/log-labels.ts
+++ b/src/core/log-labels.ts
@@ -1,0 +1,48 @@
+// The ingest log's section labels, one table for all languages.
+//
+// `LogWriter` writes them (`**Created pages**: …`), `log-parser.ts` reads
+// them back for the Operation History Panel. Both sides come here, so a
+// label the writer can produce is a label the parser recognises, in every
+// language the plugin offers (`WIKI_LANGUAGES`). Kept out of the locale
+// files on purpose: a table of all languages inside a file of one language
+// invites translation of the wrong rows (#667).
+//
+// Pure, no Obsidian dependencies.
+
+import { escapeRegex } from '../wiki/lint/utils';
+
+export interface LogLabels {
+  createdPages: string;
+  updatedPages: string;
+  contradictionsFound: string;
+}
+
+export const LOG_LABELS: Record<string, LogLabels> = {
+  en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
+  zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
+  'zh-Hant': { createdPages: '建立頁面', updatedPages: '更新頁面', contradictionsFound: '發現矛盾' },
+  ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
+  ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
+  de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
+  fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
+  es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
+  pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
+  it: { createdPages: 'Pagine create', updatedPages: 'Pagine aggiornate', contradictionsFound: 'Contraddizioni trovate' },
+  ru: { createdPages: 'Созданные страницы', updatedPages: 'Обновлённые страницы', contradictionsFound: 'Найдены противоречия' },
+};
+
+/** Labels for `lang`; English when the language has no entry. */
+export function getLogLabels(lang: string | undefined): LogLabels {
+  return lang && Object.prototype.hasOwnProperty.call(LOG_LABELS, lang) ? LOG_LABELS[lang] : LOG_LABELS.en;
+}
+
+/**
+ * Regex matching one `**<label>**: rest` line for `field` in any language,
+ * with the rest of the line captured as group 1. Old entries were written
+ * by older writers, so every language's label is accepted regardless of the
+ * vault's current setting.
+ */
+export function logLabelLineRe(field: keyof LogLabels): RegExp {
+  const labels = [...new Set(Object.values(LOG_LABELS).map(l => l[field]))].map(escapeRegex);
+  return new RegExp(`^\\*\\*(?:${labels.join('|')})\\*\\*[：:]\\s*(.*)$`);
+}

--- a/src/core/log-parser.ts
+++ b/src/core/log-parser.ts
@@ -26,6 +26,8 @@
 // Operation kinds are inferred from the H2 text (no separate marker field), so
 // the parser must be tolerant: if it can't classify, it falls back to 'other'.
 
+import { logLabelLineRe } from './log-labels';
+
 /** Ingest-specific metadata parsed from the H2 line suffix. */
 export interface IngestMetrics {
   /** Ingest duration in seconds (HH:MM timestamp in H2 also drives `date`+`time`). */
@@ -150,8 +152,11 @@ export type LogEntry = {
 // ── Regex patterns ───────────────────────────────────────────────
 
 const H2_RE = /^## \[([0-9]{4}-[0-9]{2}-[0-9]{2})(?: ([0-9]{2}:[0-9]{2}))?\] (.+)$/;
-const CREATED_RE = /^\*\*(?:Created pages|创建页面|作成ページ|생성 페이지|Erstellte Seiten|Pages créées|Páginas criadas|Páginas criadas|Pagine create)\*\*[：:]\s*(.*)$/;
-const UPDATED_RE = /^\*\*(?:Updated pages|更新页面|更新ページ|업데이트 페이지|Aktualisierte Seiten|Pages mises à jour|Páginas actualizadas|Páginas atualizadas|Pagine aggiornate)\*\*[：:]\s*(.*)$/;
+// Built from the writer's own table, so a language the writer can produce
+// is one the parser reads. The hand-typed alternation that stood here had
+// lost Spanish (`Páginas creadas`) and never gained ru or zh-Hant (#667).
+const CREATED_RE = logLabelLineRe('createdPages');
+const UPDATED_RE = logLabelLineRe('updatedPages');
 const BLOCKQUOTE_RE = /^>\s?(.*)$/;
 const H3_SECTION_RE = /^###\s+(.+)$/;
 const BULLET_RE = /^\s*[-*+]\s+(.+)$/;

--- a/src/texts/de.ts
+++ b/src/texts/de.ts
@@ -349,16 +349,6 @@ export const DE_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: 'Extraktion',

--- a/src/texts/en.ts
+++ b/src/texts/en.ts
@@ -363,16 +363,6 @@ export const EN_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: 'Extraction',

--- a/src/texts/es.ts
+++ b/src/texts/es.ts
@@ -349,16 +349,6 @@ export const ES_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: 'Extracción',

--- a/src/texts/fr.ts
+++ b/src/texts/fr.ts
@@ -349,16 +349,6 @@ export const FR_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: 'Extraction',

--- a/src/texts/it.ts
+++ b/src/texts/it.ts
@@ -358,16 +358,6 @@ export const IT_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Impostazioni Estrazione
     extractionSectionTitle: 'Estrazione',

--- a/src/texts/ja.ts
+++ b/src/texts/ja.ts
@@ -347,16 +347,6 @@ export const JA_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: '知識抽出',

--- a/src/texts/ko.ts
+++ b/src/texts/ko.ts
@@ -348,16 +348,6 @@ export const KO_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: '추출',

--- a/src/texts/pt.ts
+++ b/src/texts/pt.ts
@@ -349,16 +349,6 @@ export const PT_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Extraction Settings
     extractionSectionTitle: 'Extração',

--- a/src/texts/ru.ts
+++ b/src/texts/ru.ts
@@ -366,16 +366,6 @@ export const RU_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // Настройки извлечения
     extractionSectionTitle: 'Извлечение',

--- a/src/texts/zh-hant.ts
+++ b/src/texts/zh-hant.ts
@@ -346,16 +346,6 @@ export const ZH_HANT_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '建立頁面', updatedPages: '更新頁面', contradictionsFound: '發現矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // 知识提取
     extractionSectionTitle: '知識提取',

--- a/src/texts/zh.ts
+++ b/src/texts/zh.ts
@@ -348,16 +348,6 @@ export const ZH_TEXTS = {
       es: { subtitle: 'Directorio de base de conocimiento generado automáticamente', entities: 'Entidades', concepts: 'Conceptos', sources: 'Fuentes' },
       pt: { subtitle: 'Diretório de base de conhecimento gerado automaticamente', entities: 'Entidades', concepts: 'Conceitos', sources: 'Fontes' },
     },
-    logLabels: {
-      en: { createdPages: 'Created pages', updatedPages: 'Updated pages', contradictionsFound: 'Contradictions found' },
-      zh: { createdPages: '创建页面', updatedPages: '更新页面', contradictionsFound: '发现矛盾' },
-      ja: { createdPages: '作成ページ', updatedPages: '更新ページ', contradictionsFound: '矛盾を発見' },
-      ko: { createdPages: '생성 페이지', updatedPages: '업데이트 페이지', contradictionsFound: '모순 발견' },
-      de: { createdPages: 'Erstellte Seiten', updatedPages: 'Aktualisierte Seiten', contradictionsFound: 'Widersprüche gefunden' },
-      fr: { createdPages: 'Pages créées', updatedPages: 'Pages mises à jour', contradictionsFound: 'Contradictions trouvées' },
-      es: { createdPages: 'Páginas creadas', updatedPages: 'Páginas actualizadas', contradictionsFound: 'Contradicciones encontradas' },
-      pt: { createdPages: 'Páginas criadas', updatedPages: 'Páginas atualizadas', contradictionsFound: 'Contradições encontradas' },
-    },
 
     // 知识提取
     extractionSectionTitle: '知识提取',

--- a/src/wiki/engine-internals/log-writer.ts
+++ b/src/wiki/engine-internals/log-writer.ts
@@ -15,7 +15,7 @@
  *   - The actual `vault.read` and `vault.process` calls live in WikiEngine's
  *     tryReadFile / createOrUpdateFile. LogWriter receives these as injected
  *     closures so it stays unit-testable.
- *   - Localized log label translation lives in TEXTS (per-locale logLabels table).
+ *   - The section labels live in `core/log-labels.ts`, shared with the parser.
  *
  * Why extracted:
  *   - updateLog + logLintFix + formatIngestMetricsSuffix + formatBytes together
@@ -27,7 +27,7 @@
  */
 
 import type { SourceAnalysis } from '../../types';
-import { TEXTS } from '../../texts';
+import { getLogLabels } from '../../core/log-labels';
 import { dedupPages } from './dedup-pages';
 import { buildLogHeader } from '../../core/log-header';
 import { formatBytes, localDateStamp } from '../../core/format';
@@ -76,7 +76,7 @@ export class LogWriter {
   ): Promise<void> {
     const logPath = `${this.wikiFolder}/log.md`;
     const { date, time } = this.timestamp();
-    const labels = this.labels();
+    const labels = getLogLabels(this.wikiLanguage);
 
     const h2Suffix = metrics ? this.formatIngestMetricsSuffix(metrics) : '';
     let entry = `\n\n## [${date} ${time}] ${operation} | ${analysis.source_title}${h2Suffix}\n\n`;
@@ -167,13 +167,6 @@ export class LogWriter {
       date: localDateStamp(now),
       time: now.toTimeString().slice(0, 5), // HH:MM
     };
-  }
-
-  private labels(): { createdPages: string; updatedPages: string; contradictionsFound: string } {
-    const lang = this.wikiLanguage || 'en';
-    type LogLangKey = keyof typeof TEXTS.en.logLabels;
-    const langKey: LogLangKey = (lang in TEXTS.en.logLabels) ? lang as LogLangKey : 'en';
-    return TEXTS.en.logLabels[langKey];
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #667.

**What was wrong.** The ingest log's section labels were an eight-language table nested inside every one of the eleven locale files, and only `en`'s copy was read. `zh-Hant`, `it` and `ru` were not in it, so a vault in one of those languages wrote English headings into `wiki/log.md` while the rest of its UI was translated. `zh-hant.ts` had meanwhile received a correct Traditional rendering under the `zh` key, reachable by nobody.

**The second copy.** The Operation History Panel's parser carried its own hand-typed alternation for the Created/Updated lines (`log-parser.ts`). It listed `Páginas criadas` twice and `Páginas creadas` never, so a Spanish vault's ingest entries reached the panel without their pages; ru and zh-Hant were absent there too. Same drift class, one step downstream.

**The fix.** `core/log-labels.ts` holds one table keyed by language, covering every entry of `WIKI_LANGUAGES`. The writer looks up by language with an English fallback; the parser builds its two patterns from the same values, so a label the writer can produce is one the parser reads. It keeps accepting every language's label regardless of the vault's current setting, as before, because older entries were written under older settings. The eleven nested copies are gone. New translations: `it` (Pagine create / Pagine aggiornate / Contraddizioni trovate), `ru` (Созданные страницы / Обновлённые страницы / Найдены противоречия); `zh-Hant` takes the rendering that was already in the tree.

**Observed, not changed:** `classifyOperation` in the same parser keeps a hand-typed list of maintenance-report keywords for six of the eleven languages. Same class; a separate issue if you want it.

Tests: 4028 → 4035. The new ones pin coverage against `WIKI_LANGUAGES`, the English fallback (including a prototype key such as `constructor`), and, for es, it, ru and zh-Hant, that what the writer writes, the parser reads. `/simplify` and `/code-review` ran before the push; the shared `escapeRegex` and the prototype-safe lookup came out of them.

Touches `log-writer.ts` in a different hunk than #684; whichever merges second needs a trivial rebase (the new test builds a `SourceAnalysis` with the `contradictions` field that #684 removes).

Gate 1: lint 0/0 · tsc 0 · build · 4035/4035 · css-lint 0.
