### PR TITLE
fix(llm-sdk): strict structured-output dialect as a negotiated tier at the schema boundary (#658)

### DIFF
--- a/src/__tests__/core/task-policy.test.ts
+++ b/src/__tests__/core/task-policy.test.ts
@@ -206,3 +206,10 @@ describe('parseTaskPolicySpec — bounded thinking', () => {
     expect(thinkingEffort('default')).toBeUndefined();
   });
 });
+
+describe('json_schema_strict as a pinnable mode (Issue #658)', () => {
+  it('parses `strict` and `json_schema_strict` to the strict tier', () => {
+    expect(parseTaskPolicySpec('extract=strict:off').extract?.outputMode).toBe('json_schema_strict');
+    expect(parseTaskPolicySpec('*=json_schema_strict:default')['*']?.outputMode).toBe('json_schema_strict');
+  });
+});

--- a/src/__tests__/llm-sdk/__snapshots__/strict-schema/FixDeadLinkSchema.json
+++ b/src/__tests__/llm-sdk/__snapshots__/strict-schema/FixDeadLinkSchema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "correct_link": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "stub_title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "stub_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "action",
+    "correct_link",
+    "stub_title",
+    "stub_type"
+  ],
+  "type": "object"
+}

--- a/src/__tests__/llm-sdk/__snapshots__/strict-schema/SourceAnalysisLLMSchema.json
+++ b/src/__tests__/llm-sdk/__snapshots__/strict-schema/SourceAnalysisLLMSchema.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "source_title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "summary": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "entities": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mentions_in_source": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "mentions_with_provenance": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "quote": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "translation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "source_path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "source_slug": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "extracted_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "quote",
+                "translation",
+                "source_path",
+                "source_slug",
+                "extracted_at"
+              ],
+              "type": "object"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "related_entities": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "related_concepts": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "coverage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "domains": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "aliases",
+          "summary",
+          "mentions_in_source",
+          "mentions_with_provenance",
+          "related_entities",
+          "related_concepts",
+          "coverage",
+          "domains"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "concepts": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "mentions_in_source": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "mentions_with_provenance": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "quote": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "translation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "source_path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "source_slug": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "extracted_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "quote",
+                "translation",
+                "source_path",
+                "source_slug",
+                "extracted_at"
+              ],
+              "type": "object"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "related_concepts": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "related_entities": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "coverage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "domains": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "aliases",
+          "summary",
+          "mentions_in_source",
+          "mentions_with_provenance",
+          "related_concepts",
+          "related_entities",
+          "coverage",
+          "domains"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "contradictions": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "claim": {
+            "type": "string"
+          },
+          "source_page": {
+            "type": "string"
+          },
+          "contradicted_by": {
+            "type": "string"
+          },
+          "resolution": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "claim",
+          "source_page",
+          "contradicted_by",
+          "resolution"
+        ],
+        "type": "object"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "related_pages": {
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    },
+    "key_points": {
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "source_title",
+    "summary",
+    "entities",
+    "concepts",
+    "contradictions",
+    "related_pages",
+    "key_points"
+  ],
+  "type": "object"
+}

--- a/src/__tests__/llm-sdk/openai-compat-request-body.test.ts
+++ b/src/__tests__/llm-sdk/openai-compat-request-body.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { OpenAICompatSdkClient } from '../../llm-sdk/openai-compat-sdk-client';
+import { FixDeadLinkSchema, type FixDeadLink } from '../../llm-sdk/output-schemas';
 
 // Everything this client adds beyond the standard fields travels as
 // `providerOptions`. The AI SDK forwards those to the request body only
@@ -434,5 +435,128 @@ describe('OpenAICompatSdkClient — Issue #414: repetitionPenalty dialect dispat
       const body = await captureBody('lmstudio', 0.5);
       expect(body.repeat_penalty).toBe(0.5);
     });
+  });
+});
+
+// Issue #658: a strict OpenAI-compatible endpoint rejected `FixDeadLinkSchema`
+// because `required` did not list its four optional properties
+// (`'required' is required to be supplied and to be an array including every
+// key in properties. Missing 'action'`). The strict dialect is a negotiated
+// tier: the plain body goes first (unchanged for every backend that accepts
+// it — LM Studio measured), the strict rewrite is sent after that 400 and
+// remembered per (baseURL, model). These tests read what the SDK actually
+// sends and what the caller actually receives.
+describe('OpenAICompatSdkClient — Issue #658: strict schema dialect as a negotiated tier', () => {
+  const STRICT_REJECTION = `Invalid schema for response_format 'response': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'action'.`;
+
+  const respond = (content: string): Response => new Response(JSON.stringify({
+    id: 'x', object: 'chat.completion', created: 0, model: 'm',
+    choices: [{ index: 0, message: { role: 'assistant', content }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+  const reject400 = (message: string): Response => new Response(JSON.stringify({ error: { message } }), { status: 400, headers: { 'content-type': 'application/json' } });
+
+  type Body = Record<string, unknown>;
+  const schemaOf = (body: Body): Record<string, unknown> =>
+    (body.response_format as { json_schema: { schema: Record<string, unknown> } }).json_schema.schema;
+
+  /** A client whose fetch answers from a script of responses and records every request body. */
+  function scripted(provider: string, script: Array<() => Response>) {
+    const bodies: Body[] = [];
+    const stub = vi.fn(async (_url: string, init?: { body?: unknown }) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      const next = script.shift();
+      if (!next) throw new Error('script exhausted');
+      return next();
+    });
+    const client = new OpenAICompatSdkClient({
+      apiKey: 'k', baseURL: 'http://localhost/v1/', provider,
+      fetch: stub as never,
+    });
+    const call = () => client.createMessageWithOutput<FixDeadLink>({
+      model: 'm', max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+      response_format: { type: 'json_object', schema: FixDeadLinkSchema },
+    });
+    return { bodies, call };
+  }
+
+  const STRICT_BODY = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    additionalProperties: false,
+    properties: {
+      action: { type: ['string', 'null'] },
+      correct_link: { type: ['string', 'null'] },
+      stub_title: { type: ['string', 'null'] },
+      stub_type: { type: ['string', 'null'] },
+    },
+    required: ['action', 'correct_link', 'stub_title', 'stub_type'],
+    type: 'object',
+  };
+
+  it('LM Studio: the first body is the plain adapter body, unchanged (optionals not required)', async () => {
+    const { bodies, call } = scripted('lmstudio', [() => respond('{"action":"skip"}')]);
+    await call();
+    expect(bodies).toHaveLength(1);
+    const schema = schemaOf(bodies[0]);
+    expect(schema.required).toBeUndefined();
+    expect(schema.properties).toEqual({
+      action: { type: 'string' }, correct_link: { type: 'string' }, stub_title: { type: 'string' }, stub_type: { type: 'string' },
+    });
+    expect((bodies[0].response_format as { json_schema: { strict: boolean } }).json_schema.strict).toBe(true);
+  });
+
+  it('custom strict endpoint: the #658 400 is answered with the strict body, and the caller sees the answer', async () => {
+    const { bodies, call } = scripted('custom', [
+      () => reject400(STRICT_REJECTION),
+      () => respond('{"action":"stub","correct_link":null,"stub_title":"Kreatin","stub_type":"entity"}'),
+    ]);
+    const result = await call();
+    expect(bodies).toHaveLength(2);
+    expect(schemaOf(bodies[1])).toEqual(STRICT_BODY);
+    expect(result.outputMode).toBe('json_schema_strict');
+    expect(result.output).toEqual({ action: 'stub', stub_title: 'Kreatin', stub_type: 'entity' });
+  });
+
+  it('the strict tier is remembered: the next call goes strict directly, no second 400', async () => {
+    const { bodies, call } = scripted('custom', [
+      () => reject400(STRICT_REJECTION),
+      () => respond('{"action":"skip","correct_link":null,"stub_title":null,"stub_type":null}'),
+      () => respond('{"action":"skip","correct_link":null,"stub_title":null,"stub_type":null}'),
+    ]);
+    await call();
+    const second = await call();
+    expect(bodies).toHaveLength(3);
+    expect(schemaOf(bodies[2])).toEqual(STRICT_BODY);
+    expect(second.output).toEqual({ action: 'skip' });
+  });
+
+  it('a backend that rejects json_schema as a field still demotes to json_object, not to strict', async () => {
+    const { bodies, call } = scripted('custom', [
+      () => reject400("Unsupported parameter: 'response_format.json_schema'"),
+      () => respond('{"action":"skip"}'),
+    ]);
+    const result = await call();
+    expect(bodies).toHaveLength(2);
+    expect(bodies[1].response_format).toEqual({ type: 'json_object' });
+    expect(result.outputMode).toBe('json_object');
+  });
+
+  it('the non-typed branch is unchanged: no schema, no dialect, json_object on the wire', async () => {
+    let body: Body = {};
+    const stub = vi.fn(async (_url: string, init?: { body?: unknown }) => {
+      body = JSON.parse(String(init?.body));
+      return respond('{}');
+    });
+    const client = new OpenAICompatSdkClient({
+      apiKey: 'k', baseURL: 'http://localhost/v1/', provider: 'custom',
+      fetch: stub as never,
+    });
+    await client.createMessage({
+      model: 'm', max_tokens: 100,
+      messages: [{ role: 'user', content: 'hi' }],
+      response_format: { type: 'json_object' },
+    });
+    expect(body.response_format).toEqual({ type: 'json_object' });
   });
 });

--- a/src/__tests__/llm-sdk/output-mode-prober.test.ts
+++ b/src/__tests__/llm-sdk/output-mode-prober.test.ts
@@ -180,3 +180,26 @@ describe('Classifier input contract: responseBody vs message', () => {
     expect(OutputModeProber.isJsonObjectFieldError(err.responseBody ?? '')).toBe(true);
   });
 });
+describe('OutputModeProber.isStrictSchemaRejection — Tier 0 → Tier 0-strict (Issue #658)', () => {
+  it('matches the #658 endpoint body verbatim (no REJECTION_VERBS phrase in it)', () => {
+    expect(
+      OutputModeProber.isStrictSchemaRejection(
+        `Invalid schema for response_format 'response': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'action'.`,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches an additionalProperties complaint', () => {
+    expect(OutputModeProber.isStrictSchemaRejection('additionalProperties must be false in strict mode')).toBe(true);
+  });
+
+  it('does NOT match the field rejections that drive Tier 1 / Tier 2', () => {
+    expect(OutputModeProber.isStrictSchemaRejection(`'response_format.type' must be 'json_schema' or 'text'`)).toBe(false);
+    expect(OutputModeProber.isStrictSchemaRejection("Unsupported parameter: 'response_format.json_schema'")).toBe(false);
+  });
+
+  it('does NOT match an unrelated 400', () => {
+    expect(OutputModeProber.isStrictSchemaRejection('model not found')).toBe(false);
+    expect(OutputModeProber.isStrictSchemaRejection('')).toBe(false);
+  });
+});

--- a/src/__tests__/llm-sdk/strict-schema.test.ts
+++ b/src/__tests__/llm-sdk/strict-schema.test.ts
@@ -1,0 +1,274 @@
+// Issue #658: strict structured-output normalisation at the schema-emitting
+// boundary. Pins (1) what the normaliser does to a schema, (2) that the
+// validator still sees the original value shape, (3) that the normalised
+// body is byte-equal whether zod 3 (`zod-to-json-schema`) or zod 4
+// (`z.toJSONSchema()`) produced the raw schema — the wire-body regression
+// coverage #669 asks for, and (4) the exact bytes for the two schemas #669
+// names, as file snapshots that the zod 4 migration must leave unchanged.
+
+import { describe, it, expect } from 'vitest';
+import { zodSchema } from 'ai';
+import type { JSONSchema7 } from 'ai';
+import { z as z3 } from 'zod';
+import { z as z4 } from 'zod/v4';
+import {
+  normalizeStrictJsonSchema,
+  strictSchemaFor,
+  stripOptionalNulls,
+  toStrictSchema,
+} from '../../llm-sdk/strict-schema';
+import * as OutputSchemas from '../../llm-sdk/output-schemas';
+import { FixDeadLinkSchema, SourceAnalysisLLMSchema } from '../../llm-sdk/output-schemas';
+
+/** Emits what `buildOutputArgs` hands to `Output.object()` for a zod schema. */
+function wireBody(schema: Parameters<typeof zodSchema>[0]): JSONSchema7 {
+  return toStrictSchema(zodSchema(schema)).jsonSchema as JSONSchema7;
+}
+
+/**
+ * The strict dialect as a checker: every object node lists every property
+ * in `required`, in property order, and forbids additional properties.
+ * Mirrors the rule the endpoint in #658 enforces (`'required' is required
+ * to be supplied and to be an array including every key in properties`).
+ */
+function assertStrictDialect(node: JSONSchema7 | boolean, path = '$'): void {
+  if (typeof node === 'boolean') return;
+  if (node.type === 'object' || node.properties !== undefined) {
+    const names = Object.keys(node.properties ?? {});
+    expect(node.required, `${path}.required`).toEqual(names);
+    expect(node.additionalProperties, `${path}.additionalProperties`).toBe(false);
+    for (const name of names) assertStrictDialect(node.properties![name], `${path}.${name}`);
+  }
+  if (node.items !== undefined && !Array.isArray(node.items)) assertStrictDialect(node.items, `${path}[]`);
+  for (const branch of [...(node.anyOf ?? []), ...(node.oneOf ?? []), ...(node.allOf ?? [])]) {
+    assertStrictDialect(branch, `${path}|`);
+  }
+}
+
+describe('normalizeStrictJsonSchema', () => {
+  it('lists every property in required and makes the former optionals nullable', () => {
+    const out = normalizeStrictJsonSchema({
+      type: 'object',
+      properties: { action: { type: 'string' }, count: { type: 'number' } },
+      required: ['count'],
+    });
+    expect(out).toEqual({
+      additionalProperties: false,
+      properties: { action: { type: ['string', 'null'] }, count: { type: 'number' } },
+      required: ['action', 'count'],
+      type: 'object',
+    });
+  });
+
+  it('applies the same rule to nested objects and to objects inside arrays', () => {
+    const out = normalizeStrictJsonSchema({
+      type: 'object',
+      properties: {
+        inner: { type: 'object', properties: { a: { type: 'string' }, b: { type: 'boolean' } }, required: ['a'] },
+        list: { type: 'array', items: { type: 'object', properties: { n: { type: 'string' }, k: { type: 'number' } }, required: ['n'] } },
+      },
+      required: ['inner'],
+    });
+    assertStrictDialect(out);
+    const inner = out.properties!.inner as JSONSchema7;
+    expect(inner.type).toBe('object');
+    expect(inner.required).toEqual(['a', 'b']);
+    expect((inner.properties!.b as JSONSchema7).type).toEqual(['boolean', 'null']);
+    const list = out.properties!.list as JSONSchema7;
+    expect(list.type).toEqual(['array', 'null']);
+    const item = list.items as JSONSchema7;
+    expect(item.required).toEqual(['n', 'k']);
+    expect((item.properties!.k as JSONSchema7).type).toEqual(['number', 'null']);
+  });
+
+  it('extends an optional enum with null and leaves an already nullable property alone', () => {
+    const out = normalizeStrictJsonSchema({
+      type: 'object',
+      properties: {
+        kind: { type: 'string', enum: ['entity', 'concept'] },
+        path: { type: ['string', 'null'] },
+      },
+      required: ['path'],
+    });
+    expect(out.properties!.kind).toEqual({ enum: ['entity', 'concept', null], type: ['string', 'null'] });
+    expect(out.properties!.path).toEqual({ type: ['string', 'null'] });
+  });
+
+  it('leaves an open map (additionalProperties as a schema, no fixed keys) open and normalises its value schema', () => {
+    const out = normalizeStrictJsonSchema({
+      type: 'object',
+      additionalProperties: { type: 'object', properties: { a: { type: 'string' } } },
+    });
+    expect(out).toEqual({
+      additionalProperties: { additionalProperties: false, properties: { a: { type: ['string', 'null'] } }, required: ['a'], type: 'object' },
+      type: 'object',
+    });
+  });
+
+  it('admits null through a union when an optional node has no type to widen ($ref, const)', () => {
+    const out = normalizeStrictJsonSchema({
+      type: 'object',
+      properties: { ref: { $ref: '#/definitions/X' }, lit: { const: 'a' }, union: { anyOf: [{ type: 'string', minLength: 1 }, { type: 'number' }] } },
+    });
+    expect(out.properties!.ref).toEqual({ anyOf: [{ $ref: '#/definitions/X' }, { type: 'null' }] });
+    expect(out.properties!.lit).toEqual({ anyOf: [{ const: 'a' }, { type: 'null' }] });
+    expect(out.properties!.union).toEqual({ anyOf: [{ minLength: 1, type: 'string' }, { type: 'number' }, { type: 'null' }] });
+  });
+
+  it('does not mutate its input', () => {
+    const input: JSONSchema7 = { type: 'object', properties: { a: { type: 'string' } } };
+    const copy = JSON.parse(JSON.stringify(input));
+    normalizeStrictJsonSchema(input);
+    expect(input).toEqual(copy);
+  });
+
+  it('emits a canonical key order regardless of the input order', () => {
+    const a = normalizeStrictJsonSchema({ type: 'object', properties: { x: { type: 'string' } }, additionalProperties: true, $schema: 's' });
+    const b = normalizeStrictJsonSchema({ $schema: 's', additionalProperties: true, properties: { x: { type: 'string' } }, type: 'object' });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});
+
+describe('stripOptionalNulls', () => {
+  const original: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      action: { type: 'string' },
+      path: { type: ['string', 'null'] },
+      items: { type: 'array', items: { type: 'object', properties: { n: { type: 'string' }, k: { type: 'number' } }, required: ['n'] } },
+    },
+    required: ['path'],
+  };
+
+  it('drops null only from properties the original schema did not require', () => {
+    expect(stripOptionalNulls({ action: null, path: null }, original)).toEqual({ path: null });
+  });
+
+  it('descends into arrays of objects and keeps unknown keys', () => {
+    expect(stripOptionalNulls({ path: 'p', items: [{ n: 'a', k: null }, { n: 'b', k: 2 }], extra: null }, original))
+      .toEqual({ path: 'p', items: [{ n: 'a' }, { n: 'b', k: 2 }], extra: null });
+  });
+
+  it('passes non-object values through', () => {
+    expect(stripOptionalNulls('text', original)).toBe('text');
+    expect(stripOptionalNulls(null, original)).toBe(null);
+  });
+});
+
+describe('toStrictSchema — the Schema object Output.object() receives', () => {
+  it('emits the strict dialect on the wire side', () => {
+    const body = wireBody(FixDeadLinkSchema);
+    assertStrictDialect(body);
+    expect(body.required).toEqual(['action', 'correct_link', 'stub_title', 'stub_type']);
+    expect((body.properties!.action as JSONSchema7).type).toEqual(['string', 'null']);
+  });
+
+  it('accepts a strict-provider answer that fills optionals with null, and hands the validator the original shape', async () => {
+    const schema = toStrictSchema(zodSchema(FixDeadLinkSchema));
+    const result = await schema.validate!({ action: null, correct_link: null, stub_title: 'Kreatin', stub_type: null });
+    expect(result).toEqual({ success: true, value: { stub_title: 'Kreatin' } });
+  });
+
+  it('still rejects a wrong type — the original validator is the one that runs', async () => {
+    const schema = toStrictSchema(zodSchema(FixDeadLinkSchema));
+    const result = await schema.validate!({ action: 42 });
+    expect(result.success).toBe(false);
+  });
+
+  it('an optional field that also allows null counts as optional: null is dropped (PathResolutionLLMSchema.path — callers read `match && path`)', async () => {
+    const schema = toStrictSchema(zodSchema(OutputSchemas.PathResolutionLLMSchema));
+    const result = await schema.validate!({ match: false, path: null, classification: null });
+    expect(result).toEqual({ success: true, value: { match: false } });
+  });
+
+  it('is memoised per schema object, so retries do not re-adapt or re-normalise', () => {
+    let adaptions = 0;
+    const adapt = () => { adaptions += 1; return zodSchema(FixDeadLinkSchema); };
+    const first = strictSchemaFor(FixDeadLinkSchema, adapt);
+    const second = strictSchemaFor(FixDeadLinkSchema, adapt);
+    expect(second).toBe(first);
+    expect(adaptions).toBe(1);
+  });
+
+  it('leaves a schema without a validator without one', () => {
+    const { jsonSchema } = zodSchema(FixDeadLinkSchema);
+    const bare = toStrictSchema({ jsonSchema, validate: undefined } as unknown as Parameters<typeof toStrictSchema>[0]);
+    expect(bare.validate).toBeUndefined();
+  });
+});
+
+describe('every exported output schema reaches the wire in the strict dialect', () => {
+  const exported = Object.entries(OutputSchemas).filter(([name]) => name.endsWith('Schema'));
+
+  it('covers the 17 schemas at the boundary', () => {
+    expect(exported.map(([name]) => name).sort()).toMatchInlineSnapshot(`
+      [
+        "AliasGenerationLLMSchema",
+        "ConversationDedupStatusLLMSchema",
+        "DedupResultLLMSchema",
+        "FixDeadLinkSchema",
+        "LemmaClassifyLLMSchema",
+        "LinkOrphanSchema",
+        "MergeTriageSchema",
+        "PathResolutionLLMSchema",
+        "QueryKeywordsSchema",
+        "QueryViewValueSchema",
+        "SchemaSuggestionLLMSchema",
+        "SeedSelectorSchema",
+        "SourceAnalysisLLMSchema",
+        "SourceStanceSchema",
+        "TagFixLLMSchema",
+        "TypeRepairLLMSchema",
+        "WelcomeTranslationLLMSchema",
+      ]
+    `);
+  });
+
+  it.each(exported)('%s', (_name, schema) => {
+    assertStrictDialect(wireBody(schema as Parameters<typeof zodSchema>[0]));
+  });
+});
+
+describe('wire-body regression across zod 3 and zod 4 (#669)', () => {
+  // The same shape written twice: zod 3 `.passthrough()` (what
+  // output-schemas.ts uses today) and zod 4 `.looseObject()` (its documented
+  // replacement). zod 3.25.x ships both APIs, so the comparison runs without
+  // a dependency change. The raw bodies differ (`additionalProperties`,
+  // the nullable form, key order — the SDK routes zod 4 through
+  // `z.toJSONSchema()` and then forces `additionalProperties: false`); the
+  // normalised bodies must not.
+  const shape3 = z3.object({
+    action: z3.enum(['fix', 'stub', 'skip']).optional(),
+    path: z3.string().nullable(),
+    items: z3.array(z3.object({ n: z3.string(), k: z3.number().optional() }).passthrough()).optional(),
+    inner: z3.object({ a: z3.boolean().optional() }).passthrough(),
+  }).passthrough();
+  const shape4 = z4.looseObject({
+    action: z4.enum(['fix', 'stub', 'skip']).optional(),
+    path: z4.string().nullable(),
+    items: z4.array(z4.looseObject({ n: z4.string(), k: z4.number().optional() })).optional(),
+    inner: z4.looseObject({ a: z4.boolean().optional() }),
+  });
+
+  it('the raw bodies differ — documented, not asserted as a contract', () => {
+    const raw3 = JSON.stringify(zodSchema(shape3).jsonSchema);
+    const raw4 = JSON.stringify(zodSchema(shape4).jsonSchema);
+    expect(raw3).not.toBe(raw4);
+    expect(raw3).toContain('"additionalProperties":true');
+    expect(raw4).toContain('"additionalProperties":false');
+  });
+
+  it('the normalised bodies are byte-equal', () => {
+    expect(JSON.stringify(wireBody(shape3))).toBe(JSON.stringify(wireBody(shape4)));
+  });
+
+  it('FixDeadLinkSchema — pinned bytes', async () => {
+    await expect(JSON.stringify(wireBody(FixDeadLinkSchema), null, 2))
+      .toMatchFileSnapshot('./__snapshots__/strict-schema/FixDeadLinkSchema.json');
+  });
+
+  it('SourceAnalysisLLMSchema — pinned bytes', async () => {
+    await expect(JSON.stringify(wireBody(SourceAnalysisLLMSchema), null, 2))
+      .toMatchFileSnapshot('./__snapshots__/strict-schema/SourceAnalysisLLMSchema.json');
+  });
+});

--- a/src/core/task-policy.ts
+++ b/src/core/task-policy.ts
@@ -122,6 +122,8 @@ const MODE_ALIASES: Readonly<Record<string, TaskOutputMode>> = {
   'default': 'default',
   'schema': 'json_schema',
   'json_schema': 'json_schema',
+  'strict': 'json_schema_strict',
+  'json_schema_strict': 'json_schema_strict',
   'json': 'json_object',
   'json_object': 'json_object',
   'text': 'text_prompt',

--- a/src/llm-sdk/openai-compat-sdk-client.ts
+++ b/src/llm-sdk/openai-compat-sdk-client.ts
@@ -182,7 +182,7 @@ export class OpenAICompatSdkClient implements LLMClient {
    */
   private getCurrentOutputMode(model: string): OutputMode {
     const cached = this.outputModeProber.getMode(this.baseURL, model);
-    if (cached === 'json_schema' && !this.supportsStructuredOutputs) {
+    if ((cached === 'json_schema' || cached === 'json_schema_strict') && !this.supportsStructuredOutputs) {
       this.outputModeProber.markMode(this.baseURL, model, 'json_object');
       return 'json_object';
     }
@@ -689,13 +689,16 @@ export class OpenAICompatSdkClient implements LLMClient {
       //   iterate so that a retry's error can re-trigger the demotion
       //   branch with the (now-updated) mode.
       let tentativeDemotion: OutputMode | null = null;
-      // Up to 2 demotions: Tier 0→1, then Tier 1→2.
-      for (let chainAttempt = 0; chainAttempt < 2; chainAttempt++) {
+      // Up to 3 demotions: Tier 0 → 0-strict (#658), then → 1, then → 2.
+      for (let chainAttempt = 0; chainAttempt < 3; chainAttempt++) {
         const currentMode = this.outputModeProber.getMode(this.baseURL, model);
 
         // Determine target tier based on current mode and last error body.
         let demotedMode: OutputMode | null = null;
-        if (currentMode === 'json_schema' && OutputModeProber.isJsonSchemaFieldError(lastErrBody)) {
+        if (currentMode === 'json_schema' && OutputModeProber.isStrictSchemaRejection(lastErrBody)) {
+          // Issue #658: same tier, strict dialect — one 400 per (baseURL, model).
+          demotedMode = 'json_schema_strict';
+        } else if ((currentMode === 'json_schema' || currentMode === 'json_schema_strict') && OutputModeProber.isJsonSchemaFieldError(lastErrBody)) {
           demotedMode = 'json_object';
         } else if (currentMode === 'json_object' && OutputModeProber.isJsonObjectFieldError(lastErrBody)) {
           demotedMode = 'text_prompt';
@@ -1168,10 +1171,13 @@ export class OpenAICompatSdkClient implements LLMClient {
       ) {
         let lastErrBody: string = err.responseBody ?? err.message ?? '';
         let tentativeDemotion: OutputMode | null = null;
-        for (let chainAttempt = 0; chainAttempt < 2; chainAttempt++) {
+        for (let chainAttempt = 0; chainAttempt < 3; chainAttempt++) {
           const iterMode = this.outputModeProber.getMode(this.baseURL, model);
           let demotedMode: OutputMode | null = null;
-          if (iterMode === 'json_schema' && OutputModeProber.isJsonSchemaFieldError(lastErrBody)) {
+          if (iterMode === 'json_schema' && OutputModeProber.isStrictSchemaRejection(lastErrBody)) {
+            // Issue #658: same tier, strict dialect — one 400 per (baseURL, model).
+            demotedMode = 'json_schema_strict';
+          } else if ((iterMode === 'json_schema' || iterMode === 'json_schema_strict') && OutputModeProber.isJsonSchemaFieldError(lastErrBody)) {
             demotedMode = 'json_object';
           } else if (iterMode === 'json_object' && OutputModeProber.isJsonObjectFieldError(lastErrBody)) {
             demotedMode = 'text_prompt';

--- a/src/llm-sdk/output-args.ts
+++ b/src/llm-sdk/output-args.ts
@@ -80,8 +80,10 @@
 //   });
 
 import { jsonSchema, Output, zodSchema } from 'ai';
+import type { Schema } from 'ai';
 import type { z } from 'zod';
 import type { OutputMode } from './output-mode-prober';
+import { strictSchemaFor } from './strict-schema';
 
 /**
  * v1.26.3 PATCH simplify round: Output.json() is a no-arg factory that
@@ -142,6 +144,8 @@ export interface ResponseFormatWithSchema {
  * |-----------------|--------------|---------------------------------------------|
  * | undefined       | any          | `{}` (caller has no JSON intent)            |
  * | {schema}        | json_schema  | `{output: Output.object({schema, name})}`   |
+ * | {schema}        | json_schema_strict | same, schema rewritten into the strict |
+ * |                 |              | dialect (Issue #658, `strict-schema.ts`)    |
  * | {no schema}     | json_schema  | `{output: Output.json()}` (fallback — no    |
  * |                 |              | schema to constrain; SDK encodes json_object)|
  * | any             | json_object  | `{output: Output.json()}` (schema silently  |
@@ -203,8 +207,12 @@ export function buildOutputArgs(
   // via `zodSchema()`; a raw JSON Schema (legacy callers) via
   // `jsonSchema()`. Both return a `Schema` the AI SDK accepts on
   // `Output.object`. `isZodSchema` narrows the union.
-  const adapted = isZodSchema(schema)
-    ? zodSchema(schema)
-    : jsonSchema(schema);
+  const adapt = (): Schema => (isZodSchema(schema) ? zodSchema(schema) : jsonSchema(schema));
+  // Issue #658: at the strict tier the schema is rewritten into the strict
+  // structured-output dialect — once per schema object, regardless of which
+  // adapter produced it; see `strict-schema.ts` for what changes and why the
+  // validator is wrapped alongside. The plain tier sends the adapter's own
+  // body, so a backend that accepts it (measured: LM Studio) is unaffected.
+  const adapted = mode === 'json_schema_strict' ? strictSchemaFor(schema, adapt) : adapt();
   return { output: Output.object({ schema: adapted, name }) };
 }

--- a/src/llm-sdk/output-mode-prober.ts
+++ b/src/llm-sdk/output-mode-prober.ts
@@ -59,7 +59,13 @@ import { classifyFieldError } from './shared-rejection-verbs';
  * with Tier N's rejection demotes to Tier N+1. The order is encoded in
  * the literal union (kept in sync with the prober's demotion chain).
  */
-export type OutputMode = 'json_schema' | 'json_object' | 'text_prompt';
+// Issue #658: `json_schema_strict` sits between `json_schema` and
+// `json_object`. It is the same wire shape with the schema rewritten into the
+// strict structured-output dialect (`strict-schema.ts`); a backend reaches it
+// only by rejecting the plain schema with a strict-mode complaint, so
+// backends that accept today's body never see it. Task policies can pin it
+// (`extract=strict:off`).
+export type OutputMode = 'json_schema' | 'json_schema_strict' | 'json_object' | 'text_prompt';
 
 /**
  * Field markers for the Tier 1 demotion classifier (json_object /
@@ -87,6 +93,25 @@ const JSON_SCHEMA_FIELD_MARKERS = [
   'json-schema',
   'response_format.json_schema',
   'response-format.json-schema',
+] as const;
+
+/**
+ * Issue #658: phrases a strict structured-output validator emits when the
+ * schema itself is accepted but its dialect is not — `required` missing a
+ * property, `additionalProperties` not `false`. Verbatim from the endpoint in
+ * #658: `Invalid schema for response_format 'response': In context=(),
+ * 'required' is required to be supplied and to be an array including every
+ * key in properties. Missing 'action'.` No rejection verb from
+ * `REJECTION_VERBS` appears in it, so this classifier matches on the phrase
+ * alone; the phrases are specific enough not to collide with a field
+ * rejection (`json_schema` unsupported → Tier 1) or an unrelated 400.
+ */
+const STRICT_SCHEMA_MARKERS = [
+  'required to be supplied',
+  "'required' is required",
+  'must be required',
+  'additionalproperties',
+  'invalid schema for response_format',
 ] as const;
 
 export class OutputModeProber {
@@ -142,6 +167,12 @@ export class OutputModeProber {
    * IMPORTANT — input MUST be the response body, not the APICallError
    * message (same contract as isJsonSchemaFieldError above).
    */
+  /** Issue #658: the plain schema was accepted as a field but rejected as a dialect. */
+  static isStrictSchemaRejection(body: string): boolean {
+    const lower = body.toLowerCase();
+    return STRICT_SCHEMA_MARKERS.some((m) => lower.includes(m));
+  }
+
   static isJsonObjectFieldError(body: string): boolean {
     return classifyFieldError(body, JSON_OBJECT_FIELD_MARKERS);
   }

--- a/src/llm-sdk/strict-schema.ts
+++ b/src/llm-sdk/strict-schema.ts
@@ -1,0 +1,228 @@
+// Issue #658: strict structured-output normalisation at the schema-emitting
+// boundary.
+//
+// Strict OpenAI-compatible endpoints reject a `response_format` schema unless
+// `required` lists every property and every object carries
+// `additionalProperties: false`. The AI SDK already puts `strict: true` on the
+// wire for every openai-compatible provider (`@ai-sdk/openai-compatible`
+// defaults `strictJsonSchema` to `true`), so the body a strict endpoint sees
+// today is `strict: true` + an incomplete `required` — the combination the
+// endpoint in #658 rejects (`Missing 'action'`).
+//
+// This module rewrites the emitted JSON Schema into the strict dialect. It
+// runs at the `json_schema_strict` tier only (`output-mode-prober.ts`): the
+// plain body goes first and stays as it is for every backend that accepts it
+// (LM Studio measured — on the full ingest path the strict body cost a
+// quarter to a third of the extracted items), the strict body is sent after a
+// strict-mode 400 and remembered per (baseURL, model), or pinned by task
+// policy (`extract=strict:off`). At that tier, for every schema:
+//
+//   * every property is listed in `required`, in property order;
+//   * a property that was optional becomes nullable (`type: [..., "null"]`,
+//     the form verified against LM Studio in #658 — not `anyOf`);
+//   * every object node gets `additionalProperties: false`;
+//   * keys are emitted in a canonical order, so two converters that agree on
+//     content produce the same bytes (zod 3's `zod-to-json-schema` and zod 4's
+//     `z.toJSONSchema()` differ in `additionalProperties`, the nullable form
+//     and key order — see #669).
+//
+// "Optional → nullable" has a reading half. The SDK validates the model's
+// answer with the same `Schema` object it emitted, and a zod `.optional()`
+// rejects `null`. `stripOptionalNulls` removes `null` from exactly the
+// properties the normaliser made nullable (the ones the *original* schema
+// did not require) before the validator runs, so the 17 zod schemas in
+// `output-schemas.ts` stay untouched and see the value shape they always saw.
+
+import { jsonSchema } from 'ai';
+import type { JSONSchema7, Schema } from 'ai';
+
+type JSONSchema7Definition = JSONSchema7 | boolean;
+type JSONSchema7TypeName = Extract<JSONSchema7['type'], string>;
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof (value as { then?: unknown })?.then === 'function';
+}
+
+/** Adds `null` to a property schema so a strict provider may answer `null`. */
+function makeNullable(node: JSONSchema7): JSONSchema7 {
+  const out: JSONSchema7 = { ...node };
+  if (typeof out.type === 'string') {
+    out.type = out.type === 'null' ? out.type : [out.type, 'null'];
+  } else if (Array.isArray(out.type)) {
+    if (!out.type.includes('null')) out.type = [...out.type, 'null'];
+  }
+  if (Array.isArray(out.enum) && !out.enum.includes(null)) {
+    out.enum = [...out.enum, null];
+  }
+  if (out.type !== undefined) return out;
+  for (const key of ['anyOf', 'oneOf'] as const) {
+    const branches = out[key];
+    if (Array.isArray(branches)) {
+      const hasNull = branches.some((b) => isObject(b) && (b as JSONSchema7).type === 'null');
+      if (!hasNull) out[key] = [...branches, { type: 'null' }];
+      return out;
+    }
+  }
+  // No `type`, no union to extend (`$ref`, `const`, an empty `{}`): the
+  // only way to admit null is a union around the node.
+  return { anyOf: [out, { type: 'null' }] };
+}
+
+/**
+ * Emits a node with its keys in a fixed order. `properties` keeps the
+ * author's member order (it is meaningful to the model); `required` follows
+ * the same order. Everything else is sorted by key.
+ */
+function canonical(node: JSONSchema7): JSONSchema7 {
+  const out: JsonObject = {};
+  for (const key of Object.keys(node).sort()) {
+    out[key] = (node as JsonObject)[key];
+  }
+  return out;
+}
+
+/**
+ * Folds `anyOf: [{type: "string"}, {type: "null"}]` into
+ * `type: ["string", "null"]`. Both mean the same; zod 3's converter writes
+ * the array form for `.nullable()`, zod 4's writes the `anyOf` form. One
+ * form on the wire — the one verified against LM Studio in #658.
+ */
+function foldTypeUnion(node: JSONSchema7): JSONSchema7 {
+  for (const key of ['anyOf', 'oneOf'] as const) {
+    const branches = node[key];
+    if (!Array.isArray(branches) || node.type !== undefined) continue;
+    const isTypeOnlyUnion = branches.every((b) => isObject(b) && typeof b.type === 'string' && Object.keys(b).length === 1);
+    if (!isTypeOnlyUnion) continue;
+    const folded: JSONSchema7 = { ...node, type: branches.map((b) => (b as JSONSchema7).type as JSONSchema7TypeName) };
+    delete folded[key];
+    return folded;
+  }
+  return node;
+}
+
+function normalizeNode(def: JSONSchema7Definition): JSONSchema7Definition {
+  if (typeof def === 'boolean') return def;
+  const node: JSONSchema7 = foldTypeUnion({ ...def });
+
+  const isMap = node.properties === undefined && isObject(node.additionalProperties);
+  if (isMap) {
+    // An open map (`additionalProperties: <schema>`, no fixed keys) has no
+    // strict form; normalise the value schema and leave the map open rather
+    // than turning it into an object that admits no key at all.
+    node.additionalProperties = normalizeNode(node.additionalProperties as JSONSchema7);
+  } else if (node.type === 'object' || node.properties !== undefined) {
+    const properties = node.properties ?? {};
+    const names = Object.keys(properties);
+    const wasRequired = new Set(Array.isArray(node.required) ? node.required : []);
+    const nextProperties: Record<string, JSONSchema7Definition> = {};
+    for (const name of names) {
+      const child = normalizeNode(properties[name]);
+      nextProperties[name] = typeof child === 'boolean' || wasRequired.has(name)
+        ? child
+        : makeNullable(child);
+    }
+    node.properties = nextProperties;
+    node.required = names;
+    node.additionalProperties = false;
+  }
+
+  if (node.items !== undefined) {
+    node.items = Array.isArray(node.items)
+      ? node.items.map(normalizeNode)
+      : normalizeNode(node.items);
+  }
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    const branches = node[key];
+    if (Array.isArray(branches)) node[key] = branches.map(normalizeNode);
+  }
+  // `$ref`/`definitions` never reach this boundary: the SDK adapters inline
+  // (`$refStrategy: 'none'`, `reused: 'inline'`) and no raw caller writes them.
+  return canonical(node);
+}
+
+/**
+ * Rewrites a JSON Schema into the strict structured-output dialect: every
+ * property required, former optionals nullable, `additionalProperties: false`
+ * on every object, canonical key order. Pure — the input is not mutated.
+ */
+export function normalizeStrictJsonSchema(schema: JSONSchema7): JSONSchema7 {
+  const out = normalizeNode(schema);
+  return typeof out === 'boolean' ? schema : out;
+}
+
+/**
+ * Removes `null` from the properties that `normalizeStrictJsonSchema` made
+ * nullable — those the *original* schema did not list in `required` — so the
+ * original validator sees the shape it was written for. Properties the
+ * original schema already allowed to be `null` are left alone. Pure.
+ */
+export function stripOptionalNulls(value: unknown, original: JSONSchema7Definition): unknown {
+  if (typeof original === 'boolean') return value;
+  if (Array.isArray(value)) {
+    const items = original.items;
+    if (items === undefined || Array.isArray(items)) return value;
+    return value.map((item) => stripOptionalNulls(item, items));
+  }
+  if (!isObject(value)) return value;
+  const properties = original.properties;
+  if (properties === undefined) return value;
+  const wasRequired = new Set(Array.isArray(original.required) ? original.required : []);
+  const out: JsonObject = {};
+  for (const key of Object.keys(value)) {
+    const child = properties[key];
+    if (child === undefined) {
+      out[key] = value[key];
+    } else if (value[key] === null && !wasRequired.has(key)) {
+      continue;
+    } else {
+      out[key] = stripOptionalNulls(value[key], child);
+    }
+  }
+  return out;
+}
+
+/**
+ * Wraps an AI SDK `Schema` so that the wire sees the strict dialect and the
+ * validator sees the original value shape. Both halves read the adapter's
+ * JSON Schema once, lazily — the SDK's `jsonSchema()` memoises a thunk — so
+ * neither the zod conversion nor the normalisation runs before the wire
+ * needs it, and neither runs twice.
+ */
+export function toStrictSchema<T>(adapted: Schema<T>): Schema<T> {
+  let original: JSONSchema7 | PromiseLike<JSONSchema7> | undefined;
+  const readOriginal = (): JSONSchema7 | PromiseLike<JSONSchema7> => (original ??= adapted.jsonSchema);
+  const validate = adapted.validate;
+  return jsonSchema<T>(
+    () => {
+      const raw = readOriginal();
+      return isPromiseLike(raw) ? raw.then(normalizeStrictJsonSchema) : normalizeStrictJsonSchema(raw);
+    },
+    {
+      validate: validate === undefined
+        ? undefined
+        : async (value) => validate(stripOptionalNulls(value, await readOriginal())),
+    },
+  );
+}
+
+const strictByKey = new WeakMap<object, Schema<unknown>>();
+
+/**
+ * `toStrictSchema` memoised on the caller's schema object. The schemas in
+ * `output-schemas.ts` are module constants and `buildOutputArgs` runs on every
+ * call and every retry, so the adaptation and the normalisation happen once
+ * per schema for the life of the process instead of once per request.
+ */
+export function strictSchemaFor<T>(key: object, adapt: () => Schema<T>): Schema<T> {
+  const cached = strictByKey.get(key);
+  if (cached !== undefined) return cached as Schema<T>;
+  const strict = toStrictSchema(adapt());
+  strictByKey.set(key, strict);
+  return strict;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -915,7 +915,7 @@ export interface LLMClient {
   }): Promise<{
     text: string;
     output?: T;
-    outputMode: 'json_schema' | 'json_object' | 'text_prompt';
+    outputMode: 'json_schema' | 'json_schema_strict' | 'json_object' | 'text_prompt';
     finishReason: LLMFinishReason;
     usage?: LLMUsage;
   }>;

--- a/src/wiki/query-engine/pipeline/query-keywords.ts
+++ b/src/wiki/query-engine/pipeline/query-keywords.ts
@@ -50,7 +50,7 @@ export interface KeywordGenClient {
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     response_format?: { type: 'json_object'; schema?: Record<string, unknown> | z.ZodType };
     enableThinking?: boolean;
-  }): Promise<{ text: string; output?: T; outputMode: 'json_schema' | 'json_object' | 'text_prompt' }>;
+  }): Promise<{ text: string; output?: T; outputMode: 'json_schema' | 'json_schema_strict' | 'json_object' | 'text_prompt' }>;
 }
 
 /** Settings surface — model + disableThinking only. */

--- a/src/wiki/query-engine/pipeline/seed-selector.ts
+++ b/src/wiki/query-engine/pipeline/seed-selector.ts
@@ -44,7 +44,7 @@ export interface SeedLLMClient {
     messages: Array<{ role: 'user' | 'assistant'; content: string }>;
     response_format?: { type: 'json_object'; schema?: Record<string, unknown> | z.ZodType };
     enableThinking?: boolean;
-  }): Promise<{ text: string; output?: T; outputMode: 'json_schema' | 'json_object' | 'text_prompt' }>;
+  }): Promise<{ text: string; output?: T; outputMode: 'json_schema' | 'json_schema_strict' | 'json_object' | 'text_prompt' }>;
 }
 
 /** Settings surface used by seed selector — disableThinking / model only.


### PR DESCRIPTION
## Summary

Closes #658.

**What was wrong.** A strict OpenAI-compatible endpoint rejected `FixDeadLinkSchema` because `required` did not list its four optional properties. The AI SDK already sends `strict: true` for every openai-compatible provider, so the body a strict endpoint saw was `strict: true` with an incomplete `required` and `additionalProperties: true`. Twelve of the seventeen schemas in `output-schemas.ts` carry optional fields, four of them on the ingest path. The 400 body names none of the rejection verbs the demotion chain knows, so the call failed hard instead of demoting.

**The fix.** A new tier `json_schema_strict` between `json_schema` and `json_object`. Same wire shape, schema rewritten by `llm-sdk/strict-schema.ts`: every property in `required` in property order, former optionals nullable as `type: [..., "null"]` (the form verified against LM Studio in the issue), `anyOf` type unions folded into the same form, `additionalProperties: false` on every object, canonical key order. The validator is wrapped alongside: `null` is dropped from exactly the properties the original schema did not require before the original validator runs, so the seventeen zod schemas are untouched and callers see the value shape they always saw. Rewritten once per schema object, lazily. Raw JSON schemas take the same path.

**Why a tier and not the boundary for every backend.** The issue scoped one normalisation for all providers. I built that first and measured it on the full ingest path (dev-instrument, gemma-4-26b on LM Studio, extract pinned to `json_schema`, two notes, one draw each):

| note | items, strict body | items, plain body | output tokens | wall clock |
|---|---|---|---|---|
| Thymian | 15 | 20 | 19.2k vs 30.5k | 453 s vs 646 s |
| L-Theanin | 5 | 8 | 7.1k vs 9.6k | 189 s vs 234 s |

Under the strict grammar every item must carry every key, and the model trades breadth for it: a quarter to a third fewer items, for fewer tokens. The plain body's single truncation at the token cap (Thymian, batch 1) is the known schema-arm collapse; the strict arm had none. Two draws are a direction, not a number, but a cost of that direction is not one a backend that accepts today's body should pay. So the plain body goes first, unchanged; the strict body follows the strict-mode 400 and is remembered per (baseURL, model), like the other tiers. A user can pin it with `extract=strict:off` in the task policies. Field rejections still demote to `json_object`; the chain allows three steps.

**Behaviour change** (release note): none for a backend that accepts today's body. On a strict backend the model is asked for every property (`null` when it has nothing) and unknown keys are refused by the server instead of passed through. Both are what strict mode means; no setting added.

**For #669.** `strict-schema.test.ts` pins that the same shape under zod 3 `.passthrough()` and zod 4 `.looseObject()` differs raw and is byte-equal normalised, and pins `FixDeadLinkSchema` and `SourceAnalysisLLMSchema` as file snapshots the zod 4 migration must leave unchanged.

Tests: 4035 → 4076. Strict-rejection classifier on the #658 body verbatim; the plain tier pinned unchanged for lmstudio; 400 → strict body → nulls round-tripped through `createMessageWithOutput`; the strict tier remembered on the next call; field rejection still → `json_object`; the non-typed branch pinned; policy alias parsed; normaliser unit tests (optional top-level, nested, arrays of objects, enum, already-nullable, open maps, nodes without a type, purity, key order); all seventeen exported schemas checked against the strict dialect. `/code-review` and `/simplify` ran before the push; the WeakMap memo, the open-map rule and the null fallback for nodes without a type came out of them. Both pinned strict bodies accepted by LM Studio as `strict: true` json_schema, HTTP 200.

@wstczyw: a candidate build for your endpoint is this branch; the first call will take one 400, every call after it goes strict directly.

Gate 1: lint 0/0 · tsc 0 · build · 4076/4076 · css-lint 0.
