### PR TITLE
fix(ingest): a skipped file releases the ingest lifecycle (#688)

### DIFF
--- a/src/__tests__/__support__/wiki-engine-harness.ts
+++ b/src/__tests__/__support__/wiki-engine-harness.ts
@@ -31,6 +31,10 @@ export interface WikiEngineHarness {
   stats: { llmCalls: number; vaultMarkdownScans: number };
   /** Filenames delivered to `onIngestionStart` (status-bar text hooks). */
   startedFilenames: string[];
+  /** How many times `onIngestionEnd` fired — the status-bar teardown hook.
+   *  Paired with `startedFilenames` it exposes a teardown that never ran (#688).
+   *  A live getter on the returned object, not a captured number. */
+  endedCount: number;
   /** Paths handed to fileManager.trashFile, in order. */
   trashedPaths: string[];
   /** Progress messages delivered to `onProgress` (PDF "Reading PDF: …"). */
@@ -67,6 +71,7 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
   const reports: IngestReport[] = [];
   const stats = { llmCalls: 0, vaultMarkdownScans: 0 };
   const trashedPaths: string[] = [];
+  let endedCount = 0;
   let llmIdx = 0;
 
   const app = {
@@ -150,10 +155,15 @@ export function createWikiEngineHarness(opts: HarnessOptions = {}): WikiEngineHa
   // can read `startedFilenames` to assert the status bar text was set.
   engine.setIngestionCallbacks(
     (filename?: string) => { if (filename) startedFilenames.push(filename); },
-    () => { /* onEnd: nothing to capture */ },
+    () => { endedCount += 1; },
   );
 
-  return { engine, llmRequests, writtenPaths, reports, files, stats, startedFilenames, progressMessages, trashedPaths };
+  return {
+    engine, llmRequests, writtenPaths, reports, files, stats, startedFilenames, progressMessages, trashedPaths,
+    // Getter, not a field: a bare number is copied by value at construction and
+    // would stay 0 however often the hook fires (the arrays above are references).
+    get endedCount() { return endedCount; },
+  };
 }
 
 /** True if any written path is a wiki entity/concept/source page (the #164 symptom). */

--- a/src/__tests__/wiki/wiki-engine-skip-teardown.test.ts
+++ b/src/__tests__/wiki/wiki-engine-skip-teardown.test.ts
@@ -1,0 +1,61 @@
+// #688 — a file the requirements gate skips returns above the method's main
+// try/finally, so the teardown that lives there never ran. Two consequences,
+// and the second is worse than the reported symptom:
+//
+//   1. `onIngestionEnd` never fired, so the status bar stayed visible. (The
+//      progress Notice the issue also reports is *not* this path — `reportSkip`
+//      dispatches `onDone` with `skipped: true`, which reaches
+//      `dismissProgress` in `onIngestDoneDispatch` for every non-`auto`
+//      trigger. Checked against the code rather than the issue text.)
+//   2. `this.abortController` stayed non-null. The guard at the top of
+//      `ingestSource` only builds a controller — and only calls
+//      `onIngestionStart` — when it finds none, so every later file in the
+//      same batch inherited the skipped file's controller: no fresh signal,
+//      no start hook, and `wasCancelled` never reset.
+//
+// The gate rejection is triggered with an empty note, which `checkNonEmpty`
+// rejects with reason 'empty' — the shortest deterministic path to the skip
+// and the same one the reported reproduction takes.
+
+import { describe, it, expect } from 'vitest';
+import { TFile } from 'obsidian';
+import { createWikiEngineHarness } from '../__support__/wiki-engine-harness';
+
+function sourceFile(path: string): TFile {
+  const name = path.split('/').pop() ?? path;
+  const dot = name.lastIndexOf('.');
+  return Object.assign(new TFile(), {
+    path,
+    name,
+    basename: dot > 0 ? name.slice(0, dot) : name,
+    extension: dot > 0 ? name.slice(dot + 1) : 'md',
+  });
+}
+
+describe('WikiEngine.ingestSource — a skipped file still tears down (#688)', () => {
+  it('fires onIngestionEnd and clears the controller when the gate rejects', async () => {
+    const h = createWikiEngineHarness({ files: { 'Notizen/blank.md': '' } });
+
+    await h.engine.ingestSource(sourceFile('Notizen/blank.md'), { interactive: true });
+
+    expect(h.startedFilenames).toEqual(['blank']);
+    expect(h.endedCount).toBe(1);
+    expect(h.engine.isIngesting()).toBe(false);
+  });
+
+  it('leaves no controller for the next file of a batch to inherit', async () => {
+    const h = createWikiEngineHarness({
+      files: { 'Notizen/blank-a.md': '', 'Notizen/blank-b.md': '' },
+    });
+
+    await h.engine.ingestSource(sourceFile('Notizen/blank-a.md'), {});
+    await h.engine.ingestSource(sourceFile('Notizen/blank-b.md'), {});
+
+    // Both files reach the start hook only when the first released the
+    // controller — the second skips `new AbortController()` + the start call
+    // otherwise.
+    expect(h.startedFilenames).toEqual(['blank-a', 'blank-b']);
+    expect(h.endedCount).toBe(2);
+    expect(h.engine.isIngesting()).toBe(false);
+  });
+});

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -572,6 +572,24 @@ export class WikiEngine {
     return 'sourceRejectedEmpty';
   }
 
+  /**
+   * Release the ingest lifecycle: drop the shared controller and fire the end
+   * hook, which is what takes the status bar down.
+   *
+   * Extracted in #688. The requirements gate's skip returns above the method's
+   * main `try`, so the teardown that lives there never ran for a skipped file.
+   * The visible half was a status bar stuck on "extracting…" until restart; the
+   * half nobody reported is worse — `abortController` stayed non-null, and the
+   * guard at the top of `ingestSource` only builds a controller and calls
+   * `onIngestionStart` when it finds none. So every later file in the same
+   * batch inherited the skipped file's controller: no fresh signal to cancel,
+   * no start hook, and `wasCancelled` never reset.
+   */
+  private endIngestion(): void {
+    this.abortController = null;
+    this.onIngestionEnd?.();
+  }
+
   /** Log + (interactive only) notify + report a gate skip without creating any pages. */
   private reportSkip(file: TFile, rejection: SourceRejection, opts?: IngestOptions): void {
     console.warn(`[Ingest skipped] ${file.path}: ${rejection.reason}${rejection.detail ? ` — ${rejection.detail}` : ''}`);
@@ -955,17 +973,18 @@ export class WikiEngine {
       } finally {
         // Successful conversion re-enters this method and clears the shared
         // controller in the main finally block. Pre-conversion exits do not.
-        if (this.abortController !== null) {
-          this.abortController = null;
-          this.onIngestionEnd?.();
-        }
+        if (this.abortController !== null) this.endIngestion();
       }
       }
     }
 
-    // #164 pre-ingest requirements gate — runs BEFORE any cancellation/UI setup so
-    // a rejected file returns cleanly with nothing to tear down. Empty/type are
-    // hard skips; a duplicate auto-skips, except interactive ingest prompts first.
+    // #164 pre-ingest requirements gate. Empty/type are hard skips; a duplicate
+    // auto-skips, except interactive ingest prompts first.
+    //
+    // #688: this gate no longer runs "BEFORE any cancellation/UI setup" — the
+    // controller and the start hook were moved above it in v1.25.0, because the
+    // PDF branch needs them. A skip here therefore has something to tear down,
+    // and the return below sits above the main `try`, so it must do it itself.
     const fileContent = opts?.contentOverride ?? await this.app.vault.read(file);
     const rejection = opts?.forceReingest ? null : await this.checkRequirements(file, fileContent, opts?.batchCtx);
     if (rejection) {
@@ -974,6 +993,7 @@ export class WikiEngine {
         : false;
       if (!confirmed) {
         this.reportSkip(file, rejection, opts);
+        this.endIngestion();
         return;
       }
     }
@@ -1604,8 +1624,7 @@ export class WikiEngine {
       throw error;
     } finally {
       this.triageContradictions = null;
-      this.abortController = null;
-      this.onIngestionEnd?.();
+      this.endIngestion();
     }
   }
 


### PR DESCRIPTION
Closes #688.

**The defect.** The requirements gate's skip returns above the method's main `try`, so the teardown that lives in that `finally` never ran for a skipped file:

```
wiki-engine.ts:914   if (this.abortController === null) { …; this.onIngestionStart?.(file.basename); }   ← status bar shown
wiki-engine.ts:996   this.reportSkip(file, rejection, opts); return;                                     ← early return
wiki-engine.ts:1627  } finally { this.triageContradictions = null; this.endIngestion(); }                ← never reached
```

**Two consequences, and the unreported one is worse.** The status bar stayed on "extracting…" until Obsidian restarted — that is what the issue describes. But `abortController` also stayed non-null, and the guard at the top of `ingestSource` only builds a controller *and only calls `onIngestionStart`* when it finds none. So every later file in the same batch inherited the skipped file's controller: no fresh signal for the status bar's cancel click to abort, no start hook for the file being processed, and `wasCancelled` never reset. The second test below pins exactly that.

**The fix.** `endIngestion()` becomes the single owner of the teardown, called from the three sites that need it: the conversion branch's guarded `finally`, the gate's skip, and the main `finally`. The guard in the first is what keeps the PDF re-entry from firing the end hook twice — the outer call's `finally` sees a null controller after the re-entered call already cleared it.

The gate's stale comment is corrected too. It claimed the gate "runs BEFORE any cancellation/UI setup so a rejected file returns cleanly with nothing to tear down", which stopped being true in v1.25.0 when the controller and start hook were moved above it for the PDF branch. That stale justification is why the missing teardown survived two years of reading.

**Not changed — and this is deliberate.** The issue also reports an undismissed progress Notice. I could not reproduce that from source: `reportSkip` dispatches `onDone` with `skipped: true`, and `onIngestDoneDispatch` calls `dismissProgress()` for every non-`auto` trigger, so the Notice is dismissed on the skip path. I left it alone rather than "fixing" a path that works. If it still reproduces for you, the ingest path and the console output would tell us which branch you hit.

## Tests

`src/__tests__/wiki/wiki-engine-skip-teardown.test.ts` drives the gate with an empty note (`checkNonEmpty` → reason `empty`), the shortest deterministic path to the rejection. Both cases were RED first, for the reasons above:

| Assertion | Before |
|---|---|
| single file: end hook fires once, controller released | `endedCount` 0 |
| batch: the second file still reaches the start hook | `startedFilenames` was `['blank-a']` |

The harness gained `endedCount` as a live getter — a plain number field is copied by value when the return object is built, so it read 0 no matter how often the hook fired.

## Gate 1

lint 0 / tsc 0 / build clean / **4117 tests, 289 files** / css-lint 0.

## Gate 4: Performance

| Dim | Status | Notes |
|-----|--------|-------|
| CPU | ✅ | One extra method call on the skip path; no loop or hot-path change |
| Memory | ✅ improved | One fewer leaked AbortController per batch — the leak was one per skipped file |
| IO | N/A | No vault read or write touched |
| Network | ✅ improved | A leaked controller meant the status-bar cancel click aborted a stale signal; every file now gets a fresh one `cancelIngestion()` can reach |
| Token | N/A | No LLM call shape changed |
