### PR TITLE
fix(lint): Delete Empty Stubs collects a Fix Dead Links stub (#678)

### DIFF
--- a/src/__tests__/wiki/lint/delete-empty-stubs.test.ts
+++ b/src/__tests__/wiki/lint/delete-empty-stubs.test.ts
@@ -1,0 +1,161 @@
+// #678 — a page Fix Dead Links writes is never collected by "Delete Empty
+// Stubs". #197 (d53caab) replaced the stub sentence and left `STUB_MARKER` on
+// the old one, so `isPageEmpty` stopped recognising these pages: the current
+// placeholder clears MIN_SUBSTANTIVE_CHARS by roughly a factor of two once
+// EMPTY_CONTENT_STRIP has run.
+//
+// The fix keys off `stub: true` instead — the marker `fix-dead-link.ts`
+// documents as the one that actually carries "this is a stub", and which
+// `merge-page.ts` strips when a source that treats the subject fills the page.
+// It is deliberately NOT folded into `isPageEmpty`, because that predicate also
+// decides which pages "Expand Empty Pages" hands to the LLM, and #197's policy
+// gate forbids fabricating content for an unresolvable link. The last test
+// below pins that separation so a later edit cannot merge the two predicates
+// back together by accident.
+
+import { describe, it, expect } from 'vitest';
+import { deleteEmptyStubs } from '../../../wiki/lint/delete-empty-stubs';
+import { isPageEmpty } from '../../../wiki/lint/utils';
+import { buildDissentStubContent } from '../../../wiki/page-factory/stub-page';
+import { createMockContext } from '../../__support__/engine-context';
+
+const WIKI = 'wiki';
+const STUB_PATH = `${WIKI}/concepts/smart-batch-skip.md`;
+
+function deadLinkStub(title: string, referrer: string): string {
+  return `---\ntype: concept\ncreated: 2026-09-12\nsources:\n  - "[[${referrer}]]"\ntags: [thema/wissen]\nstub: true\ngeneration_complete: false\n---\n# ${title}\n\n> Stub created by Fix Dead Links — referenced by [[${referrer}]]. Will be filled by next ingest of an actual source that defines this entity.\n`;
+}
+
+/** Built by the real gate writer, so the shape cannot drift away from the test. */
+function dissentStub(withSummary: boolean, withMention = true): string {
+  return buildDissentStubContent({
+    item: {
+      name: 'Smart Batch Skip',
+      type: 'term',
+      summary: withSummary ? 'An optimisation that skips batches nothing changed in.' : '',
+      // `buildDissentStubContent` drops `quoteBlock` entirely when this is
+      // empty (`stub-page.ts:138`), which is the third form below.
+      mentions_in_source: withMention ? ['Batches whose inputs are unchanged are skipped entirely.'] : [],
+      related_concepts: [],
+    },
+    stubType: 'concept',
+    sourceSlug: 'some-source',
+    cell: 'unnamed-but-present',
+  });
+}
+
+const SUBSTANTIVE = `---\ntype: concept\n---\n# Real Page\n\nA page with a paragraph of actual content, comfortably past the substantive-character floor used by the empty-page predicate.\n`;
+
+async function runDelete(vaultFiles: Record<string, string>) {
+  const { ctx } = createMockContext({ vaultFiles });
+  const deleted: string[] = [];
+  ctx.deleteFile = async (p: string) => { deleted.push(p); };
+  const result = await deleteEmptyStubs(ctx, WIKI);
+  return { deleted, result };
+}
+
+describe('deleteEmptyStubs — a Fix Dead Links stub is collected (#678)', () => {
+  it('deletes the stub even though its placeholder text is not "empty"', async () => {
+    const stub = deadLinkStub('Smart Batch Skip', 'Notizen/note.md');
+    // The premise of the bug: the placeholder clears the floor, so the
+    // text-based predicate says the page is fine.
+    expect(isPageEmpty(stub)).toBe(false);
+
+    const { deleted, result } = await runDelete({ [STUB_PATH]: stub });
+
+    expect(deleted).toEqual([STUB_PATH]);
+    expect(result.deleted).toBe(1);
+  });
+
+  it('keeps a page that carries real content', async () => {
+    const { deleted, result } = await runDelete({ [`${WIKI}/concepts/real.md`]: SUBSTANTIVE });
+
+    expect(deleted).toEqual([]);
+    expect(result.deleted).toBe(0);
+  });
+
+  it('keeps a stub the user marked reviewed', async () => {
+    const reviewed = deadLinkStub('Kept On Purpose', 'Notizen/note.md')
+      .replace('stub: true\n', 'stub: true\nreviewed: true\n');
+
+    const { deleted } = await runDelete({ [STUB_PATH]: reviewed });
+
+    expect(deleted).toEqual([]);
+  });
+
+  it('keeps a page a source has filled — merge-page strips the marker', async () => {
+    const filled = deadLinkStub('Filled By Ingest', 'Notizen/note.md').replace('stub: true\n', '');
+
+    const { deleted } = await runDelete({ [STUB_PATH]: filled });
+
+    expect(deleted).toEqual([]);
+  });
+
+  it('collects an empty page that is not a stub — the text predicate still governs those', async () => {
+    const empty = `---\ntype: concept\n---\n# Thin\n\nTiny.\n`;
+
+    const { deleted, result } = await runDelete({ [`${WIKI}/concepts/thin.md`]: empty });
+
+    expect(deleted).toEqual([`${WIKI}/concepts/thin.md`]);
+    expect(result.deleted).toBe(1);
+  });
+
+  it('leaves isPageEmpty alone, so Expand Empty Pages never sees a stub (#197)', () => {
+    // If a stub ever became "empty" here it would be offered to fillEmptyPage,
+    // which #197's gate exists to prevent. Deleting and filling are different
+    // decisions and must stay in different predicates.
+    expect(isPageEmpty(deadLinkStub('Smart Batch Skip', 'Notizen/note.md'))).toBe(false);
+  });
+
+  // The marker `stub: true` has two writers. The dead-link one writes a
+  // placeholder and nothing else; the ingest candidate gate writes a
+  // placeholder PLUS the extraction's summary and a verbatim quote. Everything
+  // below keeps that second kind on disk — the action is named "Delete Empty
+  // Stubs" and those pages are not empty.
+  it('keeps a gate stub that carries a summary and a quote', async () => {
+    const stub = dissentStub(true);
+    expect(isPageEmpty(stub)).toBe(false);
+    expect(stub).toContain('stub: true');
+
+    const { deleted } = await runDelete({ [STUB_PATH]: stub });
+
+    expect(deleted).toEqual([]);
+  });
+
+  it('keeps a gate stub whose summary is empty — its quote is still content', async () => {
+    const stub = dissentStub(false);
+    expect(stub).toContain('stub: true');
+
+    const { deleted } = await runDelete({ [STUB_PATH]: stub });
+
+    expect(deleted).toEqual([]);
+  });
+
+  it('still collects the dead-link stub that sits beside those', async () => {
+    // Same helper, same frontmatter, same marker — only the body differs. This
+    // is the pair that makes the distinction mean something.
+    const deadLink = deadLinkStub('Smart Batch Skip', 'Notizen/note.md');
+    const gate = dissentStub(true);
+
+    const { deleted } = await runDelete({ [`${WIKI}/concepts/from-dead-link.md`]: deadLink, [`${WIKI}/concepts/from-gate.md`]: gate });
+
+    expect(deleted).toEqual([`${WIKI}/concepts/from-dead-link.md`]);
+  });
+
+  // The gate stub's third form, and the one a later reader is most likely to
+  // mistake for a bug. With neither a summary nor a mention, `quoteBlock` is
+  // empty (`stub-page.ts:138`), so the body is a heading and its placeholder —
+  // the dead-link shape exactly. Collecting it is deliberate: there is nothing
+  // on the page a model produced, which is the same test the dead-link stub
+  // fails. Without this case, someone "fixing" isEmptyStub to spare gate stubs
+  // would silently reintroduce #678.
+  it('collects a gate stub with neither a summary nor a quote — nothing was paid for', async () => {
+    const stub = dissentStub(false, false);
+    expect(stub).toContain('stub: true');
+    expect(stub).not.toContain('> "');
+
+    const { deleted } = await runDelete({ [STUB_PATH]: stub });
+
+    expect(deleted).toEqual([STUB_PATH]);
+  });
+});

--- a/src/wiki/lint/delete-empty-stubs.ts
+++ b/src/wiki/lint/delete-empty-stubs.ts
@@ -1,7 +1,48 @@
 import { EngineContext } from '../../types';
-import { parseFrontmatter } from '../../core/frontmatter';
+import { parseFrontmatter, extractBody } from '../../core/frontmatter';
 import { isPageEmpty } from './utils';
+import { isStubPage } from '../page-factory/stub-page';
 import { isInFolderScope } from '../../core/folder-scope';
+
+/**
+ * A stub is empty when all it holds is its own title and its own placeholder
+ * line — nothing the plugin paid a model for.
+ *
+ * `stub: true` alone cannot answer that. Two writers set the marker and their
+ * bodies differ in kind: `fix-dead-link.ts` writes a placeholder pointing at a
+ * page that does not exist yet, while the ingest candidate gate
+ * (`buildDissentStubContent`, `stub-page.ts`) writes a placeholder *plus the
+ * extraction's summary and a verbatim quote*. Deleting the second kind would
+ * take real content off disk under an action named "Delete Empty Stubs".
+ *
+ * So the shape is asserted directly: one heading, one quoted line, no prose.
+ * That is exact for the dead-link stub, and it sorts the gate stub's three
+ * forms by whether a model produced anything on the page:
+ *
+ *   summary + quote  → prose present        → kept
+ *   summary, no quote → prose present       → kept
+ *   neither          → nothing paid for     → collected, on purpose
+ *
+ * The third form is the one to read twice. `buildDissentStubContent` drops
+ * `quoteBlock` when the item carries no mention (`stub-page.ts:138`), so a
+ * gate stub with no summary *and* no mention has exactly the dead-link shape
+ * and is collected. That is the intent, not an oversight — by the rule above
+ * there is nothing on that page a model produced, which is the same reason
+ * the dead-link stub goes. Pinned by test so it is not "fixed" later.
+ *
+ * Fail-safe by construction: anything a future writer adds that is neither a
+ * heading nor a quote keeps the page.
+ */
+function isEmptyStub(content: string): boolean {
+  const lines = extractBody(content)
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+  const headings = lines.filter(line => line.startsWith('#'));
+  const quotes = lines.filter(line => line.startsWith('>'));
+  const prose = lines.filter(line => !line.startsWith('#') && !line.startsWith('>'));
+  return headings.length === 1 && quotes.length === 1 && prose.length === 0;
+}
 
 export async function deleteEmptyStubs(
   ctx: EngineContext,
@@ -21,9 +62,21 @@ export async function deleteEmptyStubs(
   for (const file of files) {
     try {
       const content = await ctx.app.vault.read(file);
-      if (!isPageEmpty(content)) continue;
       const fm = parseFrontmatter(content);
       if (fm?.reviewed === true) continue;
+      // #678: a stub carries `stub: true` and a placeholder sentence that clears
+      // MIN_SUBSTANTIVE_CHARS by roughly a factor of two, so the text-based
+      // predicate alone never recognised one — every Fix Dead Links stub
+      // survived this action for good.
+      //
+      // Deliberately NOT folded into `isPageEmpty`: that predicate also decides
+      // which pages "Expand Empty Pages" hands to the LLM, and #197's gate
+      // forbids fabricating content for an unresolvable link. Deleting a stub
+      // and filling it are different decisions and stay in different places.
+      //
+      // The stub test is `isEmptyStub`, not `isStubPage` — the marker is set by
+      // two writers whose bodies differ; see its doc comment above.
+      if (!isPageEmpty(content) && !(isStubPage(fm) && isEmptyStub(content))) continue;
       await ctx.deleteFile(file.path);
       deleted++;
     } catch (e) {

--- a/src/wiki/lint/utils.ts
+++ b/src/wiki/lint/utils.ts
@@ -63,6 +63,11 @@ export function fixDoubleNestedWikiLinks(content: string): { fixed: number; cont
 
 export const EMPTY_CONTENT_STRIP = /[#*\-_>\s\n[\]|—]/g;
 export const MIN_SUBSTANTIVE_CHARS = 50;
+/** The stub sentence written before #197 (d53caab) replaced it with the
+ *  "Stub created by Fix Dead Links — …" placeholder. Kept so a page written by
+ *  an older version is still recognised as empty; nothing writes it any more,
+ *  and a current stub is recognised by its `stub: true` frontmatter instead
+ *  (`isStubPage`, used by deleteEmptyStubs for #678). */
 export const STUB_MARKER = 'Auto-generated stub page';
 
 export function isPageEmpty(content: string): boolean {


### PR DESCRIPTION
`Delete Empty Stubs` never deleted a `Fix Dead Links` stub. It asked `isPageEmpty`, which measures substantive text — and a stub's placeholder sentence clears `MIN_SUBSTANTIVE_CHARS` by roughly a factor of two. Every stub the action exists to collect survived it.

## The fix

`src/wiki/lint/delete-empty-stubs.ts` — the predicate is now a pair:

```ts
if (!isPageEmpty(content) && !(isStubPage(fm) && isEmptyStub(content))) continue;
```

`isStubPage` alone would have been wrong, and that is the part worth reading closely. `stub: true` has **two writers in main**:

| Writer | Body |
|---|---|
| `fix-dead-link.ts:95` | placeholder pointing at a page that does not exist yet |
| `stub-page.ts:140` (`buildDissentStubContent`, #485/#607) | placeholder **plus the extraction's summary and a verbatim quote** |

Their frontmatter is identical in shape, so the marker cannot separate them. Recognising it alone would have deleted pages holding paid-for extraction output, under an action named "Delete Empty Stubs" — a content-loss class change and not what #678 asked for.

`isEmptyStub` therefore asserts the shape directly: **one heading, one quoted line, no prose**. That sorts all four bodies by whether a model produced anything on the page:

| Body | Shape | Outcome |
|---|---|---|
| dead-link stub | 1 heading + 1 placeholder quote | **collected** |
| gate stub, summary + quote | prose present | kept |
| gate stub, summary only | prose present | kept |
| gate stub, neither | 1 heading + 1 placeholder quote | **collected, on purpose** |

The fourth row is deliberate: `buildDissentStubContent` drops `quoteBlock` when the item carries no mention (`stub-page.ts:138`), so that stub matches the dead-link shape exactly — and by the rule above there is nothing on it a model produced. Fail-safe by construction: anything a future writer adds that is neither a heading nor a quote keeps the page.

## Tests — ten cases in `delete-empty-stubs.test.ts`

Gate stubs are built by `buildDissentStubContent` itself rather than hand-written, so the shape cannot drift from what the writer produces.

1. deletes the stub even though its placeholder text is not "empty" — the #678 case
2. keeps a page that carries real content
3. keeps a stub the user marked `reviewed`
4. keeps a page a source has filled — `merge-page` strips the marker
5. collects an empty page that is not a stub — the text predicate still governs those
6. `isPageEmpty` is unchanged, so Expand Empty Pages never sees a stub (#197)
7. keeps a gate stub that carries a summary and a quote
8. keeps a gate stub whose summary is empty — its quote is still content
9. a dead-link stub and a gate stub side by side: same helper, same frontmatter, same marker, only the body differs — exactly one collected
10. collects a gate stub with neither a summary nor a quote

Case 6 is the reason the predicate was **not** folded into `isPageEmpty`: that function also decides which pages Expand Empty Pages hands to the LLM, and #197's gate forbids fabricating content for an unresolvable link. Deleting a stub and filling it are different decisions and stay in different places.

Case 10 is mutation-checked rather than assumed: making `isEmptyStub` spare gate stubs fails it and nothing else (1 failed / 9 passed), so a later reader who reads that row as a bug hits the test instead of silently reintroducing #678.

Case 5 was renamed from "keeps an empty page that is not a stub" to match what it asserts — the name had been inverted, which in a deletion path invites a reader to "repair" the behaviour toward keeping.

Gate 1: lint 0 / tsc 0 / build OK / **4108 tests, 291 files** / css-lint 0.

Closes #678.
