### PR TITLE
ci: gate package-lock.json against package.json

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -46,6 +46,21 @@ jobs:
       - name: Install (lockfile-pinned)
         run: pnpm install --frozen-lockfile
 
+      - name: Lockfile sync (package.json against package-lock.json)
+        # The npm-side lockfile has no other gate: `pnpm install
+        # --frozen-lockfile` above and `pnpm audit` below both read *pnpm's*
+        # lockfile, so package-lock.json can drift from package.json for a
+        # whole release cycle without anything noticing. That is what happened
+        # in #652 — vitest moved to 5.0.0 in package.json and pnpm-lock.yaml
+        # while package-lock.json stayed on 4.1.10, and it surfaced later as
+        # two Dependabot advisories filed against the stale copy.
+        #
+        # Offline and exact by construction: it compares the specifiers the
+        # lockfile recorded against the ones package.json declares. No npm
+        # resolution, so a legitimate newer patch inside a range cannot read
+        # as drift.
+        run: pnpm lockfile-check
+
       - name: Audit (dev + prod, high+)
         # Dependency security gate: fail the PR the day a vulnerable transitive
         # dep lands, not when a human notices the Dependabot alert. `--audit-level

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src/ --max-warnings=0",
     "lint:tools-bot": "eslint --config eslint.tools-bot.config.mjs tools/ --max-warnings=-1 || true",
     "css-lint": "node scripts/css-lint.mjs",
+    "lockfile-check": "node scripts/check-lockfile-sync.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-lockfile-sync.mjs
+++ b/scripts/check-lockfile-sync.mjs
@@ -1,0 +1,58 @@
+// package.json and package-lock.json must agree on every direct dependency.
+//
+// They have drifted twice. #501/#556 documented the class — npm does not read
+// pnpm's lockfile, so the two carry the same dependency graph in two formats
+// with nothing keeping them in step. #652 reintroduced it by bumping vitest in
+// package.json and pnpm-lock.yaml while package-lock.json stayed on the old
+// major, and nothing caught it: CI installs with `pnpm install
+// --frozen-lockfile` and the audit step reads pnpm's lockfile, so the npm-side
+// lockfile had no gate at all between releases. It surfaced eventually as two
+// Dependabot advisories filed against the stale copy.
+//
+// The check reads what the lockfile recorded about its own inputs. A lockfile's
+// root entry (`packages[""]`) carries the dependency specifiers package.json
+// held when it was generated, so if a specifier has changed since, the two
+// disagree and the lockfile is stale by definition.
+//
+// Deliberately offline and exact rather than "regenerate and diff". npm
+// re-resolves ranges, so a legitimate newer patch inside a range would read as
+// drift and fail a clean tree; comparing recorded specifiers cannot produce
+// that false positive, needs no semver library (this repo has none), and needs
+// no network.
+
+import { readFileSync } from 'node:fs';
+
+const read = (name) => JSON.parse(readFileSync(new URL(`../${name}`, import.meta.url), 'utf8'));
+
+const pkg = read('package.json');
+const lock = read('package-lock.json');
+const lockRoot = lock.packages?.[''] ?? {};
+
+const SECTIONS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
+const problems = [];
+
+for (const section of SECTIONS) {
+  const declared = pkg[section] ?? {};
+  const recorded = lockRoot[section] ?? {};
+  for (const name of [...new Set([...Object.keys(declared), ...Object.keys(recorded)])].sort()) {
+    const want = declared[name];
+    const have = recorded[name];
+    if (want === have) continue;
+    if (want === undefined) {
+      problems.push(`${name}: in package-lock.json under ${section} as ${have}, but not declared in package.json`);
+    } else if (have === undefined) {
+      problems.push(`${name}: declared ${want} in package.json, absent from package-lock.json`);
+    } else {
+      problems.push(`${name}: package.json declares ${want}, package-lock.json was generated for ${have}`);
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error('package-lock.json is out of sync with package.json:');
+  for (const problem of problems) console.error(`  - ${problem}`);
+  console.error('\nRegenerate it with: npm install --legacy-peer-deps --package-lock-only');
+  process.exit(1);
+}
+
+console.log('lockfile-sync: package-lock.json matches package.json');


### PR DESCRIPTION
Adds the gate that was missing, so the drift #692 repairs cannot recur silently.

**Stacked on #692** — deliberately. The new check fails against main's current `package-lock.json`, which is the point of it; this PR is only green once #692's regeneration is in. Merge #692 first.

## The gap

`pnpm install --frozen-lockfile` and the `pnpm audit` step added in #637 both read **pnpm's** lockfile. Nothing read `package-lock.json`, so it could drift from `package.json` for a whole release cycle unnoticed — which is what #652 did (vitest to 5.0.0 in `package.json` + `pnpm-lock.yaml`, `package-lock.json` left on 4.1.10). It surfaced only when Dependabot filed two advisories against the stale copy.

## The check

`scripts/check-lockfile-sync.mjs` compares the two files directly, using something a lockfile records about its own inputs: the root entry (`packages[""]`) carries the dependency specifiers `package.json` held when it was generated. If a specifier changed since, the two disagree and the lockfile is stale by definition. It covers `dependencies`, `devDependencies`, `optionalDependencies` and `peerDependencies` in both directions — a specifier that changed, a dependency added, or one removed from `package.json` but still recorded.

**Offline and exact, by choice.** The obvious check is `npm install --package-lock-only && git diff --exit-code`, and it is wrong for this purpose: npm re-resolves ranges, so a legitimate newer patch inside a range would read as drift and fail a clean tree. Comparing recorded specifiers cannot produce that false positive, needs no semver library (this repo has none) and no network, and runs in well under a second.

Wired as `pnpm lockfile-check`, and as its own CI step between Install and Audit.

**Not folded into `gate:1`.** That would turn the documented Five-Gate into six and rename a contract that AGENTS.md and the CI job name both reference. Folding it in is a follow-up decision, not a side effect of this PR — say the word and I will do it as its own change with the docs updated.

## Verified in both directions

Against the real defect, using `main`'s stale lockfile:

```
package-lock.json is out of sync with package.json:
  - vitest: package.json declares 5.0.0, package-lock.json was generated for 4.1.10

Regenerate it with: npm install --legacy-peer-deps --package-lock-only
exit=1
```

Against the fixed lockfile: `lockfile-sync: package-lock.json matches package.json`, `exit=0`, no diff.

## Gate 1

lint 0 / tsc 0 / build clean / 4115 tests, 288 files / css-lint 0.

## Note on merging

This PR touches `.github/workflows/pr-ci.yml`, so `gh pr merge` refuses it with *"refusing to allow an OAuth App to create or update workflow … without `workflow` scope"* — the same wall #639 hits. It needs a web-UI merge (or a token with that scope), not an API merge.
