### PR TITLE
docs(memory): a close keyword in prose closes a PR, not just an issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,9 +158,17 @@ For contributor PRs that need rebase after base-branch move: use `gh pr update-b
 **Mandatory merge sequence (added 2026-08-18):** every merge MUST follow this exact order. Skipping any step is a procedural miss even when content review passed:
 
 ```
+gh pr view <N> --json title,body --jq '.title, .body' | grep -inE '\b(closes?|closed|fix(es|ed)?|resolve[sd]?)\s+#[0-9]+'   # ← scan FIRST; every hit must be an issue you mean to close
 gh pr review <N> --body "<file>"   # ← MANDATORY. Formal review event lands on the PR.
 gh pr merge <N> --admin --squash --delete-branch   # ← ONLY after user said "merge it"
 ```
+
+- **Scan the body before merging.** A closing keyword needs no intent and does
+  not have to aim at an issue. Writing the fix reference as prose — "its fix
+  #684" — parsed as `fix #684` and closed **PR #684** one second after the PR
+  carrying that sentence merged. The author never touched it, and the ROI
+  board merged in that same PR listed #684 as an unblock-first item. Recover
+  with `gh pr reopen <N>`; see MEMORY.md §"Issue close keyword".
 
 - **`gh pr review --approve` (or `--request-changes`) MUST be posted BEFORE `gh pr merge`.** This lands the formal review verdict on the PR timeline; downstream tooling (release notes, contributor credit, audit trail) reads from that event, not from comments.
 - For architect-level contributor PRs (e.g. @DocTpoint), per [[feedback_reply_brevity_for_architect_contributors]]: review body should be **decision + ≤5 sentences** + concrete `file:line` findings, not a long-form audit.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -144,6 +144,35 @@ auto-close. Squash-merge must preserve the keyword in the squash commit
 body. Verified 2026-08-07: the v1.26.0 MINOR batch had 5 state-drift issues
 because PRs #401/#406/#410/#411 used non-closing keywords.
 
+**The inverse hazard — a keyword in prose closes a PR (2026-09-12):** the
+keyword does not have to be deliberate and it does not have to aim at an
+issue. PR #689's body described the milestone in prose:
+
+> #604 sits on `v1.28.0 MINOR` while its **fix #684** sits on the PATCH line
+
+GitHub parsed `fix #684` as a closing directive ⇒ merging #689 **closed PR
+#684** one second after it landed. `ClosedEvent.closer` = PullRequest #689;
+the author had not touched it, and the ROI board merged in that same PR
+listed #684 as its second unblock-first item. A closed PR reads to the
+contributor as *rejected*. Rules that follow:
+
+- Never let `close[sd]?` / `fix(es|ed)?` / `resolve[sd]?` sit immediately
+  before `#N` in prose. Write "the fix for #604 is PR #684" — the article
+  breaks the match — or just "PR #684".
+- **The target decides the damage.** A keyword aimed at an issue closes the
+  issue (intended). Aimed at a PR it closes the PR.
+- **Before merging, scan the title + body and confirm every hit is an issue
+  you mean to close:**
+  `gh pr view <N> --json title,body --jq '.title, .body' | grep -inE '\b(closes?|closed|fix(es|ed)?|resolve[sd]?)\s+#[0-9]+'`
+  Open PRs at the time of writing are clean — the other matches
+  (`Fixes #592` / `#597` / `#672` / `#666` / `#688` / `#678` / `#657`) all
+  point at issues.
+- **Recover with `gh pr reopen <N>`**, and read the closer before assuming
+  the mechanism: a `closed` event carries `commit_id` when a commit message
+  did it, and leaves it empty for an API/PR-level close. This one was
+  `actor=green-dalii, commit=-`, which ruled out a commit keyword and pointed
+  at the merge that had happened one second earlier.
+
 ---
 
 ## Key design decisions (canonical references)


### PR DESCRIPTION
Records the 2026-09-12 incident where merging one PR closed another.

`### Issue close keyword` in MEMORY.md covered one direction: use `Closes`/`Fixes` when you want auto-close, not `Refs`/`See`. This adds the inverse, which nothing had written down.

PR #689's body described the milestone in prose — "#604 sits on `v1.28.0 MINOR` while its **fix #684** sits on the PATCH line". GitHub parsed `fix #684` as a closing directive, so merging #689 closed **PR #684** one second later. `ClosedEvent.closer` = PullRequest #689. Author never touched it, and the ROI board merged in that same PR lists #684 as its second unblock-first item.

Four rules, plus the mechanism for reading the evidence: a `closed` event carries `commit_id` when a commit message did it and leaves it empty for an API/PR-level close — that distinction is what ruled out a commit keyword and pointed at the merge one second earlier.

**AGENTS.md gets the same scan as the first step of the mandatory merge sequence.** In MEMORY.md it is a rule to remember; in the merge sequence it is a step that runs.

Scope: documentation only, no code. Open PRs were scanned — the other keyword matches (`Fixes #592` / `#597` / `#672` / `#666` / `#688` / `#678` / `#657`) all point at issues, which is their purpose. #684 was the only one aimed at a PR by accident, and it has been reopened.
