### PR TITLE
docs(memory): read existing PR signals before submitting a review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,19 @@ gh pr merge <N> --admin --squash --delete-branch   # ← ONLY after user said "m
 - **Post-merge audit trail:** if a `gh pr merge` was executed without the matching `--approve` event (procedural miss, not content miss), immediately post `gh pr comment <N> --body <audit-note>` recording what was skipped. Don't rebase, don't re-merge, don't amend — the merge commit hash stands; only the audit trail is patched. Incident reference: PR #478 (2026-08-18, merge `2806d24`).
 - Anti-pattern: "`gh pr merge --admin` doesn't enforce reviews, so I can skip --approve." Wrong — `--admin` bypasses the **requirement** rule, not the **review event** rule. Two separate audit surfaces.
 
+**Reviewing PRs (added 2026-09-12, after #570):** a PR decided against is **closed** once the contributor has had a fair window to answer (roughly two weeks of silence), with the decision comment naming in one line what would reopen it. An open PR states that merging is still possible — a closed one cannot collect a stray review at all.
+
+Every review submission MUST begin with the signal check:
+
+```
+gh pr view <N> --json labels,comments --jq '{labels: [.labels[].name], last_comments: [.comments[] | "\(.author.login) \(.createdAt[0:10]): \(.body[0:120])"][-3:]}'   # ← check FIRST
+gh pr review <N> --body "<file>"   # ← ONLY when the check above returned no signal
+```
+
+Two ways to get that check wrong, both caught in review of its first version: `.[0:1]` returns the **oldest** comment rather than the latest — decisions arrive late, so it hides exactly what it is looking for — and filtering on one account's login makes a decision written by any other maintainer invisible. Take the last few comments from **any** author.
+
+If a signal is present, post a short comment asking instead of a review. To undo a misfired review: dismiss it (`PUT .../pulls/<N>/reviews/<id>/dismissals`) and, if the PR is `wontfix`, convert it to draft via `convertPullRequestToDraft` (REST's `draft` field is GitHub-App-only; `gh` has no `pr draft`). MEMORY.md §"Declined PRs are closed, not left open".
+
 ---
 
 ## 📦 Development Workflow

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -173,6 +173,50 @@ contributor as *rejected*. Rules that follow:
   `actor=green-dalii, commit=-`, which ruled out a commit keyword and pointed
   at the merge that had happened one second earlier.
 
+### Declined PRs are closed, not left open
+
+A PR that has been decided against is **closed** once the contributor has
+had a fair window to answer the decision — roughly two weeks of silence is
+enough. An open pull request states that merging is still possible, which is
+exactly what a decline says is not the case; a closed one cannot collect a
+stray review at all. Closing loses nothing: the branch, the diff and the
+whole thread stay readable and linkable, which is all "preserved as a
+reference implementation" requires.
+
+A close means "not now", not "never", so the **decision comment names what
+would reopen it, in one line**. That is what keeps the door open without
+keeping the PR open.
+
+`#570` (2026-09-12) carried three signals of one decision — a `wontfix`
+label, a decision comment, and draft status — while staying open. None of
+them is the place every tool and every reader agrees on, so a
+`CHANGES_REQUESTED` review landed on it anyway, contradicting the decision
+and inviting the contributor to do work that was already declined.
+Recovered by dismissing the review (`PUT .../reviews/<id>/dismissals`),
+posting a correction comment, and converting to draft via
+`convertPullRequestToDraft` (`gh` has no `pr draft`; REST's `draft` field is
+GitHub-App-only).
+
+**Before any review, read the signals.** Two ways to get that check wrong,
+both caught in review of its first version:
+
+- **Latest, not first.** Decisions arrive late on a thread that opened with
+a greeting. `.[0:1]` returns the *oldest* comment — which on #570 happened
+to be the decision, so the check looked right on the one case it was built
+against and would hide the decision everywhere else.
+- **Any maintainer, not one account.** Keying on `.author.login ==
+"green-dalii"` makes a decision written by anyone else invisible, and the
+rule quietly stops matching the moment a second person records one.
+
+```
+gh pr view <N> --json labels,comments \
+  --jq '{labels: [.labels[].name], last_comments: [.comments[] | "\(.author.login) \(.createdAt[0:10]): \(.body[0:120])"][-3:]}'
+```
+
+Any `wontfix` / `duplicate` / `do not merge` label, or a maintainer comment
+recording a decision, means the PR is decided — **stop** and post a short
+comment asking rather than a review.
+
 ---
 
 ## Key design decisions (canonical references)


### PR DESCRIPTION
Records the 2026-09-12 incident where a review contradicted an already-decided PR.

**What happened.** #570 had been labelled `wontfix` two weeks earlier with a detailed maintainer decision comment ("we're declining this and not scheduling it for future work"). A review was submitted anyway with `CHANGES_REQUESTED`. That verdict reads as "fix these and we'll merge" — the opposite of the recorded decision — and would have told the contributor to do work that was explicitly declined.

**The rule.** Before any review submission (approve, request changes, or comment), check the PR's labels and the most recent maintainer comment. A `wontfix` / `duplicate` / `do not merge` label, or a prior decision comment, means stop and post a short comment asking instead.

**Recovered by:**
- Dismissing the review (`PUT .../reviews/<id>/dismissals`)
- Posting a one-paragraph correction comment naming the PR's actual state
- Converting the PR to draft via GraphQL `convertPullRequestToDraft` — REST's `draft` field is GitHub-App-only, and `gh` has no `pr draft` subcommand

**Where it lives:**
- `MEMORY.md` §"Review existing PR signals first" — the rule + the #570 incident + the recovery procedure
- `AGENTS.md` "Reviewing PRs" — mirrors the merge-sequence shape, with the check command as the first step

No code changes. Doc-only.
