### PR TITLE
test(lint): drop SourceAnalysis.contradictions from six fixtures (#684 follow-up)

### DIFF
--- a/src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts
+++ b/src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts
@@ -28,7 +28,6 @@ const ANALYSIS_RESPONSE = JSON.stringify({
   summary: 'Acceptance and Commitment Therapy.',
   entities: [{ name: 'Steven Hayes', type: 'person', summary: 'founder', mentions_in_source: [] }],
   concepts: [{ name: 'Psychological Flexibility', summary: 'core construct', mentions_in_source: [] }],
-  contradictions: [],
   related_pages: [],
   key_points: [],
 });

--- a/src/__tests__/wiki/wiki-engine-contradiction-count.test.ts
+++ b/src/__tests__/wiki/wiki-engine-contradiction-count.test.ts
@@ -43,7 +43,6 @@ const EXTRACTION = JSON.stringify({
     { name: 'ATP', type: 'other', summary: 'Energy carrier; CCO may not be the primary photoacceptor.', mentions_in_source: ['CCO sei nicht der primäre Photoakzeptor'] },
   ],
   concepts: [],
-  contradictions: [],
   related_pages: [],
 });
 

--- a/src/__tests__/wiki/wiki-engine-link-repoint.test.ts
+++ b/src/__tests__/wiki/wiki-engine-link-repoint.test.ts
@@ -25,7 +25,6 @@ const ANALYSIS = JSON.stringify({
     { name: 'Phosphocreatin', type: 'person', summary: 'y', mentions_in_source: [] },
   ],
   concepts: [],
-  contradictions: [],
   related_pages: [],
   key_points: [],
 });

--- a/src/__tests__/wiki/wiki-engine-summary-domains.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-domains.test.ts
@@ -31,7 +31,6 @@ function makeAnalysis(): SourceAnalysis {
     summary: 'Iron store.',
     entities: [],
     concepts: [],
-    contradictions: [],
     related_pages: [],
     key_points: [],
     created_pages: [],

--- a/src/__tests__/wiki/wiki-engine-summary-head.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-head.test.ts
@@ -35,7 +35,6 @@ function analysis(): SourceAnalysis {
     summary: 'Signalproteine.',
     entities: [],
     concepts: [],
-    contradictions: [],
     related_pages: [],
     key_points: [],
     created_pages: [],

--- a/src/__tests__/wiki/wiki-engine-summary-tags.test.ts
+++ b/src/__tests__/wiki/wiki-engine-summary-tags.test.ts
@@ -41,7 +41,6 @@ function makeAnalysis(): SourceAnalysis {
       { name: 'Jnana Yoga', type: 'philosophy', summary: 'path of knowledge', mentions_in_source: [] },
       { name: 'Karma Yoga', type: 'philosophy', summary: 'path of action', mentions_in_source: [] },
     ],
-    contradictions: [],
     related_pages: [],
     key_points: [],
     created_pages: [],


### PR DESCRIPTION
**Main is currently red.** #696's Gate 1 surfaced a `TS2353` error in `wiki-engine-summary-head.test.ts:38`: `Object literal may only specify known properties, and 'contradictions' does not exist in type 'SourceAnalysis'`. That is the regression — and it's mine.

## What happened

PR #681 added a `SourceAnalysis` test fixture with `contradictions: []` in six files. CI was green because at that commit the field existed.

PR #684 removed the field from `src/types.ts:67` (`-  contradictions: ContradictionInfo[]`) along with its dead path (`review_ok` loop, `resolveContradiction`, `clampPageSections` — the writer's only outputs were `'resolved'` and `'pending_fix'`, never `'review_ok'`). CI was green at merge time because the field still existed on `main` until the moment #684 landed. The fix passed review because the deletion's internal consistency checked out, but **the review did not run `git show <base>:src/types.ts` against the dependent test fixtures** to confirm the field's removal was matched in every fixture that referenced it.

## What this PR does

Six one-line removals from test fixtures. No code changes, no test logic changes:

```
src/__tests__/wiki/wiki-engine-cancel-cleanup.test.ts      line 31
src/__tests__/wiki/wiki-engine-summary-tags.test.ts         line 44
src/__tests__/wiki/wiki-engine-summary-head.test.ts         line 38
src/__tests__/wiki/wiki-engine-contradiction-count.test.ts  line 46
src/__tests__/wiki/wiki-engine-link-repoint.test.ts         line 28
src/__tests__/wiki/wiki-engine-summary-domains.test.ts      line 34
```

The triage-lane behaviour `wiki-engine-contradiction-count.test.ts` covers is unaffected — the test only inspects `report?.contradictionsFound` from the merge-triage JSON, which goes through a different code path that #684 did not touch. The fixture's `contradictions: []` was filler for the *extraction* JSON.

## Why this couldn't wait

Main is red. Every other open PR's CI is blocked on this. The fix is six mechanical deletions with Gate 1 already green (lint 0 / tsc 0 / build / **4098 tests / 290 files** / css-lint 0) and a small, honest commit message that names the review miss. I'd like to merge it as soon as the CI on this PR goes green, with explicit approval.
