### PR TITLE
ci(gate-1): run the Five-Gate on pushes to main, not only on PRs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -23,6 +23,13 @@ name: Gate 1 (Five-Gate)
 on:
   pull_request:
     branches: [main]
+  # Also on `main` itself. Until 2026-09-12 nothing ran Gate 1 after a merge,
+  # so the state of `main` was only ever observable through some later PR's
+  # CI. That is how #681 and #684 broke it: each was green against the `main`
+  # it branched from, the break existed only in the pair, and it surfaced
+  # when an unrelated PR (#696) reported a TS2353 that was not its own.
+  push:
+    branches: [main]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm css-lint   # WRON
 
 ### Gate 1 CI (added 2026-08-18)
 
-`.github/workflows/pr-ci.yml` runs the full Five-Gate on every PR to `main`. Status check: `Gate 1 / Five-Gate`. Branch protection requires it (`strict: false`, `require_last_push_approval: true`).
+`.github/workflows/pr-ci.yml` runs the full Five-Gate on every PR to `main` and on every push to `main` (the second trigger added 2026-09-12: a PR is green against the base it branched from, so a break that exists only in the merged pair is invisible until a later PR reports it). Status check: `Gate 1 / Five-Gate`. Branch protection requires it (`strict: false`, `require_last_push_approval: true`).
 
 CI is a **defense-in-depth** layer on top of the per-fix E2E handoff manual Gate 1 (which is still required before `git push`). CI does NOT enable auto-merge — explicit "merge it" / "合并" still required per §"⚠️ Git Safety Protocol".
 


### PR DESCRIPTION
Nothing has ever run on `main`. `pr-ci.yml` triggers on `pull_request` only and `release.yml` on `push: tags`, so the default branch has no gate of its own — its state is observable only through the CI of some later PR that happens to carry it. The runs listed under `main` in the Actions tab are all Dependabot's.

**The cost of that, today.** #681 added `contradictions: []` to six `SourceAnalysis` fixtures and #684 removed the field from `types.ts`. Both were green, both were mine, and each was green against the `main` it branched from — the break existed only in the pair. It surfaced when #696, an unrelated docs PR, reported a `TS2353` that was not its own, and #697 cleaned it up. Between 18:42 and 19:10 the default branch did not compile and nothing in the repository said so.

**What this PR does.** One event added to the existing job — no new workflow, no new steps, no source change. The job reads no `github.event.pull_request` field, so it runs unchanged on push; I parsed the file to confirm both triggers resolve and the job keeps its seven steps.

**What it does not do, and the alternative you may prefer.** This detects the class one run after it lands; it does not prevent it. What prevents it is branch protection with `strict: true` — a branch must be up to date with its base before it can merge, so the pair is evaluated before the merge rather than after. I did not touch that, for two reasons: it is a repository setting rather than a file in a PR, and it has a real cost on a merge train — five PRs merged in a row become five update-and-rewait cycles, which is exactly what you did this evening. If you would rather pay that cost and prevent the class, this PR becomes unnecessary; the two together are belt and braces, and either one alone is better than today.

**Gate 1.** Not re-run locally: the diff is a workflow trigger and a documentation line, and touches nothing `lint`, `typecheck`, `build`, `test` or `css-lint` reads. This PR's own CI is the run. The first push-triggered run will be the merge of this PR itself, which is a fair first exercise.

`AGENTS.md` §"Gate 1 CI" is updated in the same commit, since it stated the trigger.
