### PR TITLE
docs: correct the require_last_push_approval value in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm css-lint   # WRON
 
 ### Gate 1 CI (added 2026-08-18)
 
-`.github/workflows/pr-ci.yml` runs the full Five-Gate on every PR to `main` and on every push to `main` (the second trigger added 2026-09-12: a PR is green against the base it branched from, so a break that exists only in the merged pair is invisible until a later PR reports it). Status check: `Gate 1 / Five-Gate`. Branch protection requires it (`strict: false`, `require_last_push_approval: true`).
+`.github/workflows/pr-ci.yml` runs the full Five-Gate on every PR to `main` and on every push to `main` (the second trigger added 2026-09-12: a PR is green against the base it branched from, so a break that exists only in the merged pair is invisible until a later PR reports it). Status check: `Gate 1 / Five-Gate`. Branch protection requires it (`strict: false`, `require_last_push_approval: false`).
 
 CI is a **defense-in-depth** layer on top of the per-fix E2E handoff manual Gate 1 (which is still required before `git push`). CI does NOT enable auto-merge — explicit "merge it" / "合并" still required per §"⚠️ Git Safety Protocol".
 


### PR DESCRIPTION
`AGENTS.md` §"Gate 1 CI" claimed the branch protection rule sets `require_last_push_approval: true`. It sets `false`.

Not a harmless typo. The flag answers "does my last push invalidate the review I already have?" — and the doc says yes while the rule says no, so a maintainer following it waits for an approval nobody asked for. `strict: false` in the same parenthesis is correct.

Found while reviewing #698, which rewrote that sentence. I flagged it as non-blocking so it would not hold up the trigger change; it merged without the correction, so it lands here as a one-line fix.

While in there I checked the other ruleset values the doc depends on against the API — `required_approving_review_count: 1`, `strict_required_status_checks_policy: false`, `bypass_actors: []` — all accurate, and the line's claim about which check is required matches.

Docs only, one line, no code.

Refs #698.
