### PR TITLE
fix(provenance): repair the footnote's brackets so the paragraph guard can see it

### DIFF
--- a/src/__tests__/core/provenance-marker.test.ts
+++ b/src/__tests__/core/provenance-marker.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeProvenanceMarkers } from '../../core/provenance-marker';
+
+describe('normalizeProvenanceMarkers — bracket count', () => {
+  it('repairs the two-bracket form the model writes most often', () => {
+    expect(normalizeProvenanceMarkers('Satz. ^[Quelle: [[Big-Pharma-Bias]]'))
+      .toBe('Satz. ^[Quelle: [[Big-Pharma-Bias]]]');
+  });
+
+  it('trims a four-bracket overshoot down to three', () => {
+    expect(normalizeProvenanceMarkers('Satz. ^[Quelle: [[X]]]]'))
+      .toBe('Satz. ^[Quelle: [[X]]]');
+  });
+
+  it('keeps a correct marker unchanged and stays idempotent', () => {
+    const ok = 'Satz. ^[Quelle: [[Berberin]]] Weiter.';
+    expect(normalizeProvenanceMarkers(ok)).toBe(ok);
+    expect(normalizeProvenanceMarkers(normalizeProvenanceMarkers(ok))).toBe(ok);
+  });
+
+  it('preserves trailing punctuation after the marker', () => {
+    expect(normalizeProvenanceMarkers('… gesättigte Fette ^[Quelle: [[Big-Pharma-Bias]].'))
+      .toBe('… gesättigte Fette ^[Quelle: [[Big-Pharma-Bias]]].');
+  });
+
+  it('handles piped link labels and path targets', () => {
+    expect(normalizeProvenanceMarkers('S. ^[Quelle: [[Notizen/Big-Pharma-Bias|Big-Pharma-Bias]]'))
+      .toBe('S. ^[Quelle: [[Notizen/Big-Pharma-Bias|Big-Pharma-Bias]]]');
+  });
+
+  it('returns content without a wikilink unchanged (same reference)', () => {
+    const s = 'Kein Marker hier.';
+    expect(normalizeProvenanceMarkers(s)).toBe(s);
+  });
+});
+
+describe('normalizeProvenanceMarkers — the label is the vault\'s, not ours', () => {
+  it('carries an English label through verbatim', () => {
+    expect(normalizeProvenanceMarkers('A sentence. ^[Source: [[Berberine]]'))
+      .toBe('A sentence. ^[Source: [[Berberine]]]');
+  });
+
+  it('carries a non-Latin label through verbatim', () => {
+    expect(normalizeProvenanceMarkers('一句话。^[[来源: [[小檗碱]]]]'))
+      .toBe('一句话。^[来源: [[小檗碱]]]');
+  });
+
+  it('never rewrites one label into another', () => {
+    const out = normalizeProvenanceMarkers('X ^[Fonte: [[Berberina]] Y ^[Quelle: [[Berberin]]');
+    expect(out).toBe('X ^[Fonte: [[Berberina]]] Y ^[Quelle: [[Berberin]]]');
+  });
+});
+
+describe('normalizeProvenanceMarkers — swapped opening brackets', () => {
+  it('repairs the [^Quelle: form the merge model writes', () => {
+    expect(normalizeProvenanceMarkers('Satz. [^Quelle: [[Adaptogen]]]'))
+      .toBe('Satz. ^[Quelle: [[Adaptogen]]]');
+  });
+
+  it('repairs it with a wrong closing bracket count as well', () => {
+    expect(normalizeProvenanceMarkers('Satz. [^Quelle: [[Adaptogen]]'))
+      .toBe('Satz. ^[Quelle: [[Adaptogen]]]');
+  });
+});
+
+describe('normalizeProvenanceMarkers — doubled opening bracket', () => {
+  it('repairs the ^[[Quelle: form', () => {
+    expect(normalizeProvenanceMarkers('Satz. ^[[Quelle: [[Reaktive Sauerstoffspezies]]]]'))
+      .toBe('Satz. ^[Quelle: [[Reaktive Sauerstoffspezies]]]');
+  });
+
+  it('repairs it with any closing count and keeps a piped label', () => {
+    expect(normalizeProvenanceMarkers('S. ^[[Quelle: [[Notizen/Eisen|Eisen]]] Weiter.'))
+      .toBe('S. ^[Quelle: [[Notizen/Eisen|Eisen]]] Weiter.');
+  });
+
+  it('repairs the bare-name form ^[[Quelle: X]] and keeps the text after it', () => {
+    expect(normalizeProvenanceMarkers('Depletion) ^[[Quelle: Reaktive Sauerstoffspezies]]\\. Eine'))
+      .toBe('Depletion) ^[Quelle: [[Reaktive Sauerstoffspezies]]]\\. Eine');
+  });
+});
+
+describe('normalizeProvenanceMarkers — the caret lost from the front', () => {
+  it('repairs the nested form with trailing carets', () => {
+    expect(normalizeProvenanceMarkers('Satz. [[Quelle: [[Reaktive Sauerstoffspezies]]]^^^. Weiter.'))
+      .toBe('Satz. ^[Quelle: [[Reaktive Sauerstoffspezies]]]. Weiter.');
+  });
+
+  it('repairs the nested form with no caret left at all', () => {
+    expect(normalizeProvenanceMarkers('Satz. [[Quelle: [[Curcumin]]]'))
+      .toBe('Satz. ^[Quelle: [[Curcumin]]]');
+  });
+
+  it('repairs the bare form when a caret trails it', () => {
+    expect(normalizeProvenanceMarkers('Satz. [[Quelle: Curcumin]]^'))
+      .toBe('Satz. ^[Quelle: [[Curcumin]]]');
+  });
+});
+
+describe('normalizeProvenanceMarkers — what it must not touch', () => {
+  it('leaves a wikilink whose page name contains a colon alone', () => {
+    const s = 'Siehe [[Studie: Berberin 2021]] und [[COVID-19: Long Covid]].';
+    expect(normalizeProvenanceMarkers(s)).toBe(s);
+  });
+
+  it('leaves a colon-named wikilink alone when a footnote follows it', () => {
+    const s = 'Siehe [[Studie: Berberin 2021]]^[Quelle: [[Berberin]]]';
+    expect(normalizeProvenanceMarkers(s)).toBe(s);
+  });
+
+  it('leaves an ordinary inline footnote without a wikilink alone', () => {
+    const s = 'Satz.^[eine gewöhnliche Fußnote: mit Doppelpunkt]';
+    expect(normalizeProvenanceMarkers(s)).toBe(s);
+  });
+
+  it('leaves the mentions quote line alone', () => {
+    // What the mentions formatter writes on every source page — one character
+    // away from a marker, and it must never be read as one.
+    const s = '> **Quelle: [[sources/X|X]]**\n> - "ein Zitat"';
+    expect(normalizeProvenanceMarkers(s)).toBe(s);
+  });
+
+  it('leaves an ordinary wikilink alone', () => {
+    const s = 'Siehe [[Berberin]] und [[entities/Chrom|Chrom]].';
+    expect(normalizeProvenanceMarkers(s)).toBe(s);
+  });
+});

--- a/src/core/provenance-marker.ts
+++ b/src/core/provenance-marker.ts
@@ -1,0 +1,61 @@
+// Provenance-marker normalization — repair the footnote the model meant to write.
+//
+// A multi-source page ends paragraphs with an inline footnote naming the
+// source the facts came from: `^[<label>: [[Name]]]`, where the vault's
+// config decides the label (`Quelle:`, `Source:`, …). `paragraph-provenance.ts`
+// reads exactly that shape to decide which paragraph a rewrite may drop, and
+// its regex needs the footnote to be well formed.
+//
+// The model gets the brackets wrong often enough to matter: measured over a
+// rebuilt vault, about a third of the markers came back with two closing
+// brackets instead of three, and one in five with the opening bracket doubled
+// (155 of 791 on one run). Every one of those forms is invisible to the guard,
+// so the paragraph it belongs to loses its owner and becomes droppable — and
+// Obsidian reads the doubled form as a link to a page named `<label>: [[Name`,
+// one ghost node per source.
+//
+// The semantic half — which paragraph, which source — is the model's judgement
+// and is left alone. The syntactic half is machine-checkable, so the single
+// write gate repairs it before the write lands. The label is carried through
+// verbatim; this never renames a marker.
+
+/** Label class: no brackets, no newline, no colon — the colon terminates it. */
+const LABEL = '([^[\\]\\n:]+)';
+/** Link target: alias and folder tolerated, brackets and newline are not. */
+const NAME = '([^[\\]\\n]+)';
+
+/**
+ * The opener in its three written forms: correct (`^[`), with the bracket
+ * doubled (`^[[`) and with the two characters swapped (`[^`). The closing
+ * count is free — that is the shape most often wrong.
+ */
+const OPENED = new RegExp(`(?:\\^\\[\\[?|\\[\\^)${LABEL}:\\s*\\[\\[${NAME}\\]\\]\\]*`, 'g');
+/** Doubled opener with the name bare inside: `^[[L: X]]` — the link swallowed by the footnote. */
+const BARE = new RegExp(`\\^\\[\\[${LABEL}:\\s*([^[\\]\\n]+?)\\s*\\]\\]\\]*`, 'g');
+/**
+ * The caret lost from the front: `[[L: [[X]]]`, with or without carets trailing.
+ * The nested `[[` is what makes this unambiguous — a wikilink to a page whose
+ * name contains a colon never has one, so `[[Study: Berberin 2021]]` is left alone.
+ */
+const NESTED = new RegExp(`\\[\\[${LABEL}:\\s*\\[\\[([^[\\]\\n]+?)\\s*\\]\\]\\]*\\^*(?!\\[)`, 'g');
+/**
+ * The same loss with the name bare: `[[L: X]]^`. Nothing distinguishes this
+ * from an ordinary wikilink except the trailing caret, so the caret is required.
+ */
+const TRAILING_CARET = new RegExp(`\\[\\[${LABEL}:\\s*([^[\\]\\n]+?)\\s*\\]\\]\\^+(?!\\[)`, 'g');
+
+const canonical = (_m: string, label: string, name: string) => `^[${label}: [[${name}]]]`;
+
+/**
+ * Normalize every provenance footnote to `^[<label>: [[Name]]]`. Idempotent;
+ * content without a wikilink is returned unchanged (same reference, so callers
+ * can cheaply detect no-ops).
+ */
+export function normalizeProvenanceMarkers(content: string): string {
+  if (!content.includes('[[')) return content;
+  return content
+    .replace(OPENED, canonical)
+    .replace(BARE, canonical)
+    .replace(NESTED, canonical)
+    .replace(TRAILING_CARET, canonical);
+}

--- a/src/wiki/wiki-engine.ts
+++ b/src/wiki/wiki-engine.ts
@@ -32,6 +32,7 @@ import { setGenerationComplete } from '../core/incomplete-page-cleaner';
 import { convertPdfToMarkdown, UnsupportedProviderError, EncryptedPdfError } from '../core/pdf-converter';
 import { MineruPdfError, MINERU_PHASE_KEY } from '../core/mineru-converter';
 import { hashBody, checkContentRequirements } from '../core/source-requirements';
+import { normalizeProvenanceMarkers } from '../core/provenance-marker';
 import { resolveModelForTask } from '../core/model-resolver';
 import type { SourceRejection } from '../core/source-requirements';
 // v1.25.1 Phase C-PR1: detectRateLimitFailures is invoked exclusively by runBatchedWithRetry (engine-internals/page-batch-runner.ts).
@@ -1936,6 +1937,10 @@ export class WikiEngine {
     // log/schema writes pass through untouched.
     if (this.isInWikiContentFolder(path, this.settings.wikiFolder)) {
       content = normalizeHeadingSpacing(content);
+      // Repair the provenance footnote's brackets on the same pass. The model
+      // gets them wrong often enough that paragraph-provenance.ts stops seeing
+      // the marker, and a marker it cannot see is a paragraph with no owner.
+      content = normalizeProvenanceMarkers(content);
     }
 
     for (let attempt = 0; attempt < 3; attempt++) {


### PR DESCRIPTION
`paragraph-provenance.ts` decides which paragraph a rewrite may drop by reading the inline footnote that names its source. Its regex is label-agnostic on purpose, but it does need the footnote to be well formed — and the model frequently writes it otherwise.

I ran the guard's own `SOURCE_FOOTNOTE` regex over the shapes a rebuilt vault actually produced. Six of the seven are invisible to it:

| written form | seen by the guard |
|---|---|
| `^[L: [[X]]` — two closing brackets | no |
| `^[L: [[X]]]]` — four closing brackets | yes |
| `[^L: [[X]]]` — first two characters swapped | no |
| `^[[L: [[X]]]]` — opening bracket doubled | no |
| `^[[L: X]]` — doubled, name bare inside | no |
| `[[L: [[X]]]^^^` — caret trailing the link | no |
| `[[L: [[X]]]` — caret gone | no |

The first row is the common one: roughly a third of the markers. The doubled opener was one in five on a single run (155 of 791), and Obsidian renders it as a link to a page named `L: [[X` — one ghost node per source. A marker the guard cannot see is a paragraph with no owner, so the next rewrite another source triggers is free to drop it.

**Why not widen the guard's regex instead.** That would make it see the broken markers, but Obsidian would still render the ghost link and the page would still carry a footnote that does not resolve. Repairing the syntax fixes both, and the guard stays strict.

The semantic half — which paragraph, which source — is the model's judgement and is untouched. The syntactic half is machine-checkable, so `createOrUpdateFile` repairs it on the pass that already normalizes heading spacing for wiki content; log and schema writes are outside that branch.

**The label is carried through verbatim** — `Quelle:`, `Source:`, `来源:` all survive as written. Two shapes are ambiguous against ordinary content and are recognised narrowly: the nested form by its inner `[[`, which a wikilink to a colon-named page never has, and the bare form only when a caret trails it. `[[Study: Berberin 2021]]`, `[[COVID-19: Long Covid]]` and the mentions quote line `> **Quelle: [[sources/X|X]]**` are left alone, with or without a footnote behind them — all four pinned as tests.

One migration note: this repairs writes from here on. Pages already carrying a broken marker are fixed the next time something writes them.

`src/core/provenance-marker.ts` is a new pure function, 22 tests. The engine change is five lines.

Gate 1: lint 0 / tsc 0 / build OK / 4120 tests, 291 files / css-lint 0.
